### PR TITLE
chore(release): add metadata baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This file is the baseline for automated release management via Release Please.
+Subsequent entries should be generated from release automation.

--- a/package.json
+++ b/package.json
@@ -102,5 +102,6 @@
     "**/*.{json,jsonc,md}": [
       "prettier --write"
     ]
-  }
+  },
+  "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary\n- add `version` to `package.json` aligned with release-please manifest\n- add initial `CHANGELOG.md` baseline for release automation\n- reduce concrete metadata gaps reported by the platform release governance doctor\n\n## Validation\n- parsed `package.json` and confirmed `version=1.0.0`\n- verified `CHANGELOG.md` exists at repo root\n