### PR TITLE
feat(ui): wf7 — UiPageLoader, UiInlineError and ui kit barrel

### DIFF
--- a/app/components/ui/UiInlineError/UiInlineError.stories.ts
+++ b/app/components/ui/UiInlineError/UiInlineError.stories.ts
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/vue3";
+import UiInlineError from "./UiInlineError.vue";
+
+const meta: Meta<typeof UiInlineError> = {
+  title: "UI/UiInlineError",
+  component: UiInlineError,
+  tags: ["autodocs"],
+  argTypes: {
+    title: { control: "text" },
+    message: { control: "text" },
+    retryLabel: { control: "text" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof UiInlineError>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const WithMessage: Story = {
+  args: {
+    title: "Erro ao carregar dados",
+    message: "Verifique sua conexão e tente novamente.",
+  },
+};
+
+export const WithRetry: Story = {
+  args: {
+    title: "Não foi possível carregar",
+    message: "O servidor retornou um erro (503).",
+    retryLabel: "Tentar novamente",
+  },
+};
+
+export const TitleOnly: Story = {
+  args: {
+    title: "Falha ao buscar metas",
+  },
+};

--- a/app/components/ui/UiInlineError/UiInlineError.types.ts
+++ b/app/components/ui/UiInlineError/UiInlineError.types.ts
@@ -1,0 +1,21 @@
+/** Props for the UiInlineError component. */
+export interface UiInlineErrorProps {
+  /**
+   * Short descriptive title shown above the message.
+   * @default "Não foi possível carregar"
+   */
+  title?: string;
+  /** Optional detail message (e.g. the error.message string). */
+  message?: string;
+  /**
+   * Label for the retry action button.
+   * When not provided the button is not rendered.
+   */
+  retryLabel?: string;
+}
+
+/** Emits for the UiInlineError component. */
+export interface UiInlineErrorEmits {
+  /** Emitted when the user clicks the retry button. */
+  (e: "retry"): void;
+}

--- a/app/components/ui/UiInlineError/UiInlineError.vue
+++ b/app/components/ui/UiInlineError/UiInlineError.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { NButton } from "naive-ui";
+import type { UiInlineErrorProps, UiInlineErrorEmits } from "./UiInlineError.types";
+
+withDefaults(defineProps<UiInlineErrorProps>(), {
+  title: "Não foi possível carregar",
+  message: undefined,
+  retryLabel: undefined,
+});
+
+const emit = defineEmits<UiInlineErrorEmits>();
+
+/** Propagates the retry event to the parent. */
+function onRetry(): void {
+  emit("retry");
+}
+</script>
+
+<template>
+  <div class="ui-inline-error" role="alert">
+    <p class="ui-inline-error__title">{{ title }}</p>
+    <p v-if="message" class="ui-inline-error__message">{{ message }}</p>
+    <NButton
+      v-if="retryLabel"
+      class="ui-inline-error__retry"
+      size="small"
+      secondary
+      @click="onRetry"
+    >
+      {{ retryLabel }}
+    </NButton>
+  </div>
+</template>
+
+<style scoped>
+.ui-inline-error {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  border-left: 3px solid var(--color-negative);
+}
+
+.ui-inline-error__title {
+  margin: 0;
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-sm);
+  color: var(--color-negative);
+}
+
+.ui-inline-error__message {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.ui-inline-error__retry {
+  margin-top: var(--space-1);
+}
+</style>

--- a/app/components/ui/UiInlineError/__tests__/UiInlineError.spec.ts
+++ b/app/components/ui/UiInlineError/__tests__/UiInlineError.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import UiInlineError from "../UiInlineError.vue";
+
+vi.mock("naive-ui", () => ({
+  NButton: {
+    name: "NButton",
+    props: ["size", "secondary"],
+    emits: ["click"],
+    template: "<button class=\"n-button\" @click=\"$emit('click', $event)\"><slot /></button>",
+  },
+}));
+
+describe("UiInlineError", () => {
+  it("renders with role=alert", () => {
+    const wrapper = mount(UiInlineError);
+    expect(wrapper.attributes("role")).toBe("alert");
+  });
+
+  it("renders the default title when no title prop is given", () => {
+    const wrapper = mount(UiInlineError);
+    expect(wrapper.find(".ui-inline-error__title").text()).toBe(
+      "Não foi possível carregar",
+    );
+  });
+
+  it("renders a custom title", () => {
+    const wrapper = mount(UiInlineError, {
+      props: { title: "Erro ao buscar metas" },
+    });
+    expect(wrapper.find(".ui-inline-error__title").text()).toBe("Erro ao buscar metas");
+  });
+
+  it("does not render message when not provided", () => {
+    const wrapper = mount(UiInlineError);
+    expect(wrapper.find(".ui-inline-error__message").exists()).toBe(false);
+  });
+
+  it("renders the message when provided", () => {
+    const wrapper = mount(UiInlineError, {
+      props: { message: "Timeout ao conectar com o servidor." },
+    });
+    const msg = wrapper.find(".ui-inline-error__message");
+    expect(msg.exists()).toBe(true);
+    expect(msg.text()).toContain("Timeout ao conectar com o servidor.");
+  });
+
+  it("does not render retry button when retryLabel is not provided", () => {
+    const wrapper = mount(UiInlineError);
+    expect(wrapper.find(".ui-inline-error__retry").exists()).toBe(false);
+  });
+
+  it("renders retry button when retryLabel is provided", () => {
+    const wrapper = mount(UiInlineError, {
+      props: { retryLabel: "Tentar novamente" },
+    });
+    expect(wrapper.find(".ui-inline-error__retry").exists()).toBe(true);
+    expect(wrapper.find(".ui-inline-error__retry").text()).toBe("Tentar novamente");
+  });
+
+  it("emits retry when the retry button is clicked", async () => {
+    const wrapper = mount(UiInlineError, {
+      props: { retryLabel: "Tentar novamente" },
+    });
+    await wrapper.find(".n-button").trigger("click");
+    expect(wrapper.emitted("retry")).toBeTruthy();
+    expect(wrapper.emitted("retry")).toHaveLength(1);
+  });
+
+  it("emits retry multiple times on repeated clicks", async () => {
+    const wrapper = mount(UiInlineError, {
+      props: { retryLabel: "Retry" },
+    });
+    const btn = wrapper.find(".n-button");
+    await btn.trigger("click");
+    await btn.trigger("click");
+    expect(wrapper.emitted("retry")).toHaveLength(2);
+  });
+
+  it("has the ui-inline-error root class", () => {
+    const wrapper = mount(UiInlineError);
+    expect(wrapper.classes()).toContain("ui-inline-error");
+  });
+
+  it("matches snapshot with all props", () => {
+    const wrapper = mount(UiInlineError, {
+      props: {
+        title: "Falha ao carregar portfólio",
+        message: "Serviço indisponível (503).",
+        retryLabel: "Tentar novamente",
+      },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it("matches snapshot with only title", () => {
+    const wrapper = mount(UiInlineError, {
+      props: { title: "Erro genérico" },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});

--- a/app/components/ui/UiInlineError/__tests__/__snapshots__/UiInlineError.spec.ts.snap
+++ b/app/components/ui/UiInlineError/__tests__/__snapshots__/UiInlineError.spec.ts.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`UiInlineError > matches snapshot with all props 1`] = `
+"<div data-v-a58f983a="" class="ui-inline-error" role="alert">
+  <p data-v-a58f983a="" class="ui-inline-error__title">Falha ao carregar portfólio</p>
+  <p data-v-a58f983a="" class="ui-inline-error__message">Serviço indisponível (503).</p><button data-v-a58f983a="" class="n-button ui-inline-error__retry">Tentar novamente</button>
+</div>"
+`;
+
+exports[`UiInlineError > matches snapshot with only title 1`] = `
+"<div data-v-a58f983a="" class="ui-inline-error" role="alert">
+  <p data-v-a58f983a="" class="ui-inline-error__title">Erro genérico</p>
+  <!--v-if-->
+  <!--v-if-->
+</div>"
+`;

--- a/app/components/ui/UiPageLoader/UiPageLoader.stories.ts
+++ b/app/components/ui/UiPageLoader/UiPageLoader.stories.ts
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/vue3";
+import UiPageLoader from "./UiPageLoader.vue";
+
+const meta: Meta<typeof UiPageLoader> = {
+  title: "UI/UiPageLoader",
+  component: UiPageLoader,
+  tags: ["autodocs"],
+  argTypes: {
+    rows: { control: { type: "number", min: 1, max: 10 } },
+    withTitle: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof UiPageLoader>;
+
+export const Default: Story = {
+  args: { rows: 3, withTitle: false },
+};
+
+export const WithTitle: Story = {
+  args: { rows: 3, withTitle: true },
+};
+
+export const SingleRow: Story = {
+  args: { rows: 1, withTitle: false },
+};
+
+export const ManyRows: Story = {
+  args: { rows: 6, withTitle: true },
+};

--- a/app/components/ui/UiPageLoader/UiPageLoader.types.ts
+++ b/app/components/ui/UiPageLoader/UiPageLoader.types.ts
@@ -1,0 +1,14 @@
+/** Props for the UiPageLoader component. */
+export interface UiPageLoaderProps {
+  /**
+   * Number of skeleton content rows to render.
+   * @default 3
+   */
+  rows?: number;
+  /**
+   * Whether to render a taller leading skeleton row that approximates
+   * a page title or section heading.
+   * @default false
+   */
+  withTitle?: boolean;
+}

--- a/app/components/ui/UiPageLoader/UiPageLoader.vue
+++ b/app/components/ui/UiPageLoader/UiPageLoader.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { NSkeleton } from "naive-ui";
+import type { UiPageLoaderProps } from "./UiPageLoader.types";
+
+withDefaults(defineProps<UiPageLoaderProps>(), {
+  rows: 3,
+  withTitle: false,
+});
+</script>
+
+<template>
+  <div class="ui-page-loader" role="status" aria-label="Carregando…" aria-busy="true">
+    <NSkeleton
+      v-if="withTitle"
+      class="ui-page-loader__title"
+      :sharp="false"
+      height="28px"
+      width="40%"
+    />
+    <NSkeleton
+      v-for="n in rows"
+      :key="n"
+      class="ui-page-loader__row"
+      :sharp="false"
+      :height="n === 1 ? '72px' : '56px'"
+    />
+  </div>
+</template>
+
+<style scoped>
+.ui-page-loader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ui-page-loader__title {
+  margin-bottom: var(--space-1);
+}
+
+.ui-page-loader__row {
+  width: 100%;
+}
+</style>

--- a/app/components/ui/UiPageLoader/__tests__/UiPageLoader.spec.ts
+++ b/app/components/ui/UiPageLoader/__tests__/UiPageLoader.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import UiPageLoader from "../UiPageLoader.vue";
+
+vi.mock("naive-ui", () => ({
+  NSkeleton: {
+    name: "NSkeleton",
+    props: ["sharp", "height", "width"],
+    template: "<div class=\"n-skeleton\" :style=\"{ height, width }\" />",
+  },
+}));
+
+describe("UiPageLoader", () => {
+  it("renders with role=status and aria-busy", () => {
+    const wrapper = mount(UiPageLoader);
+    expect(wrapper.attributes("role")).toBe("status");
+    expect(wrapper.attributes("aria-busy")).toBe("true");
+  });
+
+  it("renders 3 content rows by default", () => {
+    const wrapper = mount(UiPageLoader);
+    const rows = wrapper.findAll(".ui-page-loader__row");
+    expect(rows).toHaveLength(3);
+  });
+
+  it("renders the given number of rows", () => {
+    const wrapper = mount(UiPageLoader, { props: { rows: 5 } });
+    expect(wrapper.findAll(".ui-page-loader__row")).toHaveLength(5);
+  });
+
+  it("renders 1 row when rows=1", () => {
+    const wrapper = mount(UiPageLoader, { props: { rows: 1 } });
+    expect(wrapper.findAll(".ui-page-loader__row")).toHaveLength(1);
+  });
+
+  it("does not render title skeleton by default", () => {
+    const wrapper = mount(UiPageLoader);
+    expect(wrapper.find(".ui-page-loader__title").exists()).toBe(false);
+  });
+
+  it("renders title skeleton when withTitle=true", () => {
+    const wrapper = mount(UiPageLoader, { props: { withTitle: true } });
+    expect(wrapper.find(".ui-page-loader__title").exists()).toBe(true);
+  });
+
+  it("renders title skeleton alongside content rows", () => {
+    const wrapper = mount(UiPageLoader, { props: { withTitle: true, rows: 2 } });
+    expect(wrapper.find(".ui-page-loader__title").exists()).toBe(true);
+    expect(wrapper.findAll(".ui-page-loader__row")).toHaveLength(2);
+  });
+
+  it("has the ui-page-loader root class", () => {
+    const wrapper = mount(UiPageLoader);
+    expect(wrapper.classes()).toContain("ui-page-loader");
+  });
+
+  it("matches snapshot with defaults", () => {
+    const wrapper = mount(UiPageLoader);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it("matches snapshot with title and custom row count", () => {
+    const wrapper = mount(UiPageLoader, { props: { withTitle: true, rows: 4 } });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});

--- a/app/components/ui/UiPageLoader/__tests__/__snapshots__/UiPageLoader.spec.ts.snap
+++ b/app/components/ui/UiPageLoader/__tests__/__snapshots__/UiPageLoader.spec.ts.snap
@@ -1,0 +1,20 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`UiPageLoader > matches snapshot with defaults 1`] = `
+"<div data-v-0e53768c="" class="ui-page-loader" role="status" aria-label="Carregando…" aria-busy="true">
+  <!--v-if-->
+  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 72px;"></div>
+  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 56px;"></div>
+  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 56px;"></div>
+</div>"
+`;
+
+exports[`UiPageLoader > matches snapshot with title and custom row count 1`] = `
+"<div data-v-0e53768c="" class="ui-page-loader" role="status" aria-label="Carregando…" aria-busy="true">
+  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__title" style="height: 28px; width: 40%;"></div>
+  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 72px;"></div>
+  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 56px;"></div>
+  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 56px;"></div>
+  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 56px;"></div>
+</div>"
+`;

--- a/app/components/ui/index.ts
+++ b/app/components/ui/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Auraxis UI Kit — barrel export.
+ *
+ * All components are auto-imported by Nuxt (pathPrefix: false) and do not
+ * require explicit imports in templates. This file exists for:
+ *   - IDE type discovery and IntelliSense in non-Nuxt contexts (Storybook, tests)
+ *   - Explicit imports in TypeScript files that need the component type
+ *   - Documentation: a single place listing every shared UI component
+ *
+ * Usage in tests / Storybook:
+ *   import { UiEmptyState } from '~/components/ui';
+ */
+
+// ── Shell & Navigation ────────────────────────────────────────────────────────
+export { default as UiAppShell } from "./UiAppShell/UiAppShell.vue";
+export { default as UiSidebarNav } from "./UiSidebarNav/UiSidebarNav.vue";
+export { default as UiSidebarNavItem } from "./UiSidebarNavItem/UiSidebarNavItem.vue";
+export { default as UiTopbar } from "./UiTopbar/UiTopbar.vue";
+export { default as UiUserMenu } from "./UiUserMenu/UiUserMenu.vue";
+
+// ── Layout & Surfaces ─────────────────────────────────────────────────────────
+export { default as UiGlassPanel } from "./UiGlassPanel/UiGlassPanel.vue";
+export { default as UiSurfaceCard } from "./UiSurfaceCard/UiSurfaceCard.vue";
+export { default as UiListPanel } from "./UiListPanel/UiListPanel.vue";
+export { default as UiPageHeader } from "./UiPageHeader/UiPageHeader.vue";
+
+// ── Data Display ──────────────────────────────────────────────────────────────
+export { default as UiMetricCard } from "./UiMetricCard/UiMetricCard.vue";
+export { default as UiTrendBadge } from "./UiTrendBadge/UiTrendBadge.vue";
+export { default as UiChartPanel } from "./UiChartPanel/UiChartPanel.vue";
+export { default as UiChart } from "./UiChart.vue";
+
+// ── Feedback & States ─────────────────────────────────────────────────────────
+export { default as UiEmptyState } from "./UiEmptyState/UiEmptyState.vue";
+export { default as UiPageLoader } from "./UiPageLoader/UiPageLoader.vue";
+export { default as UiInlineError } from "./UiInlineError/UiInlineError.vue";
+
+// ── Form & Input ──────────────────────────────────────────────────────────────
+export { default as UiFormField } from "./UiFormField/UiFormField.vue";
+export { default as UiPasswordField } from "./UiPasswordField/UiPasswordField.vue";
+export { default as UiSearchField } from "./UiSearchField/UiSearchField.vue";
+export { default as UiSegmentedControl } from "./UiSegmentedControl/UiSegmentedControl.vue";
+export { default as UiSocialAuthButtons } from "./UiSocialAuthButtons/UiSocialAuthButtons.vue";
+
+// ── Iconography & Decorative ──────────────────────────────────────────────────
+export { default as UiIcon } from "./UiIcon/UiIcon.vue";
+export { default as UiInfoTooltip } from "./UiInfoTooltip/UiInfoTooltip.vue";


### PR DESCRIPTION
## Summary

- **UiPageLoader** — NSkeleton-based loading placeholder; props rows (default 3) and withTitle (default false); role=status / aria-busy=true for accessibility
- **UiInlineError** — compact error surface with left-border negative color; props title, message, retryLabel; role=alert; emits retry when button is clicked
- **app/components/ui/index.ts** — barrel re-exporting all 22 Ui* components grouped by category (Shell & Navigation, Layout & Surfaces, Data Display, Feedback & States, Form & Input, Iconography & Decorative)

## Test plan

- [x] UiPageLoader — 100% coverage (lines / branches / functions / statements)
- [x] UiInlineError — 100% coverage
- [x] Storybook stories for Default, WithTitle, SingleRow, ManyRows (PageLoader) and Default, WithMessage, WithRetry, TitleOnly (InlineError)
- [x] pnpm quality-check passes (lint, typecheck, coverage, policy, contracts)
- [x] Pre-push hook passed