### PR TITLE
feat(stores,composables): wf5/wf6 — ui+filters stores and utility composables

### DIFF
--- a/app/composables/useConfirm/__tests__/useConfirm.spec.ts
+++ b/app/composables/useConfirm/__tests__/useConfirm.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useConfirm } from "../useConfirm";
+
+const mockWarning = vi.fn();
+
+vi.mock("naive-ui", (): Record<string, unknown> => ({
+  useDialog: () => ({
+    warning: mockWarning,
+  }),
+}));
+
+describe("useConfirm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls dialog.warning with the provided title and content", () => {
+    const { confirm } = useConfirm();
+    const onConfirm = vi.fn();
+
+    confirm({ title: "Excluir?", content: "Não pode desfazer.", onConfirm });
+
+    expect(mockWarning).toHaveBeenCalledOnce();
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Excluir?", content: "Não pode desfazer." }),
+    );
+  });
+
+  it("uses default button labels when not provided", () => {
+    const { confirm } = useConfirm();
+    confirm({ title: "T", content: "C", onConfirm: vi.fn() });
+
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ positiveText: "Confirmar", negativeText: "Cancelar" }),
+    );
+  });
+
+  it("uses custom button labels when provided", () => {
+    const { confirm } = useConfirm();
+    confirm({
+      title: "T",
+      content: "C",
+      positiveText: "Sim, excluir",
+      negativeText: "Não, voltar",
+      onConfirm: vi.fn(),
+    });
+
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ positiveText: "Sim, excluir", negativeText: "Não, voltar" }),
+    );
+  });
+
+  it("wires onConfirm to onPositiveClick", () => {
+    const { confirm } = useConfirm();
+    const onConfirm = vi.fn();
+    confirm({ title: "T", content: "C", onConfirm });
+
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ onPositiveClick: onConfirm }),
+    );
+  });
+
+  it("wires onCancel to onNegativeClick", () => {
+    const { confirm } = useConfirm();
+    const onCancel = vi.fn();
+    confirm({ title: "T", content: "C", onConfirm: vi.fn(), onCancel });
+
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ onNegativeClick: onCancel }),
+    );
+  });
+
+  it("onNegativeClick is undefined when onCancel not provided", () => {
+    const { confirm } = useConfirm();
+    confirm({ title: "T", content: "C", onConfirm: vi.fn() });
+
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ onNegativeClick: undefined }),
+    );
+  });
+});

--- a/app/composables/useConfirm/index.ts
+++ b/app/composables/useConfirm/index.ts
@@ -1,0 +1,2 @@
+export { useConfirm } from "./useConfirm";
+export type { UseConfirmReturn, ConfirmOptions } from "./useConfirm.types";

--- a/app/composables/useConfirm/useConfirm.ts
+++ b/app/composables/useConfirm/useConfirm.ts
@@ -1,0 +1,45 @@
+import { useDialog } from "naive-ui";
+import type { ConfirmOptions, UseConfirmReturn } from "./useConfirm.types";
+
+/**
+ * Composable that wraps NaiveUI's useDialog into a simplified confirmation API.
+ *
+ * Provides a single `confirm` helper that opens a "warning" style dialog
+ * (orange header) — the standard Auraxis pattern for destructive or
+ * irreversible actions.
+ *
+ * Must be called inside a component that has a NaiveUI dialog provider
+ * in its ancestor tree.
+ *
+ * @returns Object with a `confirm` helper function.
+ *
+ * @example
+ * ```ts
+ * const { confirm } = useConfirm();
+ * confirm({
+ *   title: "Excluir meta",
+ *   content: "Essa ação não pode ser desfeita.",
+ *   onConfirm: () => deleteGoalMutation.mutate(id),
+ * });
+ * ```
+ */
+export function useConfirm(): UseConfirmReturn {
+  const dialog = useDialog();
+
+  /**
+   * Opens a NaiveUI warning dialog with the given options.
+   * @param options - Dialog configuration including title, content and callbacks.
+   */
+  function confirm(options: ConfirmOptions): void {
+    dialog.warning({
+      title: options.title,
+      content: options.content,
+      positiveText: options.positiveText ?? "Confirmar",
+      negativeText: options.negativeText ?? "Cancelar",
+      onPositiveClick: options.onConfirm,
+      onNegativeClick: options.onCancel,
+    });
+  }
+
+  return { confirm };
+}

--- a/app/composables/useConfirm/useConfirm.types.ts
+++ b/app/composables/useConfirm/useConfirm.types.ts
@@ -1,0 +1,27 @@
+/** Options for the confirm dialog. */
+export interface ConfirmOptions {
+  /** Dialog title shown in the header. */
+  title: string;
+  /** Descriptive message shown in the body. */
+  content: string;
+  /** Label for the affirmative action button. Defaults to "Confirmar". */
+  positiveText?: string;
+  /** Label for the cancel button. Defaults to "Cancelar". */
+  negativeText?: string;
+  /**
+   * Callback invoked when the user confirms.
+   * May be async — the dialog's loading state is managed automatically.
+   */
+  onConfirm: () => void | Promise<void>;
+  /** Optional callback invoked when the user cancels. */
+  onCancel?: () => void;
+}
+
+/** Return type of the useConfirm composable. */
+export interface UseConfirmReturn {
+  /**
+   * Opens a confirmation dialog with the given options.
+   * @param options - Dialog configuration.
+   */
+  confirm: (options: ConfirmOptions) => void;
+}

