### PR TITLE
feat(tools): add installment vs cash public experience

### DIFF
--- a/app/features/tools/api/installment-vs-cash.client.spec.ts
+++ b/app/features/tools/api/installment-vs-cash.client.spec.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { InstallmentVsCashClient } from "./installment-vs-cash.client";
+import type { InstallmentVsCashCalculationRequestDto } from "~/features/tools/contracts/installment-vs-cash.dto";
+
+/**
+ * Creates a minimal Axios-like HTTP mock.
+ *
+ * @returns HTTP mock with post spy.
+ */
+const createHttpMock = (): { post: ReturnType<typeof vi.fn> } => ({
+  post: vi.fn(),
+});
+
+const payload: InstallmentVsCashCalculationRequestDto = {
+  cash_price: "900.00",
+  installment_count: 3,
+  installment_total: "990.00",
+  first_payment_delay_days: 30,
+  opportunity_rate_type: "manual",
+  opportunity_rate_annual: "12.00",
+  inflation_rate_annual: "4.50",
+  fees_enabled: false,
+  fees_upfront: "0.00",
+};
+
+const calculationResponse = {
+  tool_id: "installment_vs_cash",
+  rule_version: "2026.1",
+  input: {
+    cash_price: "900.00",
+    installment_count: 3,
+    installment_amount: "330.00",
+    installment_total: "990.00",
+    first_payment_delay_days: 30,
+    opportunity_rate_type: "manual",
+    opportunity_rate_annual: "12.00",
+    inflation_rate_annual: "4.50",
+    fees_upfront: "0.00",
+    scenario_label: null,
+  },
+  result: {
+    recommended_option: "cash",
+    recommendation_reason: "À vista",
+    formula_explainer: "PV",
+    comparison: {
+      cash_option_total: "900.00",
+      installment_option_total: "990.00",
+      installment_present_value: "940.00",
+      installment_real_value_today: "930.00",
+      present_value_delta_vs_cash: "40.00",
+      absolute_delta_vs_cash: "90.00",
+      relative_delta_vs_cash_percent: "4.44",
+      break_even_discount_percent: "9.09",
+      break_even_opportunity_rate_annual: "18.20",
+    },
+    options: {
+      cash: { total: "900.00" },
+      installment: {
+        count: 3,
+        amounts: ["330.00", "330.00", "330.00"],
+        installment_amount: "330.00",
+        nominal_total: "990.00",
+        upfront_fees: "0.00",
+        first_payment_delay_days: 30,
+      },
+    },
+    neutrality_band: {
+      absolute_brl: "10.00",
+      relative_percent: "1.00",
+    },
+    assumptions: {
+      opportunity_rate_type: "manual",
+      opportunity_rate_annual_percent: "12.00",
+      inflation_rate_annual_percent: "4.50",
+      periodicity: "monthly",
+      first_payment_delay_days: 30,
+      upfront_fees_apply_to: "installment",
+      neutrality_rule: "hybrid",
+    },
+    indicator_snapshot: null,
+    schedule: [],
+  },
+} as const;
+
+const goalBridgeResponse = {
+  goal: {
+    id: "goal-1",
+    title: "Notebook",
+    description: null,
+    category: null,
+    target_amount: "900.00",
+    current_amount: "0.00",
+    priority: 3,
+    target_date: null,
+    status: "active",
+    created_at: null,
+    updated_at: null,
+  },
+  simulation: {
+    id: "sim-1",
+    user_id: "user-1",
+    tool_id: "installment_vs_cash",
+    rule_version: "2026.1",
+    inputs: calculationResponse.input,
+    result: calculationResponse.result,
+    saved: true,
+    goal_id: "goal-1",
+    created_at: "2026-03-20T00:00:00.000Z",
+  },
+} as const;
+
+describe("InstallmentVsCashClient", () => {
+  it("calls the public calculate endpoint", async () => {
+    const http = createHttpMock();
+    http.post.mockResolvedValue({ data: calculationResponse });
+
+    const client = new InstallmentVsCashClient(http as never);
+    const result = await client.calculate(payload);
+
+    expect(http.post).toHaveBeenCalledWith(
+      "/simulations/installment-vs-cash/calculate",
+      payload,
+    );
+    expect(result.toolId).toBe("installment_vs_cash");
+  });
+
+  it("calls the premium goal bridge endpoint", async () => {
+    const http = createHttpMock();
+    http.post.mockResolvedValue({ data: goalBridgeResponse });
+
+    const client = new InstallmentVsCashClient(http as never);
+    const result = await client.createGoalFromSimulation("sim-1", {
+      title: "Notebook",
+      selectedOption: "cash",
+      currentAmount: 0,
+    });
+
+    expect(http.post).toHaveBeenCalledWith("/simulations/sim-1/goal", {
+      title: "Notebook",
+      selected_option: "cash",
+      description: undefined,
+      category: undefined,
+      target_date: undefined,
+      priority: undefined,
+      current_amount: "0.00",
+    });
+    expect(result.goal.title).toBe("Notebook");
+  });
+
+  it("calls the authenticated save endpoint", async () => {
+    const http = createHttpMock();
+    http.post.mockResolvedValue({
+      data: {
+        simulation: {
+          id: "sim-1",
+          user_id: "user-1",
+          tool_id: "installment_vs_cash",
+          rule_version: "2026.1",
+          inputs: calculationResponse.input,
+          result: calculationResponse.result,
+          saved: true,
+          goal_id: null,
+          created_at: "2026-03-20T00:00:00.000Z",
+        },
+        calculation: calculationResponse,
+      },
+    });
+
+    const client = new InstallmentVsCashClient(http as never);
+    const result = await client.save(payload);
+
+    expect(http.post).toHaveBeenCalledWith(
+      "/simulations/installment-vs-cash/save",
+      payload,
+    );
+    expect(result.simulation.saved).toBe(true);
+  });
+
+  it("calls the planned-expense bridge endpoint", async () => {
+    const http = createHttpMock();
+    http.post.mockResolvedValue({
+      data: {
+        transactions: [
+          {
+            id: "txn-1",
+            title: "Notebook",
+            amount: "330.00",
+            type: "expense",
+            due_date: "2026-04-15",
+            start_date: null,
+            end_date: null,
+            description: null,
+            observation: null,
+            is_recurring: false,
+            is_installment: true,
+            installment_count: 3,
+            tag_id: null,
+            account_id: null,
+            credit_card_id: null,
+            status: "pending",
+            currency: "BRL",
+            created_at: null,
+            updated_at: null,
+          },
+        ],
+        simulation: goalBridgeResponse.simulation,
+      },
+    });
+
+    const client = new InstallmentVsCashClient(http as never);
+    const result = await client.createPlannedExpenseFromSimulation("sim-1", {
+      title: "Notebook",
+      selectedOption: "installment",
+      firstDueDate: "2026-04-15",
+    });
+
+    expect(http.post).toHaveBeenCalledWith("/simulations/sim-1/planned-expense", {
+      title: "Notebook",
+      selected_option: "installment",
+      description: undefined,
+      observation: undefined,
+      due_date: undefined,
+      first_due_date: "2026-04-15",
+      upfront_due_date: undefined,
+      tag_id: undefined,
+      account_id: undefined,
+      credit_card_id: undefined,
+      currency: "BRL",
+      status: "pending",
+    });
+    expect(result.transactions[0]?.title).toBe("Notebook");
+  });
+});

--- a/app/features/tools/api/installment-vs-cash.client.ts
+++ b/app/features/tools/api/installment-vs-cash.client.ts
@@ -1,0 +1,147 @@
+import type { AxiosInstance } from "axios";
+
+import { useHttp } from "~/composables/useHttp";
+import type {
+  CreateGoalFromInstallmentVsCashDto,
+  CreateGoalFromInstallmentVsCashResponseDto,
+  CreatePlannedExpenseFromInstallmentVsCashDto,
+  CreatePlannedExpenseFromInstallmentVsCashResponseDto,
+  InstallmentVsCashCalculationRequestDto,
+  InstallmentVsCashCalculationResponseDto,
+  InstallmentVsCashSaveRequestDto,
+  InstallmentVsCashSaveResponseDto,
+} from "~/features/tools/contracts/installment-vs-cash.dto";
+import {
+  mapInstallmentVsCashCalculationDto,
+  mapInstallmentVsCashGoalBridgeResponseDto,
+  mapInstallmentVsCashPlannedExpenseBridgeResponseDto,
+  mapInstallmentVsCashSaveResponseDto,
+} from "~/features/tools/api/installment-vs-cash.mapper";
+import type {
+  CreateInstallmentVsCashGoalPayload,
+  CreateInstallmentVsCashPlannedExpensePayload,
+  InstallmentVsCashCalculation,
+  InstallmentVsCashGoalBridgeResponse,
+  InstallmentVsCashPlannedExpenseBridgeResponse,
+  InstallmentVsCashSavedCalculation,
+} from "~/features/tools/model/installment-vs-cash";
+
+/**
+ * API client encapsulating the installment-vs-cash feature contract.
+ */
+export class InstallmentVsCashClient {
+  readonly #http: AxiosInstance;
+
+  /**
+   * @param http Axios instance already configured for the Auraxis API.
+   */
+  constructor(http: AxiosInstance) {
+    this.#http = http;
+  }
+
+  /**
+   * Calls the public calculate endpoint.
+   *
+   * @param payload Request body for the simulation.
+   * @returns Domain calculation object.
+   */
+  async calculate(
+    payload: InstallmentVsCashCalculationRequestDto,
+  ): Promise<InstallmentVsCashCalculation> {
+    const response = await this.#http.post<InstallmentVsCashCalculationResponseDto>(
+      "/simulations/installment-vs-cash/calculate",
+      payload,
+    );
+    return mapInstallmentVsCashCalculationDto(response.data);
+  }
+
+  /**
+   * Saves a calculation for the authenticated user.
+   *
+   * @param payload Request body for the save endpoint.
+   * @returns Domain bundle with simulation and calculation.
+   */
+  async save(
+    payload: InstallmentVsCashSaveRequestDto,
+  ): Promise<InstallmentVsCashSavedCalculation> {
+    const response = await this.#http.post<InstallmentVsCashSaveResponseDto>(
+      "/simulations/installment-vs-cash/save",
+      payload,
+    );
+    return mapInstallmentVsCashSaveResponseDto(response.data);
+  }
+
+  /**
+   * Creates a goal from a saved simulation.
+   *
+   * @param simulationId Saved simulation id.
+   * @param payload Goal-creation request payload.
+   * @returns Goal bridge response.
+   */
+  async createGoalFromSimulation(
+    simulationId: string,
+    payload: CreateInstallmentVsCashGoalPayload,
+  ): Promise<InstallmentVsCashGoalBridgeResponse> {
+    const body: CreateGoalFromInstallmentVsCashDto = {
+      title: payload.title,
+      selected_option: payload.selectedOption,
+      description: payload.description,
+      category: payload.category,
+      target_date: payload.targetDate,
+      priority: payload.priority,
+      current_amount: payload.currentAmount !== undefined
+        ? payload.currentAmount.toFixed(2)
+        : undefined,
+    };
+
+    const response =
+      await this.#http.post<CreateGoalFromInstallmentVsCashResponseDto>(
+        `/simulations/${simulationId}/goal`,
+        body,
+      );
+    return mapInstallmentVsCashGoalBridgeResponseDto(response.data);
+  }
+
+  /**
+   * Creates planned expenses from a saved simulation.
+   *
+   * @param simulationId Saved simulation id.
+   * @param payload Planned-expense request payload.
+   * @returns Planned-expense bridge response.
+   */
+  async createPlannedExpenseFromSimulation(
+    simulationId: string,
+    payload: CreateInstallmentVsCashPlannedExpensePayload,
+  ): Promise<InstallmentVsCashPlannedExpenseBridgeResponse> {
+    const body: CreatePlannedExpenseFromInstallmentVsCashDto = {
+      title: payload.title,
+      selected_option: payload.selectedOption,
+      description: payload.description,
+      observation: payload.observation,
+      due_date: payload.dueDate,
+      first_due_date: payload.firstDueDate,
+      upfront_due_date: payload.upfrontDueDate,
+      tag_id: payload.tagId,
+      account_id: payload.accountId,
+      credit_card_id: payload.creditCardId,
+      currency: payload.currency ?? "BRL",
+      status: payload.status ?? "pending",
+    };
+
+    const response =
+      await this.#http.post<CreatePlannedExpenseFromInstallmentVsCashResponseDto>(
+        `/simulations/${simulationId}/planned-expense`,
+        body,
+      );
+    return mapInstallmentVsCashPlannedExpenseBridgeResponseDto(response.data);
+  }
+}
+
+/**
+ * Resolves the canonical feature client using the shared HTTP layer.
+ *
+ * @returns InstallmentVsCashClient bound to the shared HTTP adapter.
+ */
+export const useInstallmentVsCashClient = (): InstallmentVsCashClient => {
+  return new InstallmentVsCashClient(useHttp());
+};

--- a/app/features/tools/api/installment-vs-cash.mapper.spec.ts
+++ b/app/features/tools/api/installment-vs-cash.mapper.spec.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  mapInstallmentVsCashCalculationDto,
+  mapInstallmentVsCashGoalBridgeResponseDto,
+  mapInstallmentVsCashPlannedExpenseBridgeResponseDto,
+  mapInstallmentVsCashSaveResponseDto,
+} from "./installment-vs-cash.mapper";
+import type {
+  CreateGoalFromInstallmentVsCashResponseDto,
+  CreatePlannedExpenseFromInstallmentVsCashResponseDto,
+  InstallmentVsCashCalculationResponseDto,
+  InstallmentVsCashSaveResponseDto,
+} from "~/features/tools/contracts/installment-vs-cash.dto";
+
+const calculationDto: InstallmentVsCashCalculationResponseDto = {
+  tool_id: "installment_vs_cash",
+  rule_version: "2026.1",
+  input: {
+    cash_price: "900.00",
+    installment_count: 3,
+    installment_amount: "330.00",
+    installment_total: "990.00",
+    first_payment_delay_days: 30,
+    opportunity_rate_type: "manual",
+    opportunity_rate_annual: "12.00",
+    inflation_rate_annual: "4.50",
+    fees_upfront: "0.00",
+    scenario_label: "Notebook",
+  },
+  result: {
+    recommended_option: "cash",
+    recommendation_reason: "À vista ficou melhor.",
+    formula_explainer: "Comparação por valor presente.",
+    comparison: {
+      cash_option_total: "900.00",
+      installment_option_total: "990.00",
+      installment_present_value: "940.00",
+      installment_real_value_today: "930.00",
+      present_value_delta_vs_cash: "40.00",
+      absolute_delta_vs_cash: "90.00",
+      relative_delta_vs_cash_percent: "4.44",
+      break_even_discount_percent: "9.09",
+      break_even_opportunity_rate_annual: "18.20",
+    },
+    options: {
+      cash: { total: "900.00" },
+      installment: {
+        count: 3,
+        amounts: ["330.00", "330.00", "330.00"],
+        installment_amount: "330.00",
+        nominal_total: "990.00",
+        upfront_fees: "0.00",
+        first_payment_delay_days: 30,
+      },
+    },
+    neutrality_band: {
+      absolute_brl: "10.00",
+      relative_percent: "1.00",
+    },
+    assumptions: {
+      opportunity_rate_type: "manual",
+      opportunity_rate_annual_percent: "12.00",
+      inflation_rate_annual_percent: "4.50",
+      periodicity: "monthly",
+      first_payment_delay_days: 30,
+      upfront_fees_apply_to: "installment",
+      neutrality_rule: "hybrid",
+    },
+    indicator_snapshot: null,
+    schedule: [
+      {
+        installment_number: 1,
+        due_in_days: 30,
+        amount: "330.00",
+        present_value: "326.00",
+        real_value_today: "328.00",
+        cumulative_nominal: "330.00",
+        cumulative_present_value: "326.00",
+        cumulative_real_value_today: "328.00",
+        cash_cumulative: "900.00",
+      },
+    ],
+  },
+};
+
+describe("installment-vs-cash mapper", () => {
+  it("maps the calculate response into a numeric domain object", () => {
+    const result = mapInstallmentVsCashCalculationDto(calculationDto);
+
+    expect(result.toolId).toBe("installment_vs_cash");
+    expect(result.input.cashPrice).toBe(900);
+    expect(result.result.comparison.installmentPresentValue).toBe(940);
+    expect(result.result.schedule[0]?.presentValue).toBe(326);
+  });
+
+  it("maps the save response bundle", () => {
+    const dto: InstallmentVsCashSaveResponseDto = {
+      simulation: {
+        id: "sim-1",
+        user_id: "user-1",
+        tool_id: "installment_vs_cash",
+        rule_version: "2026.1",
+        inputs: calculationDto.input,
+        result: calculationDto.result,
+        saved: true,
+        goal_id: null,
+        created_at: "2026-03-20T00:00:00.000Z",
+      },
+      calculation: calculationDto,
+    };
+
+    const result = mapInstallmentVsCashSaveResponseDto(dto);
+
+    expect(result.simulation.saved).toBe(true);
+    expect(result.calculation.result.recommendedOption).toBe("cash");
+  });
+
+  it("maps the goal bridge response", () => {
+    const dto: CreateGoalFromInstallmentVsCashResponseDto = {
+      goal: {
+        id: "goal-1",
+        title: "Notebook novo",
+        description: null,
+        category: null,
+        target_amount: "900.00",
+        current_amount: "0.00",
+        priority: 3,
+        target_date: null,
+        status: "active",
+        created_at: null,
+        updated_at: null,
+      },
+      simulation: {
+        id: "sim-1",
+        user_id: "user-1",
+        tool_id: "installment_vs_cash",
+        rule_version: "2026.1",
+        inputs: calculationDto.input,
+        result: calculationDto.result,
+        saved: true,
+        goal_id: "goal-1",
+        created_at: "2026-03-20T00:00:00.000Z",
+      },
+    };
+
+    const result = mapInstallmentVsCashGoalBridgeResponseDto(dto);
+
+    expect(result.goal.targetAmount).toBe(900);
+    expect(result.simulation.goalId).toBe("goal-1");
+  });
+
+  it("maps the planned-expense bridge response", () => {
+    const dto: CreatePlannedExpenseFromInstallmentVsCashResponseDto = {
+      transactions: [
+        {
+          id: "txn-1",
+          title: "Notebook",
+          amount: "330.00",
+          type: "expense",
+          due_date: "2026-04-15",
+          start_date: null,
+          end_date: null,
+          description: null,
+          observation: null,
+          is_recurring: false,
+          is_installment: true,
+          installment_count: 3,
+          tag_id: null,
+          account_id: null,
+          credit_card_id: null,
+          status: "pending",
+          currency: "BRL",
+          created_at: null,
+          updated_at: null,
+        },
+      ],
+      simulation: {
+        id: "sim-1",
+        user_id: "user-1",
+        tool_id: "installment_vs_cash",
+        rule_version: "2026.1",
+        inputs: calculationDto.input,
+        result: calculationDto.result,
+        saved: true,
+        goal_id: null,
+        created_at: "2026-03-20T00:00:00.000Z",
+      },
+    };
+
+    const result = mapInstallmentVsCashPlannedExpenseBridgeResponseDto(dto);
+
+    expect(result.transactions[0]?.amount).toBe(330);
+    expect(result.transactions[0]?.isInstallment).toBe(true);
+  });
+});

