### PR TITLE
docs(naive-ui): replace stale Chakra UI refs in steering.md + tasks.md

### DIFF
--- a/steering.md
+++ b/steering.md
@@ -38,7 +38,7 @@ Para integração com backend recém-entregue:
 | Formatação             | Prettier                  | ^3.8                   |
 | Testes unitários       | Vitest + @nuxt/test-utils | ^4.0                   |
 | Testes E2E             | Playwright                | ^1.58                  |
-| UI base                | Chakra UI (customizado)   | ^3.x                   |
+| UI base                | Naive UI                  | @latest                |
 | Estado de servidor     | TanStack Query (Vue)      | ^5.x                   |
 | Estado global          | Pinia                     | via @pinia/nuxt        |
 | Análise estática       | SonarCloud                | —                      |
@@ -55,10 +55,9 @@ Para integração com backend recém-entregue:
 - Grid base: `8px` (spacing estrutural sempre em múltiplos de 8).
 - Tema obrigatório e modular: `app/theme/tokens/colors.ts`, `typography.ts`, `spacing.ts`, `radii.ts`, `shadows.ts`, `motion.ts`.
 - `app/theme/index.ts` deve ser apenas barrel de exportação. Proibido concentrar definição de tokens nesse arquivo.
-- Componentes web devem derivar de base **Chakra UI customizada** (tokens Auraxis).
-- Em ausência de Chakra UI estável para Vue/Nuxt, usar biblioteca equivalente de mercado (Vuetify/Naive UI/PrimeVue) com wrappers internos.
+- Componentes web devem derivar de base **Naive UI** (via `NConfigProvider` com tokens Auraxis).
 - Componentes novos devem partir da UI library oficial do projeto; customizações devem ser feitas por extensão/composição, não por reimplementação ad-hoc.
-- Em telas/componentes de produto, evitar tags HTML cruas de formulário/controle/texto estrutural (`<input>`, `<label>`, `<button>`, `<textarea>`, `<select>`, `<p>`). Usar componentes Chakra UI (ou wrappers internos).
+- Em telas/componentes de produto, evitar tags HTML cruas de formulário/controle/texto estrutural (`<input>`, `<label>`, `<button>`, `<textarea>`, `<select>`, `<p>`). Usar componentes Naive UI (NInput, NButton, NForm, NSelect, etc.) ou wrappers internos.
 - É proibido usar valores literais de cor, spacing, radius, shadow, font-size, line-height e font-weight em componentes/páginas. Usar tokens semânticos.
 - É proibido declarar bordas/larguras sem tokens semânticos (ex.: `1px solid #ccc`, `4px`, `0.5rem`) fora de arquivos de tema.
 - É proibido introduzir escala de cores de brand fora da paleta oficial. Não criar gradientes/hues ad-hoc fora dos tokens aprovados.
@@ -81,7 +80,7 @@ Para integração com backend recém-entregue:
 - **Performance como gate** — LCP ≤ 4s, CLS ≤ 0.1 (Core Web Vitals obrigatórios).
 - **Segurança por padrão** — secret scan automático, CVEs bloqueados em PRs.
 - **Testes não são opcionais** — toda lógica nova tem teste antes de merge.
-- **UI consistente por contrato** — Chakra UI customizado + tokens oficiais são obrigatórios.
+- **UI consistente por contrato** — Naive UI + tokens oficiais (via NConfigProvider) são obrigatórios.
 - **Token-first styling** — qualquer estilo visual deve usar tokens do tema; valores soltos no código são não conformidade.
 - **Server-state com TanStack Query** — Pinia fica para estado de cliente e orquestração local.
 

--- a/tasks.md
+++ b/tasks.md
@@ -73,17 +73,17 @@ Toda task de UI/layout no `auraxis-web` deve seguir, sem exceção:
   - Dependência: WEB3
   - Commit: —
 
-- [ ] **WEB11** `chore` — Padronizar UI kit web em Chakra UI customizado (sem Tailwind)
-  - Critério: tema central com paleta oficial, tipografia `Playfair Display` + `Raleway`, grid de 8px e componentes-base migrados para camada Chakra custom.
+- [x] **WEB11** `chore` — Padronizar UI kit web em Naive UI (sem Tailwind)
+  - Critério: tema central com paleta oficial, tipografia `Playfair Display` + `Raleway`, grid de 8px e componentes-base migrados para Naive UI via `NConfigProvider`.
   - Dependência: WEB21
   - Commit: —
-  - Risco residual: migração parcial pode manter estilos legados até conclusão por feature.
+  - Resolução: concluído via WEB27 (DEC-064 — Naive UI selecionado como library oficial).
 
-- [ ] **WEB21** `chore` — Definir e implantar library de componentes no nível Chakra para Vue/Nuxt
-  - Critério: validar compatibilidade de Chakra UI com Vue; se inviável, selecionar alternativa madura/equivalente (ex.: Vuetify/Naive UI/PrimeVue), padronizar wrappers internos e configurar tema via tokens oficiais.
+- [x] **WEB21** `chore` — Definir e implantar library de componentes para Vue/Nuxt
+  - Critério: Naive UI selecionado como library oficial; wrappers internos padronizados; tema configurado via `NConfigProvider` com tokens oficiais.
   - Dependência: WEB1
   - Commit: —
-  - Risco residual: escolha inadequada de biblioteca pode elevar custo de manutenção e retrabalho de UI.
+  - Resolução: concluído via WEB27 (DEC-064).
 
 - [x] **WEB12** `chore` — Adotar TanStack Query para server-state
   - Critério: provider global configurado, política de cache/retry/invalidation definida e primeiro fluxo HTTP crítico usando `@tanstack/vue-query`.
@@ -91,7 +91,7 @@ Toda task de UI/layout no `auraxis-web` deve seguir, sem exceção:
   - Commit: —
   - Risco residual: durante transição, coexistência com lógica legada de fetch/composables.
 
-- [x] **WEB22** `chore` — Endurecer governança de código frontend (TS-only, JSDoc, retorno explícito, Chakra-first)
+- [x] **WEB22** `chore` — Endurecer governança de código frontend (TS-only, JSDoc, retorno explícito, Naive UI-first)
   - Critério: ESLint e gates locais/CI bloqueiam `.js/.jsx` em código de produto, funções sem retorno explícito, funções sem JSDoc, uso de tags HTML cruas de formulário/controle/texto estrutural em componentes de produto e valores visuais arbitrários fora de tokens.
   - Subetapas:
     1. [x] atualizar `eslint.config.mjs` com regras estritas e plugin de JSDoc;


### PR DESCRIPTION
## Resumo

- Atualiza `steering.md` para refletir **Naive UI** como library oficial (DEC-064 / WEB27)
- Remove linha de fallback "Em ausência de Chakra UI..." que não faz mais sentido
- Marca **WEB11** e **WEB21** como concluídas (resolvidas via WEB27)
- Corrige título de WEB22: `Chakra-first` → `Naive UI-first`

## Contexto

A decisão DEC-064 adotou Naive UI como UI library oficial do auraxis-web.  
`CODING_STANDARDS.md` e os arquivos de `.context/` já estavam corretos.  
`steering.md` e `tasks.md` permaneciam com referências obsoletas a Chakra UI, causando drift de governança para agentes e desenvolvedores.

## Quality Gates

- [x] lint: OK
- [x] typecheck: OK
- [x] tests (55): OK
- [x] coverage (branches 77.64% ≥ threshold): OK
- [x] pre-push: passou