### PR TITLE
feat(ui): UiAppShell — authenticated layout shell [MIC-13]

### DIFF
--- a/app/composables/useAuthRedirectContext/index.ts
+++ b/app/composables/useAuthRedirectContext/index.ts
@@ -1,0 +1,2 @@
+export { useAuthRedirectContext } from "./useAuthRedirectContext";
+export type { AuthRedirectContext } from "./useAuthRedirectContext";

--- a/app/composables/useAuthRedirectContext/useAuthRedirectContext.spec.ts
+++ b/app/composables/useAuthRedirectContext/useAuthRedirectContext.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { useAuthRedirectContext } from "./useAuthRedirectContext";
+
+describe("useAuthRedirectContext", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("saves and consumes a redirect path", () => {
+    const ctx = useAuthRedirectContext();
+    ctx.saveRedirect("/goals");
+    expect(ctx.consumeRedirect()).toBe("/goals");
+  });
+
+  it("clears the saved path after consuming", () => {
+    const ctx = useAuthRedirectContext();
+    ctx.saveRedirect("/wallet");
+    ctx.consumeRedirect();
+    expect(ctx.peekRedirect()).toBeNull();
+  });
+
+  it("returns fallback path when nothing is saved", () => {
+    const ctx = useAuthRedirectContext();
+    expect(ctx.consumeRedirect()).toBe("/dashboard");
+  });
+
+  it("normalizes paths not starting with / to fallback", () => {
+    const ctx = useAuthRedirectContext();
+    ctx.saveRedirect("evil.com/steal");
+    expect(ctx.consumeRedirect()).toBe("/dashboard");
+  });
+
+  it("peekRedirect reads without clearing", () => {
+    const ctx = useAuthRedirectContext();
+    ctx.saveRedirect("/transactions");
+    expect(ctx.peekRedirect()).toBe("/transactions");
+    expect(ctx.peekRedirect()).toBe("/transactions"); // still there
+  });
+
+  it("clearRedirect removes stored value", () => {
+    const ctx = useAuthRedirectContext();
+    ctx.saveRedirect("/dashboard");
+    ctx.clearRedirect();
+    expect(ctx.peekRedirect()).toBeNull();
+  });
+
+  it("stores valid absolute paths as-is", () => {
+    const ctx = useAuthRedirectContext();
+    ctx.saveRedirect("/features/tools/simulator");
+    expect(ctx.consumeRedirect()).toBe("/features/tools/simulator");
+  });
+});

--- a/app/composables/useAuthRedirectContext/useAuthRedirectContext.ts
+++ b/app/composables/useAuthRedirectContext/useAuthRedirectContext.ts
@@ -1,0 +1,75 @@
+const REDIRECT_KEY = "auraxis:auth:redirect";
+const FALLBACK_PATH = "/dashboard";
+
+export interface AuthRedirectContext {
+  /** Salva a URL atual como destino pós-login. */
+  saveRedirect(path: string): void
+  /** Consome e retorna o caminho salvo (limpa após leitura). Retorna fallback se não houver nada salvo. */
+  consumeRedirect(): string
+  /** Lê sem consumir. */
+  peekRedirect(): string | null
+  /** Remove explicitamente o redirect salvo. */
+  clearRedirect(): void
+}
+
+/**
+ * Composable que gerencia o contexto de redirecionamento pós-autenticação.
+ * Persiste em sessionStorage para sobreviver a reloads dentro da mesma aba.
+ *
+ * MIC-29
+ *
+ * @returns Conjunto de operações para salvar, consumir e limpar o redirect de auth.
+ */
+export function useAuthRedirectContext(): AuthRedirectContext {
+  const isClient = typeof window !== "undefined";
+
+  /**
+   * Salva o caminho de destino pós-login.
+   * Caminhos que não iniciam com "/" são ignorados e substituídos pelo fallback.
+   * @param path - Caminho absoluto do destino (deve iniciar com "/").
+   */
+  const saveRedirect = (path: string): void => {
+    if (!isClient) {
+      return;
+    }
+    const safe = path.startsWith("/") ? path : FALLBACK_PATH;
+    sessionStorage.setItem(REDIRECT_KEY, safe);
+  };
+
+  /**
+   * Lê e remove o caminho salvo.
+   * Retorna o fallback "/dashboard" se nenhum caminho estiver armazenado.
+   * @returns O caminho salvo ou "/dashboard" como fallback.
+   */
+  const consumeRedirect = (): string => {
+    if (!isClient) {
+      return FALLBACK_PATH;
+    }
+    const saved = sessionStorage.getItem(REDIRECT_KEY);
+    sessionStorage.removeItem(REDIRECT_KEY);
+    return saved ?? FALLBACK_PATH;
+  };
+
+  /**
+   * Lê o caminho salvo sem removê-lo.
+   * @returns O caminho salvo ou null se não houver nenhum.
+   */
+  const peekRedirect = (): string | null => {
+    if (!isClient) {
+      return null;
+    }
+    return sessionStorage.getItem(REDIRECT_KEY);
+  };
+
+  /**
+   * Remove explicitamente o redirect salvo.
+   */
+  const clearRedirect = (): void => {
+    if (!isClient) {
+      return;
+    }
+    sessionStorage.removeItem(REDIRECT_KEY);
+  };
+
+  return { saveRedirect, consumeRedirect, peekRedirect, clearRedirect };
+}

--- a/app/features/auth/components/AuthBrandPanel/AuthBrandPanel.vue
+++ b/app/features/auth/components/AuthBrandPanel/AuthBrandPanel.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+// FEAT-01 — AuthBrandPanel
+// Left-side branding panel for the split auth layout.
+// Static by design; no props needed.
+</script>
+
+<template>
+  <aside class="auth-brand-panel" aria-label="Auraxis — painel de marca">
+    <div class="auth-brand-panel__inner">
+      <!-- Logo -->
+      <div class="auth-brand-panel__logo" aria-label="Auraxis">
+        <span class="auth-brand-panel__logo-mark">A</span>
+        <span class="auth-brand-panel__logo-name">uraxis</span>
+      </div>
+
+      <!-- Headline -->
+      <div class="auth-brand-panel__copy">
+        <p class="auth-brand-panel__tagline">
+          Dados financeiros complexos.<br>
+          Clareza radical.
+        </p>
+        <p class="auth-brand-panel__sub">
+          Gerencie seu patrimônio, metas e transações em um único lugar — com a precisão que você merece.
+        </p>
+      </div>
+
+      <!-- Decorative accent -->
+      <div class="auth-brand-panel__accent" aria-hidden="true" />
+    </div>
+
+    <!-- Background aurora -->
+    <div class="auth-brand-panel__aurora" aria-hidden="true">
+      <div class="auth-brand-panel__aurora-blob auth-brand-panel__aurora-blob--a" />
+      <div class="auth-brand-panel__aurora-blob auth-brand-panel__aurora-blob--b" />
+    </div>
+  </aside>
+</template>
+
+<style scoped>
+.auth-brand-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+  min-height: 100dvh;
+  padding: var(--space-5) var(--space-6);
+  background: var(--color-bg-base);
+  overflow: hidden;
+  color: var(--color-text-primary);
+}
+
+.auth-brand-panel__inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  max-width: 380px;
+}
+
+/* Logo */
+.auth-brand-panel__logo {
+  display: flex;
+  align-items: baseline;
+  gap: 1px;
+  font-family: var(--font-heading);
+  font-size: var(--font-size-heading-lg);
+  line-height: 1;
+}
+
+.auth-brand-panel__logo-mark {
+  color: var(--color-brand-400);
+  font-weight: var(--font-weight-bold);
+}
+
+.auth-brand-panel__logo-name {
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-bold);
+}
+
+/* Copy */
+.auth-brand-panel__copy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.auth-brand-panel__tagline {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-heading-xl);
+  line-height: var(--line-height-heading-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.auth-brand-panel__sub {
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-md);
+  color: var(--color-text-secondary);
+  margin: 0;
+  max-width: 320px;
+}
+
+/* Gold accent bar */
+.auth-brand-panel__accent {
+  width: 48px;
+  height: 3px;
+  background: var(--color-brand-400);
+  border-radius: var(--radius-full);
+}
+
+/* Aurora blobs */
+.auth-brand-panel__aurora {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.auth-brand-panel__aurora-blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.25;
+}
+
+.auth-brand-panel__aurora-blob--a {
+  width: 420px;
+  height: 420px;
+  top: -80px;
+  left: -100px;
+  background: radial-gradient(circle, var(--color-brand-700) 0%, transparent 70%);
+}
+
+.auth-brand-panel__aurora-blob--b {
+  width: 320px;
+  height: 320px;
+  bottom: -60px;
+  right: -60px;
+  background: radial-gradient(circle, var(--color-brand-500) 0%, transparent 70%);
+  opacity: 0.15;
+}
+</style>

--- a/app/features/auth/components/AuthBrandPanel/index.ts
+++ b/app/features/auth/components/AuthBrandPanel/index.ts
@@ -1,0 +1,1 @@
+export { default as AuthBrandPanel } from "./AuthBrandPanel.vue";

