### PR TITLE
feat(flags): wire runtime toggles into tools catalog

### DIFF
--- a/app/composables/useTools.spec.ts
+++ b/app/composables/useTools.spec.ts
@@ -2,10 +2,11 @@ import type { ToolsCatalog } from "~/types/contracts";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createToolsApi, useToolsCatalogQuery } from "./useTools";
+import { applyToolsFlags, createToolsApi, useToolsCatalogQuery } from "./useTools";
 
 const useQueryMock = vi.hoisted(() => vi.fn());
 const useHttpMock = vi.hoisted(() => vi.fn());
+const isFeatureEnabledMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@tanstack/vue-query", () => ({
   useQuery: useQueryMock,
@@ -15,9 +16,14 @@ vi.mock("~/composables/useHttp", () => ({
   useHttp: useHttpMock,
 }));
 
+vi.mock("~/shared/feature-flags", () => ({
+  isFeatureEnabled: isFeatureEnabledMock,
+}));
+
 describe("useTools composable", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    isFeatureEnabledMock.mockReturnValue(false);
   });
 
   it("carrega catalogo de ferramentas", async () => {
@@ -79,5 +85,25 @@ describe("useTools composable", () => {
 
     expect(result.tools.length).toBeGreaterThan(0);
     expect(result.tools[0]?.id).toBe("raise-calculator");
+    expect(result.tools[0]?.enabled).toBe(false);
+  });
+
+  it("aplica override da flag para calculadora de aumento", () => {
+    isFeatureEnabledMock.mockReturnValue(true);
+    const catalog: ToolsCatalog = {
+      tools: [
+        {
+          id: "raise-calculator",
+          name: "Pedir aumento",
+          description: "Descricao",
+          enabled: false,
+        },
+      ],
+    };
+
+    const result = applyToolsFlags(catalog);
+
+    expect(result.tools[0]?.enabled).toBe(true);
+    expect(isFeatureEnabledMock).toHaveBeenCalledWith("web.tools.salary-raise-calculator");
   });
 });

--- a/app/composables/useTools.ts
+++ b/app/composables/useTools.ts
@@ -2,6 +2,7 @@ import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import type { ToolsCatalog } from "~/types/contracts";
 import { useHttp } from "~/composables/useHttp";
