### PR TITLE
feat(chart): MIC-33 — useChartSeriesMapper shared composable

### DIFF
--- a/app/components/dashboard/DashboardTimeseriesChart.vue
+++ b/app/components/dashboard/DashboardTimeseriesChart.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { BarChart2 } from "lucide-vue-next";
 
 import type { DashboardTimeseriesPoint } from "~/features/dashboard/model/dashboard-overview";
 import { formatCurrency } from "~/utils/currency";
+import { useChartSeriesMapper } from "~/composables/useChartSeriesMapper";
 
 interface Props {
   data: DashboardTimeseriesPoint[];
@@ -11,6 +13,20 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   isLoading: false,
+});
+
+const { mapTimeseries } = useChartSeriesMapper();
+
+const mapped = computed(() => mapTimeseries(props.data));
+
+/** Colors derived from design tokens via the chart series mapper. */
+const seriesColors = computed(() => {
+  const [income, expense, balance] = mapped.value.series;
+  return {
+    income: income?.color ?? "",
+    expense: expense?.color ?? "",
+    balance: balance?.color ?? "",
+  };
 });
 
 /**
@@ -70,9 +86,9 @@ const formatDate = (value: string): string => {
           <span>{{ formatCurrency(point.balance) }}</span>
         </div>
         <div class="series-bars" aria-hidden="true">
-          <span class="series-bars__income" :style="barStyles(point).income" />
-          <span class="series-bars__expense" :style="barStyles(point).expense" />
-          <span class="series-bars__balance" :style="barStyles(point).balance" />
+          <span class="series-bars__income" :style="{ ...barStyles(point).income, background: seriesColors.income }" />
+          <span class="series-bars__expense" :style="{ ...barStyles(point).expense, background: seriesColors.expense }" />
+          <span class="series-bars__balance" :style="{ ...barStyles(point).balance, background: seriesColors.balance }" />
         </div>
       </div>
     </div>
@@ -134,15 +150,4 @@ const formatDate = (value: string): string => {
   border-radius: var(--radius-lg);
 }
 
-.series-bars__income {
-  background: rgba(35, 133, 84, 0.8);
-}
-
-.series-bars__expense {
-  background: rgba(199, 91, 57, 0.82);
-}
-
-.series-bars__balance {
-  background: rgba(255, 190, 77, 0.85);
-}
 </style>

--- a/app/composables/useChartSeriesMapper/index.ts
+++ b/app/composables/useChartSeriesMapper/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Chart series mapper composable.
+ *
+ * Normalizes domain time-series data into chart series with
+ * Auraxis design-token colors and PT-BR labels.
+ */
+export { useChartSeriesMapper } from "./useChartSeriesMapper";
+export type { ChartSeriesMapperResult } from "./useChartSeriesMapper";
+export type { ChartSeries, ChartSeriesResult } from "./types";

--- a/app/composables/useChartSeriesMapper/types.ts
+++ b/app/composables/useChartSeriesMapper/types.ts
@@ -1,0 +1,18 @@
+/**
+ * A single data series for rendering in a chart.
+ */
+export interface ChartSeries {
+  readonly name: string;
+  readonly data: number[];
+  readonly color: string;
+}
+
+/**
+ * Normalized result of the chart series mapper.
+ * Consumers use `labels` for the x-axis and `series` for the data lines/bars.
+ */
+export interface ChartSeriesResult {
+  readonly labels: string[];
+  readonly series: ChartSeries[];
+  readonly isEmpty: boolean;
+}