--- a/app/features/auth/components/AuthFeatureList/AuthFeatureList.types.ts
+++ b/app/features/auth/components/AuthFeatureList/AuthFeatureList.types.ts
@@ -1,0 +1,13 @@
+export interface AuthFeature {
+  /** Ícone representativo (emoji ou shortname — mantido como string para portabilidade) */
+  icon: string
+  /** Título do benefício */
+  title: string
+  /** Descrição curta */
+  description: string
+}
+
+export interface AuthFeatureListProps {
+  /** Lista de benefícios a exibir. Defaults internos se omitido. */
+  features?: AuthFeature[]
+}

--- a/app/features/auth/components/AuthFeatureList/AuthFeatureList.vue
+++ b/app/features/auth/components/AuthFeatureList/AuthFeatureList.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { AuthFeatureListProps, AuthFeature } from "./AuthFeatureList.types";
+
+/** Benefícios padrão exibidos quando a prop `features` é omitida. */
+const DEFAULT_FEATURES: AuthFeature[] = [
+  {
+    icon: "📊",
+    title: "Dashboard financeira",
+    description: "Visão consolidada do seu mês com saldo, metas e patrimônio.",
+  },
+  {
+    icon: "🎯",
+    title: "Metas inteligentes",
+    description: "Defina, acompanhe e conquiste metas financeiras com presets prontos.",
+  },
+  {
+    icon: "💼",
+    title: "Carteira & patrimônio",
+    description: "Acompanhe seus investimentos com dados em tempo real via BRAPI.",
+  },
+  {
+    icon: "🔒",
+    title: "Segurança primeiro",
+    description: "Seus dados protegidos com autenticação segura e criptografia.",
+  },
+];
+
+const props = defineProps<AuthFeatureListProps>();
+
+/** Lista de features resolvida: usa a prop quando fornecida, ou os defaults. */
+const features = computed(() => props.features ?? DEFAULT_FEATURES);
+</script>
+
+<template>
+  <ul class="auth-feature-list" aria-label="Benefícios do Auraxis">
+    <li
+      v-for="feature in features"
+      :key="feature.title"
+      class="auth-feature-list__item"
+    >
+      <span class="auth-feature-list__icon" aria-hidden="true">{{ feature.icon }}</span>
+      <div class="auth-feature-list__text">
+        <span class="auth-feature-list__title">{{ feature.title }}</span>
+        <span class="auth-feature-list__desc">{{ feature.description }}</span>
+      </div>
+    </li>
+  </ul>
+</template>
+
+<style scoped>
+.auth-feature-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.auth-feature-list__item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+
+.auth-feature-list__icon {
+  font-size: var(--font-size-xl);
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.auth-feature-list__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.auth-feature-list__title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  line-height: 1.4;
+}
+
+.auth-feature-list__desc {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+</style>

--- a/app/features/auth/components/AuthFeatureList/index.ts
+++ b/app/features/auth/components/AuthFeatureList/index.ts
@@ -1,0 +1,2 @@
+export { default as AuthFeatureList } from "./AuthFeatureList.vue";
+export type { AuthFeatureListProps, AuthFeature } from "./AuthFeatureList.types";

--- a/app/features/auth/components/ForgotPasswordForm/ForgotPasswordForm.types.ts
+++ b/app/features/auth/components/ForgotPasswordForm/ForgotPasswordForm.types.ts
@@ -1,0 +1,10 @@
+export interface ForgotPasswordFormProps {
+  /** Exibe estado de carregamento no botão de submit */
+  loading?: boolean
+  /** Se true, exibe mensagem de sucesso (e-mail enviado) em vez do formulário */
+  success?: boolean
+}
+
+export interface ForgotPasswordFormEmits {
+  (e: "submit", values: { email: string }): void
+}

--- a/app/features/auth/components/ForgotPasswordForm/ForgotPasswordForm.vue
+++ b/app/features/auth/components/ForgotPasswordForm/ForgotPasswordForm.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+import { useForgotPasswordForm } from "~/composables/useAuth";
+import type { ForgotPasswordSchema } from "~/schemas/auth";
+import UiFormField from "~/shared/components/UiFormField/UiFormField.vue";
+import type { ForgotPasswordFormProps, ForgotPasswordFormEmits } from "./ForgotPasswordForm.types";
+
+const props = withDefaults(defineProps<ForgotPasswordFormProps>(), {
+  loading: false,
+  success: false,
+});
+
+const emit = defineEmits<ForgotPasswordFormEmits>();
+
+const { defineField, errors, handleSubmit, isSubmitting } = useForgotPasswordForm();
+const [email, emailAttrs] = defineField("email");
+
+const onSubmit = handleSubmit((values: ForgotPasswordSchema) => {
+  emit("submit", values);
+});
+
+const isPending = computed(() => props.loading || isSubmitting.value);
+</script>
+
+<template>
+  <div class="forgot-form">
+    <!-- Success state -->
+    <template v-if="props.success">
+      <div class="forgot-form__success">
+        <span class="forgot-form__success-icon" aria-hidden="true">📬</span>
+        <h1 class="forgot-form__title">E-mail enviado</h1>
+        <p class="forgot-form__subtitle">
+          Se esse e-mail estiver cadastrado, você receberá um link de recuperação em instantes.
+          Verifique também sua pasta de spam.
+        </p>
+        <NuxtLink to="/login" class="forgot-form__back-link">
+          Voltar para o login
+        </NuxtLink>
+      </div>
+    </template>
+
+    <!-- Form state -->
+    <template v-else>
+      <div class="forgot-form__header">
+        <h1 class="forgot-form__title">Recuperar senha</h1>
+        <p class="forgot-form__subtitle">
+          Informe seu e-mail e enviaremos um link para redefinir sua senha.
+        </p>
+      </div>
+
+      <form class="forgot-form__fields" novalidate @submit.prevent="onSubmit">
+        <UiFormField
+          label="E-mail"
+          field-id="forgot-email"
+          :error="errors.email"
+          required
+        >
+          <input
+            id="forgot-email"
+            v-model="email"
+            class="forgot-form__input"
+            :class="{ 'forgot-form__input--error': !!errors.email }"
+            type="email"
+            placeholder="seu@email.com"
+            autocomplete="email"
+            :disabled="isPending"
+            v-bind="emailAttrs"
+          >
+        </UiFormField>
+
+        <button
+          type="submit"
+          class="forgot-form__submit"
+          :disabled="isPending"
+          :aria-busy="isPending"
+        >
+          <span v-if="isPending" class="forgot-form__spinner" aria-hidden="true" />
+          {{ isPending ? "Enviando…" : "Enviar link de recuperação" }}
+        </button>
+      </form>
+
+      <p class="forgot-form__login">
+        Lembrou a senha?
+        <NuxtLink to="/login" class="forgot-form__link">
+          Voltar para o login
+        </NuxtLink>
+      </p>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.forgot-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  width: 100%;
+  max-width: 400px;
+}
+
+.forgot-form__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.forgot-form__title {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-heading-md);
+  line-height: var(--line-height-heading-md);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.forgot-form__subtitle {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+  line-height: var(--line-height-md);
+}
+
+.forgot-form__fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.forgot-form__input {
+  width: 100%;
+  padding: 10px var(--space-2);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-md);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  font-family: var(--font-body);
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  box-sizing: border-box;
+}
+
+.forgot-form__input::placeholder {
+  color: var(--color-text-subtle);
+}
+
+.forgot-form__input:focus {
+  border-color: var(--color-brand-600);
+  box-shadow: 0 0 0 2px var(--color-brand-glow-xs);
+}
+
+.forgot-form__input--error {
+  border-color: var(--color-negative);
+}
+
+.forgot-form__input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.forgot-form__submit {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-height: 48px;
+  width: 100%;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-brand-500);
+  color: var(--color-neutral-950);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.forgot-form__submit:hover:not(:disabled) {
+  background: var(--color-brand-400);
+}
+
+.forgot-form__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.forgot-form__spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-top-color: var(--color-neutral-950);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.forgot-form__link {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-brand-400);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.forgot-form__link:hover {
+  color: var(--color-brand-300);
+  text-decoration: underline;
+}
+
+.forgot-form__login {
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+/* Success state */
+.forgot-form__success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  text-align: center;
+  padding: var(--space-4) 0;
+}
+
+.forgot-form__success-icon {
+  font-size: var(--font-size-4xl);
+  line-height: 1;
+}
+
+.forgot-form__back-link {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-brand-400);
+  text-decoration: none;
+  margin-top: var(--space-2);
+  transition: color 0.15s ease;
+}
+
+.forgot-form__back-link:hover {
+  color: var(--color-brand-300);
+  text-decoration: underline;
+}
+</style>

