### PR TITLE
fix(locale): export raw config to fix CSR Composer init (_s crash)

### DIFF
--- a/i18n.config.ts
+++ b/i18n.config.ts
@@ -3,12 +3,15 @@
 // synchronously during SSG hydration. Lazy loading caused a race condition
 // where components called t() before the async locale fetch resolved,
 // producing "Cannot read properties of undefined (reading '_s')".
+//
+// NOTE: defineI18nConfig is NOT auto-imported outside app/ — exporting the
+// raw options object directly avoids the wrapper call failing at runtime.
 import pt from "./app/locales/pt.json";
 import en from "./app/locales/en.json";
 
-export default defineI18nConfig(() => ({
+export default {
   legacy: false,
   locale: "pt",
   fallbackLocale: "pt",
   messages: { pt, en },
-}));
+};


### PR DESCRIPTION
## Root Cause

`defineI18nConfig` is a Nuxt auto-import that **only works inside `app/`**. The file `i18n.config.ts` lives at the project root, outside that boundary. At CSR runtime the wrapper is `undefined`, causing the factory call to fail silently — the `@nuxtjs/i18n` plugin receives a broken config, the vue-i18n Composer is initialized without a valid message cache, and any `t()` call immediately throws:

```
TypeError: Cannot read properties of undefined (reading '_s')
```

## Fix

Export a plain options object directly. Per the `@nuxtjs/i18n` source, `defineI18nConfig` is literally an identity wrapper (`return factory`), so there is zero functional difference:

```ts
// before
export default defineI18nConfig(() => ({ legacy: false, messages: { pt, en } }))

// after
export default { legacy: false, messages: { pt, en } }
```

## Test plan
- [ ] Login page loads without 500 error
- [ ] Translations render correctly (`t('auth.login.title')` → "Bem-vindo de volta")
- [ ] No hydration mismatch in console
- [ ] Build and deploy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)