--- a/app/composables/useChartSeriesMapper/useChartSeriesMapper.spec.ts
+++ b/app/composables/useChartSeriesMapper/useChartSeriesMapper.spec.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import { useChartSeriesMapper } from "./useChartSeriesMapper";
+import { colors } from "~/theme/tokens/colors";
+import type { DashboardTimeseriesPoint } from "~/features/dashboard/model/dashboard-overview";
+
+/**
+ * Creates a DashboardTimeseriesPoint fixture for testing.
+ *
+ * @param overrides Partial fields to override (date, income, expense, balance).
+ * @returns A complete timeseries point.
+ */
+const makePoint = (overrides: Partial<DashboardTimeseriesPoint>): DashboardTimeseriesPoint => ({
+  date: "2024-01-01",
+  income: 0,
+  expense: 0,
+  balance: 0,
+  ...overrides,
+});
+
+describe("useChartSeriesMapper", () => {
+  describe("mapTimeseries", () => {
+    it("returns isEmpty=true and empty labels/data when given an empty array", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+      const result = mapTimeseries([]);
+
+      expect(result.isEmpty).toBe(true);
+      expect(result.labels).toEqual([]);
+      expect(result.series).toHaveLength(3);
+      for (const s of result.series) {
+        expect(s.data).toEqual([]);
+      }
+    });
+
+    it("returns correct series names for empty input", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+      const result = mapTimeseries([]);
+      const [income, expense, balance] = result.series;
+
+      expect(income?.name).toBe("Receitas");
+      expect(expense?.name).toBe("Despesas");
+      expect(balance?.name).toBe("Saldo");
+    });
+
+    it("returns isEmpty=false for a single point", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+      const result = mapTimeseries([makePoint({ date: "2024-01-15", income: 1000, expense: 500, balance: 500 })]);
+
+      expect(result.isEmpty).toBe(false);
+      expect(result.labels).toHaveLength(1);
+      for (const s of result.series) {
+        expect(s.data).toHaveLength(1);
+      }
+    });
+
+    it("maps income, expense, balance data correctly for a single point", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+      const result = mapTimeseries([makePoint({ date: "2024-01-15", income: 1000, expense: 500, balance: 500 })]);
+      const [incomeSeries, expenseSeries, balanceSeries] = result.series;
+
+      expect(incomeSeries?.data[0]).toBe(1000);
+      expect(expenseSeries?.data[0]).toBe(500);
+      expect(balanceSeries?.data[0]).toBe(500);
+    });
+
+    it("handles multiple points with correct label and data length", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+      const points = [
+        makePoint({ date: "2024-01-01", income: 1000, expense: 400, balance: 600 }),
+        makePoint({ date: "2024-02-01", income: 1200, expense: 600, balance: 600 }),
+        makePoint({ date: "2024-03-01", income: 900, expense: 300, balance: 600 }),
+      ];
+      const result = mapTimeseries(points);
+
+      expect(result.isEmpty).toBe(false);
+      expect(result.labels).toHaveLength(3);
+      for (const s of result.series) {
+        expect(s.data).toHaveLength(3);
+      }
+    });
+
+    it("maps income data values correctly across multiple points", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+      const points = [
+        makePoint({ date: "2024-01-01", income: 100, expense: 50, balance: 50 }),
+        makePoint({ date: "2024-02-01", income: 200, expense: 80, balance: 120 }),
+        makePoint({ date: "2024-03-01", income: 150, expense: 60, balance: 90 }),
+      ];
+      const result = mapTimeseries(points);
+      const [incomeSeries, expenseSeries, balanceSeries] = result.series;
+
+      expect(incomeSeries?.data).toEqual([100, 200, 150]);
+      expect(expenseSeries?.data).toEqual([50, 80, 60]);
+      expect(balanceSeries?.data).toEqual([50, 120, 90]);
+    });
+
+    it("always returns series in order: income, expense, balance", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+
+      const emptyResult = mapTimeseries([]);
+      const [ei, ee, eb] = emptyResult.series;
+      expect(ei?.name).toBe("Receitas");
+      expect(ee?.name).toBe("Despesas");
+      expect(eb?.name).toBe("Saldo");
+
+      const nonEmptyResult = mapTimeseries([makePoint({ income: 100, expense: 50, balance: 50 })]);
+      const [ni, ne, nb] = nonEmptyResult.series;
+      expect(ni?.name).toBe("Receitas");
+      expect(ne?.name).toBe("Despesas");
+      expect(nb?.name).toBe("Saldo");
+    });
+
+    it("assigns correct design-token colors to each series", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+      const result = mapTimeseries([makePoint({ income: 100, expense: 50, balance: 50 })]);
+      const [incomeSeries, expenseSeries, balanceSeries] = result.series;
+
+      expect(incomeSeries?.color).toBe(colors.positive.DEFAULT);
+      expect(expenseSeries?.color).toBe(colors.negative.DEFAULT);
+      expect(balanceSeries?.color).toBe(colors.brand[600]);
+    });
+
+    it("assigns correct design-token colors in empty case too", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+      const result = mapTimeseries([]);
+      const [incomeSeries, expenseSeries, balanceSeries] = result.series;
+
+      expect(incomeSeries?.color).toBe(colors.positive.DEFAULT);
+      expect(expenseSeries?.color).toBe(colors.negative.DEFAULT);
+      expect(balanceSeries?.color).toBe(colors.brand[600]);
+    });
+
+    it("generates a PT-BR formatted label for a known date", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+      const result = mapTimeseries([makePoint({ date: "2024-01-15" })]);
+      const [label] = result.labels;
+
+      expect(label).toMatch(/15/);
+      expect(label).toMatch(/2024/);
+    });
+
+    it("handles negative balance values in data arrays", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+      const result = mapTimeseries([makePoint({ income: 500, expense: 800, balance: -300 })]);
+      const [, , balanceSeries] = result.series;
+
+      expect(balanceSeries?.data[0]).toBe(-300);
+    });
+
+    it("handles zero values in all fields", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+      const result = mapTimeseries([makePoint({ income: 0, expense: 0, balance: 0 })]);
+      const [incomeSeries, expenseSeries, balanceSeries] = result.series;
+
+      expect(result.isEmpty).toBe(false);
+      expect(incomeSeries?.data[0]).toBe(0);
+      expect(expenseSeries?.data[0]).toBe(0);
+      expect(balanceSeries?.data[0]).toBe(0);
+    });
+
+    it("labels array length always matches input points length", () => {
+      const { mapTimeseries } = useChartSeriesMapper();
+      const points = Array.from({ length: 6 }, (_, i) =>
+        makePoint({ date: `2024-0${i + 1}-01`, income: i * 100, expense: i * 50, balance: i * 50 }),
+      );
+      const result = mapTimeseries(points);
+
+      expect(result.labels).toHaveLength(6);
+      for (const s of result.series) {
+        expect(s.data).toHaveLength(6);
+      }
+    });
+  });
+});