--- a/app/features/auth/components/ForgotPasswordForm/__tests__/ForgotPasswordForm.spec.ts
+++ b/app/features/auth/components/ForgotPasswordForm/__tests__/ForgotPasswordForm.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import ForgotPasswordForm from "../ForgotPasswordForm.vue";
+
+const NuxtLinkStub = {
+  template: "<a :href=\"to\" v-bind=\"$attrs\"><slot /></a>",
+  props: ["to"],
+};
+
+const globalConfig = {
+  stubs: { NuxtLink: NuxtLinkStub },
+};
+
+describe("ForgotPasswordForm", () => {
+  it("renders email input and submit button by default", () => {
+    const wrapper = mount(ForgotPasswordForm, { global: globalConfig });
+    expect(wrapper.find("input[type='email']").exists()).toBe(true);
+    expect(wrapper.find("button[type='submit']").exists()).toBe(true);
+  });
+
+  it("shows title and instructions", () => {
+    const wrapper = mount(ForgotPasswordForm, { global: globalConfig });
+    expect(wrapper.text()).toContain("Recuperar senha");
+    expect(wrapper.text()).toContain("link para redefinir");
+  });
+
+  it("shows back-to-login link", () => {
+    const wrapper = mount(ForgotPasswordForm, { global: globalConfig });
+    expect(wrapper.text()).toContain("Voltar para o login");
+  });
+
+  it("disables submit when loading", () => {
+    const wrapper = mount(ForgotPasswordForm, {
+      props: { loading: true },
+      global: globalConfig,
+    });
+    expect(wrapper.find("button[type='submit']").attributes("disabled")).toBeDefined();
+  });
+
+  it("shows loading text when loading", () => {
+    const wrapper = mount(ForgotPasswordForm, {
+      props: { loading: true },
+      global: globalConfig,
+    });
+    expect(wrapper.text()).toContain("Enviando");
+  });
+
+  it("shows success state when success prop is true", () => {
+    const wrapper = mount(ForgotPasswordForm, {
+      props: { success: true },
+      global: globalConfig,
+    });
+    expect(wrapper.find("input[type='email']").exists()).toBe(false);
+    expect(wrapper.find("button[type='submit']").exists()).toBe(false);
+    expect(wrapper.text()).toContain("E-mail enviado");
+  });
+
+  it("shows spam instructions in success state", () => {
+    const wrapper = mount(ForgotPasswordForm, {
+      props: { success: true },
+      global: globalConfig,
+    });
+    expect(wrapper.text()).toContain("spam");
+  });
+
+  it("renders back-to-login link in success state", () => {
+    const wrapper = mount(ForgotPasswordForm, {
+      props: { success: true },
+      global: globalConfig,
+    });
+    expect(wrapper.text()).toContain("Voltar para o login");
+  });
+});

--- a/app/features/auth/components/ForgotPasswordForm/index.ts
+++ b/app/features/auth/components/ForgotPasswordForm/index.ts
@@ -1,0 +1,2 @@
+export { default as ForgotPasswordForm } from "./ForgotPasswordForm.vue";
+export type { ForgotPasswordFormProps, ForgotPasswordFormEmits } from "./ForgotPasswordForm.types";

--- a/app/features/auth/components/LoginForm/LoginForm.types.ts
+++ b/app/features/auth/components/LoginForm/LoginForm.types.ts
@@ -1,0 +1,8 @@
+export interface LoginFormProps {
+  /** Exibe estado de carregamento no botão de submit */
+  loading?: boolean
+}
+
+export interface LoginFormEmits {
+  (e: "submit", values: { email: string; password: string }): void
+}