--- a/app/composables/useErrorBoundary/__tests__/useErrorBoundary.spec.ts
+++ b/app/composables/useErrorBoundary/__tests__/useErrorBoundary.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { captureException } from "~/core/observability";
+import { useErrorBoundary } from "../useErrorBoundary";
+
+vi.mock("~/core/observability", () => ({
+  captureException: vi.fn(),
+}));
+
+describe("useErrorBoundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initialises with no error", () => {
+    const { error, hasError } = useErrorBoundary();
+    expect(error.value).toBeNull();
+    expect(hasError.value).toBe(false);
+  });
+
+  describe("capture", () => {
+    it("stores an Error instance directly", () => {
+      const { error, capture } = useErrorBoundary();
+      const err = new Error("something went wrong");
+      capture(err);
+      expect(error.value).toBe(err);
+    });
+
+    it("normalises a string to an Error", () => {
+      const { error, capture } = useErrorBoundary();
+      capture("network timeout");
+      expect(error.value).toBeInstanceOf(Error);
+      expect(error.value?.message).toBe("network timeout");
+    });
+
+    it("normalises a non-Error object to an Error", () => {
+      const { error, capture } = useErrorBoundary();
+      capture({ code: 500 });
+      expect(error.value).toBeInstanceOf(Error);
+    });
+
+    it("sets hasError to true after capture", () => {
+      const { hasError, capture } = useErrorBoundary();
+      capture(new Error("oops"));
+      expect(hasError.value).toBe(true);
+    });
+
+    it("calls captureException with the normalised error", () => {
+      const { capture } = useErrorBoundary();
+      const err = new Error("boom");
+      capture(err);
+      expect(captureException).toHaveBeenCalledWith(err);
+    });
+
+    it("calls captureException with a new Error when string is captured", () => {
+      const { capture } = useErrorBoundary();
+      capture("plain string error");
+      expect(captureException).toHaveBeenCalledOnce();
+      expect(captureException).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "plain string error" }),
+      );
+    });
+  });
+
+  describe("reset", () => {
+    it("clears the error", () => {
+      const { error, hasError, capture, reset } = useErrorBoundary();
+      capture(new Error("oops"));
+      reset();
+      expect(error.value).toBeNull();
+      expect(hasError.value).toBe(false);
+    });
+  });
+});

--- a/app/composables/useErrorBoundary/index.ts
+++ b/app/composables/useErrorBoundary/index.ts
@@ -1,0 +1,2 @@
+export { useErrorBoundary } from "./useErrorBoundary";
+export type { UseErrorBoundaryReturn } from "./useErrorBoundary.types";

--- a/app/composables/useErrorBoundary/useErrorBoundary.ts
+++ b/app/composables/useErrorBoundary/useErrorBoundary.ts
@@ -1,0 +1,55 @@
+import { ref, computed, readonly } from "vue";
+import { captureException } from "~/core/observability";
+import type { UseErrorBoundaryReturn } from "./useErrorBoundary.types";
+
+/**
+ * Composable for local error boundary state.
+ *
+ * Captures thrown values (Error instances, strings, or anything else),
+ * normalises them to Error, forwards to the observability layer and
+ * exposes reactive state that the template can render.
+ *
+ * Intended for use in page and section components that need to show
+ * an inline error state without crashing the entire app.
+ *
+ * @returns Reactive error state and capture/reset helpers.
+ *
+ * @example
+ * ```ts
+ * const { hasError, error, capture, reset } = useErrorBoundary();
+ *
+ * async function loadData() {
+ *   try {
+ *     data.value = await fetchData();
+ *   } catch (err) {
+ *     capture(err);
+ *   }
+ * }
+ * ```
+ */
+export function useErrorBoundary(): UseErrorBoundaryReturn {
+  const error = ref<Error | null>(null);
+  const hasError = computed(() => error.value !== null);
+
+  /**
+   * Captures a thrown value, normalises it to an Error and forwards to observability.
+   * @param err - Any value caught in a try/catch block.
+   */
+  function capture(err: unknown): void {
+    const normalized = err instanceof Error ? err : new Error(String(err));
+    error.value = normalized;
+    captureException(normalized);
+  }
+
+  /** Clears the captured error and resets hasError to false. */
+  function reset(): void {
+    error.value = null;
+  }
+
+  return {
+    error: readonly(error),
+    hasError,
+    capture,
+    reset,
+  };
+}

