### PR TITLE
chore(flags): add canonical env fallback for web provider runtime

### DIFF
--- a/app/shared/feature-flags/service.spec.ts
+++ b/app/shared/feature-flags/service.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  fetchUnleashSnapshot,
   getLocalFlag,
   getProviderMode,
   isFeatureEnabled,
@@ -86,5 +87,32 @@ describe("feature flag service", () => {
       "web.tools.salary-raise-calculator",
     );
     expect(providerDecision).toBeUndefined();
+  });
+
+  it("aceita provider canônico AURAXIS_FLAG_PROVIDER como fallback", () => {
+    vi.stubEnv("AURAXIS_FLAG_PROVIDER", "unleash");
+    expect(getProviderMode()).toBe("unleash");
+  });
+
+  it("aceita URL canônica AURAXIS_UNLEASH_URL para snapshot remoto", async () => {
+    vi.stubEnv("AURAXIS_FLAG_PROVIDER", "unleash");
+    vi.stubEnv("AURAXIS_UNLEASH_URL", "https://flags.local");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          features: [
+            {
+              name: "web.tools.salary-raise-calculator",
+              enabled: true,
+            },
+          ],
+        }),
+      }),
+    );
+
+    const snapshot = await fetchUnleashSnapshot();
+    expect(snapshot["web.tools.salary-raise-calculator"]).toBe(true);
   });
 });