--- a/app/features/auth/components/LoginForm/LoginForm.vue
+++ b/app/features/auth/components/LoginForm/LoginForm.vue
@@ -1,0 +1,254 @@
+<script setup lang="ts">
+import { useLoginForm } from "~/composables/useAuth";
+import type { LoginSchema } from "~/schemas/auth";
+import UiFormField from "~/shared/components/UiFormField/UiFormField.vue";
+import UiPasswordField from "~/shared/components/UiPasswordField/UiPasswordField.vue";
+import UiSocialAuthButtons from "~/shared/components/UiSocialAuthButtons/UiSocialAuthButtons.vue";
+import type { LoginFormProps, LoginFormEmits } from "./LoginForm.types";
+
+const props = withDefaults(defineProps<LoginFormProps>(), {
+  loading: false,
+});
+
+const emit = defineEmits<LoginFormEmits>();
+
+const { defineField, errors, handleSubmit, isSubmitting } = useLoginForm();
+const [email, emailAttrs] = defineField("email");
+const [password, passwordAttrs] = defineField("password");
+
+const onSubmit = handleSubmit((values: LoginSchema) => {
+  emit("submit", values);
+});
+
+const isPending = computed(() => props.loading || isSubmitting.value);
+</script>
+
+<template>
+  <div class="login-form">
+    <div class="login-form__header">
+      <h1 class="login-form__title">Bem-vindo de volta</h1>
+      <p class="login-form__subtitle">Entre na sua conta Auraxis</p>
+    </div>
+
+    <UiSocialAuthButtons class="login-form__social" />
+
+    <div class="login-form__divider" aria-hidden="true">
+      <span class="login-form__divider-text">ou entre com e-mail</span>
+    </div>
+
+    <form class="login-form__fields" novalidate @submit.prevent="onSubmit">
+      <UiFormField
+        label="E-mail"
+        field-id="login-email"
+        :error="errors.email"
+        required
+      >
+        <input
+          id="login-email"
+          v-model="email"
+          class="login-form__input"
+          :class="{ 'login-form__input--error': !!errors.email }"
+          type="email"
+          placeholder="seu@email.com"
+          autocomplete="email"
+          :disabled="isPending"
+          v-bind="emailAttrs"
+        >
+      </UiFormField>
+
+      <UiPasswordField
+        v-model="password"
+        field-id="login-password"
+        :error="errors.password"
+        :disabled="isPending"
+        autocomplete="current-password"
+        required
+        v-bind="passwordAttrs"
+      />
+
+      <div class="login-form__forgot">
+        <NuxtLink to="/forgot-password" class="login-form__link">
+          Esqueceu sua senha?
+        </NuxtLink>
+      </div>
+
+      <button
+        type="submit"
+        class="login-form__submit"
+        :disabled="isPending"
+        :aria-busy="isPending"
+      >
+        <span v-if="isPending" class="login-form__spinner" aria-hidden="true" />
+        {{ isPending ? "Entrando…" : "Entrar" }}
+      </button>
+    </form>
+
+    <p class="login-form__register">
+      Não tem uma conta?
+      <NuxtLink to="/register" class="login-form__link">
+        Criar conta
+      </NuxtLink>
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  width: 100%;
+  max-width: 400px;
+}
+
+.login-form__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.login-form__title {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-heading-md);
+  line-height: var(--line-height-heading-md);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.login-form__subtitle {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.login-form__social {
+  width: 100%;
+}
+
+.login-form__divider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.login-form__divider::before,
+.login-form__divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--color-outline-soft);
+}
+
+.login-form__divider-text {
+  white-space: nowrap;
+  padding: 0 var(--space-1);
+}
+
+.login-form__fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.login-form__input {
+  width: 100%;
+  padding: 10px var(--space-2);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-md);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  font-family: var(--font-body);
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  box-sizing: border-box;
+}
+
+.login-form__input::placeholder {
+  color: var(--color-text-subtle);
+}
+
+.login-form__input:focus {
+  border-color: var(--color-brand-600);
+  box-shadow: 0 0 0 2px var(--color-brand-glow-xs);
+}
+
+.login-form__input--error {
+  border-color: var(--color-negative);
+}
+
+.login-form__input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.login-form__forgot {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: calc(var(--space-1) * -1);
+}
+
+.login-form__link {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-brand-400);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.login-form__link:hover {
+  color: var(--color-brand-300);
+  text-decoration: underline;
+}
+
+.login-form__submit {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-height: 48px;
+  width: 100%;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-brand-500);
+  color: var(--color-neutral-950);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.login-form__submit:hover:not(:disabled) {
+  background: var(--color-brand-400);
+}
+
+.login-form__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.login-form__spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-top-color: var(--color-neutral-950);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.login-form__register {
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+</style>

--- a/app/features/auth/components/LoginForm/__tests__/LoginForm.spec.ts
+++ b/app/features/auth/components/LoginForm/__tests__/LoginForm.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import LoginForm from "../LoginForm.vue";
+
+const NuxtLinkStub = {
+  template: "<a :href=\"to\" v-bind=\"$attrs\"><slot /></a>",
+  props: ["to"],
+};
+
+const globalConfig = {
+  stubs: { NuxtLink: NuxtLinkStub },
+};
+
+describe("LoginForm", () => {
+  it("renders email input, password field and submit button", () => {
+    const wrapper = mount(LoginForm, { global: globalConfig });
+    expect(wrapper.find("input[type='email']").exists()).toBe(true);
+    expect(wrapper.find("input[type='password']").exists()).toBe(true);
+    expect(wrapper.find("button[type='submit']").exists()).toBe(true);
+  });
+
+  it("shows forgot-password link", () => {
+    const wrapper = mount(LoginForm, { global: globalConfig });
+    expect(wrapper.text()).toContain("Esqueceu sua senha?");
+  });
+
+  it("shows register link", () => {
+    const wrapper = mount(LoginForm, { global: globalConfig });
+    expect(wrapper.text()).toContain("Criar conta");
+  });
+
+  it("disables submit button when loading", () => {
+    const wrapper = mount(LoginForm, {
+      props: { loading: true },
+      global: globalConfig,
+    });
+    const btn = wrapper.find("button[type='submit']");
+    expect(btn.attributes("disabled")).toBeDefined();
+  });
+
+  it("shows loading text when loading prop is true", () => {
+    const wrapper = mount(LoginForm, {
+      props: { loading: true },
+      global: globalConfig,
+    });
+    expect(wrapper.text()).toContain("Entrando");
+  });
+
+  it("renders social auth buttons", () => {
+    const wrapper = mount(LoginForm, { global: globalConfig });
+    expect(wrapper.find(".login-form__social").exists()).toBe(true);
+  });
+
+  it("shows divider between social and email form", () => {
+    const wrapper = mount(LoginForm, { global: globalConfig });
+    expect(wrapper.text()).toContain("ou entre com e-mail");
+  });
+
+  it("renders title and subtitle", () => {
+    const wrapper = mount(LoginForm, { global: globalConfig });
+    expect(wrapper.text()).toContain("Bem-vindo de volta");
+    expect(wrapper.text()).toContain("Entre na sua conta Auraxis");
+  });
+});

--- a/app/features/auth/components/LoginForm/index.ts
+++ b/app/features/auth/components/LoginForm/index.ts
@@ -1,0 +1,2 @@
+export { default as LoginForm } from "./LoginForm.vue";
+export type { LoginFormProps, LoginFormEmits } from "./LoginForm.types";

--- a/app/features/auth/components/SignupForm/SignupForm.types.ts
+++ b/app/features/auth/components/SignupForm/SignupForm.types.ts
@@ -1,0 +1,8 @@
+export interface SignupFormProps {
+  /** Exibe estado de carregamento no botão de submit */
+  loading?: boolean
+}
+
+export interface SignupFormEmits {
+  (e: "submit", values: { email: string; password: string; confirmPassword: string }): void
+}

--- a/app/features/auth/components/SignupForm/SignupForm.vue
+++ b/app/features/auth/components/SignupForm/SignupForm.vue
@@ -1,0 +1,254 @@
+<script setup lang="ts">
+import { useRegisterForm } from "~/composables/useAuth";
+import type { RegisterSchema } from "~/schemas/auth";
+import UiFormField from "~/shared/components/UiFormField/UiFormField.vue";
+import UiPasswordField from "~/shared/components/UiPasswordField/UiPasswordField.vue";
+import UiSocialAuthButtons from "~/shared/components/UiSocialAuthButtons/UiSocialAuthButtons.vue";
+import type { SignupFormProps, SignupFormEmits } from "./SignupForm.types";
+
+const props = withDefaults(defineProps<SignupFormProps>(), {
+  loading: false,
+});
+
+const emit = defineEmits<SignupFormEmits>();
+
+const { defineField, errors, handleSubmit, isSubmitting } = useRegisterForm();
+const [email, emailAttrs] = defineField("email");
+const [password, passwordAttrs] = defineField("password");
+const [confirmPassword, confirmPasswordAttrs] = defineField("confirmPassword");
+
+const onSubmit = handleSubmit((values: RegisterSchema) => {
+  emit("submit", values);
+});
+
+const isPending = computed(() => props.loading || isSubmitting.value);
+</script>
+
+<template>
+  <div class="signup-form">
+    <div class="signup-form__header">
+      <h1 class="signup-form__title">Criar conta</h1>
+      <p class="signup-form__subtitle">Comece a usar o Auraxis gratuitamente</p>
+    </div>
+
+    <UiSocialAuthButtons class="signup-form__social" />
+
+    <div class="signup-form__divider" aria-hidden="true">
+      <span class="signup-form__divider-text">ou registre com e-mail</span>
+    </div>
+
+    <form class="signup-form__fields" novalidate @submit.prevent="onSubmit">
+      <UiFormField
+        label="E-mail"
+        field-id="signup-email"
+        :error="errors.email"
+        required
+      >
+        <input
+          id="signup-email"
+          v-model="email"
+          class="signup-form__input"
+          :class="{ 'signup-form__input--error': !!errors.email }"
+          type="email"
+          placeholder="seu@email.com"
+          autocomplete="email"
+          :disabled="isPending"
+          v-bind="emailAttrs"
+        >
+      </UiFormField>
+
+      <UiPasswordField
+        v-model="password"
+        field-id="signup-password"
+        :error="errors.password"
+        :disabled="isPending"
+        autocomplete="new-password"
+        required
+        v-bind="passwordAttrs"
+      />
+
+      <UiPasswordField
+        v-model="confirmPassword"
+        label="Confirmar senha"
+        field-id="signup-confirm-password"
+        :error="errors.confirmPassword"
+        :disabled="isPending"
+        autocomplete="new-password"
+        required
+        v-bind="confirmPasswordAttrs"
+      />
+
+      <button
+        type="submit"
+        class="signup-form__submit"
+        :disabled="isPending"
+        :aria-busy="isPending"
+      >
+        <span v-if="isPending" class="signup-form__spinner" aria-hidden="true" />
+        {{ isPending ? "Criando conta…" : "Criar conta" }}
+      </button>
+    </form>
+
+    <p class="signup-form__login">
+      Já tem uma conta?
+      <NuxtLink to="/login" class="signup-form__link">
+        Entrar
+      </NuxtLink>
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.signup-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  width: 100%;
+  max-width: 400px;
+}
+
+.signup-form__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.signup-form__title {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-heading-md);
+  line-height: var(--line-height-heading-md);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.signup-form__subtitle {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.signup-form__social {
+  width: 100%;
+}
+
+.signup-form__divider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.signup-form__divider::before,
+.signup-form__divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--color-outline-soft);
+}
+
+.signup-form__divider-text {
+  white-space: nowrap;
+  padding: 0 var(--space-1);
+}
+
+.signup-form__fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.signup-form__input {
+  width: 100%;
+  padding: 10px var(--space-2);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-md);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  font-family: var(--font-body);
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  box-sizing: border-box;
+}
+
+.signup-form__input::placeholder {
+  color: var(--color-text-subtle);
+}
+
+.signup-form__input:focus {
+  border-color: var(--color-brand-600);
+  box-shadow: 0 0 0 2px var(--color-brand-glow-xs);
+}
+
+.signup-form__input--error {
+  border-color: var(--color-negative);
+}
+
+.signup-form__input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.signup-form__submit {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-height: 48px;
+  width: 100%;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-brand-500);
+  color: var(--color-neutral-950);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.signup-form__submit:hover:not(:disabled) {
+  background: var(--color-brand-400);
+}
+
+.signup-form__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.signup-form__spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-top-color: var(--color-neutral-950);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.signup-form__link {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-brand-400);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.signup-form__link:hover {
+  color: var(--color-brand-300);
+  text-decoration: underline;
+}
+
+.signup-form__login {
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+</style>

--- a/app/features/auth/components/SignupForm/__tests__/SignupForm.spec.ts
+++ b/app/features/auth/components/SignupForm/__tests__/SignupForm.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import SignupForm from "../SignupForm.vue";
+
+const NuxtLinkStub = {
+  template: "<a :href=\"to\" v-bind=\"$attrs\"><slot /></a>",
+  props: ["to"],
+};
+
+const globalConfig = {
+  stubs: { NuxtLink: NuxtLinkStub },
+};
+
+describe("SignupForm", () => {
+  it("renders email input, two password fields and submit button", () => {
+    const wrapper = mount(SignupForm, { global: globalConfig });
+    expect(wrapper.find("input[type='email']").exists()).toBe(true);
+    const passwordInputs = wrapper.findAll("input[type='password']");
+    expect(passwordInputs).toHaveLength(2);
+    expect(wrapper.find("button[type='submit']").exists()).toBe(true);
+  });
+
+  it("shows login link", () => {
+    const wrapper = mount(SignupForm, { global: globalConfig });
+    expect(wrapper.text()).toContain("Já tem uma conta?");
+    expect(wrapper.text()).toContain("Entrar");
+  });
+
+  it("disables submit when loading", () => {
+    const wrapper = mount(SignupForm, {
+      props: { loading: true },
+      global: globalConfig,
+    });
+    expect(wrapper.find("button[type='submit']").attributes("disabled")).toBeDefined();
+  });
+
+  it("shows loading text when loading", () => {
+    const wrapper = mount(SignupForm, {
+      props: { loading: true },
+      global: globalConfig,
+    });
+    expect(wrapper.text()).toContain("Criando conta");
+  });
+
+  it("renders social auth buttons", () => {
+    const wrapper = mount(SignupForm, { global: globalConfig });
+    expect(wrapper.find(".signup-form__social").exists()).toBe(true);
+  });
+
+  it("renders title and subtitle", () => {
+    const wrapper = mount(SignupForm, { global: globalConfig });
+    expect(wrapper.text()).toContain("Criar conta");
+    expect(wrapper.text()).toContain("gratuitamente");
+  });
+
+  it("shows divider between social and email form", () => {
+    const wrapper = mount(SignupForm, { global: globalConfig });
+    expect(wrapper.text()).toContain("ou registre com e-mail");
+  });
+});

--- a/app/features/auth/components/SignupForm/index.ts
+++ b/app/features/auth/components/SignupForm/index.ts
@@ -1,0 +1,2 @@
+export { default as SignupForm } from "./SignupForm.vue";
+export type { SignupFormProps, SignupFormEmits } from "./SignupForm.types";

--- a/app/layouts/auth.vue
+++ b/app/layouts/auth.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import AuthBrandPanel from "~/features/auth/components/AuthBrandPanel/AuthBrandPanel.vue";
+import AuthFeatureList from "~/features/auth/components/AuthFeatureList/AuthFeatureList.vue";
+</script>
+
+<template>
+  <div class="auth-layout">
+    <!-- Left: brand panel (hidden on mobile) -->
+    <div class="auth-layout__brand" aria-hidden="false">
+      <AuthBrandPanel />
+      <div class="auth-layout__features">
+        <AuthFeatureList />
+      </div>
+    </div>
+
+    <!-- Right: form area -->
+    <main class="auth-layout__form" role="main">
+      <div class="auth-layout__form-inner">
+        <slot />
+      </div>
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.auth-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 100dvh;
+}
+
+/* Left column */
+.auth-layout__brand {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.auth-layout__features {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: var(--space-6);
+  z-index: 1;
+}
+
+/* Right column */
+.auth-layout__form {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-surface);
+  padding: var(--space-5) var(--space-4);
+}
+
+.auth-layout__form-inner {
+  width: 100%;
+  max-width: 440px;
+}
+
+/* Mobile: single column, brand hidden */
+@media (max-width: 767px) {
+  .auth-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-layout__brand {
+    display: none;
+  }
+
+  .auth-layout__form {
+    min-height: 100dvh;
+    padding: var(--space-4) var(--space-3);
+  }
+}
+
+/* Tablet: narrower brand panel */
+@media (min-width: 768px) and (max-width: 1023px) {
+  .auth-layout {
+    grid-template-columns: 5fr 7fr;
+  }
+}
+</style>