--- a/app/features/tools/api/installment-vs-cash.mapper.ts
+++ b/app/features/tools/api/installment-vs-cash.mapper.ts
@@ -1,0 +1,279 @@
+import type {
+  InstallmentVsCashAssumptionsDto,
+  CreateGoalFromInstallmentVsCashResponseDto,
+  InstallmentVsCashComparisonDto,
+  InstallmentVsCashNormalizedInputDto,
+  InstallmentVsCashResultDto,
+  InstallmentVsCashScheduleItemDto,
+  CreatePlannedExpenseFromInstallmentVsCashResponseDto,
+  InstallmentVsCashCalculationResponseDto,
+  InstallmentVsCashIndicatorSnapshotDto,
+  InstallmentVsCashSaveResponseDto,
+  InstallmentVsCashSavedSimulationDto,
+} from "~/features/tools/contracts/installment-vs-cash.dto";
+import {
+  parseDecimalString,
+  type InstallmentVsCashCalculation,
+  type InstallmentVsCashComparison,
+  type InstallmentVsCashGoalBridgeResponse,
+  type InstallmentVsCashIndicatorSnapshot,
+  type InstallmentVsCashNormalizedInput,
+  type InstallmentVsCashPlannedExpenseBridgeResponse,
+  type InstallmentVsCashResult,
+  type InstallmentVsCashScheduleItem,
+  type InstallmentVsCashSavedCalculation,
+  type InstallmentVsCashSavedSimulation,
+} from "~/features/tools/model/installment-vs-cash";
+
+/**
+ * Maps an optional indicator snapshot DTO.
+ *
+ * @param dto Raw indicator snapshot.
+ * @returns Domain snapshot or null.
+ */
+const mapIndicatorSnapshot = (
+  dto: InstallmentVsCashIndicatorSnapshotDto | null,
+): InstallmentVsCashIndicatorSnapshot | null => {
+  if (!dto) {
+    return null;
+  }
+
+  return {
+    presetType: dto.preset_type,
+    source: dto.source,
+    annualRatePercent: parseDecimalString(dto.annual_rate_percent),
+    asOf: dto.as_of,
+  };
+};
+
+/**
+ * Maps the normalized input block.
+ *
+ * @param dto Raw normalized input DTO.
+ * @returns Domain normalized input.
+ */
+const mapNormalizedInput = (
+  dto: InstallmentVsCashNormalizedInputDto,
+): InstallmentVsCashNormalizedInput => ({
+  cashPrice: parseDecimalString(dto.cash_price),
+  installmentCount: dto.installment_count,
+  installmentAmount: parseDecimalString(dto.installment_amount),
+  installmentTotal: parseDecimalString(dto.installment_total),
+  firstPaymentDelayDays: dto.first_payment_delay_days,
+  opportunityRateType: dto.opportunity_rate_type,
+  opportunityRateAnnual: parseDecimalString(dto.opportunity_rate_annual),
+  inflationRateAnnual: parseDecimalString(dto.inflation_rate_annual),
+  feesUpfront: parseDecimalString(dto.fees_upfront),
+  scenarioLabel: dto.scenario_label ?? null,
+});
+
+/**
+ * Maps the comparison block.
+ *
+ * @param dto Raw comparison DTO.
+ * @returns Domain comparison object.
+ */
+const mapComparison = (
+  dto: InstallmentVsCashComparisonDto,
+): InstallmentVsCashComparison => ({
+  cashOptionTotal: parseDecimalString(dto.cash_option_total),
+  installmentOptionTotal: parseDecimalString(dto.installment_option_total),
+  installmentPresentValue: parseDecimalString(dto.installment_present_value),
+  installmentRealValueToday: parseDecimalString(dto.installment_real_value_today),
+  presentValueDeltaVsCash: parseDecimalString(dto.present_value_delta_vs_cash),
+  absoluteDeltaVsCash: parseDecimalString(dto.absolute_delta_vs_cash),
+  relativeDeltaVsCashPercent: parseDecimalString(dto.relative_delta_vs_cash_percent),
+  breakEvenDiscountPercent: parseDecimalString(dto.break_even_discount_percent),
+  breakEvenOpportunityRateAnnual: parseDecimalString(
+    dto.break_even_opportunity_rate_annual,
+  ),
+});
+
+/**
+ * Maps the assumptions block.
+ *
+ * @param dto Raw assumptions DTO.
+ * @returns Domain assumptions object.
+ */
+const mapAssumptions = (
+  dto: InstallmentVsCashAssumptionsDto,
+): InstallmentVsCashResult["assumptions"] => ({
+  opportunityRateType: dto.opportunity_rate_type,
+  opportunityRateAnnualPercent: parseDecimalString(
+    dto.opportunity_rate_annual_percent,
+  ),
+  inflationRateAnnualPercent: parseDecimalString(dto.inflation_rate_annual_percent),
+  periodicity: dto.periodicity,
+  firstPaymentDelayDays: dto.first_payment_delay_days,
+  upfrontFeesApplyTo: dto.upfront_fees_apply_to,
+  neutralityRule: dto.neutrality_rule,
+});
+
+/**
+ * Maps a single schedule item.
+ *
+ * @param dto Raw schedule DTO.
+ * @returns Domain schedule row.
+ */
+const mapScheduleItem = (
+  dto: InstallmentVsCashScheduleItemDto,
+): InstallmentVsCashScheduleItem => ({
+  installmentNumber: dto.installment_number,
+  dueInDays: dto.due_in_days,
+  amount: parseDecimalString(dto.amount),
+  presentValue: parseDecimalString(dto.present_value),
+  realValueToday: parseDecimalString(dto.real_value_today),
+  cumulativeNominal: parseDecimalString(dto.cumulative_nominal),
+  cumulativePresentValue: parseDecimalString(dto.cumulative_present_value),
+  cumulativeRealValueToday: parseDecimalString(dto.cumulative_real_value_today),
+  cashCumulative: parseDecimalString(dto.cash_cumulative),
+});
+
+/**
+ * Maps the result block.
+ *
+ * @param dto Raw result DTO.
+ * @returns Domain result object.
+ */
+const mapResult = (dto: InstallmentVsCashResultDto): InstallmentVsCashResult => ({
+  recommendedOption: dto.recommended_option,
+  recommendationReason: dto.recommendation_reason,
+  formulaExplainer: dto.formula_explainer,
+  comparison: mapComparison(dto.comparison),
+  options: {
+    cash: {
+      total: parseDecimalString(dto.options.cash.total),
+    },
+    installment: {
+      count: dto.options.installment.count,
+      amounts: dto.options.installment.amounts.map(parseDecimalString),
+      installmentAmount: parseDecimalString(dto.options.installment.installment_amount),
+      nominalTotal: parseDecimalString(dto.options.installment.nominal_total),
+      upfrontFees: parseDecimalString(dto.options.installment.upfront_fees),
+      firstPaymentDelayDays: dto.options.installment.first_payment_delay_days,
+    },
+  },
+  neutralityBand: {
+    absoluteBrl: parseDecimalString(dto.neutrality_band.absolute_brl),
+    relativePercent: parseDecimalString(dto.neutrality_band.relative_percent),
+  },
+  assumptions: mapAssumptions(dto.assumptions),
+  indicatorSnapshot: mapIndicatorSnapshot(dto.indicator_snapshot),
+  schedule: dto.schedule.map(mapScheduleItem),
+});
+
+/**
+ * Maps a specialized saved simulation DTO.
+ *
+ * @param dto Raw simulation DTO.
+ * @returns Domain simulation object.
+ */
+const mapSavedSimulation = (
+  dto: InstallmentVsCashSavedSimulationDto,
+): InstallmentVsCashSavedSimulation => {
+  return {
+    id: dto.id,
+    userId: dto.user_id,
+    toolId: dto.tool_id,
+    ruleVersion: dto.rule_version,
+    inputs: mapNormalizedInput(dto.inputs),
+    result: mapResult(dto.result),
+    saved: dto.saved,
+    goalId: dto.goal_id,
+    createdAt: dto.created_at,
+  };
+};
+
+/**
+ * Maps the calculate endpoint response into the domain model used by the page.
+ *
+ * @param dto Raw API response.
+ * @returns Strongly typed calculation domain object.
+ */
+export const mapInstallmentVsCashCalculationDto = (
+  dto: InstallmentVsCashCalculationResponseDto,
+): InstallmentVsCashCalculation => {
+  return {
+    toolId: dto.tool_id,
+    ruleVersion: dto.rule_version,
+    input: mapNormalizedInput(dto.input),
+    result: mapResult(dto.result),
+  };
+};
+
+/**
+ * Maps the save endpoint response.
+ *
+ * @param dto Raw API response.
+ * @returns Strongly typed saved-calculation bundle.
+ */
+export const mapInstallmentVsCashSaveResponseDto = (
+  dto: InstallmentVsCashSaveResponseDto,
+): InstallmentVsCashSavedCalculation => {
+  return {
+    simulation: mapSavedSimulation(dto.simulation),
+    calculation: mapInstallmentVsCashCalculationDto(dto.calculation),
+  };
+};
+
+/**
+ * Maps the goal bridge response.
+ *
+ * @param dto Raw API response.
+ * @returns Domain response for the goal bridge.
+ */
+export const mapInstallmentVsCashGoalBridgeResponseDto = (
+  dto: CreateGoalFromInstallmentVsCashResponseDto,
+): InstallmentVsCashGoalBridgeResponse => {
+  return {
+    goal: {
+      id: dto.goal.id,
+      title: dto.goal.title,
+      description: dto.goal.description,
+      category: dto.goal.category,
+      targetAmount: parseDecimalString(dto.goal.target_amount),
+      currentAmount: parseDecimalString(dto.goal.current_amount),
+      priority: dto.goal.priority,
+      targetDate: dto.goal.target_date,
+      status: dto.goal.status,
+      createdAt: dto.goal.created_at,
+      updatedAt: dto.goal.updated_at,
+    },
+    simulation: mapSavedSimulation(dto.simulation),
+  };
+};
+
+/**
+ * Maps the planned-expense bridge response.
+ *
+ * @param dto Raw API response.
+ * @returns Domain response for the planned-expense bridge.
+ */
+export const mapInstallmentVsCashPlannedExpenseBridgeResponseDto = (
+  dto: CreatePlannedExpenseFromInstallmentVsCashResponseDto,
+): InstallmentVsCashPlannedExpenseBridgeResponse => {
+  return {
+    transactions: dto.transactions.map((item) => ({
+      id: item.id,
+      title: item.title,
+      amount: parseDecimalString(item.amount),
+      type: item.type,
+      dueDate: item.due_date,
+      startDate: item.start_date,
+      endDate: item.end_date,
+      description: item.description,
+      observation: item.observation,
+      isRecurring: item.is_recurring,
+      isInstallment: item.is_installment,
+      installmentCount: item.installment_count,
+      tagId: item.tag_id,
+      accountId: item.account_id,
+      creditCardId: item.credit_card_id,
+      status: item.status,
+      currency: item.currency,
+      createdAt: item.created_at,
+      updatedAt: item.updated_at,
+    })),
+    simulation: mapSavedSimulation(dto.simulation),
+  };
+};

--- a/app/features/tools/components/InstallmentVsCashActionBar.spec.ts
+++ b/app/features/tools/components/InstallmentVsCashActionBar.spec.ts
@@ -1,0 +1,50 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import InstallmentVsCashActionBar from "./InstallmentVsCashActionBar.vue";
+
+const stubs = {
+  NButton: {
+    props: ["type", "size", "loading", "disabled", "ghost"],
+    template: "<button class='n-button' @click='$emit(\"click\")'><slot /></button>",
+    emits: ["click"],
+  },
+  NTag: {
+    props: ["size", "round", "type"],
+    template: "<span class='n-tag'><slot /></span>",
+  },
+};
+
+describe("InstallmentVsCashActionBar", () => {
+  it("renders the save CTA and premium helper copy", () => {
+    const wrapper = mount(InstallmentVsCashActionBar, {
+      props: {
+        isAuthenticated: false,
+        hasPremiumAccess: false,
+        isSaving: false,
+        isBridging: false,
+        hasSavedSimulation: false,
+      },
+      global: { stubs },
+    });
+
+    expect(wrapper.text()).toContain("Salvar simulação");
+    expect(wrapper.text()).toContain("Faça login para desbloquear meta");
+  });
+
+  it("shows the saved badge once a simulation exists", () => {
+    const wrapper = mount(InstallmentVsCashActionBar, {
+      props: {
+        isAuthenticated: true,
+        hasPremiumAccess: true,
+        isSaving: false,
+        isBridging: false,
+        hasSavedSimulation: true,
+      },
+      global: { stubs },
+    });
+
+    expect(wrapper.text()).toContain("Simulação salva");
+    expect(wrapper.text()).toContain("Pronta para reaproveitar");
+  });
+});