--- a/app/composables/useErrorBoundary/useErrorBoundary.types.ts
+++ b/app/composables/useErrorBoundary/useErrorBoundary.types.ts
@@ -1,0 +1,17 @@
+import type { DeepReadonly, Ref, ComputedRef } from "vue";
+
+/** Return type of the useErrorBoundary composable. */
+export interface UseErrorBoundaryReturn {
+  /** The captured error, or null when no error is present. Readonly. */
+  error: DeepReadonly<Ref<Error | null>>;
+  /** Whether an error is currently captured. */
+  hasError: ComputedRef<boolean>;
+  /**
+   * Captures an error.
+   * Accepts any thrown value and normalises it to an Error instance.
+   * @param err - The caught value.
+   */
+  capture: (err: unknown) => void;
+  /** Clears the captured error and resets hasError to false. */
+  reset: () => void;
+}

--- a/app/composables/useFilters/__tests__/useFilters.spec.ts
+++ b/app/composables/useFilters/__tests__/useFilters.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useFilters } from "../useFilters";
+
+describe("useFilters", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("exposes initial state from the store", () => {
+    const filters = useFilters();
+    expect(filters.period.value).toBe("current_month");
+    expect(filters.customStart.value).toBe("");
+    expect(filters.customEnd.value).toBe("");
+    expect(filters.isCustomPeriod.value).toBe(false);
+    expect(filters.isCustomRangeComplete.value).toBe(false);
+  });
+
+  it("setPeriod updates period", () => {
+    const filters = useFilters();
+    filters.setPeriod("3m");
+    expect(filters.period.value).toBe("3m");
+  });
+
+  it("setPeriod clears custom range when not custom", () => {
+    const filters = useFilters();
+    filters.setCustomRange("2025-01-01", "2025-01-31");
+    filters.setPeriod("12m");
+    expect(filters.customStart.value).toBe("");
+    expect(filters.customEnd.value).toBe("");
+  });
+
+  it("setCustomRange sets range and switches to custom period", () => {
+    const filters = useFilters();
+    filters.setCustomRange("2025-06-01", "2025-06-30");
+    expect(filters.period.value).toBe("custom");
+    expect(filters.customStart.value).toBe("2025-06-01");
+    expect(filters.customEnd.value).toBe("2025-06-30");
+    expect(filters.isCustomPeriod.value).toBe(true);
+    expect(filters.isCustomRangeComplete.value).toBe(true);
+  });
+
+  it("reset restores defaults", () => {
+    const filters = useFilters();
+    filters.setCustomRange("2025-01-01", "2025-12-31");
+    filters.reset();
+    expect(filters.period.value).toBe("current_month");
+    expect(filters.customStart.value).toBe("");
+    expect(filters.isCustomRangeComplete.value).toBe(false);
+  });
+
+  it("state is shared between multiple useFilters instances", () => {
+    const a = useFilters();
+    const b = useFilters();
+    a.setPeriod("6m");
+    expect(b.period.value).toBe("6m");
+  });
+});

--- a/app/composables/useFilters/index.ts
+++ b/app/composables/useFilters/index.ts
@@ -1,0 +1,2 @@
+export { useFilters } from "./useFilters";
+export type { UseFiltersReturn } from "./useFilters.types";

--- a/app/composables/useFilters/useFilters.ts
+++ b/app/composables/useFilters/useFilters.ts
@@ -1,0 +1,36 @@
+import { computed } from "vue";
+import { useFiltersStore, type FilterPeriod } from "~/stores/filters";
+import type { UseFiltersReturn } from "./useFilters.types";
+
+/**
+ * Composable facade over the global filters Pinia store.
+ *
+ * Provides a computed-only view of the current filter state alongside
+ * action helpers. Components should use this composable rather than
+ * calling the store directly, keeping store coupling at the composable layer.
+ *
+ * @returns Reactive filter state and mutation helpers.
+ */
+export function useFilters(): UseFiltersReturn {
+  const store = useFiltersStore();
+
+  return {
+    period: computed(() => store.period),
+    customStart: computed(() => store.customStart),
+    customEnd: computed(() => store.customEnd),
+    isCustomPeriod: computed(() => store.isCustomPeriod),
+    isCustomRangeComplete: computed(() => store.isCustomRangeComplete),
+
+    setPeriod(period: FilterPeriod): void {
+      store.setPeriod(period);
+    },
+
+    setCustomRange(start: string, end: string): void {
+      store.setCustomRange(start, end);
+    },
+
+    reset(): void {
+      store.reset();
+    },
+  };
+}

