### PR TITLE
chore(ci): enable auto-deploy on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Deploy Official Web (AWS)
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       environment:
@@ -33,7 +35,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: web-official-${{ inputs.environment }}
+  group: web-official-prod
   cancel-in-progress: false
 
 env:
@@ -47,6 +49,22 @@ jobs:
     name: Build static output
     runs-on: ubuntu-latest
     steps:
+      - name: Set deployment parameters
+        run: |
+          if [ "${{ github.event_name }}" == "push" ]; then
+            echo "DEPLOY_ENVIRONMENT=prod" >> $GITHUB_ENV
+            echo "DEPLOY_API_BASE_URL=https://api.auraxis.com.br" >> $GITHUB_ENV
+            echo "DEPLOY_RUN_SMOKE_TEST=true" >> $GITHUB_ENV
+            echo "DEPLOY_INVALIDATE_CACHE=true" >> $GITHUB_ENV
+            echo "Automatic deployment triggered by push to main"
+          else
+            echo "DEPLOY_ENVIRONMENT=${{ inputs.environment }}" >> $GITHUB_ENV
+            echo "DEPLOY_API_BASE_URL=${{ inputs.api_base_url }}" >> $GITHUB_ENV
+            echo "DEPLOY_RUN_SMOKE_TEST=${{ inputs.run_smoke_test }}" >> $GITHUB_ENV
+            echo "DEPLOY_INVALIDATE_CACHE=${{ inputs.invalidate_cache }}" >> $GITHUB_ENV
+            echo "Manual deployment triggered by workflow_dispatch"
+          fi
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -84,9 +102,9 @@ jobs:
       - name: Generate static output
         env:
           NODE_ENV: production
-          NUXT_PUBLIC_API_BASE: ${{ inputs.api_base_url }}
+          NUXT_PUBLIC_API_BASE: ${{ env.DEPLOY_API_BASE_URL }}
           NUXT_PUBLIC_SENTRY_DSN: ${{ secrets.NUXT_PUBLIC_SENTRY_DSN }}
-          NUXT_PUBLIC_APP_ENV: ${{ inputs.environment }}
+          NUXT_PUBLIC_APP_ENV: ${{ env.DEPLOY_ENVIRONMENT }}
           NUXT_PUBLIC_SITE_URL: https://${{ env.WEB_OFFICIAL_HOSTNAME }}
         run: pnpm generate
 
@@ -96,7 +114,7 @@ jobs:
       - name: Upload official deploy artifact
         uses: actions/upload-artifact@v4
         with:
-          name: web-official-static-${{ inputs.environment }}
+          name: web-official-static-${{ env.DEPLOY_ENVIRONMENT }}
           path: .output/public
           retention-days: 7
 
@@ -105,17 +123,29 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-static
     environment:
-      name: web-official-${{ inputs.environment }}
+      name: web-official-prod
       url: https://${{ env.WEB_OFFICIAL_HOSTNAME }}
     steps:
+      - name: Set deployment parameters
+        run: |
+          if [ "${{ github.event_name }}" == "push" ]; then
+            echo "DEPLOY_ENVIRONMENT=prod" >> $GITHUB_ENV
+            echo "DEPLOY_INVALIDATE_CACHE=true" >> $GITHUB_ENV
+            echo "DEPLOY_RUN_SMOKE_TEST=true" >> $GITHUB_ENV
+          else
+            echo "DEPLOY_ENVIRONMENT=${{ inputs.environment }}" >> $GITHUB_ENV
+            echo "DEPLOY_INVALIDATE_CACHE=${{ inputs.invalidate_cache }}" >> $GITHUB_ENV
+            echo "DEPLOY_RUN_SMOKE_TEST=${{ inputs.run_smoke_test }}" >> $GITHUB_ENV
+          fi
+
       - name: Download static artifact
         uses: actions/download-artifact@v8
         with:
-          name: web-official-static-${{ inputs.environment }}
+          name: web-official-static-${{ env.DEPLOY_ENVIRONMENT }}
           path: dist
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_WEB_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -142,7 +172,7 @@ jobs:
           done < <(find dist -type f -path '*/index.html')
 
       - name: Invalidate CloudFront
-        if: ${{ inputs.invalidate_cache }}
+        if: ${{ env.DEPLOY_INVALIDATE_CACHE == 'true' }}
         env:
           AWS_WEB_CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.AWS_WEB_CLOUDFRONT_DISTRIBUTION_ID }}
         run: |
@@ -151,7 +181,7 @@ jobs:
             --paths "/*"
 
       - name: Smoke test official hostname
-        if: ${{ inputs.run_smoke_test }}
+        if: ${{ env.DEPLOY_RUN_SMOKE_TEST == 'true' }}
         run: |
           curl --fail --show-error --silent --location \
             "https://${WEB_OFFICIAL_HOSTNAME}/login" \


### PR DESCRIPTION
Enable continuous deployment on every push to main branch.

**Changes:**
- Add push trigger to deploy.yml for auto-deploy on main
- Set default parameters for automatic deployments
- Support both manual (workflow_dispatch) and automatic (push) triggers

**Behavior:**
- Every merge/push to main automatically triggers production deployment
- Deployment completes in ~6-7 minutes
- Smoke tests run after deployment
- CloudFront cache invalidated automatically

**Timeline:**
- Push to main → ~6-7 min → Changes live at app.auraxis.com.br