--- a/app/features/tools/components/InstallmentVsCashActionBar.vue
+++ b/app/features/tools/components/InstallmentVsCashActionBar.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { NButton, NTag } from "naive-ui";
+
+interface Props {
+  isAuthenticated: boolean;
+  hasPremiumAccess: boolean;
+  isSaving: boolean;
+  isBridging: boolean;
+  hasSavedSimulation: boolean;
+}
+
+interface Emits {
+  (event: "save" | "goal" | "expense"): void;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<Emits>();
+
+/**
+ * Returns the helper label shown next to the premium CTA cluster.
+ *
+ * @returns PT-BR helper copy.
+ */
+const premiumLabel = computed<string>(() => {
+  if (!props.isAuthenticated) {
+    return "Faça login para desbloquear meta e despesa planejada.";
+  }
+  if (!props.hasPremiumAccess) {
+    return "Recurso premium: inclua a simulação em metas ou despesas planejadas.";
+  }
+  return "Sua conta premium pode transformar esta simulação em meta ou despesa.";
+});
+
+/**
+ * Whether save or bridge actions should be disabled by network activity.
+ *
+ * @returns True when an action is currently in flight.
+ */
+const isBusy = computed<boolean>(() => {
+  return props.isSaving || props.isBridging;
+});
+</script>
+
+<template>
+  <div class="installment-vs-cash-action-bar">
+    <div class="installment-vs-cash-action-bar__primary">
+      <NButton
+        type="primary"
+        size="large"
+        :loading="props.isSaving"
+        :disabled="isBusy"
+        @click="emit('save')"
+      >
+        {{ props.hasSavedSimulation ? "Simulação salva" : "Salvar simulação" }}
+      </NButton>
+
+      <NTag
+        v-if="props.hasSavedSimulation"
+        size="small"
+        round
+        type="success"
+      >
+        Pronta para reaproveitar
+      </NTag>
+    </div>
+
+    <div class="installment-vs-cash-action-bar__secondary">
+      <NButton
+        type="default"
+        size="medium"
+        ghost
+        :loading="props.isBridging"
+        :disabled="isBusy"
+        @click="emit('goal')"
+      >
+        Incluir em meta
+      </NButton>
+
+      <NButton
+        type="default"
+        size="medium"
+        ghost
+        :loading="props.isBridging"
+        :disabled="isBusy"
+        @click="emit('expense')"
+      >
+        Planejar despesa
+      </NButton>
+    </div>
+
+    <span class="installment-vs-cash-action-bar__hint">
+      {{ premiumLabel }}
+    </span>
+  </div>
+</template>
+
+<style scoped>
+.installment-vs-cash-action-bar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.installment-vs-cash-action-bar__primary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.installment-vs-cash-action-bar__secondary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.installment-vs-cash-action-bar__hint {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}
+</style>

--- a/app/features/tools/components/InstallmentVsCashCalculatorForm.spec.ts
+++ b/app/features/tools/components/InstallmentVsCashCalculatorForm.spec.ts
@@ -1,0 +1,76 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import InstallmentVsCashCalculatorForm from "./InstallmentVsCashCalculatorForm.vue";
+import { createDefaultInstallmentVsCashFormState } from "~/features/tools/model/installment-vs-cash";
+
+const stubs = {
+  NButton: {
+    props: ["type", "size", "loading", "disabled", "attrType"],
+    template: "<button class='n-button' @click='$emit(\"click\")'><slot /></button>",
+    emits: ["click"],
+  },
+  NForm: {
+    template: "<form class='n-form' @submit.prevent='$emit(\"submit\")'><slot /></form>",
+    emits: ["submit"],
+  },
+  NFormItem: {
+    props: ["label"],
+    template: "<div class='n-form-item'><slot /></div>",
+  },
+  NInput: {
+    props: ["value", "placeholder", "clearable", "type"],
+    template: "<input class='n-input' @input='$emit(\"update:value\", $event.target.value)' />",
+    emits: ["update:value"],
+  },
+  NInputNumber: {
+    props: ["value", "min", "max", "precision", "showButton", "placeholder"],
+    template: "<input class='n-input-number' @input='$emit(\"update:value\", Number($event.target.value))' />",
+    emits: ["update:value"],
+  },
+  NSelect: {
+    props: ["value", "options"],
+    template: "<select class='n-select' @change='$emit(\"update:value\", $event.target.value)' />",
+    emits: ["update:value"],
+  },
+  NSwitch: {
+    props: ["value"],
+    template: "<button class='n-switch' @click='$emit(\"update:value\", !value)' />",
+    emits: ["update:value"],
+  },
+  UiSegmentedControl: {
+    props: ["modelValue", "options"],
+    template: "<button class='segmented' @click='$emit(\"update:modelValue\", options[1].value)' />",
+    emits: ["update:modelValue"],
+  },
+};
+
+describe("InstallmentVsCashCalculatorForm", () => {
+  it("emits a full form update when switching the installment mode", async () => {
+    const wrapper = mount(InstallmentVsCashCalculatorForm, {
+      props: {
+        modelValue: createDefaultInstallmentVsCashFormState(),
+        loading: false,
+      },
+      global: { stubs },
+    });
+
+    await wrapper.find(".segmented").trigger("click");
+
+    expect(wrapper.emitted("update:modelValue")).toBeTruthy();
+  });
+
+  it("emits submit when the form button is clicked", async () => {
+    const wrapper = mount(InstallmentVsCashCalculatorForm, {
+      props: {
+        modelValue: createDefaultInstallmentVsCashFormState(),
+        loading: false,
+      },
+      global: { stubs },
+    });
+
+    await wrapper.find(".n-button").trigger("click");
+
+    expect(wrapper.text()).toContain("Calcular agora");
+  });
+});

--- a/app/features/tools/components/InstallmentVsCashCalculatorForm.vue
+++ b/app/features/tools/components/InstallmentVsCashCalculatorForm.vue
@@ -1,0 +1,291 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import {
+  NButton,
+  NForm,
+  NFormItem,
+  NInput,
+  NInputNumber,
+  NSelect,
+  NSwitch,
+} from "naive-ui";
+
+import type {
+  InstallmentDelayPreset,
+  InstallmentVsCashFormState,
+  InstallmentInputMode,
+  OpportunityRateType,
+} from "~/features/tools/model/installment-vs-cash";
+
+interface Props {
+  modelValue: InstallmentVsCashFormState;
+  loading: boolean;
+}
+
+interface Emits {
+  (event: "update:modelValue", value: InstallmentVsCashFormState): void;
+  (event: "submit"): void;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<Emits>();
+
+const opportunityRateOptions = [
+  { label: "Manual", value: "manual" satisfies OpportunityRateType },
+  {
+    label: "Preset do produto",
+    value: "product_default" satisfies OpportunityRateType,
+  },
+  {
+    label: "Usar só inflação",
+    value: "inflation_only" satisfies OpportunityRateType,
+  },
+];
+
+const delayOptions = [
+  { label: "Hoje", value: "today" satisfies InstallmentDelayPreset },
+  { label: "30 dias", value: "30_days" satisfies InstallmentDelayPreset },
+  { label: "45 dias", value: "45_days" satisfies InstallmentDelayPreset },
+  { label: "Personalizar", value: "custom" satisfies InstallmentDelayPreset },
+];
+
+const installmentInputOptions = [
+  { label: "Informar valor total parcelado", value: "total" satisfies InstallmentInputMode },
+  { label: "Informar valor de cada parcela", value: "amount" satisfies InstallmentInputMode },
+] as const;
+
+/**
+ * Emits a shallow form patch while preserving the remaining state.
+ *
+ * @param patch Partial state update.
+ */
+const patchForm = (patch: Partial<InstallmentVsCashFormState>): void => {
+  emit("update:modelValue", {
+    ...props.modelValue,
+    ...patch,
+  });
+};
+
+/**
+ * Whether the manual opportunity-rate field should be visible.
+ *
+ * @returns True when the manual option is selected.
+ */
+const shouldShowManualOpportunityRate = computed<boolean>(() => {
+  return props.modelValue.opportunityRateType === "manual";
+});
+
+/**
+ * Whether the custom delay field should be visible.
+ *
+ * @returns True when the custom delay preset is selected.
+ */
+const shouldShowCustomDelay = computed<boolean>(() => {
+  return props.modelValue.firstPaymentDelayPreset === "custom";
+});
+
+/**
+ * Whether the upfront-fees field should be visible.
+ *
+ * @returns True when extra fees are enabled.
+ */
+const shouldShowFeesInput = computed<boolean>(() => {
+  return props.modelValue.feesEnabled;
+});
+</script>
+
+<template>
+  <NForm
+    class="installment-vs-cash-form"
+    label-placement="top"
+    @submit.prevent="emit('submit')"
+  >
+    <NFormItem label="Compra ou cenário">
+      <NInput
+        :value="props.modelValue.scenarioLabel"
+        placeholder="Ex.: notebook, geladeira, viagem"
+        clearable
+        @update:value="(value: string) => patchForm({ scenarioLabel: value })"
+      />
+    </NFormItem>
+
+    <div class="installment-vs-cash-form__grid">
+      <NFormItem label="Preço à vista">
+        <NInputNumber
+          :value="props.modelValue.cashPrice"
+          :min="0"
+          :precision="2"
+          :show-button="false"
+          placeholder="900,00"
+          @update:value="(value: number | null) => patchForm({ cashPrice: value })"
+        />
+      </NFormItem>
+
+      <NFormItem label="Quantidade de parcelas">
+        <NInputNumber
+          :value="props.modelValue.installmentCount"
+          :min="1"
+          :max="60"
+          :show-button="false"
+          placeholder="6"
+          @update:value="(value: number | null) => patchForm({ installmentCount: value })"
+        />
+      </NFormItem>
+    </div>
+
+    <NFormItem label="Como você quer informar o parcelado">
+      <UiSegmentedControl
+        :model-value="props.modelValue.installmentInputMode"
+        :options="[...installmentInputOptions]"
+        aria-label="Modo do parcelamento"
+        @update:model-value="(value: InstallmentInputMode) => patchForm({ installmentInputMode: value })"
+      />
+    </NFormItem>
+
+    <NFormItem
+      v-if="props.modelValue.installmentInputMode === 'total'"
+      label="Valor total parcelado"
+    >
+      <NInputNumber
+        :value="props.modelValue.installmentTotal"
+        :min="0"
+        :precision="2"
+        :show-button="false"
+        placeholder="990,00"
+        @update:value="(value: number | null) => patchForm({ installmentTotal: value })"
+      />
+    </NFormItem>
+
+    <NFormItem
+      v-else
+      label="Valor de cada parcela"
+    >
+      <NInputNumber
+        :value="props.modelValue.installmentAmount"
+        :min="0"
+        :precision="2"
+        :show-button="false"
+        placeholder="165,00"
+        @update:value="(value: number | null) => patchForm({ installmentAmount: value })"
+      />
+    </NFormItem>
+
+    <div class="installment-vs-cash-form__grid">
+      <NFormItem label="Primeira parcela">
+        <NSelect
+          :value="props.modelValue.firstPaymentDelayPreset"
+          :options="delayOptions"
+          @update:value="(value: InstallmentDelayPreset) => patchForm({ firstPaymentDelayPreset: value })"
+        />
+      </NFormItem>
+
+      <NFormItem v-if="shouldShowCustomDelay" label="Dias até a primeira parcela">
+        <NInputNumber
+          :value="props.modelValue.customFirstPaymentDelayDays"
+          :min="0"
+          :max="3650"
+          :show-button="false"
+          placeholder="75"
+          @update:value="(value: number | null) => patchForm({ customFirstPaymentDelayDays: value })"
+        />
+      </NFormItem>
+    </div>
+
+    <div class="installment-vs-cash-form__grid">
+      <NFormItem label="Taxa de oportunidade">
+        <NSelect
+          :value="props.modelValue.opportunityRateType"
+          :options="opportunityRateOptions"
+          @update:value="(value: OpportunityRateType) => patchForm({ opportunityRateType: value })"
+        />
+      </NFormItem>
+
+      <NFormItem label="Inflação anual (%)">
+        <NInputNumber
+          :value="props.modelValue.inflationRateAnnual"
+          :min="0"
+          :precision="2"
+          :show-button="false"
+          placeholder="4,50"
+          @update:value="(value: number | null) => patchForm({ inflationRateAnnual: value })"
+        />
+      </NFormItem>
+    </div>
+
+    <NFormItem v-if="shouldShowManualOpportunityRate" label="Taxa de oportunidade anual (%)">
+      <NInputNumber
+        :value="props.modelValue.opportunityRateAnnual"
+        :min="0"
+        :precision="2"
+        :show-button="false"
+        placeholder="12,00"
+        @update:value="(value: number | null) => patchForm({ opportunityRateAnnual: value })"
+      />
+    </NFormItem>
+
+    <NFormItem label="Custos extras iniciais">
+      <div class="installment-vs-cash-form__fees">
+        <NSwitch
+          :value="props.modelValue.feesEnabled"
+          @update:value="(value: boolean) => patchForm({ feesEnabled: value, feesUpfront: value ? props.modelValue.feesUpfront : null })"
+        />
+
+        <NInputNumber
+          v-if="shouldShowFeesInput"
+          :value="props.modelValue.feesUpfront"
+          :min="0"
+          :precision="2"
+          :show-button="false"
+          placeholder="60,00"
+          @update:value="(value: number | null) => patchForm({ feesUpfront: value })"
+        />
+      </div>
+    </NFormItem>
+
+    <NButton
+      type="primary"
+      size="large"
+      attr-type="submit"
+      :loading="props.loading"
+      :disabled="props.loading"
+      class="installment-vs-cash-form__submit"
+    >
+      Calcular agora
+    </NButton>
+  </NForm>
+</template>
+
+<style scoped>
+.installment-vs-cash-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.installment-vs-cash-form__grid {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.installment-vs-cash-form__fees {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.installment-vs-cash-form__submit {
+  margin-top: var(--space-2);
+}
+
+@media (max-width: 767px) {
+  .installment-vs-cash-form__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .installment-vs-cash-form__fees {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+</style>

--- a/app/features/tools/components/InstallmentVsCashResults.spec.ts
+++ b/app/features/tools/components/InstallmentVsCashResults.spec.ts
@@ -1,0 +1,123 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import InstallmentVsCashResults from "./InstallmentVsCashResults.vue";
+import type { InstallmentVsCashCalculation } from "~/features/tools/model/installment-vs-cash";
+
+const calculation: InstallmentVsCashCalculation = {
+  toolId: "installment_vs_cash",
+  ruleVersion: "2026.1",
+  input: {
+    cashPrice: 900,
+    installmentCount: 3,
+    installmentAmount: 330,
+    installmentTotal: 990,
+    firstPaymentDelayDays: 30,
+    opportunityRateType: "manual",
+    opportunityRateAnnual: 12,
+    inflationRateAnnual: 4.5,
+    feesUpfront: 0,
+    scenarioLabel: "Notebook",
+  },
+  result: {
+    recommendedOption: "cash",
+    recommendationReason: "À vista ficou melhor.",
+    formulaExplainer: "Comparação por valor presente.",
+    comparison: {
+      cashOptionTotal: 900,
+      installmentOptionTotal: 990,
+      installmentPresentValue: 940,
+      installmentRealValueToday: 930,
+      presentValueDeltaVsCash: 40,
+      absoluteDeltaVsCash: 90,
+      relativeDeltaVsCashPercent: 4.44,
+      breakEvenDiscountPercent: 9.09,
+      breakEvenOpportunityRateAnnual: 18.2,
+    },
+    options: {
+      cash: { total: 900 },
+      installment: {
+        count: 3,
+        amounts: [330, 330, 330],
+        installmentAmount: 330,
+        nominalTotal: 990,
+        upfrontFees: 0,
+        firstPaymentDelayDays: 30,
+      },
+    },
+    neutralityBand: {
+      absoluteBrl: 10,
+      relativePercent: 1,
+    },
+    assumptions: {
+      opportunityRateType: "manual",
+      opportunityRateAnnualPercent: 12,
+      inflationRateAnnualPercent: 4.5,
+      periodicity: "monthly",
+      firstPaymentDelayDays: 30,
+      upfrontFeesApplyTo: "installment",
+      neutralityRule: "hybrid",
+    },
+    indicatorSnapshot: null,
+    schedule: [
+      {
+        installmentNumber: 1,
+        dueInDays: 30,
+        amount: 330,
+        presentValue: 326,
+        realValueToday: 328,
+        cumulativeNominal: 330,
+        cumulativePresentValue: 326,
+        cumulativeRealValueToday: 328,
+        cashCumulative: 900,
+      },
+    ],
+  },
+};
+
+const stubs = {
+  UiGlassPanel: { template: "<div><slot /></div>" },
+  UiSurfaceCard: { template: "<div><slot /></div>" },
+  UiPageHeader: {
+    props: ["title", "subtitle"],
+    template: "<div><span>{{ title }}</span><span>{{ subtitle }}</span></div>",
+  },
+  UiMetricCard: {
+    props: ["label", "value", "trend"],
+    template: "<div class='metric'>{{ label }} {{ value }}</div>",
+  },
+  UiChart: {
+    props: ["option", "height", "updateKey"],
+    template: "<div class='chart' />",
+  },
+  NTag: {
+    props: ["type", "size", "round"],
+    template: "<span class='n-tag'><slot /></span>",
+  },
+  NThing: {
+    props: ["title", "description"],
+    template: "<div><strong>{{ title }}</strong><span>{{ description }}</span><slot /></div>",
+  },
+  NCollapse: { template: "<div><slot /></div>" },
+  NCollapseItem: {
+    props: ["title", "name"],
+    template: "<section><h3>{{ title }}</h3><slot /></section>",
+  },
+  NDataTable: {
+    props: ["columns", "data"],
+    template: "<div class='table'>{{ data.length }}</div>",
+  },
+};
+
+describe("InstallmentVsCashResults", () => {
+  it("renders the recommendation summary and detailed sections", () => {
+    const wrapper = mount(InstallmentVsCashResults, {
+      props: { calculation },
+      global: { stubs },
+    });
+
+    expect(wrapper.text()).toContain("À vista é a melhor escolha");
+    expect(wrapper.text()).toContain("Comparação mês a mês");
+    expect(wrapper.text()).toContain("Cronograma mês a mês");
+  });
+});

--- a/app/features/tools/components/InstallmentVsCashResults.vue
+++ b/app/features/tools/components/InstallmentVsCashResults.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import {
+  NCollapse,
+  NCollapseItem,
+  NDataTable,
+  NTag,
+  NThing,
+} from "naive-ui";
+
+import {
+  buildInstallmentVsCashChartOption,
+  getRecommendationLabel,
+  type InstallmentVsCashCalculation,
+  type InstallmentVsCashScheduleItem,
+} from "~/features/tools/model/installment-vs-cash";
+import { formatCurrency } from "~/utils/currency";
+
+interface Props {
+  calculation: InstallmentVsCashCalculation;
+}
+
+const props = defineProps<Props>();
+
+/**
+ * Chart option derived from the current calculation.
+ *
+ * @returns ECharts option for the month-by-month comparison.
+ */
+const chartOption = computed(() => {
+  return buildInstallmentVsCashChartOption(props.calculation);
+});
+
+/**
+ * Columns for the detailed schedule table.
+ */
+const scheduleColumns = [
+  {
+    key: "installmentNumber",
+    title: "Parcela",
+    render: (row: InstallmentVsCashScheduleItem): string => {
+      return row.installmentNumber === 0 ? "Hoje" : `${row.installmentNumber}ª`;
+    },
+  },
+  {
+    key: "dueInDays",
+    title: "Vence em",
+    render: (row: InstallmentVsCashScheduleItem): string => `${row.dueInDays} dias`,
+  },
+  {
+    key: "amount",
+    title: "Valor",
+    render: (row: InstallmentVsCashScheduleItem): string => formatCurrency(row.amount),
+  },
+  {
+    key: "presentValue",
+    title: "Valor presente",
+    render: (row: InstallmentVsCashScheduleItem): string => formatCurrency(row.presentValue),
+  },
+  {
+    key: "cumulativeNominal",
+    title: "Acumulado nominal",
+    render: (row: InstallmentVsCashScheduleItem): string => formatCurrency(row.cumulativeNominal),
+  },
+  {
+    key: "cashCumulative",
+    title: "Acumulado à vista",
+    render: (row: InstallmentVsCashScheduleItem): string => formatCurrency(row.cashCumulative),
+  },
+];
+
+/**
+ * Recommendation tone exposed in the hero tag.
+ *
+ * @returns Naive UI tag type.
+ */
+const recommendationTagType = computed<
+  "success" | "warning" | "default"
+>(() => {
+  if (props.calculation.result.recommendedOption === "installment") {
+    return "success";
+  }
+  if (props.calculation.result.recommendedOption === "cash") {
+    return "warning";
+  }
+  return "default";
+});
+</script>
+
+<template>
+  <div class="installment-vs-cash-results">
+    <UiGlassPanel glow class="installment-vs-cash-results__hero">
+      <div class="installment-vs-cash-results__hero-header">
+        <UiPageHeader
+          :title="getRecommendationLabel(props.calculation.result.recommendedOption)"
+          :subtitle="props.calculation.result.recommendationReason"
+        />
+        <NTag
+          :type="recommendationTagType"
+          size="large"
+          round
+        >
+          {{ props.calculation.result.recommendedOption }}
+        </NTag>
+      </div>
+
+      <div class="installment-vs-cash-results__metrics">
+        <UiMetricCard
+          label="Preço à vista"
+          :value="formatCurrency(props.calculation.result.comparison.cashOptionTotal)"
+        />
+        <UiMetricCard
+          label="Parcelado nominal"
+          :value="formatCurrency(props.calculation.result.comparison.installmentOptionTotal)"
+        />
+        <UiMetricCard
+          label="Parcelado em valor presente"
+          :value="formatCurrency(props.calculation.result.comparison.installmentPresentValue)"
+          :trend="props.calculation.result.comparison.relativeDeltaVsCashPercent"
+        />
+      </div>
+    </UiGlassPanel>
+
+    <UiSurfaceCard class="installment-vs-cash-results__chart-card">
+      <NThing
+        title="Comparação mês a mês"
+        description="Veja o desembolso acumulado e o valor presente do parcelamento ao longo do tempo."
+      />
+      <UiChart
+        :option="chartOption"
+        height="360px"
+        update-key="installment-vs-cash"
+      />
+    </UiSurfaceCard>
+
+    <NCollapse arrow-placement="right">
+      <NCollapseItem title="Entenda o cálculo" name="formula">
+        <NThing
+          title="Fórmula e premissas"
+          :description="props.calculation.result.formulaExplainer"
+        >
+          <template #default>
+            <div class="installment-vs-cash-results__assumptions">
+              <span>
+                Taxa de oportunidade:
+                <strong>{{ props.calculation.result.assumptions.opportunityRateAnnualPercent.toFixed(2).replace(".", ",") }}% a.a.</strong>
+              </span>
+              <span>
+                Inflação:
+                <strong>{{ props.calculation.result.assumptions.inflationRateAnnualPercent.toFixed(2).replace(".", ",") }}% a.a.</strong>
+              </span>
+              <span>
+                Faixa de neutralidade:
+                <strong>{{ formatCurrency(props.calculation.result.neutralityBand.absoluteBrl) }}</strong>
+                ou
+                <strong>{{ props.calculation.result.neutralityBand.relativePercent.toFixed(2).replace(".", ",") }}%</strong>
+              </span>
+            </div>
+          </template>
+        </NThing>
+      </NCollapseItem>
+
+      <NCollapseItem title="Break-even e comparação detalhada" name="break-even">
+        <div class="installment-vs-cash-results__details-grid">
+          <UiMetricCard
+            label="Diferença vs à vista"
+            :value="formatCurrency(props.calculation.result.comparison.absoluteDeltaVsCash)"
+          />
+          <UiMetricCard
+            label="Desconto à vista para empatar"
+            :value="`${props.calculation.result.comparison.breakEvenDiscountPercent.toFixed(2).replace('.', ',')}%`"
+          />
+          <UiMetricCard
+            label="Taxa mínima para o parcelado empatar"
+            :value="`${props.calculation.result.comparison.breakEvenOpportunityRateAnnual.toFixed(2).replace('.', ',')}% a.a.`"
+          />
+        </div>
+      </NCollapseItem>
+
+      <NCollapseItem title="Cronograma mês a mês" name="schedule">
+        <NDataTable
+          :columns="scheduleColumns"
+          :data="props.calculation.result.schedule"
+          size="small"
+          scroll-x="960"
+        />
+      </NCollapseItem>
+    </NCollapse>
+  </div>
+</template>
+
+<style scoped>
+.installment-vs-cash-results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.installment-vs-cash-results__hero {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.installment-vs-cash-results__hero-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-2);
+}
+
+.installment-vs-cash-results__metrics {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.installment-vs-cash-results__chart-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.installment-vs-cash-results__assumptions {
+  display: grid;
+  gap: var(--space-1);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.installment-vs-cash-results__details-grid {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media (max-width: 1023px) {
+  .installment-vs-cash-results__metrics,
+  .installment-vs-cash-results__details-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .installment-vs-cash-results__hero-header {
+    flex-direction: column;
+  }
+}
+</style>

--- a/app/features/tools/contracts/installment-vs-cash.dto.ts
+++ b/app/features/tools/contracts/installment-vs-cash.dto.ts
@@ -1,0 +1,281 @@
+/**
+ * Opportunity-rate preset accepted by the installment-vs-cash API.
+ */
+export type OpportunityRateTypeDto =
+  | "manual"
+  | "product_default"
+  | "inflation_only";
+
+/**
+ * Recommendation returned by the API after comparing the payment options.
+ */
+export type RecommendedOptionDto = "cash" | "installment" | "equivalent";
+
+/**
+ * Selected payment option used in premium bridge actions.
+ */
+export type SelectedPaymentOptionDto = "cash" | "installment";
+
+/**
+ * DTO payload for the public calculate endpoint.
+ */
+export interface InstallmentVsCashCalculationRequestDto {
+  cash_price: string;
+  installment_count: number;
+  inflation_rate_annual: string;
+  fees_enabled: boolean;
+  fees_upfront: string;
+  first_payment_delay_days: number;
+  opportunity_rate_type: OpportunityRateTypeDto;
+  installment_amount?: string;
+  installment_total?: string;
+  opportunity_rate_annual?: string;
+  scenario_label?: string;
+}
+
+/**
+ * DTO payload for saving a calculation.
+ */
+export type InstallmentVsCashSaveRequestDto =
+  InstallmentVsCashCalculationRequestDto;
+
+/**
+ * DTO shape for a snapshot of preset indicators used in the calculation.
+ */
+export interface InstallmentVsCashIndicatorSnapshotDto {
+  preset_type: string;
+  source: string;
+  annual_rate_percent: string;
+  as_of: string;
+}
+
+/**
+ * DTO shape for the numeric comparison block returned by the API.
+ */
+export interface InstallmentVsCashComparisonDto {
+  cash_option_total: string;
+  installment_option_total: string;
+  installment_present_value: string;
+  installment_real_value_today: string;
+  present_value_delta_vs_cash: string;
+  absolute_delta_vs_cash: string;
+  relative_delta_vs_cash_percent: string;
+  break_even_discount_percent: string;
+  break_even_opportunity_rate_annual: string;
+}
+
+/**
+ * DTO shape for the cash option block.
+ */
+export interface InstallmentVsCashCashOptionDto {
+  total: string;
+}
+
+/**
+ * DTO shape for the installment option block.
+ */
+export interface InstallmentVsCashInstallmentOptionDto {
+  count: number;
+  amounts: string[];
+  installment_amount: string;
+  nominal_total: string;
+  upfront_fees: string;
+  first_payment_delay_days: number;
+}
+
+/**
+ * DTO shape for both payment options.
+ */
+export interface InstallmentVsCashOptionsDto {
+  cash: InstallmentVsCashCashOptionDto;
+  installment: InstallmentVsCashInstallmentOptionDto;
+}
+
+/**
+ * DTO shape for the neutrality band.
+ */
+export interface InstallmentVsCashNeutralityBandDto {
+  absolute_brl: string;
+  relative_percent: string;
+}
+
+/**
+ * DTO shape for the assumptions used in the simulation.
+ */
+export interface InstallmentVsCashAssumptionsDto {
+  opportunity_rate_type: OpportunityRateTypeDto;
+  opportunity_rate_annual_percent: string;
+  inflation_rate_annual_percent: string;
+  periodicity: string;
+  first_payment_delay_days: number;
+  upfront_fees_apply_to: string;
+  neutrality_rule: string;
+}
+
+/**
+ * DTO shape for one row of the generated schedule.
+ */
+export interface InstallmentVsCashScheduleItemDto {
+  installment_number: number;
+  due_in_days: number;
+  amount: string;
+  present_value: string;
+  real_value_today: string;
+  cumulative_nominal: string;
+  cumulative_present_value: string;
+  cumulative_real_value_today: string;
+  cash_cumulative: string;
+}
+
+/**
+ * DTO shape for the calculation result block.
+ */
+export interface InstallmentVsCashResultDto {
+  recommended_option: RecommendedOptionDto;
+  recommendation_reason: string;
+  formula_explainer: string;
+  comparison: InstallmentVsCashComparisonDto;
+  options: InstallmentVsCashOptionsDto;
+  neutrality_band: InstallmentVsCashNeutralityBandDto;
+  assumptions: InstallmentVsCashAssumptionsDto;
+  indicator_snapshot: InstallmentVsCashIndicatorSnapshotDto | null;
+  schedule: InstallmentVsCashScheduleItemDto[];
+}
+
+/**
+ * DTO shape for the normalized input returned by the API.
+ */
+export interface InstallmentVsCashNormalizedInputDto {
+  cash_price: string;
+  installment_count: number;
+  installment_amount: string;
+  installment_total: string;
+  first_payment_delay_days: number;
+  opportunity_rate_type: OpportunityRateTypeDto;
+  opportunity_rate_annual: string;
+  inflation_rate_annual: string;
+  fees_upfront: string;
+  scenario_label?: string | null;
+}
+
+/**
+ * DTO shape returned by the calculate endpoint.
+ */
+export interface InstallmentVsCashCalculationResponseDto {
+  tool_id: string;
+  rule_version: string;
+  input: InstallmentVsCashNormalizedInputDto;
+  result: InstallmentVsCashResultDto;
+}
+
+/**
+ * DTO shape for the saved simulation.
+ */
+export interface InstallmentVsCashSavedSimulationDto {
+  id: string;
+  user_id: string | null;
+  tool_id: string;
+  rule_version: string;
+  inputs: InstallmentVsCashNormalizedInputDto;
+  result: InstallmentVsCashResultDto;
+  saved: boolean;
+  goal_id: string | null;
+  created_at: string;
+}
+
+/**
+ * DTO response for the save endpoint.
+ */
+export interface InstallmentVsCashSaveResponseDto {
+  simulation: InstallmentVsCashSavedSimulationDto;
+  calculation: InstallmentVsCashCalculationResponseDto;
+}
+
+/**
+ * DTO payload used to transform a simulation into a goal.
+ */
+export interface CreateGoalFromInstallmentVsCashDto {
+  title: string;
+  selected_option: SelectedPaymentOptionDto;
+  description?: string;
+  category?: string;
+  target_date?: string;
+  priority?: number;
+  current_amount?: string;
+}
+
+/**
+ * DTO shape for a serialized goal.
+ */
+export interface GoalBridgeGoalDto {
+  id: string;
+  title: string;
+  description: string | null;
+  category: string | null;
+  target_amount: string;
+  current_amount: string;
+  priority: number;
+  target_date: string | null;
+  status: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/**
+ * DTO response for the goal bridge.
+ */
+export interface CreateGoalFromInstallmentVsCashResponseDto {
+  goal: GoalBridgeGoalDto;
+  simulation: InstallmentVsCashSavedSimulationDto;
+}
+
+/**
+ * DTO payload used to turn a simulation into a planned expense.
+ */
+export interface CreatePlannedExpenseFromInstallmentVsCashDto {
+  title: string;
+  selected_option: SelectedPaymentOptionDto;
+  description?: string;
+  observation?: string;
+  due_date?: string;
+  first_due_date?: string;
+  upfront_due_date?: string;
+  tag_id?: string;
+  account_id?: string;
+  credit_card_id?: string;
+  currency?: string;
+  status?: "pending" | "paid" | "cancelled" | "postponed" | "overdue";
+}
+
+/**
+ * DTO shape for a serialized planned transaction.
+ */
+export interface PlannedExpenseTransactionDto {
+  id: string;
+  title: string;
+  amount: string;
+  type: string;
+  due_date: string;
+  start_date: string | null;
+  end_date: string | null;
+  description: string | null;
+  observation: string | null;
+  is_recurring: boolean;
+  is_installment: boolean;
+  installment_count: number | null;
+  tag_id: string | null;
+  account_id: string | null;
+  credit_card_id: string | null;
+  status: string;
+  currency: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/**
+ * DTO response for the planned-expense bridge.
+ */
+export interface CreatePlannedExpenseFromInstallmentVsCashResponseDto {
+  transactions: PlannedExpenseTransactionDto[];
+  simulation: InstallmentVsCashSavedSimulationDto;
+}

--- a/app/features/tools/model/installment-vs-cash.spec.ts
+++ b/app/features/tools/model/installment-vs-cash.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildInstallmentVsCashChartOption,
+  createDefaultInstallmentVsCashFormState,
+  isInstallmentVsCashCalculation,
+  isInstallmentVsCashPendingPayload,
+  toInstallmentVsCashCalculationRequest,
+  validateInstallmentVsCashForm,
+  type InstallmentVsCashCalculation,
+} from "./installment-vs-cash";
+
+/**
+ * Builds a minimal valid calculation fixture.
+ *
+ * @returns Calculation fixture used in model tests.
+ */
+const makeCalculation = (): InstallmentVsCashCalculation => ({
+  toolId: "installment_vs_cash",
+  ruleVersion: "2026.1",
+  input: {
+    cashPrice: 900,
+    installmentCount: 3,
+    installmentAmount: 330,
+    installmentTotal: 990,
+    firstPaymentDelayDays: 30,
+    opportunityRateType: "manual",
+    opportunityRateAnnual: 12,
+    inflationRateAnnual: 4.5,
+    feesUpfront: 0,
+    scenarioLabel: "Notebook",
+  },
+  result: {
+    recommendedOption: "cash",
+    recommendationReason: "À vista ficou melhor.",
+    formulaExplainer: "Comparação por valor presente.",
+    comparison: {
+      cashOptionTotal: 900,
+      installmentOptionTotal: 990,
+      installmentPresentValue: 940,
+      installmentRealValueToday: 930,
+      presentValueDeltaVsCash: 40,
+      absoluteDeltaVsCash: 90,
+      relativeDeltaVsCashPercent: 4.44,
+      breakEvenDiscountPercent: 9.09,
+      breakEvenOpportunityRateAnnual: 18.2,
+    },
+    options: {
+      cash: { total: 900 },
+      installment: {
+        count: 3,
+        amounts: [330, 330, 330],
+        installmentAmount: 330,
+        nominalTotal: 990,
+        upfrontFees: 0,
+        firstPaymentDelayDays: 30,
+      },
+    },
+    neutralityBand: {
+      absoluteBrl: 10,
+      relativePercent: 1,
+    },
+    assumptions: {
+      opportunityRateType: "manual",
+      opportunityRateAnnualPercent: 12,
+      inflationRateAnnualPercent: 4.5,
+      periodicity: "monthly",
+      firstPaymentDelayDays: 30,
+      upfrontFeesApplyTo: "installment",
+      neutralityRule: "hybrid",
+    },
+    indicatorSnapshot: null,
+    schedule: [
+      {
+        installmentNumber: 0,
+        dueInDays: 0,
+        amount: 0,
+        presentValue: 0,
+        realValueToday: 0,
+        cumulativeNominal: 0,
+        cumulativePresentValue: 0,
+        cumulativeRealValueToday: 0,
+        cashCumulative: 900,
+      },
+      {
+        installmentNumber: 1,
+        dueInDays: 30,
+        amount: 330,
+        presentValue: 326,
+        realValueToday: 328,
+        cumulativeNominal: 330,
+        cumulativePresentValue: 326,
+        cumulativeRealValueToday: 328,
+        cashCumulative: 900,
+      },
+    ],
+  },
+});
+
+describe("installment-vs-cash model helpers", () => {
+  it("creates a request dto from a valid form state", () => {
+    const form = createDefaultInstallmentVsCashFormState();
+    form.scenarioLabel = "Notebook";
+    form.cashPrice = 900;
+    form.installmentCount = 3;
+    form.installmentTotal = 990;
+
+    const payload = toInstallmentVsCashCalculationRequest(form);
+
+    expect(payload.cash_price).toBe("900.00");
+    expect(payload.installment_total).toBe("990.00");
+    expect(payload.first_payment_delay_days).toBe(30);
+    expect(payload.scenario_label).toBe("Notebook");
+  });
+
+  it("validates missing required fields", () => {
+    const errors = validateInstallmentVsCashForm(
+      createDefaultInstallmentVsCashFormState(),
+    );
+
+    expect(errors.map((item) => item.field)).toContain("cashPrice");
+    expect(errors.map((item) => item.field)).toContain("installmentTotal");
+  });
+
+  it("builds chart option with the expected series", () => {
+    const option = buildInstallmentVsCashChartOption(makeCalculation());
+    const series = option.series as Array<{ name: string }>;
+
+    expect(series).toHaveLength(3);
+    expect(series.map((item) => item.name)).toEqual([
+      "À vista",
+      "Parcelado nominal",
+      "Parcelado em valor presente",
+    ]);
+  });
+
+  it("accepts a valid pending payload shape", () => {
+    const payload = { form: createDefaultInstallmentVsCashFormState() };
+    expect(isInstallmentVsCashPendingPayload(payload)).toBe(true);
+  });
+
+  it("accepts a valid restored calculation", () => {
+    expect(isInstallmentVsCashCalculation(makeCalculation())).toBe(true);
+  });
+});

--- a/app/features/tools/model/installment-vs-cash.ts
+++ b/app/features/tools/model/installment-vs-cash.ts
@@ -1,0 +1,726 @@
+import type { EChartsOption } from "echarts";
+
+import { tokens } from "~/utils/naive-theme";
+import type {
+  InstallmentVsCashCalculationRequestDto,
+  OpportunityRateTypeDto,
+  RecommendedOptionDto,
+  SelectedPaymentOptionDto,
+} from "~/features/tools/contracts/installment-vs-cash.dto";
+
+/**
+ * Canonical feature id used across API, persistence and tool context restore.
+ */
+export const INSTALLMENT_VS_CASH_TOOL_ID = "installment_vs_cash";
+
+/**
+ * Public route for the page.
+ */
+export const INSTALLMENT_VS_CASH_PUBLIC_PATH = "/tools/parcelado-vs-a-vista";
+
+/**
+ * Human-friendly delay presets exposed by the calculator form.
+ */
+export type InstallmentDelayPreset = "today" | "30_days" | "45_days" | "custom";
+
+/**
+ * Which installment input the user wants to provide.
+ */
+export type InstallmentInputMode = "amount" | "total";
+
+/**
+ * Domain alias for the opportunity-rate selector.
+ */
+export type OpportunityRateType = OpportunityRateTypeDto;
+
+/**
+ * Domain alias for the recommendation returned by the calculator.
+ */
+export type RecommendedOption = RecommendedOptionDto;
+
+/**
+ * Domain alias for selected payment option used in bridge actions.
+ */
+export type SelectedPaymentOption = SelectedPaymentOptionDto;
+
+/**
+ * UI state for the public calculator form.
+ */
+export interface InstallmentVsCashFormState {
+  scenarioLabel: string;
+  cashPrice: number | null;
+  installmentCount: number | null;
+  installmentInputMode: InstallmentInputMode;
+  installmentAmount: number | null;
+  installmentTotal: number | null;
+  firstPaymentDelayPreset: InstallmentDelayPreset;
+  customFirstPaymentDelayDays: number | null;
+  opportunityRateType: OpportunityRateType;
+  opportunityRateAnnual: number | null;
+  inflationRateAnnual: number | null;
+  feesEnabled: boolean;
+  feesUpfront: number | null;
+}
+
+/**
+ * Normalized input displayed back to the user after calculation.
+ */
+export interface InstallmentVsCashNormalizedInput {
+  cashPrice: number;
+  installmentCount: number;
+  installmentAmount: number;
+  installmentTotal: number;
+  firstPaymentDelayDays: number;
+  opportunityRateType: OpportunityRateType;
+  opportunityRateAnnual: number;
+  inflationRateAnnual: number;
+  feesUpfront: number;
+  scenarioLabel: string | null;
+}
+
+/**
+ * Snapshot of preset indicators used by the calculator.
+ */
+export interface InstallmentVsCashIndicatorSnapshot {
+  presetType: string;
+  source: string;
+  annualRatePercent: number;
+  asOf: string;
+}
+
+/**
+ * Numeric comparison output used to explain the recommendation.
+ */
+export interface InstallmentVsCashComparison {
+  cashOptionTotal: number;
+  installmentOptionTotal: number;
+  installmentPresentValue: number;
+  installmentRealValueToday: number;
+  presentValueDeltaVsCash: number;
+  absoluteDeltaVsCash: number;
+  relativeDeltaVsCashPercent: number;
+  breakEvenDiscountPercent: number;
+  breakEvenOpportunityRateAnnual: number;
+}
+
+/**
+ * Cash option block.
+ */
+export interface InstallmentVsCashCashOption {
+  total: number;
+}
+
+/**
+ * Installment option block.
+ */
+export interface InstallmentVsCashInstallmentOption {
+  count: number;
+  amounts: number[];
+  installmentAmount: number;
+  nominalTotal: number;
+  upfrontFees: number;
+  firstPaymentDelayDays: number;
+}
+
+/**
+ * Both options presented in the result.
+ */
+export interface InstallmentVsCashOptions {
+  cash: InstallmentVsCashCashOption;
+  installment: InstallmentVsCashInstallmentOption;
+}
+
+/**
+ * Thresholds used to classify close scenarios as equivalent.
+ */
+export interface InstallmentVsCashNeutralityBand {
+  absoluteBrl: number;
+  relativePercent: number;
+}
+
+/**
+ * Assumptions block displayed to the user.
+ */
+export interface InstallmentVsCashAssumptions {
+  opportunityRateType: OpportunityRateType;
+  opportunityRateAnnualPercent: number;
+  inflationRateAnnualPercent: number;
+  periodicity: string;
+  firstPaymentDelayDays: number;
+  upfrontFeesApplyTo: string;
+  neutralityRule: string;
+}
+
+/**
+ * Schedule line item used for detailed explanation and charting.
+ */
+export interface InstallmentVsCashScheduleItem {
+  installmentNumber: number;
+  dueInDays: number;
+  amount: number;
+  presentValue: number;
+  realValueToday: number;
+  cumulativeNominal: number;
+  cumulativePresentValue: number;
+  cumulativeRealValueToday: number;
+  cashCumulative: number;
+}
+
+/**
+ * Full result returned by the calculator.
+ */
+export interface InstallmentVsCashResult {
+  recommendedOption: RecommendedOption;
+  recommendationReason: string;
+  formulaExplainer: string;
+  comparison: InstallmentVsCashComparison;
+  options: InstallmentVsCashOptions;
+  neutralityBand: InstallmentVsCashNeutralityBand;
+  assumptions: InstallmentVsCashAssumptions;
+  indicatorSnapshot: InstallmentVsCashIndicatorSnapshot | null;
+  schedule: InstallmentVsCashScheduleItem[];
+}
+
+/**
+ * Full calculation object used by the page.
+ */
+export interface InstallmentVsCashCalculation {
+  toolId: string;
+  ruleVersion: string;
+  input: InstallmentVsCashNormalizedInput;
+  result: InstallmentVsCashResult;
+}
+
+/**
+ * Specialized saved simulation returned by the feature save endpoint.
+ */
+export interface InstallmentVsCashSavedSimulation {
+  id: string;
+  userId: string | null;
+  toolId: string;
+  ruleVersion: string;
+  inputs: InstallmentVsCashNormalizedInput;
+  result: InstallmentVsCashResult;
+  saved: boolean;
+  goalId: string | null;
+  createdAt: string;
+}
+
+/**
+ * Combined response returned by the save endpoint.
+ */
+export interface InstallmentVsCashSavedCalculation {
+  simulation: InstallmentVsCashSavedSimulation;
+  calculation: InstallmentVsCashCalculation;
+}
+
+/**
+ * Goal created from a saved simulation.
+ */
+export interface InstallmentVsCashGoal {
+  id: string;
+  title: string;
+  description: string | null;
+  category: string | null;
+  targetAmount: number;
+  currentAmount: number;
+  priority: number;
+  targetDate: string | null;
+  status: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+/**
+ * Response returned by the goal bridge.
+ */
+export interface InstallmentVsCashGoalBridgeResponse {
+  goal: InstallmentVsCashGoal;
+  simulation: InstallmentVsCashSavedSimulation;
+}
+
+/**
+ * Planned transaction generated from the premium expense bridge.
+ */
+export interface InstallmentVsCashPlannedTransaction {
+  id: string;
+  title: string;
+  amount: number;
+  type: string;
+  dueDate: string;
+  startDate: string | null;
+  endDate: string | null;
+  description: string | null;
+  observation: string | null;
+  isRecurring: boolean;
+  isInstallment: boolean;
+  installmentCount: number | null;
+  tagId: string | null;
+  accountId: string | null;
+  creditCardId: string | null;
+  status: string;
+  currency: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+/**
+ * Response returned by the planned-expense bridge.
+ */
+export interface InstallmentVsCashPlannedExpenseBridgeResponse {
+  transactions: InstallmentVsCashPlannedTransaction[];
+  simulation: InstallmentVsCashSavedSimulation;
+}
+
+/**
+ * Payload used to create a goal from a saved simulation.
+ */
+export interface CreateInstallmentVsCashGoalPayload {
+  title: string;
+  selectedOption: SelectedPaymentOption;
+  description?: string;
+  category?: string;
+  targetDate?: string;
+  priority?: number;
+  currentAmount?: number;
+}
+
+/**
+ * Payload used to create a planned expense from a saved simulation.
+ */
+export interface CreateInstallmentVsCashPlannedExpensePayload {
+  title: string;
+  selectedOption: SelectedPaymentOption;
+  description?: string;
+  observation?: string;
+  dueDate?: string;
+  firstDueDate?: string;
+  upfrontDueDate?: string;
+  tagId?: string;
+  accountId?: string;
+  creditCardId?: string;
+  currency?: "BRL";
+  status?: "pending" | "paid" | "cancelled" | "postponed" | "overdue";
+}
+
+/**
+ * Shape persisted in the tool-context store so the page can survive login
+ * redirects without losing the latest form state.
+ */
+export interface InstallmentVsCashPendingPayload {
+  form: InstallmentVsCashFormState;
+}
+
+/**
+ * User-facing validation error for the calculator form.
+ */
+export interface InstallmentVsCashValidationError {
+  field: keyof InstallmentVsCashFormState | "general";
+  message: string;
+}
+
+/**
+ * Appends an error to the accumulator when the predicate fails.
+ *
+ * @param errors Current validation accumulator.
+ * @param validation Validation envelope with field, message and predicate result.
+ */
+const pushValidationError = (
+  errors: InstallmentVsCashValidationError[],
+  validation: InstallmentVsCashValidationError & { valid: boolean },
+): void => {
+  if (!validation.valid) {
+    errors.push({
+      field: validation.field,
+      message: validation.message,
+    });
+  }
+};
+
+/**
+ * Validates the installment value/total block.
+ *
+ * @param form Current form state.
+ * @returns Validation errors related to the payment amount block.
+ */
+const validateInstallmentInput = (
+  form: InstallmentVsCashFormState,
+): InstallmentVsCashValidationError[] => {
+  const errors: InstallmentVsCashValidationError[] = [];
+
+  if (form.installmentInputMode === "amount") {
+    pushValidationError(
+      errors,
+      {
+        valid: form.installmentAmount !== null && form.installmentAmount > 0,
+        field: "installmentAmount",
+        message: "Informe o valor de cada parcela.",
+      },
+    );
+    return errors;
+  }
+
+  pushValidationError(
+    errors,
+    {
+      valid: form.installmentTotal !== null && form.installmentTotal > 0,
+      field: "installmentTotal",
+      message: "Informe o valor total do parcelamento.",
+    },
+  );
+  return errors;
+};
+
+/**
+ * Validates the optional custom-delay block.
+ *
+ * @param form Current form state.
+ * @returns Validation errors related to the first-installment timing.
+ */
+const validateDelayInput = (
+  form: InstallmentVsCashFormState,
+): InstallmentVsCashValidationError[] => {
+  if (form.firstPaymentDelayPreset !== "custom") {
+    return [];
+  }
+
+  const errors: InstallmentVsCashValidationError[] = [];
+  pushValidationError(
+    errors,
+    {
+      valid: form.customFirstPaymentDelayDays !== null
+        && form.customFirstPaymentDelayDays >= 0,
+      field: "customFirstPaymentDelayDays",
+      message: "Informe em quantos dias a primeira parcela vence.",
+    },
+  );
+  return errors;
+};
+
+/**
+ * Validates the rate assumptions block.
+ *
+ * @param form Current form state.
+ * @returns Validation errors related to rates and fees.
+ */
+const validateRateInputs = (
+  form: InstallmentVsCashFormState,
+): InstallmentVsCashValidationError[] => {
+  const errors: InstallmentVsCashValidationError[] = [];
+
+  pushValidationError(
+    errors,
+    {
+      valid: form.inflationRateAnnual !== null && form.inflationRateAnnual >= 0,
+      field: "inflationRateAnnual",
+      message: "Informe a inflação anual usada como premissa.",
+    },
+  );
+
+  if (form.opportunityRateType === "manual") {
+    pushValidationError(
+      errors,
+      {
+        valid: form.opportunityRateAnnual !== null
+          && form.opportunityRateAnnual >= 0,
+        field: "opportunityRateAnnual",
+        message: "Informe a taxa de oportunidade anual.",
+      },
+    );
+  }
+
+  if (form.feesEnabled) {
+    pushValidationError(
+      errors,
+      {
+        valid: form.feesUpfront !== null && form.feesUpfront >= 0,
+        field: "feesUpfront",
+        message: "Informe os custos extras iniciais.",
+      },
+    );
+  }
+
+  return errors;
+};
+
+/**
+ * Default UI state for the calculator.
+ *
+ * @returns Fresh form state instance.
+ */
+export const createDefaultInstallmentVsCashFormState =
+(): InstallmentVsCashFormState => ({
+  scenarioLabel: "",
+  cashPrice: null,
+  installmentCount: 6,
+  installmentInputMode: "total",
+  installmentAmount: null,
+  installmentTotal: null,
+  firstPaymentDelayPreset: "30_days",
+  customFirstPaymentDelayDays: null,
+  opportunityRateType: "manual",
+  opportunityRateAnnual: 12,
+  inflationRateAnnual: 4.5,
+  feesEnabled: false,
+  feesUpfront: null,
+});
+
+/**
+ * Validates the current form state before calling the API.
+ *
+ * @param form Current form state.
+ * @returns Flat list of user-facing validation errors.
+ */
+export const validateInstallmentVsCashForm = (
+  form: InstallmentVsCashFormState,
+): InstallmentVsCashValidationError[] => {
+  const errors: InstallmentVsCashValidationError[] = [];
+
+  pushValidationError(
+    errors,
+    {
+      valid: form.cashPrice !== null && form.cashPrice > 0,
+      field: "cashPrice",
+      message: "Informe um preço à vista maior que zero.",
+    },
+  );
+  pushValidationError(
+    errors,
+    {
+      valid: form.installmentCount !== null && form.installmentCount >= 1,
+      field: "installmentCount",
+      message: "Informe uma quantidade válida de parcelas.",
+    },
+  );
+  errors.push(...validateInstallmentInput(form));
+  errors.push(...validateDelayInput(form));
+  errors.push(...validateRateInputs(form));
+
+  return errors;
+};
+
+/**
+ * Resolves the actual delay in days from the UI preset state.
+ *
+ * @param form The current form state.
+ * @returns Delay in days sent to the API.
+ */
+export const resolveFirstPaymentDelayDays = (
+  form: InstallmentVsCashFormState,
+): number => {
+  if (form.firstPaymentDelayPreset === "today") {
+    return 0;
+  }
+  if (form.firstPaymentDelayPreset === "30_days") {
+    return 30;
+  }
+  if (form.firstPaymentDelayPreset === "45_days") {
+    return 45;
+  }
+  return Math.max(0, Math.trunc(form.customFirstPaymentDelayDays ?? 0));
+};
+
+/**
+ * Converts a numeric value into the decimal-string format expected by the API.
+ *
+ * @param value Numeric UI value.
+ * @returns Decimal string with two fraction digits.
+ */
+export const toDecimalString = (value: number): string => {
+  return value.toFixed(2);
+};
+
+/**
+ * Parses a decimal string returned by the API.
+ *
+ * @param value Raw decimal string.
+ * @returns Numeric representation for display and charting.
+ */
+export const parseDecimalString = (value: string): number => {
+  return Number.parseFloat(value);
+};
+
+/**
+ * Converts the current form state into the API request body.
+ *
+ * @param form Current form state.
+ * @returns Request DTO expected by the API.
+ */
+export const toInstallmentVsCashCalculationRequest = (
+  form: InstallmentVsCashFormState,
+): InstallmentVsCashCalculationRequestDto => {
+  const payload: InstallmentVsCashCalculationRequestDto = {
+    cash_price: toDecimalString(form.cashPrice ?? 0),
+    installment_count: Math.trunc(form.installmentCount ?? 0),
+    inflation_rate_annual: toDecimalString(form.inflationRateAnnual ?? 0),
+    fees_enabled: form.feesEnabled,
+    fees_upfront: toDecimalString(form.feesUpfront ?? 0),
+    first_payment_delay_days: resolveFirstPaymentDelayDays(form),
+    opportunity_rate_type: form.opportunityRateType,
+  };
+
+  if (form.installmentInputMode === "amount") {
+    payload.installment_amount = toDecimalString(form.installmentAmount ?? 0);
+  } else {
+    payload.installment_total = toDecimalString(form.installmentTotal ?? 0);
+  }
+
+  if (form.opportunityRateType === "manual") {
+    payload.opportunity_rate_annual = toDecimalString(
+      form.opportunityRateAnnual ?? 0,
+    );
+  }
+
+  if (form.scenarioLabel.trim().length > 0) {
+    payload.scenario_label = form.scenarioLabel.trim();
+  }
+
+  return payload;
+};
+
+/**
+ * Builds the chart option comparing cash and installment scenarios month by month.
+ *
+ * @param calculation Latest calculation.
+ * @returns ECharts option configured for the Auraxis chart wrapper.
+ */
+export const buildInstallmentVsCashChartOption = (
+  calculation: InstallmentVsCashCalculation,
+): EChartsOption => {
+  const labels = calculation.result.schedule.map((item) => {
+    return item.installmentNumber === 0
+      ? "Hoje"
+      : `${item.installmentNumber}ª parcela`;
+  });
+
+  return {
+    tooltip: {
+      trigger: "axis",
+    },
+    legend: {
+      top: 0,
+      textStyle: {
+        color: tokens.text.muted,
+      },
+    },
+    grid: {
+      left: 24,
+      right: 16,
+      bottom: 24,
+      top: 56,
+      containLabel: true,
+    },
+    xAxis: {
+      type: "category",
+      data: labels,
+      boundaryGap: false,
+    },
+    yAxis: {
+      type: "value",
+    },
+    series: [
+      {
+        name: "À vista",
+        type: "line",
+        smooth: true,
+        lineStyle: {
+          color: tokens.brand.secondary,
+        },
+        itemStyle: {
+          color: tokens.brand.secondary,
+        },
+        data: calculation.result.schedule.map((item) => item.cashCumulative),
+      },
+      {
+        name: "Parcelado nominal",
+        type: "line",
+        smooth: true,
+        lineStyle: {
+          color: tokens.status.dangerSoft,
+        },
+        itemStyle: {
+          color: tokens.status.dangerSoft,
+        },
+        data: calculation.result.schedule.map((item) => item.cumulativeNominal),
+      },
+      {
+        name: "Parcelado em valor presente",
+        type: "line",
+        smooth: true,
+        lineStyle: {
+          color: tokens.status.successSoft,
+        },
+        itemStyle: {
+          color: tokens.status.successSoft,
+        },
+        data: calculation.result.schedule.map(
+          (item) => item.cumulativePresentValue,
+        ),
+      },
+    ],
+  };
+};
+
+/**
+ * Returns a compact label for the recommendation.
+ *
+ * @param option Recommendation value.
+ * @returns PT-BR copy for the result hero.
+ */
+export const getRecommendationLabel = (option: RecommendedOption): string => {
+  if (option === "cash") {
+    return "À vista é a melhor escolha";
+  }
+  if (option === "installment") {
+    return "Parcelado é a melhor escolha";
+  }
+  return "As opções estão praticamente empatadas";
+};
+
+/**
+ * Checks whether an unknown payload can restore the calculator form state.
+ *
+ * @param value Unknown persisted payload.
+ * @returns True when the payload matches the expected shape.
+ */
+export const isInstallmentVsCashPendingPayload = (
+  value: unknown,
+): value is InstallmentVsCashPendingPayload => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as { form?: unknown };
+  if (typeof candidate.form !== "object" || candidate.form === null) {
+    return false;
+  }
+
+  const form = candidate.form as Record<string, unknown>;
+  return typeof form.scenarioLabel === "string"
+    && typeof form.installmentInputMode === "string"
+    && typeof form.firstPaymentDelayPreset === "string"
+    && typeof form.opportunityRateType === "string"
+    && typeof form.feesEnabled === "boolean";
+};
+
+/**
+ * Checks whether an unknown value matches the calculation shape.
+ *
+ * @param value Unknown result payload.
+ * @returns True when the result can be safely restored by the page.
+ */
+export const isInstallmentVsCashCalculation = (
+  value: unknown,
+): value is InstallmentVsCashCalculation => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const result = candidate.result as Record<string, unknown> | undefined;
+  return typeof candidate.toolId === "string"
+    && typeof candidate.ruleVersion === "string"
+    && typeof candidate.input === "object"
+    && typeof result === "object"
+    && typeof result?.recommendedOption === "string";
+};

--- a/app/features/tools/queries/installment-vs-cash.mutations.spec.ts
+++ b/app/features/tools/queries/installment-vs-cash.mutations.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { useCreateGoalFromInstallmentVsCashMutation } from "./use-create-goal-from-installment-vs-cash-mutation";
+import { useCreatePlannedExpenseFromInstallmentVsCashMutation } from "./use-create-planned-expense-from-installment-vs-cash-mutation";
+import { useInstallmentVsCashCalculateMutation } from "./use-installment-vs-cash-calculate-mutation";
+import { useSaveInstallmentVsCashMutation } from "./use-save-installment-vs-cash-mutation";
+
+const useMutationMock = vi.hoisted(() => vi.fn());
+const invalidateQueriesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/vue-query", () => ({
+  useMutation: useMutationMock,
+  useQueryClient: (): { invalidateQueries: typeof invalidateQueriesMock } => ({
+    invalidateQueries: invalidateQueriesMock,
+  }),
+}));
+
+describe("installment-vs-cash mutation hooks", () => {
+  it("wires the calculate mutation to client.calculate", async () => {
+    const client = {
+      calculate: vi.fn().mockResolvedValue({ ok: true }),
+    };
+    useMutationMock.mockImplementation((options: Record<string, unknown>) => options);
+
+    const mutation = useInstallmentVsCashCalculateMutation(client as never) as
+      unknown as {
+        mutationFn: (payload: Record<string, unknown>) => Promise<unknown>;
+      };
+
+    await mutation.mutationFn({ cash_price: "900.00" });
+
+    expect(client.calculate).toHaveBeenCalledWith({ cash_price: "900.00" });
+  });
+
+  it("wires the save mutation to client.save", async () => {
+    const client = {
+      save: vi.fn().mockResolvedValue({ ok: true }),
+    };
+    useMutationMock.mockImplementation((options: Record<string, unknown>) => options);
+
+    const mutation = useSaveInstallmentVsCashMutation(client as never) as
+      unknown as {
+        mutationFn: (payload: Record<string, unknown>) => Promise<unknown>;
+      };
+
+    await mutation.mutationFn({ cash_price: "900.00" });
+
+    expect(client.save).toHaveBeenCalledWith({ cash_price: "900.00" });
+  });
+
+  it("wires the goal mutation to client.createGoalFromSimulation", async () => {
+    const client = {
+      createGoalFromSimulation: vi.fn().mockResolvedValue({ ok: true }),
+    };
+    useMutationMock.mockImplementation((options: Record<string, unknown>) => options);
+
+    const mutation = useCreateGoalFromInstallmentVsCashMutation(
+      client as never,
+    ) as unknown as {
+      mutationFn: (payload: {
+        simulationId: string;
+        payload: Record<string, unknown>;
+      }) => Promise<unknown>;
+    };
+
+    await mutation.mutationFn({
+      simulationId: "sim-1",
+      payload: { title: "Notebook" },
+    });
+
+    expect(client.createGoalFromSimulation).toHaveBeenCalledWith("sim-1", {
+      title: "Notebook",
+    });
+  });
+
+  it("wires the planned-expense mutation to client.createPlannedExpenseFromSimulation", async () => {
+    const client = {
+      createPlannedExpenseFromSimulation: vi.fn().mockResolvedValue({ ok: true }),
+    };
+    useMutationMock.mockImplementation((options: Record<string, unknown>) => options);
+
+    const mutation = useCreatePlannedExpenseFromInstallmentVsCashMutation(
+      client as never,
+    ) as unknown as {
+      mutationFn: (payload: {
+        simulationId: string;
+        payload: Record<string, unknown>;
+      }) => Promise<unknown>;
+    };
+
+    await mutation.mutationFn({
+      simulationId: "sim-1",
+      payload: { title: "Notebook" },
+    });
+
+    expect(client.createPlannedExpenseFromSimulation).toHaveBeenCalledWith(
+      "sim-1",
+      { title: "Notebook" },
+    );
+  });
+});

--- a/app/features/tools/queries/use-create-goal-from-installment-vs-cash-mutation.ts
+++ b/app/features/tools/queries/use-create-goal-from-installment-vs-cash-mutation.ts
@@ -1,0 +1,45 @@
+import { type UseMutationReturnType, useMutation, useQueryClient } from "@tanstack/vue-query";
+
+import {
+  type InstallmentVsCashClient,
+  useInstallmentVsCashClient,
+} from "~/features/tools/api/installment-vs-cash.client";
+import type {
+  CreateInstallmentVsCashGoalPayload,
+  InstallmentVsCashGoalBridgeResponse,
+} from "~/features/tools/model/installment-vs-cash";
+
+interface CreateGoalVariables {
+  simulationId: string;
+  payload: CreateInstallmentVsCashGoalPayload;
+}
+
+/**
+ * Mutation hook for the premium "add as goal" action.
+ *
+ * @param providedClient Optional injected client for tests.
+ * @returns Mutation state for the goal bridge.
+ */
+export const useCreateGoalFromInstallmentVsCashMutation = (
+  providedClient?: InstallmentVsCashClient,
+): UseMutationReturnType<
+  InstallmentVsCashGoalBridgeResponse,
+  Error,
+  CreateGoalVariables,
+  unknown
+> => {
+  const client = providedClient ?? useInstallmentVsCashClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      simulationId,
+      payload,
+    }: CreateGoalVariables): Promise<InstallmentVsCashGoalBridgeResponse> => {
+      return client.createGoalFromSimulation(simulationId, payload);
+    },
+    onSuccess: async (): Promise<void> => {
+      await queryClient.invalidateQueries({ queryKey: ["simulations"] });
+    },
+  });
+};

--- a/app/features/tools/queries/use-create-planned-expense-from-installment-vs-cash-mutation.ts
+++ b/app/features/tools/queries/use-create-planned-expense-from-installment-vs-cash-mutation.ts
@@ -1,0 +1,45 @@
+import { type UseMutationReturnType, useMutation, useQueryClient } from "@tanstack/vue-query";
+
+import {
+  type InstallmentVsCashClient,
+  useInstallmentVsCashClient,
+} from "~/features/tools/api/installment-vs-cash.client";
+import type {
+  CreateInstallmentVsCashPlannedExpensePayload,
+  InstallmentVsCashPlannedExpenseBridgeResponse,
+} from "~/features/tools/model/installment-vs-cash";
+
+interface CreatePlannedExpenseVariables {
+  simulationId: string;
+  payload: CreateInstallmentVsCashPlannedExpensePayload;
+}
+
+/**
+ * Mutation hook for the premium "planned expense" bridge action.
+ *
+ * @param providedClient Optional injected client for tests.
+ * @returns Mutation state for the planned-expense bridge.
+ */
+export const useCreatePlannedExpenseFromInstallmentVsCashMutation = (
+  providedClient?: InstallmentVsCashClient,
+): UseMutationReturnType<
+  InstallmentVsCashPlannedExpenseBridgeResponse,
+  Error,
+  CreatePlannedExpenseVariables,
+  unknown
+> => {
+  const client = providedClient ?? useInstallmentVsCashClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      simulationId,
+      payload,
+    }: CreatePlannedExpenseVariables): Promise<InstallmentVsCashPlannedExpenseBridgeResponse> => {
+      return client.createPlannedExpenseFromSimulation(simulationId, payload);
+    },
+    onSuccess: async (): Promise<void> => {
+      await queryClient.invalidateQueries({ queryKey: ["simulations"] });
+    },
+  });
+};

