### PR TITLE
fix(auth): persist web session across refresh

### DIFF
--- a/app/composables/useHttp.ts
+++ b/app/composables/useHttp.ts
@@ -78,5 +78,5 @@ export const useHttp = (): AxiosInstance => {
   const sessionStore = useSessionStore();
   const apiBase = String(runtimeConfig.public.apiBase ?? DEFAULT_API_BASE);
 
-  return createHttpClient(apiBase, () => sessionStore.accessToken);
+  return createHttpClient(apiBase, () => sessionStore.getAccessToken());
 };

--- a/app/middleware/authenticated.ts
+++ b/app/middleware/authenticated.ts
@@ -2,6 +2,7 @@ import { useSessionStore } from "~/stores/session";
 
 export default defineNuxtRouteMiddleware(() => {
   const sessionStore = useSessionStore();
+  sessionStore.restore();
 
   if (!sessionStore.isAuthenticated) {
     return navigateTo("/login");

--- a/app/middleware/guest-only.ts
+++ b/app/middleware/guest-only.ts
@@ -2,6 +2,7 @@ import { useSessionStore } from "~/stores/session";
 
 export default defineNuxtRouteMiddleware(() => {
   const sessionStore = useSessionStore();
+  sessionStore.restore();
 
   if (sessionStore.isAuthenticated) {
     return navigateTo("/dashboard");

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,6 +2,7 @@
 import { useSessionStore } from "~/stores/session";
 
 const sessionStore = useSessionStore();
+sessionStore.restore();
 
 await navigateTo(sessionStore.isAuthenticated ? "/dashboard" : "/login");
 </script>

--- a/app/plugins/session.ts
+++ b/app/plugins/session.ts
@@ -1,0 +1,6 @@
+import { useSessionStore } from "~/stores/session";
+
+export default defineNuxtPlugin(() => {
+  const sessionStore = useSessionStore();
+  sessionStore.restore();
+});

--- a/app/stores/session.spec.ts
+++ b/app/stores/session.spec.ts
@@ -1,11 +1,34 @@
 import { createPinia, setActivePinia } from "pinia";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useSessionStore } from "./session";
+
+interface SessionCookiePayload {
+  accessToken: string;
+  userEmail: string;
+}
+
+const sessionCookieState = vi.hoisted(() => ({
+  value: null as SessionCookiePayload | null,
+}));
+
+vi.mock("#app", () => ({
+  useCookie: (): {
+    value: SessionCookiePayload | null;
+  } => ({
+    get value(): SessionCookiePayload | null {
+      return sessionCookieState.value;
+    },
+    set value(nextValue: SessionCookiePayload | null) {
+      sessionCookieState.value = nextValue;
+    },
+  }),
+}));
 
 describe("session store", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    sessionCookieState.value = null;
   });
 
   it("faz sign-in e sign-out", () => {
@@ -14,9 +37,41 @@ describe("session store", () => {
     store.signIn("token", "user@auraxis.com");
     expect(store.isAuthenticated).toBe(true);
     expect(store.userEmail).toBe("user@auraxis.com");
+    expect(sessionCookieState.value).toEqual({
+      accessToken: "token",
+      userEmail: "user@auraxis.com",
+    });
 
     store.signOut();
     expect(store.isAuthenticated).toBe(false);
     expect(store.userEmail).toBeNull();
+    expect(sessionCookieState.value).toBeNull();
+  });
+
+  it("restaura sessao a partir do cookie", () => {
+    sessionCookieState.value = {
+      accessToken: "cookie-token",
+      userEmail: "cookie@auraxis.com",
+    };
+
+    const store = useSessionStore();
+    store.restore();
+
+    expect(store.isAuthenticated).toBe(true);
+    expect(store.accessToken).toBe("cookie-token");
+    expect(store.userEmail).toBe("cookie@auraxis.com");
+  });
+
+  it("reidrata o token quando getAccessToken e chamado com store vazio", () => {
+    sessionCookieState.value = {
+      accessToken: "cookie-token",
+      userEmail: "cookie@auraxis.com",
+    };
+
+    const store = useSessionStore();
+
+    expect(store.accessToken).toBeNull();
+    expect(store.getAccessToken()).toBe("cookie-token");
+    expect(store.userEmail).toBe("cookie@auraxis.com");
   });
 });

--- a/app/stores/session.ts
+++ b/app/stores/session.ts
@@ -1,9 +1,44 @@
+import { useCookie } from "#app";
 import { defineStore } from "pinia";
+import type { Ref } from "vue";
+
+interface SessionCookiePayload {
+  accessToken: string;
+  userEmail: string;
+}
 
 interface SessionState {
   accessToken: string | null;
   userEmail: string | null;
 }
+
+const SESSION_COOKIE_KEY = "auraxis_session";
+
+/**
+ * Resolve o cookie canônico da sessão autenticada.
+ * @returns Referência reativa do cookie de sessão.
+ */
+const useSessionCookie = (): Ref<SessionCookiePayload | null> => {
+  return useCookie<SessionCookiePayload | null>(SESSION_COOKIE_KEY, {
+    default: () => null,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    watch: false,
+  }) as Ref<SessionCookiePayload | null>;
+};
+
+/**
+ * Aplica o payload persistido do cookie no estado local da store.
+ * @param state Estado mutável da sessão.
+ * @param payload Payload persistido ou nulo quando não houver sessão.
+ */
+const applyCookiePayloadToState = (
+  state: SessionState,
+  payload: SessionCookiePayload | null,
+): void => {
+  state.accessToken = payload?.accessToken ?? null;
+  state.userEmail = payload?.userEmail ?? null;
+};
 
 export const useSessionStore = defineStore("session", {
   state: (): SessionState => ({
@@ -14,13 +49,34 @@ export const useSessionStore = defineStore("session", {
     isAuthenticated: (state): boolean => state.accessToken !== null,
   },
   actions: {
+    restore(): void {
+      const sessionCookie = useSessionCookie();
+
+      applyCookiePayloadToState(this, sessionCookie.value);
+    },
+    getAccessToken(): string | null {
+      if (this.accessToken) {
+        return this.accessToken;
+      }
+
+      this.restore();
+      return this.accessToken;
+    },
     signIn(accessToken: string, userEmail: string): void {
       this.accessToken = accessToken;
       this.userEmail = userEmail;
+
+      const sessionCookie = useSessionCookie();
+      sessionCookie.value = {
+        accessToken,
+        userEmail,
+      };
     },
     signOut(): void {
-      this.accessToken = null;
-      this.userEmail = null;
+      applyCookiePayloadToState(this, null);
+
+      const sessionCookie = useSessionCookie();
+      sessionCookie.value = null;
     },
   },
 });


### PR DESCRIPTION
## Summary
- persist authenticated web session in a cookie-backed Pinia store
- restore session state before guest/authenticated route guards run
- make the shared HTTP client rehydrate the token on demand

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test -- --run app/stores/session.spec.ts app/composables/useAuth/mutations.spec.ts app/composables/useHttp.spec.ts
- pnpm quality-check

## Project linkage
- Closes #159