--- a/app/composables/useChartSeriesMapper/useChartSeriesMapper.ts
+++ b/app/composables/useChartSeriesMapper/useChartSeriesMapper.ts
@@ -1,0 +1,83 @@
+import type { DashboardTimeseriesPoint } from "~/features/dashboard/model/dashboard-overview";
+import { colors } from "~/theme/tokens/colors";
+import type { ChartSeries, ChartSeriesResult } from "./types";
+
+type TimeseriesKey = "income" | "expense" | "balance";
+
+interface SeriesMeta {
+  readonly name: string;
+  readonly color: string;
+}
+
+const TIMESERIES_SERIES: Record<TimeseriesKey, SeriesMeta> = {
+  income:  { name: "Receitas",  color: colors.positive.DEFAULT },
+  expense: { name: "Despesas",  color: colors.negative.DEFAULT },
+  balance: { name: "Saldo",     color: colors.brand[600] },
+};
+
+/**
+ * Formats an ISO calendar date to a compact PT-BR label.
+ *
+ * @param dateStr ISO date string (YYYY-MM-DD).
+ * @returns Compact localized date label.
+ */
+const formatLabel = (dateStr: string): string =>
+  new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  }).format(new Date(`${dateStr}T00:00:00`));
+
+/**
+ * Return type for {@link useChartSeriesMapper}.
+ */
+export interface ChartSeriesMapperResult {
+  /**
+   * Maps an array of dashboard timeseries points to normalized chart series
+   * with PT-BR labels and design-token colors.
+   *
+   * @param points Array of timeseries data points.
+   * @returns Normalized chart series result.
+   */
+  mapTimeseries: (points: DashboardTimeseriesPoint[]) => ChartSeriesResult;
+}
+
+/**
+ * Shared composable that normalizes domain data into chart series.
+ *
+ * Centralizes label formatting and color assignment so that dashboard,
+ * wallet, goals and tools screens share a single source of truth for
+ * series rendering.
+ *
+ * @returns Object with chart mapping utilities.
+ */
+export function useChartSeriesMapper(): ChartSeriesMapperResult {
+  /**
+   * Maps an array of dashboard timeseries points to normalized chart series.
+   *
+   * @param points Array of timeseries data points.
+   * @returns Normalized chart series result with PT-BR labels and design-token colors.
+   */
+  const mapTimeseries = (points: DashboardTimeseriesPoint[]): ChartSeriesResult => {
+    if (points.length === 0) {
+      const emptySeries: ChartSeries[] = (["income", "expense", "balance"] as TimeseriesKey[]).map(
+        (key) => ({ name: TIMESERIES_SERIES[key].name, data: [], color: TIMESERIES_SERIES[key].color }),
+      );
+      return { labels: [], series: emptySeries, isEmpty: true };
+    }
+
+    const labels = points.map((p) => formatLabel(p.date));
+
+    const series: ChartSeries[] = (["income", "expense", "balance"] as TimeseriesKey[]).map(
+      (key) => ({
+        name: TIMESERIES_SERIES[key].name,
+        data: points.map((p) => p[key]),
+        color: TIMESERIES_SERIES[key].color,
+      }),
+    );
+
+    return { labels, series, isEmpty: false };
+  };
+
+  return { mapTimeseries };
+}


### PR DESCRIPTION
## Summary

- Add `useChartSeriesMapper` composable that normalizes domain timeseries data into chart series with Auraxis design-token colors and PT-BR labels
- Centralizes color assignment (income=positive, expense=negative, balance=brand) away from individual components
- Wire `DashboardTimeseriesChart` as the reference consumer — removes hardcoded rgba color values from CSS
- Covers: empty input, single point, multi-point, color matching, series order

## Test plan
- [ ] `pnpm quality-check` passes
- [ ] Dashboard timeseries chart renders with correct brand colors
- [ ] Empty state still shows correctly when data is []
- [ ] useChartSeriesMapper spec covers all edge cases

Closes #235