--- a/app/features/tools/queries/use-installment-vs-cash-calculate-mutation.ts
+++ b/app/features/tools/queries/use-installment-vs-cash-calculate-mutation.ts
@@ -1,0 +1,33 @@
+import { type UseMutationReturnType, useMutation } from "@tanstack/vue-query";
+
+import {
+  type InstallmentVsCashClient,
+  useInstallmentVsCashClient,
+} from "~/features/tools/api/installment-vs-cash.client";
+import type { InstallmentVsCashCalculationRequestDto } from "~/features/tools/contracts/installment-vs-cash.dto";
+import type { InstallmentVsCashCalculation } from "~/features/tools/model/installment-vs-cash";
+
+/**
+ * Vue Query mutation used by the public page to trigger the calculation.
+ *
+ * @param providedClient Optional injected client for tests.
+ * @returns Mutation state for the public calculate action.
+ */
+export const useInstallmentVsCashCalculateMutation = (
+  providedClient?: InstallmentVsCashClient,
+): UseMutationReturnType<
+  InstallmentVsCashCalculation,
+  Error,
+  InstallmentVsCashCalculationRequestDto,
+  unknown
+> => {
+  const client = providedClient ?? useInstallmentVsCashClient();
+
+  return useMutation({
+    mutationFn: (
+      payload: InstallmentVsCashCalculationRequestDto,
+    ): Promise<InstallmentVsCashCalculation> => {
+      return client.calculate(payload);
+    },
+  });
+};