--- a/app/composables/useFilters/useFilters.types.ts
+++ b/app/composables/useFilters/useFilters.types.ts
@@ -1,0 +1,22 @@
+import type { ComputedRef } from "vue";
+import type { FilterPeriod } from "~/stores/filters";
+
+/** Return type of the useFilters composable. */
+export interface UseFiltersReturn {
+  /** Currently active period key. */
+  period: ComputedRef<FilterPeriod>;
+  /** Start date for the custom range (empty string when unset). */
+  customStart: ComputedRef<string>;
+  /** End date for the custom range (empty string when unset). */
+  customEnd: ComputedRef<string>;
+  /** Whether the current period is the free-form custom range. */
+  isCustomPeriod: ComputedRef<boolean>;
+  /** Whether both custom range dates are set. */
+  isCustomRangeComplete: ComputedRef<boolean>;
+  /** Updates the active period. Clears custom dates when not "custom". */
+  setPeriod: (period: FilterPeriod) => void;
+  /** Sets a custom range and switches period to "custom". */
+  setCustomRange: (start: string, end: string) => void;
+  /** Resets all filters to defaults. */
+  reset: () => void;
+}

--- a/app/composables/usePagination/__tests__/usePagination.spec.ts
+++ b/app/composables/usePagination/__tests__/usePagination.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { usePagination } from "../usePagination";
+
+describe("usePagination", () => {
+  it("initialises with page 1, limit 20 and total 0", () => {
+    const { page, limit, total } = usePagination();
+    expect(page.value).toBe(1);
+    expect(limit.value).toBe(20);
+    expect(total.value).toBe(0);
+  });
+
+  it("respects a custom initial limit", () => {
+    const { limit } = usePagination(10);
+    expect(limit.value).toBe(10);
+  });
+
+  describe("totalPages", () => {
+    it("returns 1 when total is 0", () => {
+      const { totalPages } = usePagination();
+      expect(totalPages.value).toBe(1);
+    });
+
+    it("computes pages correctly", () => {
+      const { totalPages, setTotal } = usePagination(10);
+      setTotal(25);
+      expect(totalPages.value).toBe(3);
+    });
+
+    it("rounds up for partial last page", () => {
+      const { totalPages, setTotal } = usePagination(10);
+      setTotal(21);
+      expect(totalPages.value).toBe(3);
+    });
+  });
+
+  describe("hasPrevPage / hasNextPage", () => {
+    it("hasPrevPage is false on page 1", () => {
+      expect(usePagination().hasPrevPage.value).toBe(false);
+    });
+
+    it("hasNextPage is false when only one page", () => {
+      const { hasNextPage } = usePagination();
+      expect(hasNextPage.value).toBe(false);
+    });
+
+    it("hasNextPage is true when more pages exist", () => {
+      const { hasNextPage, setTotal } = usePagination(10);
+      setTotal(30);
+      expect(hasNextPage.value).toBe(true);
+    });
+
+    it("hasPrevPage is true after moving past page 1", () => {
+      const { hasPrevPage, setTotal, nextPage } = usePagination(10);
+      setTotal(30);
+      nextPage();
+      expect(hasPrevPage.value).toBe(true);
+    });
+  });
+
+  describe("nextPage", () => {
+    it("advances the page when next page exists", () => {
+      const { page, setTotal, nextPage } = usePagination(10);
+      setTotal(30);
+      nextPage();
+      expect(page.value).toBe(2);
+    });
+
+    it("does not advance past the last page", () => {
+      const { page, setTotal, nextPage } = usePagination(10);
+      setTotal(10);
+      nextPage();
+      expect(page.value).toBe(1);
+    });
+  });
+
+  describe("prevPage", () => {
+    it("decrements the page when prev page exists", () => {
+      const { page, setTotal, nextPage, prevPage } = usePagination(10);
+      setTotal(30);
+      nextPage();
+      prevPage();
+      expect(page.value).toBe(1);
+    });
+
+    it("does not go below page 1", () => {
+      const { page, prevPage } = usePagination();
+      prevPage();
+      expect(page.value).toBe(1);
+    });
+  });
+
+  describe("goToPage", () => {
+    it("jumps to a specific page", () => {
+      const { page, setTotal, goToPage } = usePagination(10);
+      setTotal(50);
+      goToPage(3);
+      expect(page.value).toBe(3);
+    });
+
+    it("clamps to 1 when given 0 or negative", () => {
+      const { page, goToPage } = usePagination(10);
+      goToPage(0);
+      expect(page.value).toBe(1);
+    });
+
+    it("clamps to totalPages when given a value that is too high", () => {
+      const { page, setTotal, goToPage } = usePagination(10);
+      setTotal(20);
+      goToPage(999);
+      expect(page.value).toBe(2);
+    });
+  });
+
+  describe("setTotal", () => {
+    it("updates total correctly", () => {
+      const { total, setTotal } = usePagination();
+      setTotal(100);
+      expect(total.value).toBe(100);
+    });
+  });
+
+  describe("reset", () => {
+    it("resets page to 1 and total to 0", () => {
+      const { page, total, setTotal, nextPage, reset } = usePagination(10);
+      setTotal(50);
+      nextPage();
+      reset();
+      expect(page.value).toBe(1);
+      expect(total.value).toBe(0);
+    });
+  });
+});

--- a/app/composables/usePagination/index.ts
+++ b/app/composables/usePagination/index.ts
@@ -1,0 +1,2 @@
+export { usePagination } from "./usePagination";
+export type { UsePaginationReturn } from "./usePagination.types";

