### PR TITLE
feat(tokens): expand design token system — MIC-03

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,75 +1,116 @@
 :root {
+  /* Tipografia */
   --font-heading: "Playfair Display", "Times New Roman", serif;
   --font-body: "Raleway", "Segoe UI", sans-serif;
   --font-weight-regular: 400;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
 
-  --color-neutral-950: #0b0909;
-  --color-neutral-900: #262121;
-  --color-neutral-700: #413939;
-  --color-brand-600: #ffab1a;
-  --color-brand-500: #ffbe4d;
+  /* Font sizes */
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.875rem;
+  --font-size-4xl: 2.25rem;
+
+  /* Backgrounds */
+  --color-bg-base:     #0b0909;
+  --color-bg-surface:  #272020;
+  --color-bg-elevated: #413939;
+  --color-bg-glass:    rgba(39, 32, 32, 0.6);
+
+  /* Marca */
   --color-brand-400: #ffd180;
-  --color-surface-50: #ffd180;
-  --color-outline-soft: rgba(38, 33, 33, 0.2);
-  --color-outline-subtle: rgba(38, 33, 33, 0.08);
+  --color-brand-500: #ffbe4d;
+  --color-brand-600: #ffab1a;
+  --color-brand-700: #f59600;
+  --color-brand-800: #d97600;
 
-  --space-1: 8px;
-  --space-2: 16px;
-  --space-3: 24px;
-  --space-4: 32px;
+  /* Glows da marca */
+  --color-brand-glow-lg:  rgba(255, 171, 26, 0.4);
+  --color-brand-glow-md:  rgba(255, 171, 26, 0.3);
+  --color-brand-glow-sm:  rgba(255, 171, 26, 0.2);
+  --color-brand-glow-xs:  rgba(255, 171, 26, 0.1);
+  --color-brand-glow-2xs: rgba(255, 171, 26, 0.05);
 
-  --radius-sm: 8px;
-  --radius-md: 12px;
-  --radius-lg: 16px;
+  /* Texto */
+  --color-text-primary:   #faf9f9;
+  --color-text-secondary: #d1c7c7;
+  --color-text-muted:     #9b8888;
+  --color-text-subtle:    #6c5a5a;
 
-  --font-size-heading-md: 24px;
-  --font-size-heading-lg: 28px;
-  --font-size-body-sm: 14px;
-  --line-height-heading-md: 32px;
-  --line-height-heading-lg: 36px;
-  --line-height-body-sm: 20px;
+  /* Semântico — positivo */
+  --color-positive:      #10b981;
+  --color-positive-dark: #059669;
+  --color-positive-bg:   rgba(16, 185, 129, 0.1);
+  --color-positive-glow: rgba(16, 185, 129, 0.4);
 
-  --shadow-card: 0 10px 24px rgba(11, 9, 9, 0.08);
+  /* Semântico — negativo */
+  --color-negative:      #ef4444;
+  --color-negative-dark: #dc2626;
+  --color-negative-bg:   rgba(239, 68, 68, 0.1);
+  --color-negative-glow: rgba(239, 68, 68, 0.2);
+
+  /* Bordas */
+  --color-outline-hard:   rgba(65, 57, 57, 0.8);
+  --color-outline-soft:   rgba(65, 57, 57, 0.5);
+  --color-outline-subtle: rgba(38, 33, 33, 0.2);
+  --color-outline-ghost:  rgba(38, 33, 33, 0.08);
+
+  /* Sombras */
+  --shadow-sm:            0 1px 2px rgba(11, 9, 9, 0.4);
+  --shadow-md:            0 4px 10px rgba(11, 9, 9, 0.5);
+  --shadow-lg:            0 10px 20px rgba(11, 9, 9, 0.6);
+  --shadow-card:          0 10px 24px rgba(11, 9, 9, 0.08);
+  --shadow-brand-glow:    0 0 20px var(--color-brand-glow-md);
+  --shadow-brand-glow-sm: 0 0 10px var(--color-brand-glow-sm);
+
+  /* Radius */
+  --radius-none: 0px;
+  --radius-sm:   8px;
+  --radius-md:   12px;
+  --radius-lg:   16px;
+  --radius-full: 9999px;
+
+  /* Spacing */
+  --space-px: 1px;
+  --space-0:  0px;
+  --space-1:  8px;
+  --space-2:  16px;
+  --space-3:  24px;
+  --space-4:  32px;
+  --space-5:  40px;
+  --space-6:  48px;
+  --space-7:  56px;
+  --space-8:  64px;
 }
 
-* {
-  box-sizing: border-box;
-}
+/* Reset e base */
+*, *::before, *::after { box-sizing: border-box; }
 