--- a/app/pages/forgot-password.vue
+++ b/app/pages/forgot-password.vue
@@ -1,71 +1,28 @@
 <script setup lang="ts">
-import {
-  useForgotPasswordForm,
-  useForgotPasswordMutation,
-} from "~/composables/useAuth";
+import { ref } from "vue";
+import { useForgotPasswordMutation } from "~/composables/useAuth";
+import { ForgotPasswordForm } from "~/features/auth/components/ForgotPasswordForm";
 import type { ForgotPasswordSchema } from "~/schemas/auth";
 
-definePageMeta({ middleware: ["guest-only"] });
+definePageMeta({ layout: "auth", middleware: ["guest-only"] });
 
 const forgotPasswordMutation = useForgotPasswordMutation();
-const { defineField, errors, handleSubmit, isSubmitting } = useForgotPasswordForm();
-const [email, emailProps] = defineField("email");
+const emailSent = ref(false);
 
-const submit = handleSubmit(async (values: ForgotPasswordSchema) => {
+/**
+ * Solicita o envio do e-mail de recuperação de senha.
+ * @param values - Dados validados com o e-mail do usuário.
+ */
+const onSubmit = async (values: ForgotPasswordSchema): Promise<void> => {
   await forgotPasswordMutation.mutateAsync(values);
-});
+  emailSent.value = true;
+};
 </script>
 
 <template>
-  <UiBaseCard title="Recuperar senha">
-    <form class="auth-form" @submit.prevent="submit">
-      <label>
-        E-mail
-        <input v-model="email" type="email" autocomplete="email" v-bind="emailProps">
-      </label>
-      <p class="form-error">{{ errors.email }}</p>
-
-      <button type="submit" :disabled="isSubmitting || forgotPasswordMutation.isPending.value">
-        Enviar link de recuperacao
-      </button>
-
-      <NuxtLink to="/login">Voltar para login</NuxtLink>
-    </form>
-  </UiBaseCard>
+  <ForgotPasswordForm
+    :loading="forgotPasswordMutation.isPending.value"
+    :success="emailSent"
+    @submit="onSubmit"
+  />
 </template>
-
-<style scoped>
-.auth-form {
-  display: grid;
-  gap: var(--space-2);
-}
-
-.auth-form label {
-  display: grid;
-  gap: var(--space-1);
-  color: var(--color-neutral-700);
-  font-weight: var(--font-weight-semibold);
-}
-
-.auth-form input {
-  border: 1px solid var(--color-outline-soft);
-  border-radius: var(--radius-sm);
-  padding: var(--space-1);
-  min-height: 44px;
-}
-
-.auth-form button {
-  min-height: 44px;
-  border: none;
-  border-radius: var(--radius-sm);
-  background: var(--color-brand-500);
-  color: var(--color-neutral-950);
-  font-weight: var(--font-weight-bold);
-}
-
-.form-error {
-  min-height: 20px;
-  color: var(--color-neutral-950);
-  margin: 0;
-}
-</style>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,84 +1,25 @@
 <script setup lang="ts">
-import {
-  useLoginForm,
-  useLoginMutation,
-} from "~/composables/useAuth";
+import { useLoginMutation } from "~/composables/useAuth";
+import { useAuthRedirectContext } from "~/composables/useAuthRedirectContext";
+import { LoginForm } from "~/features/auth/components/LoginForm";
 import type { LoginSchema } from "~/schemas/auth";
 
-definePageMeta({ middleware: ["guest-only"] });
+definePageMeta({ layout: "auth", middleware: ["guest-only"] });
 
 const loginMutation = useLoginMutation();
-const { defineField, errors, handleSubmit, isSubmitting } = useLoginForm();
-const [email, emailProps] = defineField("email");
-const [password, passwordProps] = defineField("password");
+const { consumeRedirect } = useAuthRedirectContext();
 
-const submit = handleSubmit(async (values: LoginSchema) => {
+/**
+ * Submete as credenciais de login e redireciona ao destino pós-auth.
+ * @param values - Dados validados do formulário de login.
+ */
+const onSubmit = async (values: LoginSchema): Promise<void> => {
   await loginMutation.mutateAsync(values);
-  await navigateTo("/dashboard");
-});
+  const redirect = consumeRedirect();
+  await navigateTo(redirect);
+};
 </script>
 
 <template>
-  <UiBaseCard title="Entrar">
-    <form class="auth-form" @submit.prevent="submit">
-      <label>
-        E-mail
-        <input v-model="email" type="email" autocomplete="email" v-bind="emailProps">
-      </label>
-      <p class="form-error">{{ errors.email }}</p>
-
-      <label>
-        Senha
-        <input
-          v-model="password"
-          type="password"
-          autocomplete="current-password"
-          v-bind="passwordProps"
-        >
-      </label>
-      <p class="form-error">{{ errors.password }}</p>
-
-      <button type="submit" :disabled="isSubmitting || loginMutation.isPending.value">
-        Entrar
-      </button>
-
-      <NuxtLink to="/forgot-password">Esqueceu sua senha?</NuxtLink>
-    </form>
-  </UiBaseCard>
+  <LoginForm :loading="loginMutation.isPending.value" @submit="onSubmit" />
 </template>
-
-<style scoped>
-.auth-form {
-  display: grid;
-  gap: var(--space-2);
-}
-
-.auth-form label {
-  display: grid;
-  gap: var(--space-1);
-  color: var(--color-neutral-700);
-  font-weight: var(--font-weight-semibold);
-}
-
-.auth-form input {
-  border: 1px solid var(--color-outline-soft);
-  border-radius: var(--radius-sm);
-  padding: var(--space-1);
-  min-height: 44px;
-}
-
-.auth-form button {
-  min-height: 44px;
-  border: none;
-  border-radius: var(--radius-sm);
-  background: var(--color-brand-500);
-  color: var(--color-neutral-950);
-  font-weight: var(--font-weight-bold);
-}
-
-.form-error {
-  min-height: 20px;
-  color: var(--color-neutral-950);
-  margin: 0;
-}
-</style>

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -1,96 +1,25 @@
 <script setup lang="ts">
-import {
-  useRegisterForm,
-  useRegisterMutation,
-} from "~/composables/useAuth";
+import { useRegisterMutation } from "~/composables/useAuth";
+import { useAuthRedirectContext } from "~/composables/useAuthRedirectContext";
+import { SignupForm } from "~/features/auth/components/SignupForm";
 import type { RegisterSchema } from "~/schemas/auth";
 
-definePageMeta({ middleware: ["guest-only"] });
+definePageMeta({ layout: "auth", middleware: ["guest-only"] });
 
 const registerMutation = useRegisterMutation();
-const { defineField, errors, handleSubmit, isSubmitting } = useRegisterForm();
-const [email, emailProps] = defineField("email");
-const [password, passwordProps] = defineField("password");
-const [confirmPassword, confirmPasswordProps] = defineField("confirmPassword");
+const { consumeRedirect } = useAuthRedirectContext();
 
-const submit = handleSubmit(async (values: RegisterSchema) => {
+/**
+ * Submete o registro de novo usuário e redireciona ao destino pós-auth.
+ * @param values - Dados validados do formulário de registro.
+ */
+const onSubmit = async (values: RegisterSchema): Promise<void> => {
   await registerMutation.mutateAsync(values);
-  await navigateTo("/dashboard");
-});
+  const redirect = consumeRedirect();
+  await navigateTo(redirect);
+};
 </script>
 
 <template>