--- a/app/composables/usePagination/usePagination.ts
+++ b/app/composables/usePagination/usePagination.ts
@@ -1,0 +1,83 @@
+import { ref, computed, readonly } from "vue";
+import type { UsePaginationReturn } from "./usePagination.types";
+
+/**
+ * Composable for managing server-side pagination state.
+ *
+ * Tracks the current page, page size and total item count. Exposes
+ * helpers for navigating between pages and updating the total after
+ * an API response arrives.
+ *
+ * @param initialLimit - Items per page. Defaults to 20.
+ * @returns Reactive pagination state and navigation helpers.
+ *
+ * @example
+ * ```ts
+ * const { page, limit, total, setTotal, nextPage } = usePagination(10);
+ * const { data } = useQuery(['goals', page, limit], () => fetchGoals({ page: page.value, limit: limit.value }));
+ * watch(data, (d) => { if (d) setTotal(d.meta.total); });
+ * ```
+ */
+export function usePagination(initialLimit = 20): UsePaginationReturn {
+  const page = ref(1);
+  const limit = ref(initialLimit);
+  const total = ref(0);
+
+  const totalPages = computed(() =>
+    total.value === 0 ? 1 : Math.ceil(total.value / limit.value),
+  );
+
+  const hasPrevPage = computed(() => page.value > 1);
+  const hasNextPage = computed(() => page.value < totalPages.value);
+
+  /**
+   * Navigates to the given page number, clamped between 1 and totalPages.
+   * @param target - Desired page number.
+   */
+  function goToPage(target: number): void {
+    const clamped = Math.max(1, Math.min(target, totalPages.value));
+    page.value = clamped;
+  }
+
+  /** Advances to the next page if one exists. */
+  function nextPage(): void {
+    if (hasNextPage.value) {
+      page.value += 1;
+    }
+  }
+
+  /** Goes back to the previous page if one exists. */
+  function prevPage(): void {
+    if (hasPrevPage.value) {
+      page.value -= 1;
+    }
+  }
+
+  /**
+   * Updates the total item count (call after receiving the API response).
+   * @param t - Total number of items.
+   */
+  function setTotal(t: number): void {
+    total.value = t;
+  }
+
+  /** Resets page to 1 and total to 0. */
+  function reset(): void {
+    page.value = 1;
+    total.value = 0;
+  }
+
+  return {
+    page: readonly(page),
+    limit: readonly(limit),
+    total: readonly(total),
+    totalPages,
+    hasPrevPage,
+    hasNextPage,
+    goToPage,
+    nextPage,
+    prevPage,
+    setTotal,
+    reset,
+  };
+}

--- a/app/composables/usePagination/usePagination.types.ts
+++ b/app/composables/usePagination/usePagination.types.ts
@@ -1,0 +1,27 @@
+import type { DeepReadonly, Ref } from "vue";
+
+/** Return type of the usePagination composable. */
+export interface UsePaginationReturn {
+  /** Current page number (1-based). Readonly. */
+  page: DeepReadonly<Ref<number>>;
+  /** Number of items per page. Readonly. */
+  limit: DeepReadonly<Ref<number>>;
+  /** Total number of items (as reported by the API). Readonly. */
+  total: DeepReadonly<Ref<number>>;
+  /** Total number of pages derived from total and limit. */
+  totalPages: Ref<number>;
+  /** Whether there is a previous page available. */
+  hasPrevPage: Ref<boolean>;
+  /** Whether there is a next page available. */
+  hasNextPage: Ref<boolean>;
+  /** Navigate to an arbitrary page number (clamped to valid range). */
+  goToPage: (page: number) => void;
+  /** Navigate to the next page if one exists. */
+  nextPage: () => void;
+  /** Navigate to the previous page if one exists. */
+  prevPage: () => void;
+  /** Update the total item count (typically called after receiving API response). */
+  setTotal: (total: number) => void;
+  /** Reset page to 1 and total to 0. */
+  reset: () => void;
+}

--- a/app/composables/useToast/index.ts
+++ b/app/composables/useToast/index.ts
@@ -1,0 +1,2 @@
+export { useToast } from "./useToast";
+export type { UseToastReturn, ToastOptions } from "./useToast.types";