-html,
-body,
-#__nuxt {
+html, body, #__nuxt {
   min-height: 100%;
   margin: 0;
 }
 
 body {
   font-family: var(--font-body);
-  color: var(--color-neutral-900);
-  background: linear-gradient(180deg, var(--color-brand-400) 0%, var(--color-brand-500) 100%);
+  background-color: var(--color-bg-base);
+  color: var(--color-text-primary);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
+a { color: inherit; text-decoration: none; }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-heading);
   letter-spacing: 0.01em;
   margin: 0;
+  color: var(--color-text-primary);
 }
 
-button,
-input,
-select,
-textarea {
-  font: inherit;
-}
+button, input, select, textarea { font: inherit; }

--- a/app/theme/index.ts
+++ b/app/theme/index.ts
@@ -1,5 +1,7 @@
 export { colors } from "./tokens/colors";
+export type { Colors } from "./tokens/colors";
 export { fonts, fontSizes } from "./tokens/typography";
 export { space } from "./tokens/spacing";
 export { radii } from "./tokens/radii";
 export { shadows } from "./tokens/shadows";
+export type { Shadows } from "./tokens/shadows";

--- a/app/theme/tokens/__tests__/tokens.spec.ts
+++ b/app/theme/tokens/__tests__/tokens.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { colors } from "../colors";
+import { shadows } from "../shadows";
+import { semantic } from "../semantic";
+
+describe("design tokens", () => {
+  it("brand.600 is the canonical CTA color", () => {
+    expect(colors.brand[600]).toBe("#ffab1a");
+  });
+
+  it("bg tokens exist for all surface levels", () => {
+    expect(colors.bg.base).toBeDefined();
+    expect(colors.bg.surface).toBeDefined();
+    expect(colors.bg.elevated).toBeDefined();
+    expect(colors.bg.glass).toBeDefined();
+  });
+
+  it("semantic positive and negative tokens exist", () => {
+    expect(colors.positive.DEFAULT).toBe("#10b981");
+    expect(colors.negative.DEFAULT).toBe("#ef4444");
+  });
+
+  it("brand glow tokens are rgba strings", () => {
+    Object.values(colors.brandGlow).forEach((v) => {
+      expect(v).toMatch(/^rgba\(/);
+    });
+  });
+
+  it("shadow brand glow references the brand color", () => {
+    expect(shadows.brandGlow).toContain("rgba(255, 171, 26");
+  });
+
+  it("semantic aliases resolve to primitive values", () => {
+    expect(semantic.action.primary).toBe(colors.brand[600]);
+    expect(semantic.surface.card).toBe(colors.bg.surface);
+    expect(semantic.financial.positive).toBe(colors.positive.DEFAULT);
+  });
+
+  it("no token value is undefined or empty", () => {
+    const allBrandValues = Object.values(colors.brand);
+    allBrandValues.forEach((v) => {
+      expect(v).toBeTruthy();
+    });
+  });
+});

--- a/app/theme/tokens/colors.ts
+++ b/app/theme/tokens/colors.ts
@@ -1,21 +1,55 @@
 export const colors = {
+  // Backgrounds (fundo escuro quente)
+  bg: {
+    base:     "#0b0909",            // fundo mais profundo
+    surface:  "#272020",            // cards, painéis
+    elevated: "#413939",            // superfícies elevadas, dropdowns
+    glass:    "rgba(39, 32, 32, 0.6)", // glassmorphism
+  },
+  // Marca amber/gold — paleta única para todo o produto
   brand: {
-    50: "#ffd180",
-    100: "#ffbe4d",
-    200: "#ffab1a",
+    400: "#ffd180",  // mais claro — hovers, disabled
+    500: "#ffbe4d",  // accent secundário
+    600: "#ffab1a",  // DEFAULT — CTAs, links, foco
+    700: "#f59600",  // pressed
+    800: "#d97600",  // mais escuro
   },
-  neutral: {
-    900: "#262121",
-    700: "#413939",
-    950: "#0b0909",
+  // Glows da marca (alpha)
+  brandGlow: {
+    lg:  "rgba(255, 171, 26, 0.4)",
+    md:  "rgba(255, 171, 26, 0.3)",
+    sm:  "rgba(255, 171, 26, 0.2)",
+    xs:  "rgba(255, 171, 26, 0.1)",
+    xxs: "rgba(255, 171, 26, 0.05)",
   },
-  surface: {
-    50: "#ffd180",
-    100: "#ffbe4d",
-    200: "#413939",
+  // Texto
+  text: {
+    primary:   "#faf9f9",
+    secondary: "#d1c7c7",
+    muted:     "#9b8888",
+    subtle:    "#6c5a5a",
   },
+  // Semântico — positivo (valores financeiros positivos)
+  positive: {
+    DEFAULT: "#10b981",
+    dark:    "#059669",
+    bg:      "rgba(16, 185, 129, 0.1)",
+    glow:    "rgba(16, 185, 129, 0.4)",
+  },
+  // Semântico — negativo (valores financeiros negativos, erros)
+  negative: {
+    DEFAULT: "#ef4444",
+    dark:    "#dc2626",
+    bg:      "rgba(239, 68, 68, 0.1)",
+    glow:    "rgba(239, 68, 68, 0.2)",
+  },
+  // Bordas e divisores
   outline: {
-    soft: "rgba(38, 33, 33, 0.2)",
-    subtle: "rgba(38, 33, 33, 0.08)",
+    hard:   "rgba(65, 57, 57, 0.8)",
+    soft:   "rgba(65, 57, 57, 0.5)",
+    subtle: "rgba(38, 33, 33, 0.2)",
+    ghost:  "rgba(38, 33, 33, 0.08)",
   },
 } as const;
+
+export type Colors = typeof colors;

--- a/app/theme/tokens/semantic.ts
+++ b/app/theme/tokens/semantic.ts
@@ -1,0 +1,35 @@
+import { colors } from "./colors";
+
+// Aliases semânticos — use estes nos componentes, não os primitivos diretamente
+export const semantic = {
+  // Superfícies
+  surface: {
+    page:    colors.bg.base,
+    card:    colors.bg.surface,
+    overlay: colors.bg.elevated,
+    glass:   colors.bg.glass,
+  },
+  // Ações
+  action: {
+    primary:        colors.brand[600],
+    primaryHover:   colors.brand[500],
+    primaryPressed: colors.brand[700],
+    primarySubtle:  colors.brandGlow.xs,
+  },
+  // Feedback financeiro
+  financial: {
+    positive:   colors.positive.DEFAULT,
+    positiveBg: colors.positive.bg,
+    negative:   colors.negative.DEFAULT,
+    negativeBg: colors.negative.bg,
+  },
+  // Texto
+  text: {
+    primary:   colors.text.primary,
+    secondary: colors.text.secondary,
+    muted:     colors.text.muted,
+    subtle:    colors.text.subtle,
+  },
+} as const;
+
+export type Semantic = typeof semantic;

--- a/app/theme/tokens/shadows.ts
+++ b/app/theme/tokens/shadows.ts
@@ -1,5 +1,10 @@
 export const shadows = {
-  sm: "0 1px 2px rgba(11, 9, 9, 0.2)",
-  md: "0 4px 10px rgba(11, 9, 9, 0.25)",
-  lg: "0 10px 20px rgba(11, 9, 9, 0.3)",
+  sm:          "0 1px 2px rgba(11, 9, 9, 0.4)",
+  md:          "0 4px 10px rgba(11, 9, 9, 0.5)",
+  lg:          "0 10px 20px rgba(11, 9, 9, 0.6)",
+  card:        "0 10px 24px rgba(11, 9, 9, 0.08)",
+  brandGlow:   "0 0 20px rgba(255, 171, 26, 0.3)",
+  brandGlowSm: "0 0 10px rgba(255, 171, 26, 0.2)",
 } as const;
+
+export type Shadows = typeof shadows;


### PR DESCRIPTION
## Summary

- Rewrites `app/theme/tokens/colors.ts` with a complete palette: `bg`, `brand` (400–800), `brandGlow` (alpha scale), `text`, `positive`, `negative`, and `outline` groups
- Rewrites `app/theme/tokens/shadows.ts` with higher-contrast values and brand-glow shadow variants (`brandGlow`, `brandGlowSm`)
- Creates `app/theme/tokens/semantic.ts` — semantic aliases (`surface`, `action`, `financial`, `text`) that reference primitive tokens; single source of truth for component authoring
- Updates `app/theme/index.ts` to re-export new `Colors` and `Shadows` types
- Rewrites `app/assets/css/main.css` with the full CSS custom property map (backgrounds, brand, glows, text, semantic feedback, outlines, shadows, radius, spacing, font sizes/weights) and corrects body base styles to use semantic tokens
- Adds `app/theme/tokens/__tests__/tokens.spec.ts` with 7 unit tests covering brand color identity, surface levels, semantic feedback tokens, glow format, shadow content, alias resolution, and completeness

Closes #205

## Test plan

- [x] `pnpm test -- --run app/theme` — 55 test files, 231 tests, all pass
- [x] `pnpm typecheck` — zero TypeScript errors
- [x] ESLint on `app/theme/` — zero issues in token files
- [x] Token files (`colors.ts`, `shadows.ts`, `semantic.ts`) report 100% coverage
- [x] Pre-push hooks passed on both pushes: TypeScript check + full test suite with coverage