--- a/app/features/tools/queries/use-save-installment-vs-cash-mutation.ts
+++ b/app/features/tools/queries/use-save-installment-vs-cash-mutation.ts
@@ -1,0 +1,41 @@
+import {
+  type UseMutationReturnType,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/vue-query";
+
+import {
+  type InstallmentVsCashClient,
+  useInstallmentVsCashClient,
+} from "~/features/tools/api/installment-vs-cash.client";
+import type { InstallmentVsCashSaveRequestDto } from "~/features/tools/contracts/installment-vs-cash.dto";
+import type { InstallmentVsCashSavedCalculation } from "~/features/tools/model/installment-vs-cash";
+
+/**
+ * Mutation hook used to save the calculation for an authenticated user.
+ *
+ * @param providedClient Optional injected client for tests.
+ * @returns Mutation state for the save action.
+ */
+export const useSaveInstallmentVsCashMutation = (
+  providedClient?: InstallmentVsCashClient,
+): UseMutationReturnType<
+  InstallmentVsCashSavedCalculation,
+  Error,
+  InstallmentVsCashSaveRequestDto,
+  unknown
+> => {
+  const client = providedClient ?? useInstallmentVsCashClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (
+      payload: InstallmentVsCashSaveRequestDto,
+    ): Promise<InstallmentVsCashSavedCalculation> => {
+      return client.save(payload);
+    },
+    onSuccess: async (): Promise<void> => {
+      await queryClient.invalidateQueries({ queryKey: ["simulations"] });
+    },
+  });
+};