--- a/app/composables/useToast/useToast.spec.ts
+++ b/app/composables/useToast/useToast.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useToast } from "./useToast";
+
+const mockSuccess = vi.fn();
+const mockError = vi.fn();
+const mockWarning = vi.fn();
+const mockInfo = vi.fn();
+
+vi.mock("naive-ui", (): Record<string, unknown> => ({
+  useMessage: () => ({
+    success: mockSuccess,
+    error: mockError,
+    warning: mockWarning,
+    info: mockInfo,
+  }),
+}));
+
+describe("useToast", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls message.success with content and default duration", () => {
+    const toast = useToast();
+    toast.success("Salvo com sucesso!");
+    expect(mockSuccess).toHaveBeenCalledWith("Salvo com sucesso!", { duration: 3000 });
+  });
+
+  it("calls message.error with content and default duration", () => {
+    const toast = useToast();
+    toast.error("Algo deu errado.");
+    expect(mockError).toHaveBeenCalledWith("Algo deu errado.", { duration: 3000 });
+  });
+
+  it("calls message.warning with content and default duration", () => {
+    const toast = useToast();
+    toast.warning("Atenção ao limite.");
+    expect(mockWarning).toHaveBeenCalledWith("Atenção ao limite.", { duration: 3000 });
+  });
+
+  it("calls message.info with content and default duration", () => {
+    const toast = useToast();
+    toast.info("Sincronizado.");
+    expect(mockInfo).toHaveBeenCalledWith("Sincronizado.", { duration: 3000 });
+  });
+
+  it("respects a custom duration option", () => {
+    const toast = useToast();
+    toast.success("Feito!", { duration: 5000 });
+    expect(mockSuccess).toHaveBeenCalledWith("Feito!", { duration: 5000 });
+  });
+
+  it("respects duration 0 (no auto-dismiss)", () => {
+    const toast = useToast();
+    toast.error("Erro crítico", { duration: 0 });
+    expect(mockError).toHaveBeenCalledWith("Erro crítico", { duration: 0 });
+  });
+});

--- a/app/composables/useToast/useToast.ts
+++ b/app/composables/useToast/useToast.ts
@@ -1,0 +1,37 @@
+import { useMessage } from "naive-ui";
+import type { ToastOptions, UseToastReturn } from "./useToast.types";
+
+/**
+ * Composable that wraps NaiveUI's useMessage into a unified toast API.
+ *
+ * Provides consistent duration defaults and a stable interface so that
+ * callers remain decoupled from the underlying notification library.
+ *
+ * Must be called inside a component setup function or composable that
+ * runs inside a NaiveUI message provider context.
+ *
+ * @returns Object with success, error, warning and info toast helpers.
+ */
+export function useToast(): UseToastReturn {
+  const message = useMessage();
+
+  const DEFAULT_DURATION = 3000;
+
+  return {
+    success(content: string, options?: ToastOptions): void {
+      message.success(content, { duration: options?.duration ?? DEFAULT_DURATION });
+    },
+
+    error(content: string, options?: ToastOptions): void {
+      message.error(content, { duration: options?.duration ?? DEFAULT_DURATION });
+    },
+
+    warning(content: string, options?: ToastOptions): void {
+      message.warning(content, { duration: options?.duration ?? DEFAULT_DURATION });
+    },
+
+    info(content: string, options?: ToastOptions): void {
+      message.info(content, { duration: options?.duration ?? DEFAULT_DURATION });
+    },
+  };
+}

--- a/app/composables/useToast/useToast.types.ts
+++ b/app/composables/useToast/useToast.types.ts
@@ -1,0 +1,17 @@
+/** Options for configuring a toast notification. */
+export interface ToastOptions {
+  /** Duration in milliseconds before the toast auto-dismisses. Defaults to 3000. */
+  duration?: number;
+}
+
+/** Unified toast API returned by useToast. */
+export interface UseToastReturn {
+  /** Shows a success (green) toast. */
+  success: (content: string, options?: ToastOptions) => void;
+  /** Shows an error (red) toast. */
+  error: (content: string, options?: ToastOptions) => void;
+  /** Shows a warning (orange) toast. */
+  warning: (content: string, options?: ToastOptions) => void;
+  /** Shows an informational (blue) toast. */
+  info: (content: string, options?: ToastOptions) => void;
+}

