### PR TITLE
fix(ci): fix SSR artifact upload/download pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,14 +85,22 @@ jobs:
         run: pnpm build
 
       - name: Validate output folder
-        run: test -d .output/server
+        run: |
+          test -d .output/server || (echo "ERROR: .output/server not found"; exit 1)
+          test -f .output/server/index.mjs || (echo "ERROR: server entry not found"; exit 1)
+
+      - name: Package SSR build
+        # .output is in .gitignore, so upload-artifact (via @actions/glob) skips it.
+        # Packaging as tarball bypasses gitignore and preserves permissions.
+        run: tar -czf ssr-build.tar.gz .output
 
       - name: Upload SSR build artifact
         uses: actions/upload-artifact@v4
         with:
           name: web-official-ssr-${{ env.DEPLOY_ENVIRONMENT }}
-          path: .output
+          path: ssr-build.tar.gz
           retention-days: 7
+          if-no-files-found: error
 
   deploy-ssr:
     name: Deploy SSR application
@@ -113,10 +121,13 @@ jobs:
           fi
 
       - name: Download SSR build artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: web-official-ssr-${{ env.DEPLOY_ENVIRONMENT }}
-          path: .output
+          path: .
+
+      - name: Extract SSR build
+        run: tar -xzf ssr-build.tar.gz
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary

- **Root cause**: `.output` is listed in `.gitignore`. `upload-artifact@v4` uses `@actions/glob` which respects gitignore, uploading 0 files silently — deploy job then fails with _"Artifact not found"_
- Package `.output` as `ssr-build.tar.gz` before upload; extract after download (tarball not gitignored)
- Fix `download-artifact@v8` → `@v4` (v8 doesn't exist)
- Validate step now asserts `server/index.mjs` exists before packaging
- `if-no-files-found: error` ensures explicit failure if artifact is empty

## Test plan
- [ ] Build job: `Package SSR build` step produces `ssr-build.tar.gz`
- [ ] Upload step shows artifact size > 0
- [ ] Deploy job: download + extract produces `.output/server/index.mjs`
- [ ] No more "Artifact not found" error in deploy job

🤖 Generated with [Claude Code](https://claude.com/claude-code)