### PR TITLE
fix(auth): align register form with API contract

### DIFF
--- a/app/composables/useAuth/api.spec.ts
+++ b/app/composables/useAuth/api.spec.ts
@@ -59,15 +59,15 @@ describe("createAuthApi", () => {
 
     const authApi = createAuthApi({ post });
     const response = await authApi.register({
+      name: "New User",
       email: "new@auraxis.com",
-      password: "12345678",
-      confirmPassword: "12345678",
+      password: "Senha@12345",
     });
 
     expect(post).toHaveBeenCalledWith("/auth/register", {
+      name: "New User",
       email: "new@auraxis.com",
-      password: "12345678",
-      confirmPassword: "12345678",
+      password: "Senha@12345",
     });
     expect(response.user.email).toBe("new@auraxis.com");
   });

--- a/app/composables/useAuth/forms.spec.ts
+++ b/app/composables/useAuth/forms.spec.ts
@@ -39,9 +39,10 @@ describe("useAuth/forms", () => {
     });
   });
 
-  it("cria formulario de registro com confirmacao de senha", () => {
+  it("cria formulario de registro com todos os campos esperados", () => {
     const result = useRegisterForm() as unknown as {
       initialValues: {
+        name: string;
         email: string;
         password: string;
         confirmPassword: string;
@@ -50,6 +51,7 @@ describe("useAuth/forms", () => {
 
     expect(useFormMock).toHaveBeenCalledTimes(1);
     expect(result.initialValues).toEqual({
+      name: "",
       email: "",
       password: "",
       confirmPassword: "",

--- a/app/composables/useAuth/forms.ts
+++ b/app/composables/useAuth/forms.ts
@@ -32,6 +32,7 @@ export const useRegisterForm = (): ReturnType<typeof useForm<RegisterSchema>> =>
   return useForm<RegisterSchema>({
     validationSchema: toTypedSchema(registerSchema),
     initialValues: {
+      name: "",
       email: "",
       password: "",
       confirmPassword: "",

--- a/app/features/auth/components/SignupForm/SignupForm.types.ts
+++ b/app/features/auth/components/SignupForm/SignupForm.types.ts
@@ -4,5 +4,5 @@ export interface SignupFormProps {
 }
 
 export interface SignupFormEmits {
-  (e: "submit", values: { email: string; password: string; confirmPassword: string }): void
+  (e: "submit", values: { name: string; email: string; password: string; confirmPassword: string }): void
 }

--- a/app/features/auth/components/SignupForm/SignupForm.vue
+++ b/app/features/auth/components/SignupForm/SignupForm.vue
@@ -15,6 +15,7 @@ const props = withDefaults(defineProps<SignupFormProps>(), {
 const emit = defineEmits<SignupFormEmits>();
 
 const { defineField, errors, handleSubmit, isSubmitting } = useRegisterForm();
+const [name, nameAttrs] = defineField("name");
 const [email, emailAttrs] = defineField("email");
 const [password, passwordAttrs] = defineField("password");
 const [confirmPassword, confirmPasswordAttrs] = defineField("confirmPassword");
@@ -40,6 +41,25 @@ const isPending = computed(() => props.loading || isSubmitting.value);
     </div>
 
     <form class="signup-form__fields" novalidate @submit.prevent="onSubmit">
+      <UiFormField
+        :label="t('auth.register.nameLabel')"
+        field-id="signup-name"
+        :error="errors.name"
+        required
+      >
+        <input
+          id="signup-name"
+          v-model="name"
+          class="signup-form__input"
+          :class="{ 'signup-form__input--error': !!errors.name }"
+          type="text"
+          :placeholder="t('auth.register.namePlaceholder')"
+          autocomplete="name"
+          :disabled="isPending"
+          v-bind="nameAttrs"
+        >
+      </UiFormField>
+
       <UiFormField
         :label="t('auth.register.emailLabel')"
         field-id="signup-email"

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -31,6 +31,9 @@
     "register": {
       "title": "Create account",
       "subtitle": "Fill in the details below to get started",
+      "divider": "Or continue with",
+      "nameLabel": "Full name",
+      "namePlaceholder": "Your full name",
       "emailLabel": "Email",
       "emailPlaceholder": "your@email.com",
       "passwordLabel": "Password",

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -31,6 +31,9 @@
     "register": {
       "title": "Criar conta",
       "subtitle": "Preencha os dados abaixo para começar",
+      "divider": "Ou continue com",
+      "nameLabel": "Nome completo",
+      "namePlaceholder": "Seu nome completo",
       "emailLabel": "Email",
       "emailPlaceholder": "seu@email.com",
       "passwordLabel": "Senha",

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -17,8 +17,9 @@ const { consumeRedirect } = useAuthRedirectContext();
  * @param values - Dados validados do formulário de registro.
  */
 const onSubmit = async (values: RegisterSchema): Promise<void> => {
+  const { confirmPassword: _discard, ...registerPayload } = values;
   try {
-    await registerMutation.mutateAsync(values);
+    await registerMutation.mutateAsync(registerPayload);
     const redirect = consumeRedirect();
     await navigateTo(redirect);
   } catch (err) {

--- a/app/schemas/auth.ts
+++ b/app/schemas/auth.ts
@@ -7,11 +7,19 @@ export const loginSchema = z.object({
 
 export const registerSchema = z
   .object({
-    email: z.string().trim().email("Informe um e-mail valido."),
-    password: z.string().min(8, "A senha precisa ter ao menos 8 caracteres."),
-    confirmPassword: z
+    name: z
       .string()
-      .min(8, "A confirmacao de senha precisa ter ao menos 8 caracteres."),
+      .trim()
+      .min(2, "O nome precisa ter ao menos 2 caracteres.")
+      .max(128, "O nome pode ter no maximo 128 caracteres."),
+    email: z.string().trim().email("Informe um e-mail valido."),
+    password: z
+      .string()
+      .min(10, "A senha precisa ter ao menos 10 caracteres.")
+      .regex(/[A-Z]/, "A senha precisa ter ao menos uma letra maiuscula.")
+      .regex(/\d/, "A senha precisa ter ao menos um numero.")
+      .regex(/[^A-Za-z0-9]/, "A senha precisa ter ao menos um simbolo."),
+    confirmPassword: z.string().min(1, "Confirme sua senha."),
   })
   .refine((payload) => payload.password === payload.confirmPassword, {
     message: "As senhas precisam ser iguais.",

--- a/app/types/contracts/auth.ts
+++ b/app/types/contracts/auth.ts
@@ -12,9 +12,9 @@ export interface LoginResponse {
 }
 
 export interface RegisterRequest {
+  readonly name: string;
   readonly email: string;
   readonly password: string;
-  readonly confirmPassword: string;
 }
 
 export interface RegisterResponse {


### PR DESCRIPTION
## Problema

O formulário de cadastro enviava um payload incompatível com o endpoint `POST /auth/register`:

```json
{ "email": "...", "password": "...", "confirmPassword": "..." }
```

Resultado: erro `400 Validation error` com `confirmPassword: Unknown field` e `name: Missing data for required field`.

## Causa raiz

O contrato `RegisterRequest` foi definido espelhando os campos do formulário (incluindo `confirmPassword`) em vez de espelhar o contrato da API. A API (`UserRegistrationSchema`) exige `name`, `email`, `password` — sem `confirmPassword`.

## Mudanças

| Arquivo | O que mudou |
|:---|:---|
| `app/types/contracts/auth.ts` | `RegisterRequest`: removido `confirmPassword`, adicionado `name` |
| `app/schemas/auth.ts` | `registerSchema`: adicionado `name`; validação de senha alinhada com a API (min 10, uppercase, dígito, símbolo) |
| `app/pages/register.vue` | Destrói `confirmPassword` antes de chamar `mutateAsync` — API só recebe `{ name, email, password }` |
| `app/composables/useAuth/forms.ts` | `initialValues` do `useRegisterForm` recebe `name: ""` |
| `SignupForm.vue` | Campo `name` adicionado ao formulário (antes do email) |
| `SignupForm.types.ts` | `SignupFormEmits` atualizado com `name` |
| `app/i18n/locales/pt.json` | Chaves `nameLabel`, `namePlaceholder`, `divider` adicionadas em `auth.register` |
| `app/i18n/locales/en.json` | Idem em inglês |
| `api.spec.ts` | Contrato do teste atualizado: `{ name, email, password }` |
| `forms.spec.ts` | `initialValues` atualizado com `name` |

## Test plan

- [ ] 95 testes passando (zero falhas)
- [ ] TypeScript sem erros
- [ ] `POST /auth/register` com `{ name, email, password }` retorna 201
- [ ] Validação de senha no frontend alinhada com API: min 10 chars, maiúscula, dígito, símbolo
- [ ] Campo "Nome completo" visível no formulário `/register`
- [ ] Cadastro ponta a ponta funcional em produção