--- a/app/stores/filters.spec.ts
+++ b/app/stores/filters.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useFiltersStore } from "./filters";
+
+describe("useFiltersStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("has correct initial state", () => {
+    const store = useFiltersStore();
+    expect(store.period).toBe("current_month");
+    expect(store.customStart).toBe("");
+    expect(store.customEnd).toBe("");
+  });
+
+  describe("getters", () => {
+    it("isCustomPeriod is false by default", () => {
+      expect(useFiltersStore().isCustomPeriod).toBe(false);
+    });
+
+    it("isCustomPeriod is true when period is custom", () => {
+      const store = useFiltersStore();
+      store.setPeriod("custom");
+      expect(store.isCustomPeriod).toBe(true);
+    });
+
+    it("isCustomRangeComplete is false when not custom period", () => {
+      const store = useFiltersStore();
+      store.setPeriod("3m");
+      expect(store.isCustomRangeComplete).toBe(false);
+    });
+
+    it("isCustomRangeComplete is false when custom but dates missing", () => {
+      const store = useFiltersStore();
+      store.setPeriod("custom");
+      expect(store.isCustomRangeComplete).toBe(false);
+    });
+
+    it("isCustomRangeComplete is false when only start is set", () => {
+      const store = useFiltersStore();
+      store.setCustomRange("2025-01-01", "");
+      expect(store.isCustomRangeComplete).toBe(false);
+    });
+
+    it("isCustomRangeComplete is true when both dates are set", () => {
+      const store = useFiltersStore();
+      store.setCustomRange("2025-01-01", "2025-01-31");
+      expect(store.isCustomRangeComplete).toBe(true);
+    });
+  });
+
+  describe("setPeriod", () => {
+    it("updates the period", () => {
+      const store = useFiltersStore();
+      store.setPeriod("3m");
+      expect(store.period).toBe("3m");
+    });
+
+    it("clears custom range when switching away from custom", () => {
+      const store = useFiltersStore();
+      store.setCustomRange("2025-01-01", "2025-01-31");
+      store.setPeriod("6m");
+      expect(store.customStart).toBe("");
+      expect(store.customEnd).toBe("");
+    });
+
+    it("does not clear custom range when setting period to custom", () => {
+      const store = useFiltersStore();
+      store.setPeriod("custom");
+      // Range should remain empty (not cleared)
+      expect(store.customStart).toBe("");
+      expect(store.customEnd).toBe("");
+    });
+  });
+
+  describe("setCustomRange", () => {
+    it("sets start, end and switches period to custom", () => {
+      const store = useFiltersStore();
+      store.setCustomRange("2025-03-01", "2025-03-31");
+      expect(store.period).toBe("custom");
+      expect(store.customStart).toBe("2025-03-01");
+      expect(store.customEnd).toBe("2025-03-31");
+    });
+
+    it("overwrites an existing custom range", () => {
+      const store = useFiltersStore();
+      store.setCustomRange("2025-01-01", "2025-01-31");
+      store.setCustomRange("2025-06-01", "2025-06-30");
+      expect(store.customStart).toBe("2025-06-01");
+      expect(store.customEnd).toBe("2025-06-30");
+    });
+  });
+
+  describe("reset", () => {
+    it("restores initial state", () => {
+      const store = useFiltersStore();
+      store.setCustomRange("2025-01-01", "2025-12-31");
+      store.reset();
+      expect(store.period).toBe("current_month");
+      expect(store.customStart).toBe("");
+      expect(store.customEnd).toBe("");
+    });
+  });
+});

--- a/app/stores/filters.ts
+++ b/app/stores/filters.ts
@@ -1,0 +1,87 @@
+import { defineStore } from "pinia";
+
+/** Supported quick-select period keys. */
+export type FilterPeriod =
+  | "current_month"
+  | "last_month"
+  | "1m"
+  | "3m"
+  | "6m"
+  | "12m"
+  | "custom";
+
+interface FiltersState {
+  /** Active period selection. */
+  period: FilterPeriod;
+  /** Start date for the custom range (ISO date string YYYY-MM-DD or empty string). */
+  customStart: string;
+  /** End date for the custom range (ISO date string YYYY-MM-DD or empty string). */
+  customEnd: string;
+}
+
+/**
+ * Store for global filter state shared across dashboard and feature pages.
+ *
+ * Centralises period and custom-range selection so that navigating between
+ * pages preserves the last used filter without prop-drilling or URL sync.
+ */
+export const useFiltersStore = defineStore("filters", {
+  state: (): FiltersState => ({
+    period: "current_month",
+    customStart: "",
+    customEnd: "",
+  }),
+
+  getters: {
+    /**
+     * Whether the currently selected period is the free-form custom range.
+     * @param state - Current filters state.
+     * @returns True when period is "custom".
+     */
+    isCustomPeriod: (state): boolean => state.period === "custom",
+
+    /**
+     * Whether the custom range has both start and end dates filled in.
+     * Always false when the period is not "custom".
+     * @param state - Current filters state.
+     * @returns True when both customStart and customEnd are non-empty strings.
+     */
+    isCustomRangeComplete: (state): boolean =>
+      state.period === "custom" &&
+      state.customStart.length > 0 &&
+      state.customEnd.length > 0,
+  },
+
+  actions: {
+    /**
+     * Sets the active period.
+     * Clears the custom range when switching away from "custom".
+     * @param period - New period key.
+     */
+    setPeriod(period: FilterPeriod): void {
+      this.period = period;
+      if (period !== "custom") {
+        this.customStart = "";
+        this.customEnd = "";
+      }
+    },
+
+    /**
+     * Sets the custom date range and switches the period to "custom".
+     * @param start - ISO date string for the start date.
+     * @param end - ISO date string for the end date.
+     */
+    setCustomRange(start: string, end: string): void {
+      this.period = "custom";
+      this.customStart = start;
+      this.customEnd = end;
+    },
+
+    /** Resets all filters to their initial values. */
+    reset(): void {
+      this.period = "current_month";
+      this.customStart = "";
+      this.customEnd = "";
+    },
+  },
+});

