### PR TITLE
feat(obs): add minimal sentry client for official web

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,8 @@ jobs:
           NODE_ENV: production
           NUXT_PUBLIC_API_BASE: ${{ inputs.api_base_url }}
           NUXT_PUBLIC_SENTRY_DSN: ${{ secrets.NUXT_PUBLIC_SENTRY_DSN }}
+          NUXT_PUBLIC_APP_ENV: ${{ inputs.environment }}
+          NUXT_PUBLIC_SITE_URL: https://${{ env.WEB_OFFICIAL_HOSTNAME }}
         run: pnpm generate
 
       - name: Validate output folder

--- a/app/plugins/sentry.client.ts
+++ b/app/plugins/sentry.client.ts
@@ -1,0 +1,22 @@
+import * as Sentry from "@sentry/vue";
+
+/**
+ * Inicializa observabilidade mínima no cliente para o canal web oficial.
+ * Mantém o plugin inerte quando o DSN não estiver configurado.
+ */
+export default defineNuxtPlugin((nuxtApp) => {
+  const runtimeConfig = useRuntimeConfig();
+  const dsn = String(runtimeConfig.public.sentryDsn ?? "").trim();
+
+  if (!dsn) {
+    return;
+  }
+
+  Sentry.init({
+    app: nuxtApp.vueApp,
+    dsn,
+    environment: String(runtimeConfig.public.appEnv ?? "production"),
+    enabled: true,
+    tracesSampleRate: 0.1,
+  });
+});

--- a/docs/runbooks/G1-web-official.md
+++ b/docs/runbooks/G1-web-official.md
@@ -37,10 +37,19 @@ Publicar no repositório `auraxis-web`:
 1. `NUXT_PUBLIC_SENTRY_DSN`
 2. `SENTRY_AUTH_TOKEN`
 
+`NUXT_PUBLIC_SENTRY_DSN` cobre a observabilidade mínima do canal oficial.
+`SENTRY_AUTH_TOKEN` só é necessário quando quisermos evoluir para upload de sourcemaps.
+
 ## Repository variables recomendadas
 
 1. `WEB_OFFICIAL_HOSTNAME`
    - default esperado: `app.auraxis.com.br`
+
+## Decisão de domínio
+
+1. `app.auraxis.com.br` é o hostname oficial da aplicação web.
+2. `auraxis.com.br` fica reservado para site institucional / landing pública.
+3. O workflow oficial de deploy do app não deve assumir publish no apex.
 
 ## Infra AWS mínima esperada
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -21,7 +21,7 @@ export default defineNuxtConfig({
   css: ["~/assets/css/main.css"],
 
   site: {
-    url: process.env.NUXT_PUBLIC_SITE_URL ?? "http://localhost:3000",
+    url: process.env.NUXT_PUBLIC_SITE_URL ?? "https://app.auraxis.com.br",
   },
 
   // ── Módulos ──────────────────────────────────────────────────────────
@@ -52,6 +52,8 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       apiBase: process.env.NUXT_PUBLIC_API_BASE ?? "http://localhost:5000",
+      sentryDsn: process.env.NUXT_PUBLIC_SENTRY_DSN ?? "",
+      appEnv: process.env.NUXT_PUBLIC_APP_ENV ?? process.env.NODE_ENV ?? "development",
     },
   },
   googleFonts: {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@nuxtjs/seo": "3.4.0",
     "@pinia/colada-nuxt": "0.3.1",
     "@pinia/nuxt": "0.11.3",
+    "@sentry/vue": "^10.42.0",
     "@tanstack/vue-query": "^5.92.9",
     "@vee-validate/zod": "^4.15.1",
     "axios": "^1.13.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@pinia/nuxt':
         specifier: 0.11.3
         version: 0.11.3(magicast@0.5.2)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3)))
+      '@sentry/vue':
+        specifier: ^10.42.0
+        version: 10.42.0(pinia@3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))
       '@tanstack/vue-query':
         specifier: ^5.92.9
         version: 5.92.9(vue@3.5.28(typescript@5.9.3))