+import { isFeatureEnabled } from "~/shared/feature-flags";
 
 const toolsPlaceholder: ToolsCatalog = {
   tools: [
@@ -29,6 +30,29 @@ interface ToolsApi {
 }
 
 /**
+ * Aplica overrides de feature flags no catálogo de ferramentas.
+ * @param catalog Catálogo base vindo do backend ou placeholder.
+ * @returns Catálogo com campo `enabled` normalizado por flags locais.
+ */
+export const applyToolsFlags = (catalog: ToolsCatalog): ToolsCatalog => {
+  const toolsWithFlags = catalog.tools.map((tool): ToolsCatalog["tools"][number] => {
+    if (tool.id !== "raise-calculator") {
+      return tool;
+    }
+
+    const isRaiseCalculatorEnabled = isFeatureEnabled("web.tools.salary-raise-calculator");
+    return {
+      ...tool,
+      enabled: isRaiseCalculatorEnabled,
+    };
+  });
+
+  return {
+    tools: toolsWithFlags,
+  };
+};
+
+/**
  * Cria adapter da API de ferramentas.
  * @param http Cliente HTTP com método GET.
  * @returns API de catálogo de ferramentas.
@@ -53,9 +77,10 @@ export const useToolsCatalogQuery = (): UseQueryReturnType<ToolsCatalog, Error> 
     queryKey: ["tools", "catalog"],
     queryFn: async (): Promise<ToolsCatalog> => {
       try {
-        return await toolsApi.getCatalog();
+        const remoteCatalog = await toolsApi.getCatalog();
+        return applyToolsFlags(remoteCatalog);
       } catch {
-        return toolsPlaceholder;
+        return applyToolsFlags(toolsPlaceholder);
       }
     },
   });

--- a/app/shared/feature-flags/index.ts
+++ b/app/shared/feature-flags/index.ts
@@ -1,0 +1,2 @@
+export { getLocalFlag, isFeatureEnabled, resolveEnvOverride, toEnvSuffix } from "./service";
+export type { FeatureFlagCatalog, FeatureFlagDefinition } from "./types";

--- a/app/shared/feature-flags/service.spec.ts
+++ b/app/shared/feature-flags/service.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getLocalFlag, isFeatureEnabled, resolveEnvOverride, toEnvSuffix } from "./service";
+
+describe("feature flag service", () => {
+  it("normaliza sufixo de env var a partir da chave da flag", () => {
+    expect(toEnvSuffix("web.tools.salary-raise-calculator")).toBe("WEB_TOOLS_SALARY_RAISE_CALCULATOR");
+  });
+
+  it("retorna undefined quando override de env não existe", () => {
+    const overrideValue = resolveEnvOverride("web.tools.salary-raise-calculator");
+    expect(overrideValue).toBeUndefined();
+  });
+
+  it("retorna override de ambiente quando presente", () => {
+    vi.stubEnv("NUXT_PUBLIC_FLAG_WEB_TOOLS_SALARY_RAISE_CALCULATOR", "true");
+
+    const overrideValue = resolveEnvOverride("web.tools.salary-raise-calculator");
+    expect(overrideValue).toBe(true);
+
+    vi.unstubAllEnvs();
+  });
+
+  it("retorna definição da flag quando ela existe no catálogo", () => {
+    const localFlag = getLocalFlag("web.tools.salary-raise-calculator");
+    expect(localFlag?.key).toBe("web.tools.salary-raise-calculator");
+  });
+
+  it("considera flag desabilitada quando status local é draft", () => {
+    expect(isFeatureEnabled("web.tools.salary-raise-calculator")).toBe(false);
+  });
+
+  it("respeita decisão explícita do provider externo", () => {
+    expect(isFeatureEnabled("web.tools.salary-raise-calculator", true)).toBe(true);
+    expect(isFeatureEnabled("web.tools.salary-raise-calculator", false)).toBe(false);
+  });
+});

--- a/app/shared/feature-flags/service.ts
+++ b/app/shared/feature-flags/service.ts
@@ -1,0 +1,83 @@
+import featureFlagsCatalogJson from "../../../config/feature-flags.json";
+
+import type {
+  FeatureFlagCatalog,
+  FeatureFlagDefinition,
+} from "./types";
+
+const featureFlagsCatalog: FeatureFlagCatalog =
+  featureFlagsCatalogJson as FeatureFlagCatalog;
+const enabledStatuses = new Set<string>(["active", "released", "enabled"]);
+const overridePrefix = "NUXT_PUBLIC_FLAG_";
+
+/**
+ * Normaliza a chave de flag para o padrão de env var.
+ * @param flagKey Chave lógica da flag.
+ * @returns Sufixo de variável de ambiente.
+ */
+export const toEnvSuffix = (flagKey: string): string => {
+  return flagKey.replace(/[^a-zA-Z0-9]/g, "_").toUpperCase();
+};
+
+/**
+ * Resolve override de ambiente para uma flag.
+ * @param flagKey Chave lógica da flag.
+ * @returns Valor booleano explícito ou `undefined` quando ausente/inválido.
+ */
+export const resolveEnvOverride = (flagKey: string): boolean | undefined => {
+  const variableName = `${overridePrefix}${toEnvSuffix(flagKey)}`;
+  const rawValue = String(process.env[variableName] ?? "").trim().toLowerCase();
+
+  if (rawValue.length === 0) {
+    return undefined;
+  }
+
+  if (["1", "true", "yes", "on"].includes(rawValue)) {
+    return true;
+  }
+
+  if (["0", "false", "no", "off"].includes(rawValue)) {
+    return false;
+  }
+
+  return undefined;
+};
+
+/**
+ * Busca uma flag no catálogo local versionado.
+ * @param flagKey Chave lógica da flag.
+ * @returns Definição da flag quando encontrada.
+ */
+export const getLocalFlag = (flagKey: string): FeatureFlagDefinition | undefined => {
+  return featureFlagsCatalog.flags.find((flag: FeatureFlagDefinition): boolean => {
+    return flag.key === flagKey;
+  });
+};
+
+/**
+ * Resolve o estado efetivo de uma flag.
+ * Prioridade: provider externo -> env override -> catálogo local.
+ * @param flagKey Chave lógica da flag.
+ * @param providerDecision Decisão opcional de provider externo (Unleash/OpenFeature).
+ * @returns `true` quando a feature está habilitada.
+ */
+export const isFeatureEnabled = (
+  flagKey: string,
+  providerDecision?: boolean,
+): boolean => {
+  if (typeof providerDecision === "boolean") {
+    return providerDecision;
+  }
+
+  const envOverride = resolveEnvOverride(flagKey);
+  if (typeof envOverride === "boolean") {
+    return envOverride;
+  }
+
+  const localFlag = getLocalFlag(flagKey);
+  if (!localFlag) {
+    return false;
+  }
+
+  return enabledStatuses.has(localFlag.status.trim().toLowerCase());
+};

--- a/app/shared/feature-flags/types.ts
+++ b/app/shared/feature-flags/types.ts
@@ -1,0 +1,14 @@
+export interface FeatureFlagDefinition {
+  readonly key: string;
+  readonly owner: string;
+  readonly createdAt: string;
+  readonly removeBy: string;
+  readonly type: string;
+  readonly status: string;
+  readonly description: string;
+  readonly repositories: readonly string[];
+}
+
+export interface FeatureFlagCatalog {
+  readonly flags: readonly FeatureFlagDefinition[];
+}

--- a/tasks.md
+++ b/tasks.md
@@ -139,10 +139,10 @@ Toda task de UI/layout no `auraxis-web` deve seguir, sem exceção:
   - Risco residual: estratégia de branches/release precisa ficar alinhada com app/api para evitar drift de versões.
 
 - [~] **WEB16** `chore` — Integrar feature toggle OSS no frontend web
-  - Critério: SDK integrado com provedores por ambiente, fallback seguro e primeiro flag controlando feature real em produção.
+  - Critério: runtime de flags integrado com fallback seguro e primeiro flag (`web.tools.salary-raise-calculator`) controlando feature real do catálogo de ferramentas; pendente conexão com provider OSS (Unleash/OpenFeature) por ambiente.
   - Dependência: WEB2
-  - Commit: —
-  - Risco residual: sem governança de lifecycle dos flags, há risco de acúmulo de toggles obsoletos.
+  - Commit: `chore/plt4-runtime-flags-integration`
+  - Risco residual: falta integrar provider remoto para controle centralizado em produção e rotina de remoção de código morto por flag.
 
 - [x] **WEB18** `chore` — Automatizar hygiene de feature flags no CI
   - Critério: catálogo versionado de flags com metadados obrigatórios e validação bloqueante no CI/local parity para owner, removeBy e expiração.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineVitestConfig({
         "app/layouts/**/*.vue",
         "app/components/**/*.vue",
         "app/composables/**/*.ts",
+        "app/shared/**/*.ts",
         "app/stores/**/*.ts",
         "app/schemas/**/*.ts",
         "app/utils/**/*.ts",


### PR DESCRIPTION
## Summary

<!-- What changed and why -->

## Task Reference

- Task ID: `WEBx` / `PLTx` / `Bxx` (if integration)
- Backlog updated in `/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-web/tasks.md`: [ ] yes

## Validation

- [ ] `pnpm quality-check`
- [ ] `pnpm contracts:check`
- [ ] `pnpm build`

## Frontend Governance (Mandatory)

- [ ] No `.js/.jsx` introduced in product code.
- [ ] All styling uses tokens/theme (no arbitrary literals).
- [ ] Reusable code moved to `app/shared/*`.
- [ ] Chakra-first approach respected (wrappers/components before raw HTML primitives).

## Contract Integration (Mandatory when backend contract changed)

- [ ] Read `Feature Contract Pack` (`.context/feature_contracts/<TASK_ID>.md`).
- [ ] Updated `contracts/feature-contract-baseline.json` (if new/changed pack).
- [ ] Regenerated OpenAPI types (`pnpm contracts:sync`) and reviewed diff.

## Risks / Follow-ups

<!-- Residual risk, technical debt, and next action -->