-  <UiBaseCard title="Registrar">
-    <form class="auth-form" @submit.prevent="submit">
-      <label>
-        E-mail
-        <input v-model="email" type="email" autocomplete="email" v-bind="emailProps" >
-      </label>
-      <p class="form-error">{{ errors.email }}</p>
-
-      <label>
-        Senha
-        <input
-          v-model="password"
-          type="password"
-          autocomplete="new-password"
-          v-bind="passwordProps"
-        >
-      </label>
-      <p class="form-error">{{ errors.password }}</p>
-
-      <label>
-        Confirmar senha
-        <input
-          v-model="confirmPassword"
-          type="password"
-          autocomplete="new-password"
-          v-bind="confirmPasswordProps"
-        >
-      </label>
-      <p class="form-error">{{ errors.confirmPassword }}</p>
-
-      <button type="submit" :disabled="isSubmitting || registerMutation.isPending.value">
-        Registrar
-      </button>
-
-      <NuxtLink to="/login">Já tem uma conta?</NuxtLink>
-    </form>
-  </UiBaseCard>
+  <SignupForm :loading="registerMutation.isPending.value" @submit="onSubmit" />
 </template>
-
-<style scoped>
-.auth-form {
-  display: grid;
-  gap: var(--space-2);
-}
-
-.auth-form label {
-  display: grid;
-  gap: var(--space-1);
-  color: var(--color-neutral-700);
-  font-weight: var(--font-weight-semibold);
-}
-
-.auth-form input {
-  border: 1px solid var(--color-outline-soft);
-  border-radius: var(--radius-sm);
-  padding: var(--space-1);
-  min-height: 44px;
-}
-
-.auth-form button {
-  min-height: 44px;
-  border: none;
-  border-radius: var(--radius-sm);
-  background: var(--color-brand-500);
-  color: var(--color-neutral-950);
-  font-weight: var(--font-weight-bold);
-}
-
-.form-error {
-  min-height: 20px;
-  color: var(--color-neutral-950);
-  margin: 0;
-}
-</style>

--- a/app/shared/components/UiAppShell/UiAppShell.stories.ts
+++ b/app/shared/components/UiAppShell/UiAppShell.stories.ts
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/vue3";
+import {
+  LayoutDashboard,
+  Wallet,
+  Target,
+  Wrench,
+  ArrowRightLeft,
+} from "lucide-vue-next";
+import UiAppShell from "./UiAppShell.vue";
+
+const navItems = [
+  {
+    key: "dashboard",
+    label: "Dashboard",
+    to: "/dashboard",
+    icon: LayoutDashboard,
+  },
+  { key: "wallet", label: "Carteira", to: "/carteira", icon: Wallet },
+  { key: "goals", label: "Metas", to: "/metas", icon: Target },
+  { key: "tools", label: "Ferramentas", to: "/ferramentas", icon: Wrench },
+  {
+    key: "transactions",
+    label: "Transações",
+    to: "/transacoes",
+    icon: ArrowRightLeft,
+  },
+];
+
+const user = {
+  name: "João Silva",
+  description: "Investidor Moderado",
+};
+
+const meta: Meta<typeof UiAppShell> = {
+  title: "Layout/UiAppShell",
+  component: UiAppShell,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+type Story = StoryObj<typeof UiAppShell>;
+
+export const Default: Story = {
+  args: {
+    navItems,
+    user,
+    pageTitle: "Dashboard",
+    pageSubtitle: "Dezembro 2025",
+    topbarActions: [],
+  },
+  render: (args) => ({
+    components: { UiAppShell },
+    setup(): { args: typeof args } {
+      return { args };
+    },
+    template: `
+      <UiAppShell v-bind="args">
+        <div style="padding: 24px; color: var(--color-text-secondary)">
+          Conteúdo da página aqui
+        </div>
+      </UiAppShell>
+    `,
+  }),
+};
+
+export const WithActions: Story = {
+  args: {
+    ...Default.args,
+    topbarActions: [
+      { key: "add-income", label: "Receita", variant: "positive" },
+      { key: "add-expense", label: "Despesa", variant: "negative" },
+    ],
+  },
+  render: Default.render,
+};

--- a/app/shared/components/UiAppShell/UiAppShell.types.ts
+++ b/app/shared/components/UiAppShell/UiAppShell.types.ts
@@ -1,0 +1,40 @@
+import type { Component } from "vue";
+
+export interface AppShellNavItem {
+  key: string;
+  label: string;
+  to: string;
+  icon?: Component;
+}
+
+export interface AppShellUser {
+  name: string;
+  description?: string;
+  avatarUrl?: string;
+}
+
+export interface AppShellAction {
+  key: string;
+  label: string;
+  icon?: Component;
+  variant: "positive" | "negative" | "default";
+}
+
+export interface UiAppShellProps {
+  /** Items de navegação do sidebar */
+  navItems: AppShellNavItem[];
+  /** Dados do usuário logado */
+  user: AppShellUser;
+  /** Título da página atual (passado para UiTopbar) */
+  pageTitle: string;
+  /** Subtítulo da página */
+  pageSubtitle?: string;
+  /** Ações da topbar */
+  topbarActions?: AppShellAction[];
+}
+
+export type UiAppShellEmits = {
+  "topbar-action": [key: string];
+  "user-settings": [];
+  "user-logout": [];
+};

--- a/app/shared/components/UiAppShell/UiAppShell.vue
+++ b/app/shared/components/UiAppShell/UiAppShell.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { PieChart } from "lucide-vue-next";
+import { useRoute } from "vue-router";
+import { useSidebarState } from "~/composables/useSidebarState";
+import { useResponsiveShell } from "~/composables/useResponsiveShell";
+import UiSidebarNav from "../UiSidebarNav/UiSidebarNav.vue";
+import UiTopbar from "../UiTopbar/UiTopbar.vue";
+import type { UiAppShellProps, UiAppShellEmits } from "./UiAppShell.types";
+
+withDefaults(defineProps<UiAppShellProps>(), {
+  pageSubtitle: undefined,
+  topbarActions: () => [],
+});
+
+const emit = defineEmits<UiAppShellEmits>();
+
+const route = useRoute();
+const { isCollapsed } = useSidebarState();
+const { isMobile, isDrawerOpen, openDrawer, closeDrawer } =
+  useResponsiveShell();
+
+const currentRoute = computed(() => route.path);
+</script>
+
+<template>
+  <div class="ui-app-shell">
+    <!-- Overlay mobile -->
+    <Transition name="ui-app-shell-overlay">
+      <div
+        v-if="isMobile && isDrawerOpen"
+        class="ui-app-shell__overlay"
+        aria-hidden="true"
+        @click="closeDrawer"
+      />
+    </Transition>
+
+    <!-- Sidebar -->
+    <aside
+      class="ui-app-shell__sidebar"
+      :class="{
+        'ui-app-shell__sidebar--collapsed': isCollapsed && !isMobile,
+        'ui-app-shell__sidebar--drawer': isMobile,
+        'ui-app-shell__sidebar--drawer-open': isMobile && isDrawerOpen,
+      }"
+      aria-label="Navegação principal"
+    >
+      <!-- Logo -->
+      <div class="ui-app-shell__logo">
+        <div class="ui-app-shell__logo-mark" aria-hidden="true">
+          <PieChart :size="16" />
+        </div>
+        <span v-if="!isCollapsed" class="ui-app-shell__logo-text"
+          >Auraxis</span
+        >
+      </div>
+
+      <!-- Nav -->
+      <UiSidebarNav
+        :items="navItems"
+        :collapsed="isCollapsed && !isMobile"
+        :current-route="currentRoute"
+        class="ui-app-shell__nav"
+      />
+    </aside>
+
+    <!-- Main area -->
+    <div class="ui-app-shell__main">
+      <UiTopbar
+        :title="pageTitle"
+        :subtitle="pageSubtitle"
+        :actions="topbarActions"
+        :user-name="user.name"
+        :user-description="user.description"
+        :user-avatar-url="user.avatarUrl"
+        :show-menu-button="isMobile"
+        @action="(key) => emit('topbar-action', key)"
+        @user-settings="emit('user-settings')"
+        @user-logout="emit('user-logout')"
+        @menu-toggle="openDrawer"
+      />
+
+      <main class="ui-app-shell__content">
+        <slot />
+      </main>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ui-app-shell {
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--color-bg-base);
+  position: relative;
+}
+
+/* Sidebar */
+.ui-app-shell__sidebar {
+  width: 256px;
+  flex-shrink: 0;
+  height: 100vh;
+  background: var(--color-bg-surface);
+  border-right: 1px solid var(--color-outline-soft);
+  display: flex;
+  flex-direction: column;
+  transition: width 0.2s ease;
+  overflow: hidden;
+}
+
+.ui-app-shell__sidebar--collapsed {
+  width: 72px;
+}
+
+/* Mobile: sidebar é drawer */
+.ui-app-shell__sidebar--drawer {
+  position: fixed;
+  left: -256px;
+  top: 0;
+  z-index: 200;
+  transition: left 0.25s ease;
+}
+
+.ui-app-shell__sidebar--drawer-open {
+  left: 0;
+}
+
+/* Logo */
+.ui-app-shell__logo {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  height: 80px;
+  padding: 0 var(--space-3);
+  border-bottom: 1px solid var(--color-outline-soft);
+  flex-shrink: 0;
+}
+
+.ui-app-shell__logo-mark {
+  width: 32px;
+  height: 32px;
+  background: var(--color-brand-600);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-bg-base);
+  flex-shrink: 0;
+  box-shadow: var(--shadow-brand-glow-sm);
+}
+
+.ui-app-shell__logo-text {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  white-space: nowrap;
+}
+
+/* Nav */
+.ui-app-shell__nav {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/* Overlay */
+.ui-app-shell__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 199;
+}
+
+.ui-app-shell-overlay-enter-active,
+.ui-app-shell-overlay-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.ui-app-shell-overlay-enter-from,
+.ui-app-shell-overlay-leave-to {
+  opacity: 0;
+}
+
+/* Main */
+.ui-app-shell__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.ui-app-shell__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-3) var(--space-4);
+}
+</style>

