### PR TITLE
feat(http): add centralized HTTP client composable with auth interceptor (#178)

### DIFF
--- a/app/composables/useHttpClient.spec.ts
+++ b/app/composables/useHttpClient.spec.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createHttpClientMethods, type HttpClientDeps } from "./useHttpClient";
+import { ApiError } from "~/utils/apiError";
+
+const BASE = "http://api.test";
+const TOKEN = "jwt-token-abc";
+const LOGIN_PATH = "/login";
+
+type FetcherFn = NonNullable<HttpClientDeps["fetcher"]>;
+type LogoutHandler = NonNullable<HttpClientDeps["onLogout"]>;
+type NavigateHandler = NonNullable<HttpClientDeps["onNavigate"]>;
+type TokenProvider = NonNullable<HttpClientDeps["getToken"]>;
+
+let fetcher: ReturnType<typeof vi.fn> & FetcherFn;
+let getToken: ReturnType<typeof vi.fn> & TokenProvider;
+let onLogout: ReturnType<typeof vi.fn> & LogoutHandler;
+let onNavigate: ReturnType<typeof vi.fn> & NavigateHandler;
+
+/**
+ * Builds a client instance using the current mock dependencies.
+ * @returns Typed HTTP client methods backed by mocks.
+ */
+const buildClient = (): ReturnType<typeof createHttpClientMethods> =>
+  createHttpClientMethods({
+    baseUrl: BASE,
+    ctx: { fetcher, getToken, onLogout, onNavigate },
+  });
+
+beforeEach((): void => {
+  fetcher = vi.fn() as ReturnType<typeof vi.fn> & FetcherFn;
+  getToken = vi.fn() as ReturnType<typeof vi.fn> & TokenProvider;
+  onLogout = vi.fn() as ReturnType<typeof vi.fn> & LogoutHandler;
+  onNavigate = vi.fn() as ReturnType<typeof vi.fn> & NavigateHandler;
+});
+
+describe("useHttpClient — Authorization header", () => {
+  it("injects Authorization header when token is present", async (): Promise<void> => {
+    getToken.mockReturnValue(TOKEN);
+    fetcher.mockResolvedValue({ ok: true });
+
+    await buildClient().get("/users");
+
+    expect(fetcher).toHaveBeenCalledWith(
+      `${BASE}/users`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${TOKEN}`,
+        }),
+      }),
+    );
+  });
+
+  it("omits Authorization header when token is null", async (): Promise<void> => {
+    getToken.mockReturnValue(null);
+    fetcher.mockResolvedValue({ ok: true });
+
+    await buildClient().get("/users");
+
+    const [, opts] = fetcher.mock.calls[0] as [string, { headers: Record<string, string> }];
+    expect(opts.headers.Authorization).toBeUndefined();
+  });
+});
+
+describe("useHttpClient — 401 handling", () => {
+  it("calls logout and navigates to /login on 401 response", async (): Promise<void> => {
+    getToken.mockReturnValue(TOKEN);
+    fetcher.mockRejectedValue({ status: 401, message: "Unauthorized" });
+    onLogout.mockResolvedValue(undefined);
+    onNavigate.mockResolvedValue(undefined);
+
+    await expect(buildClient().get("/protected")).rejects.toBeInstanceOf(ApiError);
+
+    expect(onLogout).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith(LOGIN_PATH);
+  });
+
+  it("throws ApiError with status 401", async (): Promise<void> => {
+    getToken.mockReturnValue(null);
+    fetcher.mockRejectedValue({ status: 401, message: "Unauthorized" });
+    onLogout.mockResolvedValue(undefined);
+    onNavigate.mockResolvedValue(undefined);
+
+    const error = await buildClient().get("/protected").catch((e: unknown): unknown => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(401);
+  });
+});
+
+describe("useHttpClient — error normalisation", () => {
+  it("throws ApiError with correct status and message for non-401 errors", async (): Promise<void> => {
+    getToken.mockReturnValue(null);
+    fetcher.mockRejectedValue({ status: 422, message: "Unprocessable Entity" });
+
+    const error = await buildClient().post("/submit", {}).catch((e: unknown): unknown => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(422);
+    expect((error as ApiError).message).toBe("Unprocessable Entity");
+  });
+
+  it("includes error code from API response when present", async (): Promise<void> => {
+    getToken.mockReturnValue(null);
+    fetcher.mockRejectedValue({
+      status: 400,
+      message: "Bad Request",
+      data: { code: "VALIDATION_FAILED" },
+    });
+
+    const error = await buildClient().post("/submit", {}).catch((e: unknown): unknown => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).code).toBe("VALIDATION_FAILED");
+  });
+
+  it("wraps generic errors as ApiError with status 500", async (): Promise<void> => {
+    getToken.mockReturnValue(null);
+    fetcher.mockRejectedValue(new Error("network failure"));
+
+    const error = await buildClient().get("/health").catch((e: unknown): unknown => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(500);
+    expect((error as ApiError).message).toBe("network failure");
+  });
+
+  it("does not call logout for non-401 errors", async (): Promise<void> => {
+    getToken.mockReturnValue(TOKEN);
+    fetcher.mockRejectedValue({ status: 500, message: "Internal Server Error" });
+
+    await buildClient().get("/data").catch((): void => {});
+
+    expect(onLogout).not.toHaveBeenCalled();
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("useHttpClient — HTTP method wiring", () => {
+  it("calls GET with correct method option", async (): Promise<void> => {
+    getToken.mockReturnValue(null);
+    fetcher.mockResolvedValue({});
+
+    await buildClient().get("/ping");
+
+    expect(fetcher).toHaveBeenCalledWith(
+      `${BASE}/ping`,
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("calls POST with body", async (): Promise<void> => {
+    getToken.mockReturnValue(null);
+    fetcher.mockResolvedValue({});
+
+    await buildClient().post("/items", { name: "test" });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      `${BASE}/items`,
+      expect.objectContaining({ method: "POST", body: { name: "test" } }),
+    );
+  });
+
+  it("calls PUT with body", async (): Promise<void> => {
+    getToken.mockReturnValue(null);
+    fetcher.mockResolvedValue({});
+
+    await buildClient().put("/items/1", { name: "updated" });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      `${BASE}/items/1`,
+      expect.objectContaining({ method: "PUT", body: { name: "updated" } }),
+    );
+  });
+
+  it("calls PATCH with body", async (): Promise<void> => {
+    getToken.mockReturnValue(null);
+    fetcher.mockResolvedValue({});
+
+    await buildClient().patch("/items/1", { name: "patched" });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      `${BASE}/items/1`,
+      expect.objectContaining({ method: "PATCH", body: { name: "patched" } }),
+    );
+  });
+
+  it("calls DELETE", async (): Promise<void> => {
+    getToken.mockReturnValue(null);
+    fetcher.mockResolvedValue({});
+
+    await buildClient().del("/items/1");
+
+    expect(fetcher).toHaveBeenCalledWith(
+      `${BASE}/items/1`,
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});

--- a/app/composables/useHttpClient.ts
+++ b/app/composables/useHttpClient.ts
@@ -1,0 +1,198 @@
+import type { FetchOptions } from "ofetch";
+
+import { useSessionStore } from "~/stores/session";
+import { ApiError } from "~/utils/apiError";
+
+const DEFAULT_API_BASE = "http://localhost:3333";
+
+/**
+ * Removes trailing slashes from a URL so path concatenation never duplicates separators.
+ * @param rawUrl Candidate base URL.
+ * @returns URL without trailing slashes.
+ */
+export const normalizeHttpClientBaseUrl = (rawUrl: string): string => {
+  let end = rawUrl.length;
+
+  while (end > 0 && rawUrl.codePointAt(end - 1) === 47) {
+    end -= 1;
+  }
+
+  return rawUrl.slice(0, end);
+};
+
+type FetcherFn = <T>(url: string, opts?: FetchOptions) => Promise<T>;
+type RuntimeConfigReader = () => { public?: { apiBase?: string | null } };
+type TokenProvider = () => string | null;
+type LogoutHandler = () => Promise<void>;
+type NavigateHandler = (path: string) => Promise<void>;
+
+export interface HttpClientMethods {
+  get<T>(path: string, opts?: FetchOptions): Promise<T>;
+  post<T>(path: string, body?: unknown, opts?: FetchOptions): Promise<T>;
+  put<T>(path: string, body?: unknown, opts?: FetchOptions): Promise<T>;
+  patch<T>(path: string, body?: unknown, opts?: FetchOptions): Promise<T>;
+  del<T>(path: string, opts?: FetchOptions): Promise<T>;
+}
+
+export interface HttpClientDeps {
+  fetcher?: FetcherFn;
+  readRuntimeConfig?: RuntimeConfigReader;
+  getToken?: TokenProvider;
+  onLogout?: LogoutHandler;
+  onNavigate?: NavigateHandler;
+}
+
+interface RequestContext {
+  fetcher: FetcherFn;
+  getToken: TokenProvider;
+  onLogout: LogoutHandler;
+  onNavigate: NavigateHandler;
+}
+
+/**
+ * Builds the Authorization header value when a token is available.
+ * @param token JWT access token or null.
+ * @returns Header value string or undefined when no token exists.
+ */
+const buildAuthHeader = (token: string | null): string | undefined => {
+  return token ? `Bearer ${token}` : undefined;
+};
+
+/**
+ * Normalises a raw fetch error into a typed ApiError.
+ * @param error Unknown error thrown by the fetcher.
+ * @returns Typed ApiError with status and message.
+ */
+const toApiError = (error: unknown): ApiError => {
+  if (error instanceof ApiError) {
+    return error;
+  }
+
+  if (error !== null && typeof error === "object" && "status" in error) {
+    const fetchErr = error as { status: number; message?: string; data?: { code?: string } };
+    const status = typeof fetchErr.status === "number" ? fetchErr.status : 500;
+    const message = fetchErr.message ?? "Unexpected error";
+    const code = fetchErr.data?.code;
+    return new ApiError(status, message, code);
+  }
+
+  const message = error instanceof Error ? error.message : "Unexpected error";
+  return new ApiError(500, message);
+};
+
+/**
+ * Executes a fetch call, injecting auth headers and normalising errors.
+ * Handles 401 responses by triggering logout and redirect to /login.
+ * @param ctx Request context with fetcher and side-effect handlers.
+ * @param url Full request URL.
+ * @param opts ofetch options.
+ * @returns Typed response body.
+ */
+const executeRequest = async <T>(
+  ctx: RequestContext,
+  url: string,
+  opts: FetchOptions,
+): Promise<T> => {
+  const token = ctx.getToken();
+  const authHeader = buildAuthHeader(token);
+
+  const headers: Record<string, string> = {
+    ...(opts.headers as Record<string, string> | undefined),
+  };
+
+  if (authHeader) {
+    headers.Authorization = authHeader;
+  }
+
+  try {
+    return await ctx.fetcher<T>(url, { ...opts, headers });
+  }
+  catch (error: unknown) {
+    const apiError = toApiError(error);
+
+    if (apiError.status === 401) {
+      await ctx.onLogout();
+      await ctx.onNavigate("/login");
+    }
+
+    throw apiError;
+  }
+};
+
+interface HttpClientFactoryParams {
+  baseUrl: string;
+  ctx: RequestContext;
+}
+
+/**
+ * Creates typed HTTP client methods bound to a fixed base URL and request context.
+ * @param params Base URL and request context with auth and error handlers.
+ * @returns HTTP methods: get, post, put, patch, del.
+ */
+export const createHttpClientMethods = (params: HttpClientFactoryParams): HttpClientMethods => {
+  const { baseUrl, ctx } = params;
+
+  /**
+   * Dispatches a request to the given path using the shared request context.
+   * @param path API path relative to the base URL.
+   * @param opts ofetch options including method and body.
+   * @returns Typed response body.
+   */
+  const request = <T>(path: string, opts: FetchOptions): Promise<T> =>
+    executeRequest<T>(ctx, `${baseUrl}${path}`, opts);
+
+  return {
+    get: <T>(path: string, opts: FetchOptions = {}): Promise<T> =>
+      request<T>(path, { ...opts, method: "GET" }),
+
+    post: <T>(path: string, body?: unknown, opts: FetchOptions = {}): Promise<T> =>
+      request<T>(path, { ...opts, method: "POST", body: body as FetchOptions["body"] }),
+
+    put: <T>(path: string, body?: unknown, opts: FetchOptions = {}): Promise<T> =>
+      request<T>(path, { ...opts, method: "PUT", body: body as FetchOptions["body"] }),
+
+    patch: <T>(path: string, body?: unknown, opts: FetchOptions = {}): Promise<T> =>
+      request<T>(path, { ...opts, method: "PATCH", body: body as FetchOptions["body"] }),
+
+    del: <T>(path: string, opts: FetchOptions = {}): Promise<T> =>
+      request<T>(path, { ...opts, method: "DELETE" }),
+  };
+};
+
+/**
+ * Centralized HTTP client composable with auth injection and error normalisation.
+ *
+ * - Reads base URL from `runtimeConfig.public.apiBase`.
+ * - Injects JWT Bearer token from the session store on every request.
+ * - On 401: calls `sessionStore.signOut()` and redirects to `/login`.
+ * - All non-2xx errors are normalised into a typed `ApiError`.
+ *
+ * @param deps Optional dependency overrides for unit testing.
+ * @returns Typed HTTP methods: `get`, `post`, `put`, `patch`, `del`.
+ */
+export const useHttpClient = (deps: HttpClientDeps = {}): HttpClientMethods => {
+  const readConfig = deps.readRuntimeConfig ?? useRuntimeConfig;
+  const runtimeConfig = readConfig();
+  const rawBase = String(runtimeConfig.public?.apiBase ?? DEFAULT_API_BASE);
+  const baseUrl = normalizeHttpClientBaseUrl(rawBase);
+
+  const sessionStore = useSessionStore();
+
+  const getToken: TokenProvider = deps.getToken ?? ((): string | null => sessionStore.getAccessToken());
+
+  const onLogout: LogoutHandler = deps.onLogout ?? (async (): Promise<void> => {
+    sessionStore.signOut();
+  });
+
+  const onNavigate: NavigateHandler = deps.onNavigate ?? (async (path: string): Promise<void> => {
+    await navigateTo(path);
+  });
+
+  const fetcher: FetcherFn = deps.fetcher ?? ((<T>(url: string, opts?: FetchOptions): Promise<T> =>
+    $fetch<T>(url, opts as Parameters<typeof $fetch>[1]) as Promise<T>) as FetcherFn);
+
+  return createHttpClientMethods({
+    baseUrl,
+    ctx: { fetcher, getToken, onLogout, onNavigate },
+  });
+};

--- a/app/utils/apiError.ts
+++ b/app/utils/apiError.ts
@@ -1,0 +1,19 @@
+/**
+ * Typed error thrown by the centralized HTTP client for all non-2xx responses.
+ */
+export class ApiError extends Error {
+  /**
+   * Creates an ApiError with HTTP status, message, and optional error code.
+   * @param status HTTP status code of the failed response.
+   * @param message Human-readable error description.
+   * @param code Optional machine-readable error code from the API.
+   */
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}


### PR DESCRIPTION
## Summary

- `app/utils/apiError.ts` — classe `ApiError` tipada (`status`, `message`, `code`)
- `app/composables/useHttpClient.ts` — composable com `get/post/put/patch/del` tipados; Bearer token injetado via `useSessionStore()`; logout + redirect em 401; erros normalizados em `ApiError`; lógica pura em `createHttpClientMethods()` para testabilidade sem Nuxt globals
- `app/composables/useHttpClient.spec.ts` — 13 testes (header injection, 401 flow, error normalization, todos os 5 métodos HTTP)

## Test plan

- [ ] CI verde (lint, typecheck, coverage ≥ 85%)
- [ ] 401 de qualquer endpoint redireciona para /login e limpa sessão
- [ ] Sem token: header Authorization ausente na request

Closes #178