@@ -2526,6 +2529,43 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sentry-internal/browser-utils@10.42.0':
+    resolution: {integrity: sha512-HCEICKvepxN4/6NYfnMMMlppcSwIEwtS66X6d1/mwaHdi2ivw0uGl52p7Nfhda/lIJArbrkWprxl0WcjZajhQA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.42.0':
+    resolution: {integrity: sha512-lpPcHsog10MVYFTWE0Pf8vQRqQWwZHJpkVl2FEb9/HDdHFyTBUhCVoWo1KyKaG7GJl9AVKMAg7bp9SSNArhFNQ==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.42.0':
+    resolution: {integrity: sha512-am3m1Fj8ihoPfoYo41Qq4KeCAAICn4bySso8Oepu9dMNe9Lcnsf+reMRS2qxTPg3pZDc4JEMOcLyNCcgnAfrHw==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.42.0':
+    resolution: {integrity: sha512-Zh3EoaH39x2lqVY1YyVB2vJEyCIrT+YLUQxYl1yvP0MJgLxaR6akVjkgxbSUJahan4cX5DxpZiEHfzdlWnYPyQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.42.0':
+    resolution: {integrity: sha512-iXxYjXNEBwY1MH4lDSDZZUNjzPJDK7/YLwVIJq/3iBYpIQVIhaJsoJnf3clx9+NfJ8QFKyKfcvgae61zm+hgTA==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@10.42.0':
+    resolution: {integrity: sha512-L4rMrXMqUKBanpjpMT+TuAVk6xAijz6AWM6RiEYpohAr7SGcCEc1/T0+Ep1eLV8+pwWacfU27OvELIyNeOnGzA==}
+    engines: {node: '>=18'}
+
+  '@sentry/vue@10.42.0':
+    resolution: {integrity: sha512-D6mYt6zRV1YXMZ8xmGKXzb0VHSLANUxpDAC3tfCeRYZ9P0MEHlNI6aapvjiNAh+0Vi9bOaHIUkzpatbE1gWhOg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@tanstack/vue-router': ^1.64.0
+      pinia: 2.x || 3.x
+      vue: 2.x || 3.x
+    peerDependenciesMeta:
+      '@tanstack/vue-router':
+        optional: true
+      pinia:
+        optional: true
 
   '@shikijs/core@3.22.0':
     resolution: {integrity: sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA==}
@@ -10234,6 +10274,42 @@ snapshots:
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sentry-internal/browser-utils@10.42.0':
+    dependencies:
+      '@sentry/core': 10.42.0
+
+  '@sentry-internal/feedback@10.42.0':
+    dependencies:
+      '@sentry/core': 10.42.0
+
+  '@sentry-internal/replay-canvas@10.42.0':
+    dependencies:
+      '@sentry-internal/replay': 10.42.0
+      '@sentry/core': 10.42.0
+
+  '@sentry-internal/replay@10.42.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.42.0
+      '@sentry/core': 10.42.0
+
+  '@sentry/browser@10.42.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.42.0
+      '@sentry-internal/feedback': 10.42.0
+      '@sentry-internal/replay': 10.42.0
+      '@sentry-internal/replay-canvas': 10.42.0
+      '@sentry/core': 10.42.0
+
+  '@sentry/core@10.42.0': {}
+
+  '@sentry/vue@10.42.0(pinia@3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))':
+    dependencies:
+      '@sentry/browser': 10.42.0
+      '@sentry/core': 10.42.0
+      vue: 3.5.28(typescript@5.9.3)
+    optionalDependencies:
+      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3))
 
   '@shikijs/core@3.22.0':
     dependencies:


### PR DESCRIPTION
## Summary
- add minimal client-side Sentry initialization for the official web channel
- expose `NUXT_PUBLIC_SENTRY_DSN` and `NUXT_PUBLIC_APP_ENV` via runtime config
- wire official deploy to pass the site URL and app environment during static generation
- document the domain decision: `app.auraxis.com.br` for the app, `auraxis.com.br` for the institutional site

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm generate` with `NUXT_PUBLIC_SITE_URL=https://app.auraxis.com.br`
