### PR TITLE
feat(wallet): MVP1-P3 — wallet entry form, positions panel and allocation section

### DIFF
--- a/app/components/wallet/WalletAllocationSection/WalletAllocationSection.types.ts
+++ b/app/components/wallet/WalletAllocationSection/WalletAllocationSection.types.ts
@@ -1,0 +1,11 @@
+import type { WalletEntryDto } from "~/features/portfolio/contracts/portfolio.dto";
+
+/**
+ * Props accepted by the WalletAllocationSection component.
+ */
+export interface WalletAllocationSectionProps {
+  /** Array of wallet entry DTOs used to compute allocation breakdown. */
+  entries: WalletEntryDto[];
+  /** Whether the data is currently being fetched. */
+  isLoading?: boolean;
+}

--- a/app/components/wallet/WalletAllocationSection/WalletAllocationSection.vue
+++ b/app/components/wallet/WalletAllocationSection/WalletAllocationSection.vue
@@ -1,0 +1,170 @@
+<script setup lang="ts">
+import { NCard, NProgress, NEmpty } from "naive-ui";
+import { formatCurrency } from "~/utils/currency";
+import type { WalletEntryDto } from "~/features/portfolio/contracts/portfolio.dto";
+import type { WalletAllocationSectionProps } from "./WalletAllocationSection.types";
+
+const props = defineProps<WalletAllocationSectionProps>();
+
+/** Internal representation of a single asset-type allocation row. */
+interface AllocationRow {
+  readonly assetType: WalletEntryDto["asset_type"];
+  readonly label: string;
+  readonly count: number;
+  readonly totalValue: number;
+  readonly percentage: number;
+}
+
+/**
+ * Returns a human-readable PT-BR label for an asset type.
+ *
+ * @param assetType - The asset type value.
+ * @returns Localised label string.
+ */
+const assetTypeLabel = (assetType: WalletEntryDto["asset_type"]): string => {
+  const map: Record<WalletEntryDto["asset_type"], string> = {
+    stock: "Ações",
+    fii: "FIIs",
+    crypto: "Cripto",
+    fixed_income: "Renda Fixa",
+    other: "Outros",
+  };
+  return map[assetType];
+};
+
+/**
+ * Computes allocation breakdown from the entries array.
+ *
+ * Groups entries by asset_type, sums their current_value and derives
+ * the percentage share of each group against the grand total.
+ *
+ * @returns Sorted array of AllocationRow (descending by totalValue).
+ */
+const allocations = computed((): AllocationRow[] => {
+  if (props.entries.length === 0) { return []; }
+
+  const grandTotal = props.entries.reduce((acc, e) => acc + e.current_value, 0);
+
+  const grouped = new Map<WalletEntryDto["asset_type"], { count: number; totalValue: number }>();
+
+  for (const entry of props.entries) {
+    const existing = grouped.get(entry.asset_type);
+    if (existing) {
+      existing.count += 1;
+      existing.totalValue += entry.current_value;
+    } else {
+      grouped.set(entry.asset_type, { count: 1, totalValue: entry.current_value });
+    }
+  }
+
+  const rows: AllocationRow[] = [];
+
+  for (const [assetType, { count, totalValue }] of grouped.entries()) {
+    rows.push({
+      assetType,
+      label: assetTypeLabel(assetType),
+      count,
+      totalValue,
+      percentage: grandTotal > 0 ? (totalValue / grandTotal) * 100 : 0,
+    });
+  }
+
+  return rows.sort((a, b) => b.totalValue - a.totalValue);
+});
+</script>
+
+<template>
+  <NCard :bordered="true" class="wallet-allocation-section">
+    <template #header>
+      <span class="wallet-allocation-section__title">Alocação por tipo</span>
+    </template>
+
+    <UiPageLoader v-if="props.isLoading" :rows="3" />
+
+    <NEmpty
+      v-else-if="allocations.length === 0"
+      description="Nenhum ativo para calcular alocação."
+      class="wallet-allocation-section__empty"
+    />
+
+    <div v-else class="wallet-allocation-section__list">
+      <div
+        v-for="row in allocations"
+        :key="row.assetType"
+        class="wallet-allocation-section__row"
+      >
+        <div class="was-row__meta">
+          <span class="was-row__label">{{ row.label }}</span>
+          <div class="was-row__stats">
+            <span class="was-row__count">{{ row.count }} ativo{{ row.count !== 1 ? "s" : "" }}</span>
+            <span class="was-row__value">{{ formatCurrency(row.totalValue) }}</span>
+            <span class="was-row__pct">{{ row.percentage.toFixed(1) }}%</span>
+          </div>
+        </div>
+        <NProgress
+          type="line"
+          :percentage="row.percentage"
+          :show-indicator="false"
+          :height="6"
+          class="was-row__progress"
+        />
+      </div>
+    </div>
+  </NCard>
+</template>
+
+<style scoped>
+.wallet-allocation-section__title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.wallet-allocation-section__empty {
+  padding: var(--space-4) 0;
+}
+
+.wallet-allocation-section__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.was-row__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-1);
+  gap: var(--space-2);
+}
+
+.was-row__label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.was-row__stats {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.was-row__count {
+  font-size: var(--font-size-xs, 0.75rem);
+  color: var(--color-text-muted);
+}
+
+.was-row__value {
+  font-size: var(--font-size-xs, 0.75rem);
+  color: var(--color-text-secondary, var(--color-text-primary));
+}
+
+.was-row__pct {
+  font-size: var(--font-size-xs, 0.75rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  min-width: 40px;
+  text-align: right;
+}
+</style>

--- a/app/components/wallet/WalletEntryForm/WalletEntryForm.types.ts
+++ b/app/components/wallet/WalletEntryForm/WalletEntryForm.types.ts
@@ -1,0 +1,7 @@
+/**
+ * Props accepted by the WalletEntryForm component.
+ */
+export interface WalletEntryFormProps {
+  /** Controls the NModal open/close state. */
+  visible: boolean;
+}

--- a/app/components/wallet/WalletEntryForm/WalletEntryForm.vue
+++ b/app/components/wallet/WalletEntryForm/WalletEntryForm.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+import {
+  NModal,
+  NForm,
+  NFormItem,
+  NInput,
+  NInputNumber,
+  NSelect,
+  NDatePicker,
+  NSwitch,
+  NButton,
+  NSpace,
+  type FormInst,
+  type FormRules,
+} from "naive-ui";
+import type { CreateWalletEntryPayload } from "~/features/wallet/services/wallet.client";
+import type { WalletEntryFormProps } from "./WalletEntryForm.types";
+
+const props = defineProps<WalletEntryFormProps>();
+
+const emit = defineEmits<{
+  "update:visible": [value: boolean];
+  submit: [payload: CreateWalletEntryPayload];
+}>();
+
+const formRef = ref<FormInst | null>(null);
+
+const form = reactive({
+  name: "",
+  asset_class: null as string | null,
+  ticker: "",
+  quantity: null as number | null,
+  value: null as number | null,
+  register_date: null as number | null,
+  should_be_on_wallet: true,
+});
+
+/** Whether the current asset class expects a ticker symbol. */
+const tickerBasedClasses = ["stock", "fii", "etf", "bdr", "crypto"];
+
+const hasTicker = computed((): boolean => {
+  return tickerBasedClasses.includes(form.asset_class ?? "") && !!form.ticker;
+});
+
+const showQuantity = computed((): boolean => hasTicker.value);
+
+const showValue = computed((): boolean => !hasTicker.value);
+
+/** Asset class options with PT-BR labels. */
+const assetClassOptions = [
+  { label: "Ação", value: "stock" },
+  { label: "FII", value: "fii" },
+  { label: "ETF", value: "etf" },
+  { label: "BDR", value: "bdr" },
+  { label: "Criptomoeda", value: "crypto" },
+  { label: "CDB / Renda Fixa", value: "cdb" },
+  { label: "Personalizado", value: "custom" },
+];
+
+const rules = computed((): FormRules => ({
+  name: [{ required: true, message: "Informe o nome do ativo", trigger: "blur" }],
+  asset_class: [{ required: true, message: "Selecione o tipo de ativo", trigger: "change" }],
+  ticker: tickerBasedClasses.includes(form.asset_class ?? "")
+    ? []
+    : [],
+  quantity: showQuantity.value
+    ? [{ required: true, type: "number", message: "Informe a quantidade", trigger: ["blur", "change"] }]
+    : [],
+  value: showValue.value
+    ? [{ required: true, type: "number", message: "Informe o valor atual", trigger: ["blur", "change"] }]
+    : [],
+  register_date: [{ required: true, type: "number", message: "Selecione a data", trigger: "change" }],
+}));
+
+/**
+ * Converts a Unix timestamp (ms) produced by NDatePicker to an ISO date string.
+ *
+ * @param ts - Unix timestamp in milliseconds.
+ * @returns ISO 8601 date string (YYYY-MM-DD).
+ */
+const tsToDateString = (ts: number): string => {
+  const d = new Date(ts);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+};
+
+/**
+ * Validates the form and emits the submit event with the typed payload.
+ */
+const handleSubmit = async (): Promise<void> => {
+  try {
+    await formRef.value?.validate();
+  } catch {
+    return;
+  }
+
+  const payload: CreateWalletEntryPayload = {
+    name: form.name,
+    asset_class: (form.asset_class as CreateWalletEntryPayload["asset_class"]) ?? undefined,
+    ticker: hasTicker.value ? form.ticker || null : null,
+    quantity: showQuantity.value ? form.quantity : null,
+    value: showValue.value ? form.value : null,
+    register_date: form.register_date ? tsToDateString(form.register_date) : "",
+    should_be_on_wallet: form.should_be_on_wallet,
+  };
+
+  emit("submit", payload);
+  emit("update:visible", false);
+  resetForm();
+};
+
+/** Resets the form state to initial values. */
+const resetForm = (): void => {
+  form.name = "";
+  form.asset_class = null;
+  form.ticker = "";
+  form.quantity = null;
+  form.value = null;
+  form.register_date = null;
+  form.should_be_on_wallet = true;
+};
+
+/**
+ * Closes the modal and resets the form state.
+ */
+const handleClose = (): void => {
+  emit("update:visible", false);
+  resetForm();
+};
+</script>
+
+<template>
+  <NModal
+    :show="props.visible"
+    preset="card"
+    title="Adicionar ativo"
+    class="wallet-entry-form-modal"
+    :style="{ maxWidth: '480px', width: '100%' }"
+    @update:show="handleClose"
+  >
+    <NForm ref="formRef" :model="form" :rules="rules" label-placement="top">
+      <NFormItem label="Nome do ativo" path="name">
+        <NInput v-model:value="form.name" placeholder="Ex: Tesouro Direto IPCA+" />
+      </NFormItem>
+
+      <NFormItem label="Tipo de ativo" path="asset_class">
+        <NSelect
+          v-model:value="form.asset_class"
+          :options="assetClassOptions"
+          placeholder="Selecione o tipo"
+        />
+      </NFormItem>
+
+      <NFormItem
+        v-if="tickerBasedClasses.includes(form.asset_class ?? '')"
+        label="Ticker (opcional)"
+        path="ticker"
+      >
+        <NInput v-model:value="form.ticker" placeholder="Ex: PETR4, BTC" />
+      </NFormItem>
+
+      <NFormItem v-if="showQuantity" label="Quantidade" path="quantity">
+        <NInputNumber
+          v-model:value="form.quantity"
+          placeholder="Ex: 100"
+          :min="0"
+          style="width: 100%"
+        />
+      </NFormItem>
+
+      <NFormItem v-if="showValue" label="Valor atual (R$)" path="value">
+        <NInputNumber
+          v-model:value="form.value"
+          placeholder="Ex: 5000.00"
+          :min="0"
+          :precision="2"
+          style="width: 100%"
+        />
+      </NFormItem>
+
+      <NFormItem label="Data de registro" path="register_date">
+        <NDatePicker
+          v-model:value="form.register_date"
+          type="date"
+          style="width: 100%"
+        />
+      </NFormItem>
+
+      <NFormItem label="Incluir no patrimônio" path="should_be_on_wallet">
+        <NSwitch v-model:value="form.should_be_on_wallet" />
+      </NFormItem>
+    </NForm>
+
+    <template #footer>
+      <NSpace justify="end">
+        <NButton @click="handleClose">Cancelar</NButton>
+        <NButton type="primary" @click="handleSubmit">Salvar</NButton>
+      </NSpace>
+    </template>
+  </NModal>
+</template>
+
+<style scoped>
+.wallet-entry-form-modal {
+  color: var(--color-text-primary);
+}
+</style>

--- a/app/components/wallet/WalletPositionsPanel/WalletPositionsPanel.types.ts
+++ b/app/components/wallet/WalletPositionsPanel/WalletPositionsPanel.types.ts
@@ -1,0 +1,11 @@
+import type { WalletEntryDto } from "~/features/portfolio/contracts/portfolio.dto";
+
+/**
+ * Props accepted by the WalletPositionsPanel component.
+ */
+export interface WalletPositionsPanelProps {
+  /** Array of wallet entry DTOs to display as position cards. */
+  entries: WalletEntryDto[];
+  /** Whether the data is currently being fetched. */
+  isLoading?: boolean;
+}

--- a/app/components/wallet/WalletPositionsPanel/WalletPositionsPanel.vue
+++ b/app/components/wallet/WalletPositionsPanel/WalletPositionsPanel.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import { NCard, NTag, NEmpty } from "naive-ui";
+import { formatCurrency } from "~/utils/currency";
+import type { WalletEntryDto } from "~/features/portfolio/contracts/portfolio.dto";
+import type { WalletPositionsPanelProps } from "./WalletPositionsPanel.types";
+
+const props = defineProps<WalletPositionsPanelProps>();
+
+/**
+ * Maps an asset_type value to a NaiveUI NTag type.
+ *
+ * @param assetType - The asset type value from WalletEntryDto.
+ * @returns NaiveUI tag type string.
+ */
+const tagType = (
+  assetType: WalletEntryDto["asset_type"],
+): "info" | "success" | "warning" | "default" => {
+  const map: Record<WalletEntryDto["asset_type"], "info" | "success" | "warning" | "default"> = {
+    stock: "info",
+    fii: "success",
+    crypto: "warning",
+    fixed_income: "default",
+    other: "default",
+  };
+  return map[assetType];
+};
+
+/**
+ * Returns a human-readable PT-BR label for an asset type.
+ *
+ * @param assetType - The asset type value.
+ * @returns Localised label string.
+ */
+const assetTypeLabel = (assetType: WalletEntryDto["asset_type"]): string => {
+  const map: Record<WalletEntryDto["asset_type"], string> = {
+    stock: "Ação",
+    fii: "FII",
+    crypto: "Cripto",
+    fixed_income: "Renda Fixa",
+    other: "Outro",
+  };
+  return map[assetType];
+};
+
+/**
+ * Formats a change percentage with sign for display.
+ *
+ * @param value - Percentage number.
+ * @returns Formatted string like "+1.34%" or "-0.82%".
+ */
+const formatPercent = (value: number): string => {
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+};
+
+/**
+ * Returns the CSS color variable for a positive, neutral or negative percent.
+ *
+ * @param value - Percentage value or null.
+ * @returns CSS color string.
+ */
+const changeColor = (value: number | null): string => {
+  if (value === null) { return "var(--color-text-muted)"; }
+  if (value > 0) { return "var(--color-success, #18a058)"; }
+  if (value < 0) { return "var(--color-error, #d03050)"; }
+  return "var(--color-text-primary)";
+};
+</script>
+
+<template>
+  <div class="wallet-positions-panel">
+    <div class="wallet-positions-panel__header">
+      <span class="wallet-positions-panel__title">Posições</span>
+      <NTag v-if="!props.isLoading" size="small" :bordered="false">
+        {{ props.entries.length }}
+      </NTag>
+    </div>
+
+    <UiPageLoader v-if="props.isLoading" :rows="3" />
+
+    <NEmpty
+      v-else-if="props.entries.length === 0"
+      description="Nenhum ativo na carteira."
+      class="wallet-positions-panel__empty"
+    />
+
+    <div v-else class="wallet-positions-panel__grid">
+      <NCard
+        v-for="entry in props.entries"
+        :key="entry.id"
+        :bordered="true"
+        size="small"
+        class="wallet-positions-panel__card"
+      >
+        <div class="wpp-card__top">
+          <div class="wpp-card__name-row">
+            <span class="wpp-card__name">{{ entry.name }}</span>
+            <NTag v-if="entry.ticker" size="small" :bordered="false" class="wpp-card__ticker">
+              {{ entry.ticker }}
+            </NTag>
+          </div>
+          <NTag :type="tagType(entry.asset_type)" size="small" :bordered="false">
+            {{ assetTypeLabel(entry.asset_type) }}
+          </NTag>
+        </div>
+
+        <div class="wpp-card__bottom">
+          <span class="wpp-card__value">{{ formatCurrency(entry.current_value) }}</span>
+          <span
+            class="wpp-card__change"
+            :style="{ color: changeColor(entry.change_percent) }"
+          >
+            {{ entry.change_percent !== null ? formatPercent(entry.change_percent) : "—" }}
+          </span>
+        </div>
+      </NCard>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.wallet-positions-panel__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.wallet-positions-panel__title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.wallet-positions-panel__empty {
+  padding: var(--space-4) 0;
+}
+
+.wallet-positions-panel__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--space-3);
+}
+
+.wpp-card__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-1);
+  margin-bottom: var(--space-2);
+}
+
+.wpp-card__name-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+
+.wpp-card__name {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.wpp-card__ticker {
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.wpp-card__bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-1);
+}
+
+.wpp-card__value {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.wpp-card__change {
+  font-size: var(--font-size-xs, 0.75rem);
+  font-weight: var(--font-weight-semibold);
+}
+</style>

--- a/app/features/wallet/queries/use-create-wallet-entry-mutation.ts
+++ b/app/features/wallet/queries/use-create-wallet-entry-mutation.ts
@@ -1,0 +1,33 @@
+import type { UseMutationReturnType } from "@tanstack/vue-query";
+import { createApiMutation } from "~/core/query/use-api-mutation";
+import {
+  useWalletClient,
+  type WalletClient,
+  type CreateWalletEntryPayload,
+} from "~/features/wallet/services/wallet.client";
+import type { WalletEntryDto } from "~/features/portfolio/contracts/portfolio.dto";
+import type { ApiError } from "~/core/errors";
+
+/**
+ * Vue Query mutation hook for creating a new wallet entry.
+ *
+ * On success it invalidates both the entries list and the portfolio summary
+ * so all derived views refresh automatically.
+ *
+ * @param providedClient - Optional injected WalletClient for unit tests.
+ * @returns TanStack Vue Query mutation state.
+ */
+export const useCreateWalletEntryMutation = (
+  providedClient?: WalletClient,
+): UseMutationReturnType<WalletEntryDto, ApiError, CreateWalletEntryPayload, unknown> => {
+  const client = providedClient ?? useWalletClient();
+
+  return createApiMutation<WalletEntryDto, CreateWalletEntryPayload>(
+    (payload: CreateWalletEntryPayload): Promise<WalletEntryDto> =>
+      client.createEntry(payload),
+    {
+      successMessage: "Ativo adicionado à carteira.",
+      invalidates: [["wallet", "entries"], ["wallet", "summary"]],
+    },
+  );
+};

--- a/app/features/wallet/queries/use-delete-wallet-entry-mutation.ts
+++ b/app/features/wallet/queries/use-delete-wallet-entry-mutation.ts
@@ -1,0 +1,28 @@
+import type { UseMutationReturnType } from "@tanstack/vue-query";
+import { createApiMutation } from "~/core/query/use-api-mutation";
+import { useWalletClient, type WalletClient } from "~/features/wallet/services/wallet.client";
+import type { ApiError } from "~/core/errors";
+
+/**
+ * Vue Query mutation hook for deleting a wallet entry by its identifier.
+ *
+ * On success it invalidates both the entries list and the portfolio summary
+ * so all derived views refresh automatically.
+ *
+ * @param providedClient - Optional injected WalletClient for unit tests.
+ * @returns TanStack Vue Query mutation state.
+ */
+export const useDeleteWalletEntryMutation = (
+  providedClient?: WalletClient,
+): UseMutationReturnType<undefined, ApiError, string, unknown> => {
+  const client = providedClient ?? useWalletClient();
+
+  return createApiMutation<undefined, string>(
+    (id: string): Promise<undefined> =>
+      client.deleteEntry(id).then(() => undefined),
+    {
+      successMessage: "Ativo removido.",
+      invalidates: [["wallet", "entries"], ["wallet", "summary"]],
+    },
+  );
+};

--- a/app/features/wallet/services/wallet.client.ts
+++ b/app/features/wallet/services/wallet.client.ts
@@ -10,6 +10,26 @@ import type {
 } from "~/features/portfolio/contracts/portfolio.dto";
 
 /**
+ * Payload for creating a new wallet entry.
+ */
+export type CreateWalletEntryPayload = {
+  /** Display name for the asset. */
+  readonly name: string;
+  /** Current monetary value — required when no ticker is provided. */
+  readonly value?: number | null;
+  /** Stock/crypto/fund ticker symbol — when provided, quantity is required. */
+  readonly ticker?: string | null;
+  /** Number of units held — required when ticker is provided. */
+  readonly quantity?: number | null;
+  /** Asset class classification. */
+  readonly asset_class?: "stock" | "fii" | "etf" | "bdr" | "crypto" | "cdb" | "custom";
+  /** ISO 8601 date (YYYY-MM-DD) of the registration. */
+  readonly register_date: string;
+  /** Whether this asset should count towards total patrimony. */
+  readonly should_be_on_wallet: boolean;
+};
+
+/**
  * API client for the wallet feature.
  *
  * Encapsulates all HTTP calls to the `/wallet` endpoints and returns
@@ -53,6 +73,31 @@ export class WalletClient {
   async getEntries(): Promise<WalletEntryDto[]> {
     const response = await this.#http.get<WalletEntryDto[]>("/wallet/entries");
     return response.data;
+  }
+
+  /**
+   * Creates a new wallet entry for the authenticated user.
+   *
+   * The backend responds with `{ message, data: { investment: WalletEntryDto } }`.
+   *
+   * @param payload - Data for the new asset entry.
+   * @returns The newly created WalletEntryDto.
+   */
+  async createEntry(payload: CreateWalletEntryPayload): Promise<WalletEntryDto> {
+    const response = await this.#http.post<{ data: { investment: WalletEntryDto } }>(
+      "/wallet",
+      payload,
+    );
+    return response.data.data.investment;
+  }
+
+  /**
+   * Deletes a wallet entry by its identifier.
+   *
+   * @param id - The unique identifier of the entry to delete.
+   */
+  async deleteEntry(id: string): Promise<void> {
+    await this.#http.delete(`/wallet/${id}`);
   }
 }
 