--- a/app/stores/ui.spec.ts
+++ b/app/stores/ui.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useUiStore } from "./ui";
+
+describe("useUiStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("has correct initial state", () => {
+    const store = useUiStore();
+    expect(store.isPageLoading).toBe(false);
+    expect(store.isMobileMenuOpen).toBe(false);
+  });
+
+  describe("setPageLoading", () => {
+    it("sets isPageLoading to true", () => {
+      const store = useUiStore();
+      store.setPageLoading(true);
+      expect(store.isPageLoading).toBe(true);
+    });
+
+    it("sets isPageLoading to false", () => {
+      const store = useUiStore();
+      store.setPageLoading(true);
+      store.setPageLoading(false);
+      expect(store.isPageLoading).toBe(false);
+    });
+  });
+
+  describe("openMobileMenu", () => {
+    it("sets isMobileMenuOpen to true", () => {
+      const store = useUiStore();
+      store.openMobileMenu();
+      expect(store.isMobileMenuOpen).toBe(true);
+    });
+  });
+
+  describe("closeMobileMenu", () => {
+    it("sets isMobileMenuOpen to false", () => {
+      const store = useUiStore();
+      store.openMobileMenu();
+      store.closeMobileMenu();
+      expect(store.isMobileMenuOpen).toBe(false);
+    });
+  });
+
+  describe("toggleMobileMenu", () => {
+    it("opens when closed", () => {
+      const store = useUiStore();
+      store.toggleMobileMenu();
+      expect(store.isMobileMenuOpen).toBe(true);
+    });
+
+    it("closes when open", () => {
+      const store = useUiStore();
+      store.openMobileMenu();
+      store.toggleMobileMenu();
+      expect(store.isMobileMenuOpen).toBe(false);
+    });
+
+    it("toggles repeatedly", () => {
+      const store = useUiStore();
+      store.toggleMobileMenu(); // open
+      store.toggleMobileMenu(); // close
+      store.toggleMobileMenu(); // open
+      expect(store.isMobileMenuOpen).toBe(true);
+    });
+  });
+});

--- a/app/stores/ui.ts
+++ b/app/stores/ui.ts
@@ -1,0 +1,46 @@
+import { defineStore } from "pinia";
+
+interface UiState {
+  /** Whether the global full-page loading overlay is visible. */
+  isPageLoading: boolean;
+  /** Whether the mobile navigation drawer is open. */
+  isMobileMenuOpen: boolean;
+}
+
+/**
+ * Store for global UI state that is not tied to a specific feature.
+ *
+ * Covers full-page loading overlays and mobile navigation drawer visibility.
+ * Per-component loading states should remain local (useQuery isLoading, etc.).
+ */
+export const useUiStore = defineStore("ui", {
+  state: (): UiState => ({
+    isPageLoading: false,
+    isMobileMenuOpen: false,
+  }),
+
+  actions: {
+    /**
+     * Sets the global page-loading overlay state.
+     * @param value - true to show the overlay, false to hide it.
+     */
+    setPageLoading(value: boolean): void {
+      this.isPageLoading = value;
+    },
+
+    /** Opens the mobile navigation drawer. */
+    openMobileMenu(): void {
+      this.isMobileMenuOpen = true;
+    },
+
+    /** Closes the mobile navigation drawer. */
+    closeMobileMenu(): void {
+      this.isMobileMenuOpen = false;
+    },
+
+    /** Toggles the mobile navigation drawer open/closed. */
+    toggleMobileMenu(): void {
+      this.isMobileMenuOpen = !this.isMobileMenuOpen;
+    },
+  },
+});


### PR DESCRIPTION
## Summary

### WF5 — Pinia stores

- **`stores/ui.ts`**: global UI state — `isPageLoading`, `isMobileMenuOpen`; actions `setPageLoading`, `openMobileMenu`, `closeMobileMenu`, `toggleMobileMenu`
- **`stores/filters.ts`**: global filter state — `FilterPeriod` union type, `period`, `customStart`, `customEnd`; getters `isCustomPeriod`, `isCustomRangeComplete`; actions `setPeriod` (clears custom range on switch away from "custom"), `setCustomRange`, `reset`

### WF6 — Composables

- **`useToast`**: thin wrapper over NaiveUI `useMessage` — consistent 3 000 ms default duration; `success`, `error`, `warning`, `info` helpers; custom duration via options
- **`usePagination`**: server-side pagination — `page`, `limit`, `total` (readonly); `totalPages`, `hasPrevPage`, `hasNextPage` computed; `goToPage` (clamped), `nextPage`, `prevPage`, `setTotal`, `reset`
- **`useFilters`**: composable facade over `useFiltersStore` — computed-only view, shared across instances, action helpers
- **`useConfirm`**: wraps NaiveUI `useDialog` into a single `confirm()` — warning style, default PT-BR labels, optional `onCancel` callback
- **`useErrorBoundary`**: captures unknown thrown values, normalises to `Error`, forwards to `captureException`; `hasError` computed, `reset()`

## Quality gates

- pnpm lint: 0 warnings
- pnpm typecheck: 0 errors
- pnpm test:coverage: 100% on all new modules, all 756+ tests passing, coverage >= 85%
- pnpm policy:check: frontend-governance OK