### PR TITLE
chore(web-ops-03): add chromatic visual review workflow

### DIFF
--- a/.context/handoffs/WEB-OPS-03.md
+++ b/.context/handoffs/WEB-OPS-03.md
@@ -1,0 +1,25 @@
+# WEB-OPS-03 - Chromatic oficial
+
+## O que foi feito
+
+- workflow oficial de Chromatic adicionado em `.github/workflows/chromatic.yml`
+- documentação operacional criada em `docs/chromatic.md`
+- `README.md` atualizado com a trilha oficial de visual review
+
+## O que foi validado
+
+- `CI=1 pnpm storybook:build` em cópia temporária isolada, fora de uma árvore com `.pnp.cjs` externo
+- revisão estrutural do workflow e da documentação
+
+## Riscos pendentes
+
+- publicação real depende do secret `CHROMATIC_PROJECT_TOKEN`
+- domínio customizado `v1.design-system.auraxis.com.br` depende de configuração no painel do Chromatic e DNS externo
+- até o domínio estar ativo, a URL nativa do Chromatic continua sendo o fallback
+- workspaces locais sob diretórios pai com `.pnp.cjs` podem contaminar o Storybook; a doc do bloco já registra a mitigação
+
+## Próximo passo
+
+- abrir PR do bloco
+- validar run verde do workflow `Chromatic`
+- conectar o domínio customizado no painel do Chromatic e no DNS

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,84 @@
+name: Chromatic
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+
+concurrency:
+  group: chromatic-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '25'
+  PNPM_VERSION: '10.30.1'
+
+jobs:
+  chromatic:
+    name: Chromatic Visual Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check Chromatic capability
+        id: capability
+        env:
+          CHROMATIC_TOKEN_VALUE: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        run: |
+          if [ -n "${CHROMATIC_TOKEN_VALUE:-}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Chromatic skipped: CHROMATIC_PROJECT_TOKEN is not configured for this repository."
+          fi
+
+      - name: Checkout
+        if: steps.capability.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        if: steps.capability.outputs.enabled == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node
+        if: steps.capability.outputs.enabled == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.capability.outputs.enabled == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Chromatic
+        id: chromatic
+        if: steps.capability.outputs.enabled == 'true'
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          buildScriptName: storybook:build
+          onlyChanged: true
+          exitZeroOnChanges: true
+
+      - name: Publish summary
+        if: steps.capability.outputs.enabled == 'true'
+        run: |
+          {
+            echo "## Chromatic"
+            echo
+            echo "- Build URL: ${{ steps.chromatic.outputs.buildUrl }}"
+            echo "- Storybook URL: ${{ steps.chromatic.outputs.storybookUrl }}"
+            echo "- Captured snapshots: ${{ steps.chromatic.outputs.actualCaptureCount }}"
+            echo "- Story count: ${{ steps.chromatic.outputs.specCount }}"
+            echo "- Components: ${{ steps.chromatic.outputs.componentCount }}"
+            echo
+            echo "Target custom domain: https://v1.design-system.auraxis.com.br"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Aplicação web do Auraxis construída com Nuxt 4, TypeScript estrito e Vue 3 �
 - ESLint (`@nuxt/eslint`) + Prettier
 - Vitest / Playwright
 - Storybook (mantido para evolução do design system)
+- Chromatic (trilha oficial de visual review do design system)
 
 ## Arquitetura-alvo
 
@@ -53,6 +54,8 @@ app/
 ```bash
 pnpm install
 pnpm dev
+pnpm storybook
+pnpm storybook:build
 pnpm lint
 pnpm typecheck
 pnpm test
@@ -67,3 +70,14 @@ pnpm build
 - Não commitar diretamente em `main`/`master`.
 - Toda mudança de contrato com backend deve refletir os tipos e adapters do frontend.
 - Placeholders não devem mascarar falhas do fluxo nominal.
+
+## Visual review oficial
+
+- workflow: `.github/workflows/chromatic.yml`
+- secret esperado: `CHROMATIC_PROJECT_TOKEN`
+- domínio alvo: `https://v1.design-system.auraxis.com.br`
+- fallback operacional: URL nativa do Chromatic em cada build
+
+Referência operacional:
+
+- [Chromatic e Storybook](./docs/chromatic.md)

--- a/docs/chromatic.md
+++ b/docs/chromatic.md
@@ -1,0 +1,92 @@
+# Chromatic e Storybook
+
+## Objetivo
+
+Publicar o Storybook do `auraxis-web` no Chromatic como trilha oficial de visual review contínuo.
+
+## Superfícies oficiais
+
+- domínio alvo: `https://v1.design-system.auraxis.com.br`
+- fallback operacional: URL nativa do Chromatic gerada em cada build
+
+## Workflow
+
+Arquivo oficial:
+
+- `.github/workflows/chromatic.yml`
+
+Gatilhos:
+
+- `pull_request` para `main` e `master`
+- `push` para `main` e `master`
+- `workflow_dispatch`
+
+Comportamento:
+
+- usa `CHROMATIC_PROJECT_TOKEN` como secret obrigatório para publicação real
+- sem o secret, o workflow faz `skip` com notice explícito em vez de falhar ruidosamente
+- roda `pnpm install --frozen-lockfile`
+- publica o Storybook via `chromaui/action`
+- gera resumo com `buildUrl` e `storybookUrl` no `Step Summary`
+
+Observação importante:
+
+- para reprodutibilidade, a action fica pinada em `chromaui/action@v1`, evitando drift silencioso de `@latest`
+
+## Build canônico
+
+O build oficial do Storybook é:
+
+```bash
+pnpm storybook:build
+```
+
+Esse comando é a fonte de verdade para CI e troubleshooting local.
+
+### Nota sobre ambientes locais com Yarn PnP externo
+
+Se existir um arquivo `.pnp.cjs` em algum diretório pai do projeto, o Storybook pode falhar com erros do tipo
+`Yarn Plug'n'Play manifest forbids importing ...`, mesmo quando o `auraxis-web` usa `pnpm`.
+
+Isso não é um bug intrínseco do repositório; é contaminação do ambiente de execução.
+
+Quando isso acontecer:
+
+1. rode o build em um clone/cópia temporária fora dessa árvore pai, ou
+2. remova/renomeie o `.pnp.cjs` do diretório pai responsável, se isso for seguro no seu ambiente.
+
+O workflow de CI/Chromatic roda em ambiente limpo e é a validação canônica da publicação.
+
+## Política de visual review
+
+- mudanças visuais devem aparecer no Chromatic para revisão em PR
+- o workflow usa `onlyChanged: true` para reduzir tempo e custo de captura
+- o workflow usa `exitZeroOnChanges: true` para que diferenças visuais esperadas não bloqueiem automaticamente o pipeline
+- erros reais de build/publicação continuam bloqueando o job
+
+## Segredos e configuração
+
+Secret obrigatório:
+
+- `CHROMATIC_PROJECT_TOKEN`
+
+Configuração externa necessária:
+
+- projeto Chromatic conectado ao repositório `auraxis-web`
+- domínio customizado `v1.design-system.auraxis.com.br` configurado no painel do Chromatic
+- DNS com `CNAME` apontando para `domains.chromatic.com`
+
+## Observações de domínio
+
+- o domínio customizado aponta para a build mais recente de uma branch alvo escolhida no Chromatic
+- a recomendação é usar `main` como branch canônica do domínio
+- até o domínio estar ativo, a URL nativa do Chromatic continua sendo a referência operacional
+
+## Checklist de rollout
+
+1. configurar `CHROMATIC_PROJECT_TOKEN` no GitHub
+2. validar run verde do workflow `Chromatic`
+3. confirmar publicação da URL nativa do Storybook no Chromatic
+4. configurar `v1.design-system.auraxis.com.br` no painel do Chromatic
+5. criar `CNAME` DNS para `domains.chromatic.com`
+6. validar acesso pelo domínio customizado


### PR DESCRIPTION
## Summary
- add the official Chromatic workflow for visual review in `auraxis-web`
- document the operational rollout for `v1.design-system.auraxis.com.br`
- update the repo README with the Chromatic path and Storybook commands
- record the local `.pnp.cjs` contamination caveat so Storybook troubleshooting stays reproducible

## Validation
- `pnpm quality-check`
- `CI=1 pnpm storybook:build` in an isolated temporary copy outside the parent tree with external `.pnp.cjs`
- `git diff --check`

## Risks
- real publication still depends on the `CHROMATIC_PROJECT_TOKEN` secret
- the custom domain still depends on Chromatic dashboard + DNS configuration
- local Storybook builds can fail when the workspace sits under a parent directory with Yarn PnP (`.pnp.cjs`); CI/Chromatic runs in a clean environment and is the canonical validation path

Closes #283