--- a/app/pages/portfolio.vue
+++ b/app/pages/portfolio.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
+import { NButton } from "naive-ui";
 import { usePortfolioSummaryQuery } from "~/features/wallet/queries/use-portfolio-summary-query";
 import { useWalletEntriesQuery } from "~/features/wallet/queries/use-wallet-entries-query";
+import { useCreateWalletEntryMutation } from "~/features/wallet/queries/use-create-wallet-entry-mutation";
+import { useDeleteWalletEntryMutation } from "~/features/wallet/queries/use-delete-wallet-entry-mutation";
+import type { CreateWalletEntryPayload } from "~/features/wallet/services/wallet.client";
 
 definePageMeta({
   middleware: ["authenticated"],
@@ -13,8 +17,31 @@ useHead({ title: "Carteira | Auraxis" });
 const { data: summary, isLoading: isSummaryLoading, isError: isSummaryError } = usePortfolioSummaryQuery();
 const { data: entries, isLoading: isEntriesLoading, isError: isEntriesError } = useWalletEntriesQuery();
 
+const createMutation = useCreateWalletEntryMutation();
+const deleteMutation = useDeleteWalletEntryMutation();
+
 const isLoading = computed(() => isSummaryLoading.value || isEntriesLoading.value);
 const isError = computed(() => isSummaryError.value || isEntriesError.value);
+
+const showEntryForm = ref(false);
+
+/**
+ * Handles the submit event from WalletEntryForm.
+ *
+ * @param payload - Typed payload emitted by the form component.
+ */
+const onCreateEntry = (payload: CreateWalletEntryPayload): void => {
+  createMutation.mutate(payload);
+};
+
+/**
+ * Triggers deletion of a wallet entry by its identifier.
+ *
+ * @param id - The unique identifier of the entry to delete.
+ */
+const onDeleteEntry = (id: string): void => {
+  deleteMutation.mutate(id);
+};
 </script>
 
 <template>
@@ -26,7 +53,16 @@ const isError = computed(() => isSummaryError.value || isEntriesError.value);
           Visão geral dos seus investimentos
         </span>
       </div>
+      <NButton type="primary" size="small" @click="showEntryForm = true">
+        Adicionar ativo
+      </NButton>
     </div>
+
+    <WalletEntryForm
+      :visible="showEntryForm"
+      @update:visible="showEntryForm = $event"
+      @submit="onCreateEntry"
+    />
 
     <UiInlineError
       v-if="isError"
@@ -39,7 +75,9 @@ const isError = computed(() => isSummaryError.value || isEntriesError.value);
 
       <template v-else>
         <PortfolioSummaryBar :summary="summary ?? null" />
-        <PortfolioTable :entries="entries ?? []" />
+        <WalletPositionsPanel :entries="entries ?? []" :is-loading="isLoading" />
+        <WalletAllocationSection :entries="entries ?? []" :is-loading="isLoading" />
+        <PortfolioTable :entries="entries ?? []" @delete="onDeleteEntry" />
       </template>
     </template>
   </div>
@@ -51,6 +89,13 @@ const isError = computed(() => isSummaryError.value || isEntriesError.value);
   flex-direction: column;
   gap: var(--space-3);
   padding: var(--space-3);
+}
+
+.portfolio-page__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: var(--space-2);
 }
 
 .portfolio-page__title-block {


### PR DESCRIPTION
## Summary

- Add `createEntry` and `deleteEntry` methods to `WalletClient`
- Add `useCreateWalletEntryMutation` and `useDeleteWalletEntryMutation` using `createApiMutation`
- Add `WalletEntryForm` modal (name, asset_class, ticker/quantity or value, register_date, should_be_on_wallet)
  - Conditional fields: ticker path (quantity required) vs value path (current value required)
- Add `WalletPositionsPanel` showing asset cards with type badges and change percent
- Add `WalletAllocationSection` showing breakdown by asset type with NProgress bars
- Wire `portfolio.vue` with all new components and mutations

## Test plan
- [ ] pnpm quality-check passes
- [ ] Adicionar ativo button opens WalletEntryForm
- [ ] Submitting form with ticker creates entry and refreshes list
- [ ] Submitting form without ticker (custom/cdb) also works
- [ ] WalletPositionsPanel shows all entries with correct badges
- [ ] WalletAllocationSection shows correct percentages

Closes #196 (MAC-05), #244 (FEAT-08), #245 (FEAT-09)