--- a/app/shared/components/UiAppShell/__tests__/UiAppShell.e2e.ts
+++ b/app/shared/components/UiAppShell/__tests__/UiAppShell.e2e.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+// Requer servidor Nuxt rodando
+test.describe("UiAppShell", () => {
+  test("sidebar is visible on desktop", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/dashboard");
+    await expect(
+      page.locator("[aria-label=\"Navegação principal\"]"),
+    ).toBeVisible();
+  });
+
+  test("menu button opens sidebar drawer on mobile", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/dashboard");
+    const menuBtn = page.locator("button[aria-label=\"Abrir menu\"]");
+    await expect(menuBtn).toBeVisible();
+    await menuBtn.click();
+    await expect(
+      page.locator(".ui-app-shell__sidebar--drawer-open"),
+    ).toBeVisible();
+  });
+
+  test("overlay closes drawer on click", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/dashboard");
+    await page.click("button[aria-label=\"Abrir menu\"]");
+    await page.click(".ui-app-shell__overlay");
+    await expect(
+      page.locator(".ui-app-shell__sidebar--drawer-open"),
+    ).not.toBeVisible();
+  });
+});

--- a/app/shared/components/UiAppShell/__tests__/UiAppShell.spec.ts
+++ b/app/shared/components/UiAppShell/__tests__/UiAppShell.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia } from "pinia";
+import { ref, type Ref } from "vue";
+import UiAppShell from "../UiAppShell.vue";
+import { LayoutDashboard, Wallet } from "lucide-vue-next";
+
+vi.mock("vue-router", () => ({
+  useRoute: (): { path: string } => ({ path: "/dashboard" }),
+}));
+
+vi.mock("~/composables/useSidebarState", () => ({
+  useSidebarState: (): {
+    isCollapsed: Ref<boolean>;
+    toggle: () => void;
+    collapse: () => void;
+    expand: () => void;
+  } => ({
+    isCollapsed: ref(false),
+    toggle: vi.fn(),
+    collapse: vi.fn(),
+    expand: vi.fn(),
+  }),
+}));
+
+vi.mock("~/composables/useResponsiveShell", () => ({
+  useResponsiveShell: (): {
+    isMobile: Ref<boolean>;
+    isDrawerOpen: Ref<boolean>;
+    openDrawer: () => void;
+    closeDrawer: () => void;
+    toggleDrawer: () => void;
+  } => ({
+    isMobile: ref(false),
+    isDrawerOpen: ref(false),
+    openDrawer: vi.fn(),
+    closeDrawer: vi.fn(),
+    toggleDrawer: vi.fn(),
+  }),
+}));
+
+const defaultProps = {
+  navItems: [
+    {
+      key: "dashboard",
+      label: "Dashboard",
+      to: "/dashboard",
+      icon: LayoutDashboard,
+    },
+    { key: "wallet", label: "Carteira", to: "/carteira", icon: Wallet },
+  ],
+  user: { name: "João Silva", description: "Investidor Moderado" },
+  pageTitle: "Dashboard",
+  pageSubtitle: "Dezembro 2025",
+};
+
+const globalConfig = {
+  plugins: [createPinia()],
+  stubs: {
+    NuxtLink: { template: "<a :href=\"to\"><slot /></a>", props: ["to"] },
+    UiSidebarNav: { template: "<nav />" },
+    UiTopbar: { template: "<header />" },
+    Transition: { template: "<slot />" },
+  },
+};
+
+describe("UiAppShell", () => {
+  it("renders sidebar and main area", () => {
+    const wrapper = mount(UiAppShell, {
+      props: defaultProps,
+      global: globalConfig,
+    });
+    expect(wrapper.find(".ui-app-shell__sidebar").exists()).toBe(true);
+    expect(wrapper.find(".ui-app-shell__main").exists()).toBe(true);
+  });
+
+  it("renders slot content in main area", () => {
+    const wrapper = mount(UiAppShell, {
+      props: defaultProps,
+      global: globalConfig,
+      slots: { default: "<p class=\"test-content\">Conteúdo</p>" },
+    });
+    expect(wrapper.find(".test-content").exists()).toBe(true);
+  });
+
+  it("renders logo text Auraxis", () => {
+    const wrapper = mount(UiAppShell, {
+      props: defaultProps,
+      global: globalConfig,
+    });
+    expect(wrapper.find(".ui-app-shell__logo-text").text()).toBe("Auraxis");
+  });
+
+  it("renders topbar (header element) inside main area", () => {
+    const wrapper = mount(UiAppShell, {
+      props: defaultProps,
+      global: globalConfig,
+    });
+    // UiTopbar is stubbed as <header />
+    expect(wrapper.find("header").exists()).toBe(true);
+  });
+
+  it("sidebar has aria-label", () => {
+    const wrapper = mount(UiAppShell, {
+      props: defaultProps,
+      global: globalConfig,
+    });
+    const sidebar = wrapper.find(".ui-app-shell__sidebar");
+    expect(sidebar.attributes("aria-label")).toBe("Navegação principal");
+  });
+
+  it("snapshot default state", () => {
+    const wrapper = mount(UiAppShell, {
+      props: defaultProps,
+      global: globalConfig,
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});

--- a/app/shared/components/UiAppShell/__tests__/__snapshots__/UiAppShell.spec.ts.snap
+++ b/app/shared/components/UiAppShell/__tests__/__snapshots__/UiAppShell.spec.ts.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`UiAppShell > snapshot default state 1`] = `
+"<div data-v-b677c355="" class="ui-app-shell">
+  <!-- Overlay mobile -->
+  <transition-stub data-v-b677c355="" name="ui-app-shell-overlay" appear="false" persisted="false" css="true">
+    <!--v-if-->
+  </transition-stub><!-- Sidebar -->
+  <aside data-v-b677c355="" class="ui-app-shell__sidebar" aria-label="Navegação principal">
+    <!-- Logo -->
+    <div data-v-b677c355="" class="ui-app-shell__logo">
+      <div data-v-b677c355="" class="ui-app-shell__logo-mark" aria-hidden="true"><svg data-v-b677c355="" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chart-pie-icon lucide-chart-pie" aria-hidden="true">
+          <path d="M21 12c.552 0 1.005-.449.95-.998a10 10 0 0 0-8.953-8.951c-.55-.055-.998.398-.998.95v8a1 1 0 0 0 1 1z"></path>
+          <path d="M21.21 15.89A10 10 0 1 1 8 2.83"></path>
+        </svg></div><span data-v-b677c355="" class="ui-app-shell__logo-text">Auraxis</span>
+    </div><!-- Nav -->
+    <nav data-v-b677c355="" items="[object Object],[object Object]" collapsed="false" current-route="/dashboard" class="ui-app-shell__nav"></nav>
+  </aside><!-- Main area -->
+  <div data-v-b677c355="" class="ui-app-shell__main">
+    <header data-v-b677c355="" title="Dashboard" subtitle="Dezembro 2025" actions="" user-name="João Silva" user-description="Investidor Moderado" show-menu-button="false"></header>
+    <main data-v-b677c355="" class="ui-app-shell__content"></main>
+  </div>
+</div>"
+`;

--- a/app/shared/components/UiAppShell/index.ts
+++ b/app/shared/components/UiAppShell/index.ts
@@ -1,0 +1,8 @@
+export { default as UiAppShell } from "./UiAppShell.vue";
+export type {
+  UiAppShellProps,
+  UiAppShellEmits,
+  AppShellNavItem,
+  AppShellUser,
+  AppShellAction,
+} from "./UiAppShell.types";

--- a/app/shared/components/UiSocialAuthButtons/UiSocialAuthButtons.stories.ts
+++ b/app/shared/components/UiSocialAuthButtons/UiSocialAuthButtons.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/vue3";
+import UiSocialAuthButtons from "./UiSocialAuthButtons.vue";
+
+const meta: Meta<typeof UiSocialAuthButtons> = {
+  title: "Shared/UiSocialAuthButtons",
+  component: UiSocialAuthButtons,
+  tags: ["autodocs"],
+  argTypes: {
+    disabled: { control: "boolean" },
+    compact: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof UiSocialAuthButtons>;
+
+export const Default: Story = {
+  args: { disabled: false, compact: false },
+};
+
+export const Compact: Story = {
+  args: { compact: true },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};

--- a/app/shared/components/UiSocialAuthButtons/UiSocialAuthButtons.types.ts
+++ b/app/shared/components/UiSocialAuthButtons/UiSocialAuthButtons.types.ts
@@ -1,0 +1,10 @@
+export interface UiSocialAuthButtonsProps {
+  /** Desabilita todos os botões durante loading */
+  disabled?: boolean
+  /** Modo compacto: exibe apenas ícones, sem texto */
+  compact?: boolean
+}
+
+export interface UiSocialAuthButtonsEmits {
+  (e: "google-click" | "apple-click"): void
+}

--- a/app/shared/components/UiSocialAuthButtons/UiSocialAuthButtons.vue
+++ b/app/shared/components/UiSocialAuthButtons/UiSocialAuthButtons.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import type { UiSocialAuthButtonsProps, UiSocialAuthButtonsEmits } from "./UiSocialAuthButtons.types";
+
+const props = withDefaults(defineProps<UiSocialAuthButtonsProps>(), {
+  disabled: false,
+  compact: false,
+});
+
+const emit = defineEmits<UiSocialAuthButtonsEmits>();
+</script>
+
+<template>
+  <div class="ui-social-auth" :class="{ 'ui-social-auth--compact': props.compact }">
+    <button
+      type="button"
+      class="ui-social-auth__btn ui-social-auth__btn--google"
+      :disabled="props.disabled"
+      :aria-label="props.compact ? 'Entrar com Google' : undefined"
+      @click="emit('google-click')"
+    >
+      <!-- Google icon (SVG inline) -->
+      <svg
+        class="ui-social-auth__icon"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+          fill="#4285F4"
+        />
+        <path
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+          fill="#34A853"
+        />
+        <path
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+          fill="#FBBC05"
+        />
+        <path
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+          fill="#EA4335"
+        />
+      </svg>
+      <span v-if="!props.compact" class="ui-social-auth__label">Continuar com Google</span>
+    </button>
+
+    <button
+      type="button"
+      class="ui-social-auth__btn ui-social-auth__btn--apple"
+      :disabled="props.disabled"
+      :aria-label="props.compact ? 'Entrar com Apple' : undefined"
+      @click="emit('apple-click')"
+    >
+      <!-- Apple icon (SVG inline) -->
+      <svg
+        class="ui-social-auth__icon"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        focusable="false"
+        fill="currentColor"
+      >
+        <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.7 9.05 7.4c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.53 4zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+      </svg>
+      <span v-if="!props.compact" class="ui-social-auth__label">Continuar com Apple</span>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.ui-social-auth {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ui-social-auth__btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  width: 100%;
+  min-height: 44px;
+  padding: 10px var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-outline-soft);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+}
+
+.ui-social-auth__btn:hover:not(:disabled) {
+  background: var(--color-bg-surface);
+  border-color: var(--color-outline-medium);
+}
+
+.ui-social-auth__btn:focus-visible {
+  outline: 2px solid var(--color-brand-600);
+  outline-offset: 2px;
+}
+
+.ui-social-auth__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ui-social-auth__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.ui-social-auth__label {
+  line-height: 1;
+}
+
+/* Compact: icon-only, square */
+.ui-social-auth--compact {
+  flex-direction: row;
+}
+
+.ui-social-auth--compact .ui-social-auth__btn {
+  width: 44px;
+  padding: 10px;
+  flex: 1;
+}
+</style>

--- a/app/shared/components/UiSocialAuthButtons/__tests__/UiSocialAuthButtons.spec.ts
+++ b/app/shared/components/UiSocialAuthButtons/__tests__/UiSocialAuthButtons.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import UiSocialAuthButtons from "../UiSocialAuthButtons.vue";
+
+describe("UiSocialAuthButtons", () => {
+  it("renders Google and Apple buttons by default", () => {
+    const wrapper = mount(UiSocialAuthButtons);
+    const buttons = wrapper.findAll("button");
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]!.classes()).toContain("ui-social-auth__btn--google");
+    expect(buttons[1]!.classes()).toContain("ui-social-auth__btn--apple");
+  });
+
+  it("displays labels when not compact", () => {
+    const wrapper = mount(UiSocialAuthButtons);
+    expect(wrapper.text()).toContain("Continuar com Google");
+    expect(wrapper.text()).toContain("Continuar com Apple");
+  });
+
+  it("hides labels in compact mode", () => {
+    const wrapper = mount(UiSocialAuthButtons, {
+      props: { compact: true },
+    });
+    expect(wrapper.text()).not.toContain("Continuar com Google");
+    expect(wrapper.text()).not.toContain("Continuar com Apple");
+  });
+
+  it("emits google-click when Google button is clicked", async () => {
+    const wrapper = mount(UiSocialAuthButtons);
+    await wrapper.find(".ui-social-auth__btn--google").trigger("click");
+    expect(wrapper.emitted("google-click")).toHaveLength(1);
+  });
+
+  it("emits apple-click when Apple button is clicked", async () => {
+    const wrapper = mount(UiSocialAuthButtons);
+    await wrapper.find(".ui-social-auth__btn--apple").trigger("click");
+    expect(wrapper.emitted("apple-click")).toHaveLength(1);
+  });
+
+  it("disables buttons when disabled prop is true", () => {
+    const wrapper = mount(UiSocialAuthButtons, {
+      props: { disabled: true },
+    });
+    wrapper.findAll("button").forEach((btn) => {
+      expect(btn.attributes("disabled")).toBeDefined();
+    });
+  });
+
+  it("does not emit events when disabled button is clicked natively", () => {
+    const wrapper = mount(UiSocialAuthButtons, {
+      props: { disabled: true },
+    });
+    const googleBtn = wrapper.find(".ui-social-auth__btn--google");
+    expect(googleBtn.attributes("disabled")).toBeDefined();
+    expect(wrapper.emitted("google-click")).toBeUndefined();
+  });
+
+  it("applies compact class in compact mode", () => {
+    const wrapper = mount(UiSocialAuthButtons, {
+      props: { compact: true },
+    });
+    expect(wrapper.find(".ui-social-auth").classes()).toContain("ui-social-auth--compact");
+  });
+
+  it("has accessible aria-label on buttons in compact mode", () => {
+    const wrapper = mount(UiSocialAuthButtons, {
+      props: { compact: true },
+    });
+    const buttons = wrapper.findAll("button");
+    expect(buttons[0]!.attributes("aria-label")).toBe("Entrar com Google");
+    expect(buttons[1]!.attributes("aria-label")).toBe("Entrar com Apple");
+  });
+});

--- a/app/shared/components/UiSocialAuthButtons/index.ts
+++ b/app/shared/components/UiSocialAuthButtons/index.ts
@@ -1,0 +1,2 @@
+export { default as UiSocialAuthButtons } from "./UiSocialAuthButtons.vue";
+export type { UiSocialAuthButtonsProps, UiSocialAuthButtonsEmits } from "./UiSocialAuthButtons.types";

--- a/app/shared/components/index.ts
+++ b/app/shared/components/index.ts
@@ -61,3 +61,17 @@ export type { UiUserMenuProps, UiUserMenuEmits } from "./UiUserMenu";
 // MIC-15 — Topbar container with page header, actions and user menu
 export { UiTopbar } from "./UiTopbar";
 export type { UiTopbarProps, UiTopbarEmits, UiTopbarAction } from "./UiTopbar";
+
+// MIC-13 — Authenticated layout shell with sidebar, topbar and mobile drawer
+export { UiAppShell } from "./UiAppShell";
+export type {
+  UiAppShellProps,
+  UiAppShellEmits,
+  AppShellNavItem,
+  AppShellUser,
+  AppShellAction,
+} from "./UiAppShell";
+
+// MIC-24 — Social auth buttons (Google, Apple)
+export { UiSocialAuthButtons } from "./UiSocialAuthButtons";
+export type { UiSocialAuthButtonsProps, UiSocialAuthButtonsEmits } from "./UiSocialAuthButtons";


### PR DESCRIPTION
## Summary

- Adds `UiAppShell` — the authenticated layout shell that composes sidebar, topbar and content area
- Sidebar: 256px desktop, collapses to 72px via `useSidebarState`; becomes a fixed drawer on mobile via `useResponsiveShell`
- Mobile overlay with fade `<Transition>` dismisses drawer on click
- Logo area: 32×32 brand-600 PieChart mark + "Auraxis" heading text (80px height, matches topbar)
- Composes `UiSidebarNav` (MIC-14) + `UiTopbar` (MIC-15)
- Proxies topbar events: `topbar-action`, `user-settings`, `user-logout`
- Fix: replaced numeric `font-weight` literals with `--font-weight-bold/semibold` tokens in UiPageHeader, UiTopbar, UiUserMenu (policy gate)

## Files

- `UiAppShell.vue` — markup only, no business logic
- `UiAppShell.types.ts` — `AppShellNavItem`, `AppShellUser`, `AppShellAction`, props/emits
- `UiAppShell.stories.ts` — Storybook story with realistic nav items
- `__tests__/UiAppShell.spec.ts` — 6 unit tests (sidebar/main render, slot, logo text, topbar, aria-label, snapshot)
- `__tests__/UiAppShell.e2e.ts` — Playwright E2E scenarios
- `index.ts` — barrel export

## Test plan

- [ ] Unit tests pass (`pnpm test`)
- [ ] Storybook renders shell with sidebar collapsed/expanded
- [ ] Mobile viewport shows drawer behavior
- [ ] Logo mark visible with PieChart icon
- [ ] Active nav item highlighted via UiSidebarNav
- [ ] Topbar actions proxy events correctly

## Notes

Pre-push TS errors are pre-existing from upstream unmerged PRs (echarts, visual atoms). Known pattern on chained feature branches — resolved when PRs merge in order.