### PR TITLE
chore(release): add official aws web deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,141 @@
+name: Deploy Official Web (AWS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment
+        required: true
+        default: prod
+        type: choice
+        options:
+          - dev
+          - pilot
+          - prod
+      api_base_url:
+        description: Public API base URL for static generation
+        required: true
+        default: https://api.auraxis.com.br
+        type: string
+      run_smoke_test:
+        description: Run smoke test against official hostname after deploy
+        required: true
+        default: false
+        type: boolean
+      invalidate_cache:
+        description: Invalidate CloudFront cache after upload
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: web-official-${{ inputs.environment }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "25"
+  PNPM_VERSION: "10.30.1"
+  AWS_REGION: "us-east-1"
+  WEB_OFFICIAL_HOSTNAME: ${{ vars.WEB_OFFICIAL_HOSTNAME || 'app.auraxis.com.br' }}
+
+jobs:
+  build-static:
+    name: Build static output
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c # v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate deploy contract
+        env:
+          AWS_WEB_DEPLOY_ROLE_ARN: ${{ secrets.AWS_WEB_DEPLOY_ROLE_ARN }}
+          AWS_WEB_DEPLOY_BUCKET: ${{ secrets.AWS_WEB_DEPLOY_BUCKET }}
+          AWS_WEB_CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.AWS_WEB_CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          missing=0
+          for name in AWS_WEB_DEPLOY_ROLE_ARN AWS_WEB_DEPLOY_BUCKET AWS_WEB_CLOUDFRONT_DISTRIBUTION_ID; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Missing required secret: ${name}"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Generate static output
+        env:
+          NODE_ENV: production
+          NUXT_PUBLIC_API_BASE: ${{ inputs.api_base_url }}
+          NUXT_PUBLIC_SENTRY_DSN: ${{ secrets.NUXT_PUBLIC_SENTRY_DSN }}
+        run: pnpm generate
+
+      - name: Validate output folder
+        run: test -d .output/public
+
+      - name: Upload official deploy artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-official-static-${{ inputs.environment }}
+          path: .output/public
+          retention-days: 7
+
+  deploy-aws:
+    name: Deploy to S3 + CloudFront
+    runs-on: ubuntu-latest
+    needs: build-static
+    environment:
+      name: web-official-${{ inputs.environment }}
+      url: https://${{ env.WEB_OFFICIAL_HOSTNAME }}
+    steps:
+      - name: Download static artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: web-official-static-${{ inputs.environment }}
+          path: dist
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6d54b3c2c3a9b7f2c5e6db3f0 # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_WEB_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Sync static files to S3
+        env:
+          AWS_WEB_DEPLOY_BUCKET: ${{ secrets.AWS_WEB_DEPLOY_BUCKET }}
+        run: aws s3 sync dist "s3://${AWS_WEB_DEPLOY_BUCKET}" --delete
+
+      - name: Invalidate CloudFront
+        if: ${{ inputs.invalidate_cache }}
+        env:
+          AWS_WEB_CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.AWS_WEB_CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${AWS_WEB_CLOUDFRONT_DISTRIBUTION_ID}" \
+            --paths "/*"
+
+      - name: Smoke test official hostname
+        if: ${{ inputs.run_smoke_test }}
+        run: |
+          curl --fail --show-error --silent --location \
+            "https://${WEB_OFFICIAL_HOSTNAME}" \
+            >/tmp/web-official-smoke.html
+          test -s /tmp/web-official-smoke.html

--- a/docs/runbooks/G1-web-official.md
+++ b/docs/runbooks/G1-web-official.md
@@ -1,0 +1,74 @@
+# G1 — Web Official Deploy
+
+Atualizado: 2026-03-07
+
+## Objetivo
+
+Substituir o canal provisório de GitHub Pages por um canal oficial em AWS,
+com deploy controlado, domínio próprio, CloudFront e rollback explícito.
+
+## Workflow canônico
+
+Arquivo:
+
+- `.github/workflows/deploy.yml`
+
+Trigger:
+
+- manual (`workflow_dispatch`)
+
+Inputs:
+
+1. `environment` — `dev`, `pilot`, `prod`
+2. `api_base_url` — URL pública da API usada no build estático
+3. `run_smoke_test` — executa smoke no hostname oficial
+4. `invalidate_cache` — invalida cache do CloudFront
+
+## Secrets obrigatórios
+
+Publicar no repositório `auraxis-web`:
+
+1. `AWS_WEB_DEPLOY_ROLE_ARN`
+2. `AWS_WEB_DEPLOY_BUCKET`
+3. `AWS_WEB_CLOUDFRONT_DISTRIBUTION_ID`
+
+## Secrets opcionais, mas esperados para G1 completo
+
+1. `NUXT_PUBLIC_SENTRY_DSN`
+2. `SENTRY_AUTH_TOKEN`
+
+## Repository variables recomendadas
+
+1. `WEB_OFFICIAL_HOSTNAME`
+   - default esperado: `app.auraxis.com.br`
+
+## Infra AWS mínima esperada
+
+1. Bucket S3 para artefato web oficial
+2. Distribuição CloudFront apontando para o bucket
+3. Certificado ACM válido para `app.auraxis.com.br`
+4. Registro DNS apontando o hostname oficial para o CloudFront
+5. Role IAM com trust OIDC para GitHub Actions do repo `italofelipe/auraxis-web`
+
+## Sequência operacional
+
+1. Provisionar role, bucket, distribuição e DNS
+2. Publicar secrets/vars no repo
+3. Rodar `Deploy Official Web (AWS)` para `dev`
+4. Validar smoke e rollback
+5. Repetir para `pilot`
+6. Promover para `prod`
+
+## Critério de sucesso
+
+1. Deploy executa sem credenciais locais
+2. Arquivos são publicados no bucket oficial
+3. CloudFront é invalidado com sucesso
+4. `https://app.auraxis.com.br` responde com o build novo
+5. Rollback por rerun/tag é executável em menos de 15 minutos
+
+## Observação
+
+Enquanto `AWS_WEB_DEPLOY_ROLE_ARN`, `AWS_WEB_DEPLOY_BUCKET` e
+`AWS_WEB_CLOUDFRONT_DISTRIBUTION_ID` não existirem no repo, o workflow deve
+falhar cedo com erro explícito de contrato incompleto.

--- a/docs/runbooks/PLT2-PLT5-foundation.md
+++ b/docs/runbooks/PLT2-PLT5-foundation.md
@@ -17,6 +17,9 @@ Preparar o frontend web para:
    - `.release-please-manifest.json`
 2. Deploy mínimo via GitHub Pages:
    - `.github/workflows/deploy-minimum.yml`
+3. Deploy oficial AWS/CloudFront:
+   - `.github/workflows/deploy.yml`
+   - `docs/runbooks/G1-web-official.md`
 3. Baseline PWA:
    - `public/manifest.webmanifest`
 4. Artefatos manuais para empacotamento em stores:
@@ -38,7 +41,14 @@ Preparar o frontend web para:
 - Pipeline:
   - `pnpm generate`;
   - upload de `.output/public` como artifact;
-  - deploy no ambiente `github-pages`.
+- deploy no ambiente `github-pages`.
+
+### Deploy oficial (G1)
+
+- workflow manual: `.github/workflows/deploy.yml`
+- bucket S3 + distribuição CloudFront
+- domínio esperado: `app.auraxis.com.br`
+- invalidation explícita e smoke opcional
 
 ### Artefatos de store (manual)
 


### PR DESCRIPTION
## Summary
- add a manual AWS/CloudFront workflow for the official web channel
- document the AWS, domain and observability contract for G1
- keep the GitHub Pages baseline untouched while official infra is provisioned

## Validation
- git diff --check
- workflow contract review
- docs/runbook update