--- a/app/shared/feature-flags/service.ts
+++ b/app/shared/feature-flags/service.ts
@@ -18,6 +18,22 @@ let unleashCacheExpireAtMs = 0;
 let unleashCacheSnapshot: Record<string, boolean> = {};
 
 /**
+ * Resolve variável de ambiente por ordem de precedência.
+ * @param keys Lista ordenada de chaves candidatas.
+ * @param defaultValue Valor padrão quando nenhuma chave está definida.
+ * @returns Valor normalizado (trim).
+ */
+const readRuntimeEnv = (keys: string[], defaultValue = ""): string => {
+  for (const key of keys) {
+    const rawValue = process.env[key];
+    if (typeof rawValue === "string" && rawValue.trim().length > 0) {
+      return rawValue.trim();
+    }
+  }
+  return defaultValue;
+};
+
+/**
  * Determina se valor desconhecido é objeto indexável.
  * @param value Valor de entrada.
  * @returns `true` quando for um objeto válido.
@@ -31,7 +47,12 @@ const isObjectRecord = (value: unknown): value is Record<string, unknown> => {
  * @returns TTL em milissegundos.
  */
 const getSafeCacheTtlMs = (): number => {
-  const rawCacheTtlMs = Number(process.env.NUXT_PUBLIC_UNLEASH_CACHE_TTL_MS ?? "30000");
+  const rawCacheTtlMs = Number(
+    readRuntimeEnv(
+      ["NUXT_PUBLIC_UNLEASH_CACHE_TTL_MS", "AURAXIS_UNLEASH_CACHE_TTL_MS"],
+      "30000",
+    ),
+  );
   if (Number.isFinite(rawCacheTtlMs) && rawCacheTtlMs > 0) {
     return Math.trunc(rawCacheTtlMs);
   }
@@ -52,7 +73,10 @@ export const resetProviderCache = (): void => {
  * @returns Modo do provider (`local` ou `unleash`).
  */
 export const getProviderMode = (): "local" | "unleash" => {
-  const providerModeEnv = String(process.env.NUXT_PUBLIC_FLAG_PROVIDER ?? "local")
+  const providerModeEnv = readRuntimeEnv(
+    ["NUXT_PUBLIC_FLAG_PROVIDER", "AURAXIS_FLAG_PROVIDER"],
+    "local",
+  )
     .trim()
     .toLowerCase();
   if (providerModeEnv === "unleash") {
@@ -66,14 +90,30 @@ export const getProviderMode = (): "local" | "unleash" => {
  * @returns Dicionário de headers HTTP.
  */
 const buildUnleashHeaders = (): Record<string, string> => {
-  const unleashAppName = String(process.env.NUXT_PUBLIC_UNLEASH_APP_NAME ?? defaultUnleashAppName).trim();
-  const unleashEnvironment = String(
-    process.env.NUXT_PUBLIC_UNLEASH_ENVIRONMENT ?? defaultUnleashEnvironment,
-  ).trim();
-  const unleashInstanceId = String(
-    process.env.NUXT_PUBLIC_UNLEASH_INSTANCE_ID ?? defaultUnleashInstanceId,
-  ).trim();
-  const unleashClientKey = String(process.env.NUXT_PUBLIC_UNLEASH_CLIENT_KEY ?? "").trim();
+  const unleashAppName = readRuntimeEnv(
+    ["NUXT_PUBLIC_UNLEASH_APP_NAME", "AURAXIS_UNLEASH_APP_NAME"],
+    defaultUnleashAppName,
+  );
+  const unleashEnvironment = readRuntimeEnv(
+    [
+      "NUXT_PUBLIC_UNLEASH_ENVIRONMENT",
+      "AURAXIS_UNLEASH_ENVIRONMENT",
+      "AURAXIS_RUNTIME_ENV",
+    ],
+    defaultUnleashEnvironment,
+  );
+  const unleashInstanceId = readRuntimeEnv(
+    ["NUXT_PUBLIC_UNLEASH_INSTANCE_ID", "AURAXIS_UNLEASH_INSTANCE_ID"],
+    defaultUnleashInstanceId,
+  );
+  const unleashClientKey = readRuntimeEnv(
+    [
+      "NUXT_PUBLIC_UNLEASH_CLIENT_KEY",
+      "AURAXIS_UNLEASH_CLIENT_KEY",
+      "AURAXIS_UNLEASH_API_TOKEN",
+    ],
+    "",
+  );
   const headers: Record<string, string> = {
     Accept: "application/json",
     "UNLEASH-APPNAME": unleashAppName,
@@ -119,7 +159,10 @@ const parseUnleashPayload = (payload: unknown): Record<string, boolean> => {
  * @returns Mapa `flag -> enabled` obtido do provider.
  */
 export const fetchUnleashSnapshot = async (): Promise<Record<string, boolean>> => {
-  const unleashProxyUrl = String(process.env.NUXT_PUBLIC_UNLEASH_PROXY_URL ?? "").trim();
+  const unleashProxyUrl = readRuntimeEnv(
+    ["NUXT_PUBLIC_UNLEASH_PROXY_URL", "AURAXIS_UNLEASH_URL"],
+    "",
+  );
   if (getProviderMode() !== "unleash" || unleashProxyUrl.length === 0) {
     return {};
   }

--- a/docs/runbooks/PLT2-PLT5-foundation.md
+++ b/docs/runbooks/PLT2-PLT5-foundation.md
@@ -73,6 +73,18 @@ Variáveis de ambiente suportadas (Web):
 - `NUXT_PUBLIC_UNLEASH_ENVIRONMENT` (default `development`)
 - `NUXT_PUBLIC_UNLEASH_CACHE_TTL_MS` (default `30000`)
 
+Fallback canônico suportado (cross-repo):
+
+- `AURAXIS_FLAG_PROVIDER`
+- `AURAXIS_UNLEASH_URL`
+- `AURAXIS_UNLEASH_API_TOKEN` / `AURAXIS_UNLEASH_CLIENT_KEY`
+- `AURAXIS_UNLEASH_ENVIRONMENT` / `AURAXIS_RUNTIME_ENV`
+- `AURAXIS_UNLEASH_CACHE_TTL_MS`
+
+Bootstrap central recomendado:
+
+- `../../../../scripts/bootstrap-feature-flag-provider.sh --environment <env> --format env`
+
 ## PLT4.1 (higiene de flags) — entregue
 
 - Catálogo versionado de flags:

--- a/tasks.md
+++ b/tasks.md
@@ -141,8 +141,8 @@ Toda task de UI/layout no `auraxis-web` deve seguir, sem exceção:
 - [~] **WEB16** `chore` — Integrar feature toggle OSS no frontend web
   - Critério: runtime de flags integrado com fallback seguro e provider remoto por ambiente (`unleash`), com primeiro flag (`web.tools.salary-raise-calculator`) controlando feature real do catálogo de ferramentas.
   - Dependência: WEB2
-  - Commit: `chore/plt4-runtime-flags-integration`, `chore/plt4-oss-provider-integration`
-  - Risco residual: falta formalizar limpeza contínua de código morto pós-expiração da flag e dashboards operacionais por ambiente.
+  - Commit: `chore/plt4-runtime-flags-integration`, `chore/plt4-oss-provider-integration`, `chore/web-plt4-3-provider-runtime-bootstrap`
+  - Risco residual: pendente apenas rotina contínua de limpeza de código morto pós-expiração da flag.
 
 - [x] **WEB18** `chore` — Automatizar hygiene de feature flags no CI
   - Critério: catálogo versionado de flags com metadados obrigatórios e validação bloqueante no CI/local parity para owner, removeBy e expiração.
@@ -244,6 +244,7 @@ Toda task de UI/layout no `auraxis-web` deve seguir, sem exceção:
 - [x] PLT2 foundation (web): baseline PWA documentada com `manifest.webmanifest` e runbook inicial para empacotamento em stores | Data: 2026-02-24
 - [x] PLT2 foundation (web): workflow manual de geração de artefatos para empacotamento em stores (`pwa-store-artifacts.yml`) | Data: 2026-02-24
 - [x] PLT4.1 (web): catálogo de flags em `config/feature-flags.json` + gate `Feature Flags Hygiene` no CI + validação local em `scripts/run_ci_like_actions_local.sh` | Data: 2026-02-25
+- [x] PLT4.3 (web): runtime de flags passou a aceitar namespace canônico `AURAXIS_*` como fallback de `NUXT_PUBLIC_*` + runbook atualizado para bootstrap central por ambiente | Data: 2026-02-28
 - [x] WEB19 concluído: fundação administrativa web preparada (`@tanstack/vue-query` + `axios` + `pinia` + contratos tipados + composables de integração) | Data: 2026-02-26
 - [x] WEB20 concluído: páginas placeholder de login/forgot-password/dashboard/carteira/ferramentas com validação de formulário e tema global sem Tailwind | Data: 2026-02-26
 - [x] Governança cross-platform sincronizada: referências obrigatórias ao guideline unificado (`.context/32_frontend_unified_guideline.md`) e ao fluxo de `Feature Contract Pack` adicionadas em `steering.md` e `CODING_STANDARDS.md` | Data: 2026-02-27


### PR DESCRIPTION
## Summary

<!-- What changed and why -->

## Task Reference

- Task ID: `WEBx` / `PLTx` / `Bxx` (if integration)
- Backlog updated in `/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-web/tasks.md`: [ ] yes

## Validation

- [ ] `pnpm quality-check`
- [ ] `pnpm contracts:check`
- [ ] `pnpm build`

## Frontend Governance (Mandatory)

- [ ] No `.js/.jsx` introduced in product code.
- [ ] All styling uses tokens/theme (no arbitrary literals).
- [ ] Reusable code moved to `app/shared/*`.
- [ ] Chakra-first approach respected (wrappers/components before raw HTML primitives).

## Contract Integration (Mandatory when backend contract changed)

- [ ] Read `Feature Contract Pack` (`.context/feature_contracts/<TASK_ID>.md`).
- [ ] Updated `contracts/feature-contract-baseline.json` (if new/changed pack).
- [ ] Regenerated OpenAPI types (`pnpm contracts:sync`) and reviewed diff.

## Risks / Follow-ups

<!-- Residual risk, technical debt, and next action -->