--- a/app/pages/tools.spec.ts
+++ b/app/pages/tools.spec.ts
@@ -84,6 +84,13 @@ const globalStubs = {
     props: ["title"],
     template: "<div class='base-card'><slot /></div>",
   },
+  UiGlassPanel: {
+    template: "<div class='glass-panel'><slot /></div>",
+  },
+  UiPageHeader: {
+    props: ["title", "subtitle"],
+    template: "<div class='page-header'>{{ title }} {{ subtitle }}</div>",
+  },
   BaseSkeleton: {
     template: "<div class='skeleton' />",
   },
@@ -107,6 +114,12 @@ describe("ToolsPage (/tools)", () => {
     expect(wrapper.text()).toContain("Pedir aumento");
   });
 
+  it("destaca a ferramenta parcelado vs à vista", () => {
+    const wrapper = mount(ToolsPage, { global: { stubs: globalStubs } });
+    expect(wrapper.text()).toContain("Nova ferramenta: parcelado vs à vista");
+    expect(wrapper.text()).toContain("Abrir ferramenta");
+  });
+
   it("exibe ToolCard para cada ferramenta", () => {
     const wrapper = mount(ToolsPage, { global: { stubs: globalStubs } });
     const cards = wrapper.findAll(".tool-card");
@@ -121,7 +134,8 @@ describe("ToolsPage (/tools)", () => {
   it("abre modal quando usuário não autenticado clica em salvar resultado", async () => {
     mockIsAuthenticated.mockReturnValue(false);
     const wrapper = mount(ToolsPage, { global: { stubs: globalStubs } });
-    await wrapper.find(".n-button").trigger("click");
+    const buttons = wrapper.findAll(".n-button");
+    await buttons[1]?.trigger("click");
     await flushPromises();
     expect(wrapper.find(".n-modal").exists()).toBe(true);
   });
@@ -129,7 +143,8 @@ describe("ToolsPage (/tools)", () => {
   it("não abre modal quando usuário está autenticado e clica em salvar resultado", async () => {
     mockIsAuthenticated.mockReturnValue(true);
     const wrapper = mount(ToolsPage, { global: { stubs: globalStubs } });
-    await wrapper.find(".n-button").trigger("click");
+    const buttons = wrapper.findAll(".n-button");
+    await buttons[1]?.trigger("click");
     await flushPromises();
     expect(wrapper.find(".n-modal").exists()).toBe(false);
   });

--- a/app/pages/tools.vue
+++ b/app/pages/tools.vue
@@ -53,6 +53,11 @@ const restoredToolId = computed<string | null>(() => {
   return queryTool ?? toolContextStore.pendingToolId;
 });
 
+/** Navigates to the curated public calculator route. */
+const goToInstallmentVsCash = (): void => {
+  void router.push("/tools/parcelado-vs-a-vista");
+};
+
 /**
  * If the user is unauthenticated, persists the tool context and shows the
  * save-result modal — routing them to register/login with tool state encoded
@@ -112,6 +117,27 @@ const goToLogin = (): void => {
     <ToolsEmptyState v-else-if="!hasTools" />
 
     <template v-else>
+      <UiGlassPanel glow class="tools-page__featured-tool">
+        <div class="tools-page__featured-copy">
+          <UiPageHeader
+            title="Nova ferramenta: parcelado vs à vista"
+            subtitle="Compare desconto à vista, parcelamento, inflação e custo de oportunidade em uma experiência pública e detalhada."
+          />
+          <p class="tools-page__featured-description">
+            A ferramenta mostra uma resposta simples para iniciantes e abre os detalhes
+            matemáticos para quem quer auditar a decisão.
+          </p>
+        </div>
+
+        <NButton
+          type="primary"
+          size="large"
+          @click="goToInstallmentVsCash"
+        >
+          Abrir ferramenta
+        </NButton>
+      </UiGlassPanel>
+
       <ul class="tools-page__grid" role="list">
         <li
           v-for="tool in tools"
@@ -172,6 +198,27 @@ const goToLogin = (): void => {
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
 }
 
+.tools-page__featured-tool {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.tools-page__featured-copy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.tools-page__featured-description {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
 .tools-page__cta {
   display: flex;
   flex-direction: column;
@@ -184,5 +231,12 @@ const goToLogin = (): void => {
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   margin: 0;
+}
+
+@media (max-width: 767px) {
+  .tools-page__featured-tool {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 </style>

--- a/app/pages/tools/parcelado-vs-a-vista.spec.ts
+++ b/app/pages/tools/parcelado-vs-a-vista.spec.ts
@@ -1,0 +1,470 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref, type App } from "vue";
+
+import ParceladoVsAVistaPage from "./parcelado-vs-a-vista.vue";
+import { useToolContextStore } from "~/stores/toolContext";
+import type { InstallmentVsCashFormState } from "~/features/tools/model/installment-vs-cash";
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockSaveRedirect = vi.hoisted(() => vi.fn());
+const mockMessageSuccess = vi.hoisted(() => vi.fn());
+const mockMessageError = vi.hoisted(() => vi.fn());
+const mockCalculateMutateAsync = vi.hoisted(() => vi.fn());
+const mockSaveMutateAsync = vi.hoisted(() => vi.fn());
+const mockGoalMutateAsync = vi.hoisted(() => vi.fn());
+const mockExpenseMutateAsync = vi.hoisted(() => vi.fn());
+const mockEntitlementCheck = vi.hoisted(() => vi.fn().mockResolvedValue(false));
+const mockCaptureException = vi.hoisted(() => vi.fn());
+const mockIsAuthenticated = ref(false);
+const mockHasPremiumAccess = ref(false);
+
+vi.mock("#imports", () => ({
+  definePageMeta: vi.fn(),
+  useHead: vi.fn(),
+  useSeoMeta: vi.fn(),
+  useRouter: (): { push: typeof mockPush } => ({ push: mockPush }),
+}));
+
+vi.mock("naive-ui", () => ({
+  NAlert: {
+    props: ["type"],
+    template: "<div class='n-alert'><slot /></div>",
+  },
+  NButton: {
+    props: ["type", "size", "loading", "disabled", "quaternary"],
+    template: "<button class='n-button' @click='$emit(\"click\")'><slot /></button>",
+    emits: ["click"],
+  },
+  NDatePicker: {
+    props: ["value", "type", "clearable"],
+    template: "<input class='n-date-picker' />",
+  },
+  NForm: { template: "<form><slot /></form>" },
+  NFormItem: {
+    props: ["label"],
+    template: "<div class='n-form-item'><slot /></div>",
+  },
+  NInput: {
+    props: ["value", "type"],
+    template: "<input class='n-input' />",
+  },
+  NModal: {
+    props: ["show", "preset", "title"],
+    template: "<div v-if='show' class='n-modal'><slot /></div>",
+  },
+  NSpace: {
+    props: ["vertical", "size", "justify"],
+    template: "<div><slot /></div>",
+  },
+  NTag: {
+    props: ["round", "type"],
+    template: "<span><slot /></span>",
+  },
+  NThing: {
+    props: ["title", "description"],
+    template: "<div><strong>{{ title }}</strong><span>{{ description }}</span><slot /></div>",
+  },
+  useMessage: (): { success: typeof mockMessageSuccess; error: typeof mockMessageError } => ({
+    success: mockMessageSuccess,
+    error: mockMessageError,
+  }),
+}));
+
+vi.mock("@tanstack/vue-query", async () => {
+  const actual = await vi.importActual("@tanstack/vue-query");
+
+  return {
+    ...actual,
+    useQuery: vi.fn(() => ({
+      data: mockHasPremiumAccess,
+      isLoading: ref(false),
+      isError: ref(false),
+    })),
+  };
+});
+
+vi.mock("~/composables/useAuthRedirectContext", () => ({
+  useAuthRedirectContext: (): { saveRedirect: typeof mockSaveRedirect } => ({
+    saveRedirect: mockSaveRedirect,
+  }),
+}));
+
+vi.mock("~/stores/session", () => ({
+  useSessionStore: (): {
+    restore: ReturnType<typeof vi.fn>;
+    isAuthenticated: boolean;
+    userEmail: string | null;
+  } => ({
+    restore: vi.fn(),
+    get isAuthenticated(): boolean {
+      return mockIsAuthenticated.value;
+    },
+    userEmail: null,
+  }),
+}));
+
+vi.mock("~/features/paywall/api/entitlement.client", () => ({
+  useEntitlementClient: (): {
+    checkEntitlement: typeof mockEntitlementCheck;
+  } => ({
+    checkEntitlement: mockEntitlementCheck,
+  }),
+}));
+
+vi.mock("~/core/observability", () => ({
+  captureException: mockCaptureException,
+}));
+
+vi.mock("~/features/tools/queries/use-installment-vs-cash-calculate-mutation", () => ({
+  useInstallmentVsCashCalculateMutation: (): {
+    mutateAsync: typeof mockCalculateMutateAsync;
+    isPending: ReturnType<typeof ref<boolean>>;
+    isError: ReturnType<typeof ref<boolean>>;
+  } => ({
+    mutateAsync: mockCalculateMutateAsync,
+    isPending: ref(false),
+    isError: ref(false),
+  }),
+}));
+
+vi.mock("~/features/tools/queries/use-save-installment-vs-cash-mutation", () => ({
+  useSaveInstallmentVsCashMutation: (): {
+    mutateAsync: typeof mockSaveMutateAsync;
+    isPending: ReturnType<typeof ref<boolean>>;
+  } => ({
+    mutateAsync: mockSaveMutateAsync,
+    isPending: ref(false),
+  }),
+}));
+
+vi.mock("~/features/tools/queries/use-create-goal-from-installment-vs-cash-mutation", () => ({
+  useCreateGoalFromInstallmentVsCashMutation: (): {
+    mutateAsync: typeof mockGoalMutateAsync;
+    isPending: ReturnType<typeof ref<boolean>>;
+  } => ({
+    mutateAsync: mockGoalMutateAsync,
+    isPending: ref(false),
+  }),
+}));
+
+vi.mock("~/features/tools/queries/use-create-planned-expense-from-installment-vs-cash-mutation", () => ({
+  useCreatePlannedExpenseFromInstallmentVsCashMutation: (): {
+    mutateAsync: typeof mockExpenseMutateAsync;
+    isPending: ReturnType<typeof ref<boolean>>;
+  } => ({
+    mutateAsync: mockExpenseMutateAsync,
+    isPending: ref(false),
+  }),
+}));
+
+const globalStubs = {
+  UiPageHeader: {
+    props: ["title", "subtitle"],
+    template: "<div><h1>{{ title }}</h1><p>{{ subtitle }}</p></div>",
+  },
+  UiGlassPanel: { template: "<div><slot /></div>" },
+  UiSurfaceCard: { template: "<div><slot /></div>" },
+  UiSegmentedControl: {
+    props: ["modelValue", "options"],
+    template: "<div class='segmented' />",
+  },
+  InstallmentVsCashCalculatorForm: {
+    props: ["modelValue", "loading"],
+    template: `
+      <div>
+        <button class='calculator-update' @click='$emit("update:modelValue", validForm)'>Preencher</button>
+        <button class='calculator-submit' @click='$emit("submit")'>Calcular</button>
+      </div>
+    `,
+    data: (): { validForm: InstallmentVsCashFormState } => ({
+      validForm: {
+        scenarioLabel: "Notebook",
+        cashPrice: 900,
+        installmentCount: 3,
+        installmentInputMode: "total",
+        installmentAmount: null,
+        installmentTotal: 990,
+        firstPaymentDelayPreset: "30_days",
+        customFirstPaymentDelayDays: null,
+        opportunityRateType: "manual",
+        opportunityRateAnnual: 12,
+        inflationRateAnnual: 4.5,
+        feesEnabled: false,
+        feesUpfront: null,
+      },
+    }),
+    emits: ["submit", "update:modelValue"],
+  },
+  InstallmentVsCashResults: {
+    props: ["calculation"],
+    template: "<div class='results'>resultado</div>",
+  },
+  InstallmentVsCashActionBar: {
+    props: ["isAuthenticated", "hasPremiumAccess", "isSaving", "isBridging", "hasSavedSimulation"],
+    template: `
+      <div class='action-bar'>
+        <button class='save-action' @click='$emit("save")'>save</button>
+        <button class='goal-action' @click='$emit("goal")'>goal</button>
+        <button class='expense-action' @click='$emit("expense")'>expense</button>
+      </div>
+    `,
+    emits: ["save", "goal", "expense"],
+  },
+};
+
+const calculationResponse = {
+  toolId: "installment_vs_cash",
+  ruleVersion: "2026.1",
+  input: {
+    cashPrice: 900,
+    installmentCount: 3,
+    installmentAmount: 330,
+    installmentTotal: 990,
+    firstPaymentDelayDays: 30,
+    opportunityRateType: "manual",
+    opportunityRateAnnual: 12,
+    inflationRateAnnual: 4.5,
+    feesUpfront: 0,
+    scenarioLabel: "Notebook",
+  },
+  result: {
+    recommendedOption: "cash",
+    recommendationReason: "À vista ficou melhor.",
+    formulaExplainer: "Comparação por valor presente.",
+    comparison: {
+      cashOptionTotal: 900,
+      installmentOptionTotal: 990,
+      installmentPresentValue: 940,
+      installmentRealValueToday: 930,
+      presentValueDeltaVsCash: 40,
+      absoluteDeltaVsCash: 90,
+      relativeDeltaVsCashPercent: 4.44,
+      breakEvenDiscountPercent: 9.09,
+      breakEvenOpportunityRateAnnual: 18.2,
+    },
+    options: {
+      cash: { total: 900 },
+      installment: {
+        count: 3,
+        amounts: [330, 330, 330],
+        installmentAmount: 330,
+        nominalTotal: 990,
+        upfrontFees: 0,
+        firstPaymentDelayDays: 30,
+      },
+    },
+    neutralityBand: { absoluteBrl: 10, relativePercent: 1 },
+    assumptions: {
+      opportunityRateType: "manual",
+      opportunityRateAnnualPercent: 12,
+      inflationRateAnnualPercent: 4.5,
+      periodicity: "monthly",
+      firstPaymentDelayDays: 30,
+      upfrontFeesApplyTo: "installment",
+      neutralityRule: "hybrid",
+    },
+    indicatorSnapshot: null,
+    schedule: [],
+  },
+};
+
+/**
+ * Installs a minimal Nuxt context so composables like useHead can resolve.
+ *
+ * @param app Vue app instance under test.
+ */
+function nuxtContextPlugin(app: App): void {
+  const fakeNuxtApp = {
+    _route: {
+      path: "/tools/parcelado-vs-a-vista",
+      meta: {},
+      params: {},
+      query: {},
+    },
+    $router: { push: mockPush, replace: vi.fn() },
+    $config: { public: {} },
+    payload: { serverRendered: false },
+    ssrContext: {
+      head: {
+        push: vi.fn(() => ({
+          patch: vi.fn(),
+          dispose: vi.fn(),
+        })),
+      },
+    },
+    static: { data: {} },
+    isHydrating: false,
+    deferHydration: (): void => {},
+    runWithContext: <T>(callback: () => T): T => callback(),
+    hooks: { callHook: vi.fn(), hook: vi.fn() },
+    _asyncDataPromises: {},
+    _asyncData: {},
+  };
+
+  Reflect.set(app, "$nuxt", fakeNuxtApp);
+}
+
+/**
+ * Mounts the public calculator page with the minimal Nuxt test context.
+ *
+ * @returns Mounted wrapper for assertions and interactions.
+ */
+function mountPage(): ReturnType<typeof mount> {
+  return mount(ParceladoVsAVistaPage, {
+    global: {
+      plugins: [{ install: nuxtContextPlugin }],
+      stubs: globalStubs,
+    },
+  });
+}
+
+/**
+ * Fills the stubbed calculator form and submits it once.
+ *
+ * @param wrapper Mounted page wrapper.
+ */
+async function calculateFromStubForm(
+  wrapper: ReturnType<typeof mountPage>,
+): Promise<void> {
+  await wrapper.find(".calculator-update").trigger("click");
+  await wrapper.find(".calculator-submit").trigger("click");
+  await flushPromises();
+}
+
+/**
+ * Resets all hoisted mocks and local session state between tests.
+ */
+function resetPageState(): void {
+  setActivePinia(createPinia());
+  mockPush.mockClear();
+  mockSaveRedirect.mockClear();
+  mockCalculateMutateAsync.mockReset();
+  mockSaveMutateAsync.mockReset();
+  mockGoalMutateAsync.mockReset();
+  mockExpenseMutateAsync.mockReset();
+  mockMessageSuccess.mockClear();
+  mockMessageError.mockClear();
+  mockCaptureException.mockClear();
+  mockIsAuthenticated.value = false;
+  mockHasPremiumAccess.value = false;
+  sessionStorage.clear();
+}
+
+describe("ParceladoVsAVistaPage", () => {
+  beforeEach(() => {
+    resetPageState();
+  });
+
+  it("renders the public hero copy", () => {
+    const wrapper = mountPage();
+
+    expect(wrapper.text()).toContain("Descubra qual forma de pagamento");
+    expect(wrapper.text()).toContain("Ferramenta pública");
+  });
+
+  it("shows a validation warning before calling the API", async () => {
+    const wrapper = mountPage();
+
+    await wrapper.find(".calculator-submit").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Informe um preço à vista maior que zero.");
+    expect(mockCalculateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("submits the calculation once the form emits valid data", async () => {
+    mockCalculateMutateAsync.mockResolvedValue(calculationResponse);
+
+    const wrapper = mountPage();
+    await calculateFromStubForm(wrapper);
+
+    expect(mockCalculateMutateAsync).toHaveBeenCalledOnce();
+    expect(wrapper.find(".results").exists()).toBe(true);
+  });
+
+  it("reports and surfaces calculation failures", async () => {
+    mockCalculateMutateAsync.mockRejectedValue(new Error("boom"));
+
+    const wrapper = mountPage();
+    await calculateFromStubForm(wrapper);
+
+    expect(mockCaptureException).toHaveBeenCalledOnce();
+    expect(mockMessageError).toHaveBeenCalledWith(
+      "Não foi possível calcular agora. Revise os dados e tente novamente.",
+    );
+  });
+
+  it("persists context and redirects to login when saving unauthenticated", async () => {
+    mockCalculateMutateAsync.mockResolvedValue(calculationResponse);
+
+    const wrapper = mountPage();
+    await calculateFromStubForm(wrapper);
+    await wrapper.find(".save-action").trigger("click");
+
+    const toolContextStore = useToolContextStore();
+    expect(toolContextStore.pendingToolId).toBe("installment_vs_cash");
+    expect(mockSaveRedirect).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/login");
+  });
+
+  it("saves the simulation directly for authenticated users", async () => {
+    mockIsAuthenticated.value = true;
+    mockCalculateMutateAsync.mockResolvedValue(calculationResponse);
+    mockSaveMutateAsync.mockResolvedValue({
+      simulation: { id: "sim-1", goalId: null },
+    });
+
+    const wrapper = mountPage();
+    await calculateFromStubForm(wrapper);
+    await wrapper.find(".save-action").trigger("click");
+
+    expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
+    expect(mockMessageSuccess).toHaveBeenCalledWith("Simulação salva com sucesso.");
+  });
+
+  it("reports save failures for authenticated users", async () => {
+    mockIsAuthenticated.value = true;
+    mockCalculateMutateAsync.mockResolvedValue(calculationResponse);
+    mockSaveMutateAsync.mockRejectedValue(new Error("save failed"));
+
+    const wrapper = mountPage();
+    await calculateFromStubForm(wrapper);
+    await wrapper.find(".save-action").trigger("click");
+    await flushPromises();
+
+    expect(mockCaptureException).toHaveBeenCalledOnce();
+    expect(mockMessageError).toHaveBeenCalledWith(
+      "Não foi possível salvar a simulação agora.",
+    );
+  });
+
+  it("routes to plans when a premium action is requested without premium access", async () => {
+    mockIsAuthenticated.value = true;
+    mockCalculateMutateAsync.mockResolvedValue(calculationResponse);
+
+    const wrapper = mountPage();
+    await calculateFromStubForm(wrapper);
+    await wrapper.find(".goal-action").trigger("click");
+
+    expect(mockPush).toHaveBeenCalledWith("/planos");
+  });
+
+  it("opens the goal modal when the user is premium", async () => {
+    mockIsAuthenticated.value = true;
+    mockHasPremiumAccess.value = true;
+    mockCalculateMutateAsync.mockResolvedValue(calculationResponse);
+    mockSaveMutateAsync.mockResolvedValue({
+      simulation: { id: "sim-1", goalId: null },
+    });
+
+    const wrapper = mountPage();
+    await calculateFromStubForm(wrapper);
+    await wrapper.find(".goal-action").trigger("click");
+    await flushPromises();
+
+    expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
+    expect(wrapper.find(".n-modal").exists()).toBe(true);
+  });
+});

--- a/app/pages/tools/parcelado-vs-a-vista.vue
+++ b/app/pages/tools/parcelado-vs-a-vista.vue
@@ -1,0 +1,808 @@
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from "vue";
+import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+import {
+  NAlert,
+  NButton,
+  NDatePicker,
+  NForm,
+  NFormItem,
+  NInput,
+  NModal,
+  NSpace,
+  NThing,
+  NTag,
+  useMessage,
+} from "naive-ui";
+
+import { captureException } from "~/core/observability";
+import { useAuthRedirectContext } from "~/composables/useAuthRedirectContext";
+import { useSessionStore } from "~/stores/session";
+import { useToolContextStore } from "~/stores/toolContext";
+import { useEntitlementClient } from "~/features/paywall/api/entitlement.client";
+import InstallmentVsCashActionBar from "~/features/tools/components/InstallmentVsCashActionBar.vue";
+import InstallmentVsCashCalculatorForm from "~/features/tools/components/InstallmentVsCashCalculatorForm.vue";
+import InstallmentVsCashResults from "~/features/tools/components/InstallmentVsCashResults.vue";
+import { useCreateGoalFromInstallmentVsCashMutation } from "~/features/tools/queries/use-create-goal-from-installment-vs-cash-mutation";
+import { useCreatePlannedExpenseFromInstallmentVsCashMutation } from "~/features/tools/queries/use-create-planned-expense-from-installment-vs-cash-mutation";
+import { useInstallmentVsCashCalculateMutation } from "~/features/tools/queries/use-installment-vs-cash-calculate-mutation";
+import { useSaveInstallmentVsCashMutation } from "~/features/tools/queries/use-save-installment-vs-cash-mutation";
+import {
+  createDefaultInstallmentVsCashFormState,
+  getRecommendationLabel,
+  INSTALLMENT_VS_CASH_PUBLIC_PATH,
+  INSTALLMENT_VS_CASH_TOOL_ID,
+  isInstallmentVsCashCalculation,
+  isInstallmentVsCashPendingPayload,
+  toInstallmentVsCashCalculationRequest,
+  validateInstallmentVsCashForm,
+  type CreateInstallmentVsCashGoalPayload,
+  type CreateInstallmentVsCashPlannedExpensePayload,
+  type InstallmentVsCashCalculation,
+  type InstallmentVsCashFormState,
+  type InstallmentVsCashSavedSimulation,
+  type SelectedPaymentOption,
+} from "~/features/tools/model/installment-vs-cash";
+
+definePageMeta({
+  layout: false,
+});
+
+useSeoMeta({
+  title: "Parcelado ou à vista: simule qual opção vale mais a pena | Auraxis",
+  description:
+    "Compare pagamento à vista e parcelado considerando desconto, inflação, custo de oportunidade e custos extras. Descubra qual opção fica mais vantajosa financeiramente.",
+  ogTitle: "Parcelado ou à vista: descubra a melhor opção | Auraxis",
+  ogDescription:
+    "Ferramenta pública da Auraxis para comparar à vista e parcelado com clareza, premissas transparentes e resultado confiável.",
+  twitterCard: "summary_large_image",
+});
+
+useHead({
+  script: [
+    {
+      type: "application/ld+json",
+      innerHTML: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        mainEntity: [
+          {
+            "@type": "Question",
+            name: "Quando vale a pena pagar parcelado?",
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: "Quando o valor presente do parcelamento fica abaixo do preço à vista dentro das premissas de taxa de oportunidade, inflação e custos extras informados.",
+            },
+          },
+          {
+            "@type": "Question",
+            name: "Parcelado sem juros sempre é melhor?",
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: "Nem sempre. Se houver desconto relevante à vista ou custos extras, o pagamento único pode continuar mais vantajoso financeiramente.",
+            },
+          },
+        ],
+      }),
+    },
+  ],
+});
+
+const message = useMessage();
+const router = useRouter();
+const sessionStore = useSessionStore();
+const toolContextStore = useToolContextStore();
+const { saveRedirect } = useAuthRedirectContext();
+const entitlementClient = useEntitlementClient();
+
+const form = ref<InstallmentVsCashFormState>(
+  createDefaultInstallmentVsCashFormState(),
+);
+const calculation = ref<InstallmentVsCashCalculation | null>(null);
+const savedSimulation = ref<InstallmentVsCashSavedSimulation | null>(null);
+const validationMessage = ref<string | null>(null);
+const showGoalModal = ref(false);
+const showExpenseModal = ref(false);
+
+const goalForm = reactive<{
+  title: string;
+  selectedOption: SelectedPaymentOption;
+  description: string;
+  targetDate: number | null;
+}>({
+  title: "",
+  selectedOption: "cash",
+  description: "",
+  targetDate: null,
+});
+
+const plannedExpenseForm = reactive<{
+  title: string;
+  selectedOption: SelectedPaymentOption;
+  description: string;
+  dueDate: number | null;
+  firstDueDate: number | null;
+  upfrontDueDate: number | null;
+}>({
+  title: "",
+  selectedOption: "installment",
+  description: "",
+  dueDate: null,
+  firstDueDate: null,
+  upfrontDueDate: null,
+});
+
+const calculateMutation = useInstallmentVsCashCalculateMutation();
+const saveMutation = useSaveInstallmentVsCashMutation();
+const createGoalMutation = useCreateGoalFromInstallmentVsCashMutation();
+const createPlannedExpenseMutation =
+  useCreatePlannedExpenseFromInstallmentVsCashMutation();
+
+sessionStore.restore();
+
+const premiumAccessQuery: UseQueryReturnType<boolean, Error> = useQuery({
+  queryKey: ["entitlements", "advanced_simulations", INSTALLMENT_VS_CASH_TOOL_ID],
+  enabled: computed<boolean>(() => sessionStore.isAuthenticated),
+  queryFn: (): Promise<boolean> => {
+    return entitlementClient.checkEntitlement("advanced_simulations");
+  },
+});
+
+/**
+ * Whether the current user has a live authenticated session.
+ *
+ * @returns True when a session is available.
+ */
+const isAuthenticated = computed<boolean>(() => {
+  sessionStore.restore();
+  return sessionStore.isAuthenticated;
+});
+
+/**
+ * Whether the current user can use premium bridge actions.
+ *
+ * @returns True when the entitlement query resolved positively.
+ */
+const hasPremiumAccess = computed<boolean>(() => {
+  return premiumAccessQuery.data.value === true;
+});
+
+/**
+ * Combined activity flag for premium bridge actions.
+ *
+ * @returns True when a premium bridge mutation is pending.
+ */
+const isBridging = computed<boolean>(() => {
+  return createGoalMutation.isPending.value
+    || createPlannedExpenseMutation.isPending.value;
+});
+
+/**
+ * Reports an operational error to observability and shows a user-friendly message.
+ *
+ * @param error The original runtime error.
+ * @param context Stable context label for observability.
+ * @param fallbackMessage Human-readable message shown in the UI.
+ */
+const handleOperationalError = (
+  error: unknown,
+  context: string,
+  fallbackMessage: string,
+): void => {
+  captureException(error, {
+    context,
+    extra: {
+      toolId: INSTALLMENT_VS_CASH_TOOL_ID,
+    },
+  });
+  message.error(fallbackMessage);
+};
+
+/**
+ * Builds a YYYY-MM-DD string from a date-picker timestamp.
+ *
+ * @param value Epoch milliseconds from Naive UI.
+ * @returns ISO calendar string or undefined.
+ */
+const toIsoDate = (value: number | null): string | undefined => {
+  if (value === null) {
+    return undefined;
+  }
+
+  const date = new Date(value);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+/**
+ * Persists the current page state before redirecting the user to login.
+ */
+const persistContextAndRedirectToLogin = (): void => {
+  if (calculation.value === null) {
+    return;
+  }
+
+  toolContextStore.save(
+    INSTALLMENT_VS_CASH_TOOL_ID,
+    calculation.value,
+    { form: form.value },
+  );
+  saveRedirect(INSTALLMENT_VS_CASH_PUBLIC_PATH);
+  void router.push("/login");
+};
+
+/**
+ * Ensures a saved simulation exists before a premium bridge action.
+ *
+ * @returns The saved simulation reference.
+ */
+const ensureSavedSimulation = async (): Promise<InstallmentVsCashSavedSimulation> => {
+  if (savedSimulation.value !== null) {
+    return savedSimulation.value;
+  }
+
+  const currentCalculation = calculation.value;
+  if (currentCalculation === null) {
+    throw new Error("Nenhuma simulação disponível para salvar.");
+  }
+
+  const response = await saveMutation.mutateAsync(
+    toInstallmentVsCashCalculationRequest(form.value),
+  );
+  savedSimulation.value = response.simulation;
+  return response.simulation;
+};
+
+/**
+ * Runs the public calculation using the current form values.
+ */
+const handleCalculate = async (): Promise<void> => {
+  const errors = validateInstallmentVsCashForm(form.value);
+  if (errors.length > 0) {
+    validationMessage.value = errors[0]?.message ?? "Revise os dados informados.";
+    return;
+  }
+
+  validationMessage.value = null;
+  savedSimulation.value = null;
+  try {
+    calculation.value = await calculateMutation.mutateAsync(
+      toInstallmentVsCashCalculationRequest(form.value),
+    );
+  } catch (error: unknown) {
+    handleOperationalError(
+      error,
+      "tools.installment_vs_cash.calculate",
+      "Não foi possível calcular agora. Revise os dados e tente novamente.",
+    );
+  }
+};
+
+/**
+ * Saves the current calculation or redirects the visitor to login first.
+ */
+const handleSave = async (): Promise<void> => {
+  if (calculation.value === null) {
+    return;
+  }
+
+  if (!isAuthenticated.value) {
+    persistContextAndRedirectToLogin();
+    return;
+  }
+
+  try {
+    const response = await saveMutation.mutateAsync(
+      toInstallmentVsCashCalculationRequest(form.value),
+    );
+    savedSimulation.value = response.simulation;
+    message.success("Simulação salva com sucesso.");
+  } catch (error: unknown) {
+    handleOperationalError(
+      error,
+      "tools.installment_vs_cash.save",
+      "Não foi possível salvar a simulação agora.",
+    );
+  }
+};
+
+/**
+ * Opens the goal bridge or routes the user to the appropriate gate.
+ */
+const handleGoalAction = async (): Promise<void> => {
+  if (calculation.value === null) {
+    return;
+  }
+
+  if (!isAuthenticated.value) {
+    persistContextAndRedirectToLogin();
+    return;
+  }
+
+  if (!hasPremiumAccess.value) {
+    void router.push("/planos");
+    return;
+  }
+
+  try {
+    await ensureSavedSimulation();
+    goalForm.title = form.value.scenarioLabel.trim() || "Nova meta";
+    goalForm.selectedOption = calculation.value.result.recommendedOption === "installment"
+      ? "installment"
+      : "cash";
+    showGoalModal.value = true;
+  } catch (error: unknown) {
+    handleOperationalError(
+      error,
+      "tools.installment_vs_cash.goal.prefill",
+      "Não foi possível preparar a criação da meta agora.",
+    );
+  }
+};
+
+/**
+ * Opens the planned-expense bridge or routes the user to the appropriate gate.
+ */
+const handleExpenseAction = async (): Promise<void> => {
+  if (calculation.value === null) {
+    return;
+  }
+
+  if (!isAuthenticated.value) {
+    persistContextAndRedirectToLogin();
+    return;
+  }
+
+  if (!hasPremiumAccess.value) {
+    void router.push("/planos");
+    return;
+  }
+
+  try {
+    await ensureSavedSimulation();
+    plannedExpenseForm.title = form.value.scenarioLabel.trim() || "Compra planejada";
+    plannedExpenseForm.selectedOption =
+      calculation.value.result.recommendedOption === "cash" ? "cash" : "installment";
+    showExpenseModal.value = true;
+  } catch (error: unknown) {
+    handleOperationalError(
+      error,
+      "tools.installment_vs_cash.expense.prefill",
+      "Não foi possível preparar a despesa planejada agora.",
+    );
+  }
+};
+
+/**
+ * Submits the goal bridge modal.
+ */
+const submitGoalBridge = async (): Promise<void> => {
+  const simulation = savedSimulation.value;
+  if (simulation === null) {
+    message.error("Salve a simulação antes de criar uma meta.");
+    return;
+  }
+
+  const payload: CreateInstallmentVsCashGoalPayload = {
+    title: goalForm.title.trim(),
+    selectedOption: goalForm.selectedOption,
+    description: goalForm.description.trim() || undefined,
+    targetDate: toIsoDate(goalForm.targetDate),
+  };
+
+  try {
+    const response = await createGoalMutation.mutateAsync({
+      simulationId: simulation.id,
+      payload,
+    });
+
+    savedSimulation.value = response.simulation;
+    showGoalModal.value = false;
+    message.success("Meta criada a partir da simulação.");
+  } catch (error: unknown) {
+    handleOperationalError(
+      error,
+      "tools.installment_vs_cash.goal.submit",
+      "Não foi possível criar a meta agora.",
+    );
+  }
+};
+
+/**
+ * Submits the planned-expense bridge modal.
+ */
+const submitExpenseBridge = async (): Promise<void> => {
+  const simulation = savedSimulation.value;
+  if (simulation === null) {
+    message.error("Salve a simulação antes de planejar a despesa.");
+    return;
+  }
+
+  const payload: CreateInstallmentVsCashPlannedExpensePayload = {
+    title: plannedExpenseForm.title.trim(),
+    selectedOption: plannedExpenseForm.selectedOption,
+    description: plannedExpenseForm.description.trim() || undefined,
+    dueDate: plannedExpenseForm.selectedOption === "cash"
+      ? toIsoDate(plannedExpenseForm.dueDate)
+      : undefined,
+    firstDueDate: plannedExpenseForm.selectedOption === "installment"
+      ? toIsoDate(plannedExpenseForm.firstDueDate)
+      : undefined,
+    upfrontDueDate: toIsoDate(plannedExpenseForm.upfrontDueDate),
+  };
+
+  try {
+    const response = await createPlannedExpenseMutation.mutateAsync({
+      simulationId: simulation.id,
+      payload,
+    });
+
+    savedSimulation.value = response.simulation;
+    showExpenseModal.value = false;
+    message.success(
+      `${response.transactions.length} lançamento(s) planejado(s) criado(s).`,
+    );
+  } catch (error: unknown) {
+    handleOperationalError(
+      error,
+      "tools.installment_vs_cash.expense.submit",
+      "Não foi possível planejar a despesa agora.",
+    );
+  }
+};
+
+/**
+ * Restores pending context after a login redirect when the visitor returns to the page.
+ */
+onMounted((): void => {
+  toolContextStore.restore();
+
+  if (toolContextStore.pendingToolId !== INSTALLMENT_VS_CASH_TOOL_ID) {
+    return;
+  }
+
+  if (isInstallmentVsCashPendingPayload(toolContextStore.pendingPayload)) {
+    form.value = toolContextStore.pendingPayload.form;
+  }
+
+  if (isInstallmentVsCashCalculation(toolContextStore.pendingResult)) {
+    calculation.value = toolContextStore.pendingResult;
+  }
+
+  toolContextStore.clear();
+});
+</script>
+
+<template>
+  <div class="installment-vs-cash-page">
+    <header class="installment-vs-cash-page__header">
+      <div class="installment-vs-cash-page__brand">
+        <span class="installment-vs-cash-page__brand-mark">Auraxis</span>
+        <span class="installment-vs-cash-page__brand-copy">Ferramenta pública</span>
+      </div>
+
+      <div class="installment-vs-cash-page__header-actions">
+        <NButton quaternary @click="router.push('/tools')">
+          Ver outras ferramentas
+        </NButton>
+        <NButton type="primary" @click="router.push('/register')">
+          Criar conta gratuita
+        </NButton>
+      </div>
+    </header>
+
+    <main class="installment-vs-cash-page__content">
+      <section class="installment-vs-cash-page__hero">
+        <div class="installment-vs-cash-page__hero-copy">
+          <NTag round type="warning">
+            Parcelado ou à vista
+          </NTag>
+          <UiPageHeader
+            title="Descubra qual forma de pagamento fica mais vantajosa financeiramente"
+            subtitle="A Auraxis compara preço à vista, parcelado, custo de oportunidade, inflação e custos extras para te dar uma recomendação clara e auditável."
+          />
+
+          <NSpace vertical :size="16">
+            <NThing
+              title="Resposta rápida para iniciantes"
+              description="Você recebe um veredito direto em segundos, sem precisar entender matemática financeira."
+            />
+            <NThing
+              title="Detalhamento confiável para experts"
+              description="Expandimos a explicação com cronograma, valor presente, break-even e premissas usadas."
+            />
+          </NSpace>
+        </div>
+
+        <UiGlassPanel glow class="installment-vs-cash-page__hero-panel">
+          <InstallmentVsCashCalculatorForm
+            v-model="form"
+            :loading="calculateMutation.isPending.value"
+            @submit="handleCalculate"
+          />
+
+          <NAlert
+            v-if="validationMessage"
+            type="warning"
+            class="installment-vs-cash-page__alert"
+          >
+            {{ validationMessage }}
+          </NAlert>
+
+          <NAlert
+            v-if="calculateMutation.isError.value"
+            type="error"
+            class="installment-vs-cash-page__alert"
+          >
+            Não foi possível calcular agora. Revise os dados e tente novamente.
+          </NAlert>
+        </UiGlassPanel>
+      </section>
+
+      <section v-if="calculation" class="installment-vs-cash-page__results">
+        <InstallmentVsCashResults :calculation="calculation" />
+
+        <UiSurfaceCard>
+          <NThing
+            title="Próximo passo"
+            :description="`${getRecommendationLabel(calculation.result.recommendedOption)}. Se quiser, salve a simulação para acompanhar depois ou transforme-a em meta/despesa planejada.`"
+          />
+
+          <InstallmentVsCashActionBar
+            class="installment-vs-cash-page__actions"
+            :is-authenticated="isAuthenticated"
+            :has-premium-access="hasPremiumAccess"
+            :is-saving="saveMutation.isPending.value"
+            :is-bridging="isBridging"
+            :has-saved-simulation="savedSimulation !== null"
+            @save="handleSave"
+            @goal="handleGoalAction"
+            @expense="handleExpenseAction"
+          />
+        </UiSurfaceCard>
+      </section>
+
+      <section class="installment-vs-cash-page__seo">
+        <UiSurfaceCard>
+          <NSpace vertical :size="16">
+            <NThing
+              title="O que esta página considera"
+              description="Desconto à vista, parcelamento, custo de oportunidade, inflação e custos extras iniciais."
+            />
+            <NThing
+              title="O que esta página não substitui"
+              description="Esta é uma simulação educativa baseada nas premissas informadas. Ela não substitui proposta comercial oficial, contrato ou aconselhamento financeiro."
+            />
+            <NThing
+              title="Como usar melhor"
+              description="Teste o mesmo item com e sem desconto à vista, com parcelas diferentes e com taxas mais conservadoras. Isso te ajuda a entender a sensibilidade da decisão."
+            />
+          </NSpace>
+        </UiSurfaceCard>
+      </section>
+    </main>
+
+    <NModal
+      v-model:show="showGoalModal"
+      preset="card"
+      title="Incluir como meta"
+      class="installment-vs-cash-page__modal"
+    >
+      <NForm label-placement="top">
+        <NFormItem label="Título da meta">
+          <NInput v-model:value="goalForm.title" />
+        </NFormItem>
+
+        <NFormItem label="Descrição">
+          <NInput v-model:value="goalForm.description" type="textarea" />
+        </NFormItem>
+
+        <NFormItem label="Data alvo">
+          <NDatePicker
+            v-model:value="goalForm.targetDate"
+            type="date"
+            clearable
+          />
+        </NFormItem>
+
+        <NSpace justify="end">
+          <NButton @click="showGoalModal = false">Cancelar</NButton>
+          <NButton
+            type="primary"
+            :loading="createGoalMutation.isPending.value"
+            @click="submitGoalBridge"
+          >
+            Criar meta
+          </NButton>
+        </NSpace>
+      </NForm>
+    </NModal>
+
+    <NModal
+      v-model:show="showExpenseModal"
+      preset="card"
+      title="Planejar despesa"
+      class="installment-vs-cash-page__modal"
+    >
+      <NForm label-placement="top">
+        <NFormItem label="Título da despesa">
+          <NInput v-model:value="plannedExpenseForm.title" />
+        </NFormItem>
+
+        <NFormItem label="Descrição">
+          <NInput v-model:value="plannedExpenseForm.description" type="textarea" />
+        </NFormItem>
+
+        <NFormItem label="Modo selecionado">
+          <UiSegmentedControl
+            v-model="plannedExpenseForm.selectedOption"
+            :options="[
+              { label: 'À vista', value: 'cash' },
+              { label: 'Parcelado', value: 'installment' },
+            ]"
+            aria-label="Modo da despesa planejada"
+          />
+        </NFormItem>
+
+        <NFormItem
+          v-if="plannedExpenseForm.selectedOption === 'cash'"
+          label="Data do lançamento"
+        >
+          <NDatePicker
+            v-model:value="plannedExpenseForm.dueDate"
+            type="date"
+            clearable
+          />
+        </NFormItem>
+
+        <NFormItem
+          v-else
+          label="Primeiro vencimento"
+        >
+          <NDatePicker
+            v-model:value="plannedExpenseForm.firstDueDate"
+            type="date"
+            clearable
+          />
+        </NFormItem>
+
+        <NFormItem v-if="form.feesEnabled" label="Data dos custos iniciais">
+          <NDatePicker
+            v-model:value="plannedExpenseForm.upfrontDueDate"
+            type="date"
+            clearable
+          />
+        </NFormItem>
+
+        <NSpace justify="end">
+          <NButton @click="showExpenseModal = false">Cancelar</NButton>
+          <NButton
+            type="primary"
+            :loading="createPlannedExpenseMutation.isPending.value"
+            @click="submitExpenseBridge"
+          >
+            Planejar despesa
+          </NButton>
+        </NSpace>
+      </NForm>
+    </NModal>
+  </div>
+</template>
+
+<style scoped>
+.installment-vs-cash-page {
+  min-height: 100dvh;
+  background:
+    radial-gradient(circle at top right, var(--color-brand-glow-xs), transparent 28%),
+    linear-gradient(180deg, var(--color-bg-surface) 0%, var(--color-bg-base) 100%);
+  color: var(--color-text-primary);
+}
+
+.installment-vs-cash-page__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+}
+
+.installment-vs-cash-page__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.installment-vs-cash-page__brand-mark {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+}
+
+.installment-vs-cash-page__brand-copy {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.installment-vs-cash-page__header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.installment-vs-cash-page__content {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 var(--space-4) var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.installment-vs-cash-page__hero {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: minmax(0, 1.1fr) minmax(380px, 0.9fr);
+  align-items: start;
+}
+
+.installment-vs-cash-page__hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding-top: var(--space-5);
+}
+
+.installment-vs-cash-page__hero-panel {
+  position: sticky;
+  top: var(--space-3);
+}
+
+.installment-vs-cash-page__alert {
+  margin-top: var(--space-2);
+}
+
+.installment-vs-cash-page__results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.installment-vs-cash-page__actions {
+  margin-top: var(--space-2);
+}
+
+.installment-vs-cash-page__seo {
+  padding-bottom: var(--space-4);
+}
+
+:deep(.installment-vs-cash-page__modal) {
+  width: min(720px, calc(100vw - 32px));
+}
+
+@media (max-width: 1023px) {
+  .installment-vs-cash-page__hero {
+    grid-template-columns: 1fr;
+  }
+
+  .installment-vs-cash-page__hero-copy {
+    padding-top: var(--space-2);
+  }
+
+  .installment-vs-cash-page__hero-panel {
+    position: static;
+  }
+}
+
+@media (max-width: 767px) {
+  .installment-vs-cash-page__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .installment-vs-cash-page__content {
+    padding-inline: var(--space-2);
+  }
+}
+</style>

--- a/app/stores/toolContext.spec.ts
+++ b/app/stores/toolContext.spec.ts
@@ -1,5 +1,5 @@
-import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
 
 import { useToolContextStore } from "./toolContext";
 
@@ -9,38 +9,27 @@ describe("toolContext store", () => {
     sessionStorage.clear();
   });
 
-  it("salva tool id e resultado no estado e no sessionStorage", () => {
+  it("persists and restores payload together with result", () => {
     const store = useToolContextStore();
-    const result = { score: 42 };
 
-    store.save("raise-calculator", result);
+    store.save("installment_vs_cash", { result: true }, { form: { foo: "bar" } });
 
-    expect(store.pendingToolId).toBe("raise-calculator");
-    expect(store.pendingResult).toEqual(result);
-    expect(sessionStorage.getItem("auraxis_pending_tool_id")).toBe("raise-calculator");
-    expect(JSON.parse(sessionStorage.getItem("auraxis_pending_result") ?? "null")).toEqual(result);
+    const restoredStore = useToolContextStore();
+    restoredStore.restore();
+
+    expect(restoredStore.pendingToolId).toBe("installment_vs_cash");
+    expect(restoredStore.pendingResult).toEqual({ result: true });
+    expect(restoredStore.pendingPayload).toEqual({ form: { foo: "bar" } });
   });
 
-  it("restaura contexto a partir do sessionStorage", () => {
-    sessionStorage.setItem("auraxis_pending_tool_id", "bill-forecast");
-    sessionStorage.setItem("auraxis_pending_result", JSON.stringify({ balance: 100 }));
-
+  it("clears all persisted state", () => {
     const store = useToolContextStore();
-    store.restore();
 
-    expect(store.pendingToolId).toBe("bill-forecast");
-    expect(store.pendingResult).toEqual({ balance: 100 });
-  });
-
-  it("clear remove dados do estado e do sessionStorage", () => {
-    const store = useToolContextStore();
-    store.save("raise-calculator", { score: 1 });
-
+    store.save("installment_vs_cash", { result: true }, { form: { foo: "bar" } });
     store.clear();
 
     expect(store.pendingToolId).toBeNull();
     expect(store.pendingResult).toBeNull();
-    expect(sessionStorage.getItem("auraxis_pending_tool_id")).toBeNull();
-    expect(sessionStorage.getItem("auraxis_pending_result")).toBeNull();
+    expect(store.pendingPayload).toBeNull();
   });
 });

--- a/app/stores/toolContext.ts
+++ b/app/stores/toolContext.ts
@@ -3,6 +3,7 @@ import { defineStore } from "pinia";
 
 const STORAGE_KEY_TOOL_ID = "auraxis_pending_tool_id";
 const STORAGE_KEY_RESULT = "auraxis_pending_result";
+const STORAGE_KEY_PAYLOAD = "auraxis_pending_payload";
 
 /**
  * Persists and restores tool context across the unauthenticated → login →
@@ -12,20 +13,24 @@ const STORAGE_KEY_RESULT = "auraxis_pending_result";
 export const useToolContextStore = defineStore("toolContext", () => {
   const pendingToolId = ref<string | null>(null);
   const pendingResult = ref<unknown>(null);
+  const pendingPayload = ref<unknown>(null);
 
   /**
    * Saves the tool id and result to both reactive state and sessionStorage so
    * the context survives the login redirect.
    * @param toolId  The identifier of the tool that produced the result.
    * @param result  The result payload to restore after login.
+   * @param payload Optional input payload required to resume the flow.
    */
-  function save(toolId: string, result: unknown): void {
+  function save(toolId: string, result: unknown, payload: unknown = null): void {
     pendingToolId.value = toolId;
     pendingResult.value = result;
+    pendingPayload.value = payload;
 
     if (typeof window !== "undefined") {
       sessionStorage.setItem(STORAGE_KEY_TOOL_ID, toolId);
       sessionStorage.setItem(STORAGE_KEY_RESULT, JSON.stringify(result));
+      sessionStorage.setItem(STORAGE_KEY_PAYLOAD, JSON.stringify(payload));
     }
   }
 
@@ -40,6 +45,7 @@ export const useToolContextStore = defineStore("toolContext", () => {
 
     const toolId = sessionStorage.getItem(STORAGE_KEY_TOOL_ID);
     const rawResult = sessionStorage.getItem(STORAGE_KEY_RESULT);
+    const rawPayload = sessionStorage.getItem(STORAGE_KEY_PAYLOAD);
 
     if (toolId !== null) {
       pendingToolId.value = toolId;
@@ -52,6 +58,14 @@ export const useToolContextStore = defineStore("toolContext", () => {
         pendingResult.value = null;
       }
     }
+
+    if (rawPayload !== null) {
+      try {
+        pendingPayload.value = JSON.parse(rawPayload) as unknown;
+      } catch {
+        pendingPayload.value = null;
+      }
+    }
   }
 
   /**
@@ -60,12 +74,14 @@ export const useToolContextStore = defineStore("toolContext", () => {
   function clear(): void {
     pendingToolId.value = null;
     pendingResult.value = null;
+    pendingPayload.value = null;
 
     if (typeof window !== "undefined") {
       sessionStorage.removeItem(STORAGE_KEY_TOOL_ID);
       sessionStorage.removeItem(STORAGE_KEY_RESULT);
+      sessionStorage.removeItem(STORAGE_KEY_PAYLOAD);
     }
   }
 
-  return { pendingToolId, pendingResult, save, restore, clear };
+  return { pendingToolId, pendingResult, pendingPayload, save, restore, clear };
 });


### PR DESCRIPTION
## Summary
- add the public `parcelado vs à vista` experience under `/tools/parcelado-vs-a-vista`
- introduce typed tools contracts/model/api/mutations plus premium bridges for goal and planned expense
- spotlight the new calculator in `/tools` and persist tool context across login redirects

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:coverage`
- `pnpm policy:check`
- `pnpm contracts:check`
- `pnpm quality-check`

## Notes
- `contracts/feature-contract-baseline.json` was intentionally left out because it was already modified outside this feature scope
- product analytics is still pending a dedicated stack in the web repo

Closes #282