### PR TITLE
chore(ops-03): Chromatic CI/CD + deploy Storybook em design.auraxis.com.br

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,8 +3,24 @@ name: Chromatic
 on:
   pull_request:
     branches: [main, master]
+    paths:
+      - 'app/components/**'
+      - 'app/features/**/components/**'
+      - 'app/shared/components/**'
+      - '**/*.stories.ts'
+      - '**/*.stories.vue'
+      - '**/*.stories.mdx'
+      - '.storybook/**'
   push:
     branches: [main, master]
+    paths:
+      - 'app/components/**'
+      - 'app/features/**/components/**'
+      - 'app/shared/components/**'
+      - '**/*.stories.ts'
+      - '**/*.stories.vue'
+      - '**/*.stories.mdx'
+      - '.storybook/**'
   workflow_dispatch:
 
 concurrency:
@@ -16,6 +32,7 @@ env:
   PNPM_VERSION: '10.30.1'
 
 jobs:
+  # ── Visual regression review via Chromatic ────────────────────────────────
   chromatic:
     name: Chromatic Visual Review
     runs-on: ubuntu-latest
@@ -32,14 +49,14 @@ jobs:
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Chromatic skipped: CHROMATIC_PROJECT_TOKEN is not configured for this repository."
+            echo "::notice::Chromatic skipped: CHROMATIC_PROJECT_TOKEN is not configured."
           fi
 
       - name: Checkout
         if: steps.capability.outputs.enabled == 'true'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0  # required for TurboSnap ancestry analysis
 
       - name: Setup pnpm
         if: steps.capability.outputs.enabled == 'true'
@@ -65,8 +82,8 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: storybook:build
-          onlyChanged: true
-          exitZeroOnChanges: true
+          onlyChanged: true        # TurboSnap: snapshot only affected stories
+          exitZeroOnChanges: true  # don't block CI on visual changes; team reviews manually
 
       - name: Publish summary
         if: steps.capability.outputs.enabled == 'true'
@@ -74,11 +91,103 @@ jobs:
           {
             echo "## Chromatic"
             echo
-            echo "- Build URL: ${{ steps.chromatic.outputs.buildUrl }}"
-            echo "- Storybook URL: ${{ steps.chromatic.outputs.storybookUrl }}"
-            echo "- Captured snapshots: ${{ steps.chromatic.outputs.actualCaptureCount }}"
-            echo "- Story count: ${{ steps.chromatic.outputs.specCount }}"
-            echo "- Components: ${{ steps.chromatic.outputs.componentCount }}"
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Build URL | ${{ steps.chromatic.outputs.buildUrl }} |"
+            echo "| Storybook URL | ${{ steps.chromatic.outputs.storybookUrl }} |"
+            echo "| Snapshots captured | ${{ steps.chromatic.outputs.actualCaptureCount }} |"
+            echo "| Stories | ${{ steps.chromatic.outputs.specCount }} |"
+            echo "| Components | ${{ steps.chromatic.outputs.componentCount }} |"
             echo
-            echo "Target custom domain: https://v1.design-system.auraxis.com.br"
+            echo "Public design system: https://design.auraxis.com.br"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Deploy static Storybook to design.auraxis.com.br ─────────────────────
+  deploy-storybook:
+    name: Deploy Storybook → design.auraxis.com.br
+    runs-on: ubuntu-latest
+    needs: chromatic
+    # Only deploy on pushes to main (not PRs); skip if infra secrets not yet configured
+    if: |
+      github.event_name != 'pull_request' &&
+      github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write   # required for OIDC
+      contents: read
+    steps:
+      - name: Check deploy capability
+        id: deploy-cap
+        env:
+          BUCKET_VALUE: ${{ secrets.STORYBOOK_DEPLOY_BUCKET }}
+          CF_VALUE: ${{ secrets.STORYBOOK_CF_DISTRIBUTION_ID }}
+        run: |
+          if [ -n "${BUCKET_VALUE:-}" ] && [ -n "${CF_VALUE:-}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Storybook deploy skipped: STORYBOOK_DEPLOY_BUCKET or STORYBOOK_CF_DISTRIBUTION_ID not configured."
+            echo "::notice::Run the setup-design-infra workflow first, then add the secrets."
+          fi
+
+      - name: Checkout
+        if: steps.deploy-cap.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        if: steps.deploy-cap.outputs.enabled == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node
+        if: steps.deploy-cap.outputs.enabled == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.deploy-cap.outputs.enabled == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Storybook
+        if: steps.deploy-cap.outputs.enabled == 'true'
+        run: pnpm storybook:build
+
+      - name: Configure AWS credentials (OIDC)
+        if: steps.deploy-cap.outputs.enabled == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_WEB_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Deploy to S3
+        if: steps.deploy-cap.outputs.enabled == 'true'
+        run: |
+          # Long-lived assets (hashed filenames) — aggressive cache
+          aws s3 sync storybook-static/ s3://${{ secrets.STORYBOOK_DEPLOY_BUCKET }} \
+            --delete \
+            --exclude "*.html" \
+            --cache-control "public,max-age=31536000,immutable"
+
+          # HTML files — no cache (always revalidate)
+          aws s3 sync storybook-static/ s3://${{ secrets.STORYBOOK_DEPLOY_BUCKET }} \
+            --exclude "*" \
+            --include "*.html" \
+            --cache-control "no-cache,no-store,must-revalidate"
+
+      - name: Invalidate CloudFront
+        if: steps.deploy-cap.outputs.enabled == 'true'
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.STORYBOOK_CF_DISTRIBUTION_ID }} \
+            --paths "/*"
+
+      - name: Publish deploy summary
+        if: steps.deploy-cap.outputs.enabled == 'true'
+        run: |
+          {
+            echo "## Storybook Deploy"
+            echo
+            echo "✅ Published to [design.auraxis.com.br](https://design.auraxis.com.br)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/setup-design-infra.yml
+++ b/.github/workflows/setup-design-infra.yml
@@ -1,0 +1,166 @@
+name: Setup design.auraxis.com.br infra (one-time)
+
+# Run this ONCE to create:
+#   - S3 bucket: design.auraxis.com.br
+#   - CloudFront distribution pointing to the bucket
+#   - Route53 CNAME record
+#
+# After it runs, copy the outputs and add as repository secrets:
+#   STORYBOOK_DEPLOY_BUCKET    = design.auraxis.com.br
+#   STORYBOOK_CF_DISTRIBUTION_ID = <id printed in job summary>
+#
+# The existing *.auraxis.com.br ACM certificate (us-east-1) is reused.
+# The existing AWS_WEB_DEPLOY_ROLE_ARN OIDC role is reused — make sure
+# it has cloudfront:CreateDistribution + route53:ChangeResourceRecordSets
+# permissions before running this workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      acm_certificate_arn:
+        description: 'ACM certificate ARN for *.auraxis.com.br (us-east-1)'
+        required: true
+        type: string
+      hosted_zone_id:
+        description: 'Route53 Hosted Zone ID for auraxis.com.br'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run (print commands without executing)'
+        required: false
+        default: 'false'
+        type: boolean
+
+env:
+  BUCKET: design.auraxis.com.br
+  REGION: us-east-1
+
+jobs:
+  setup-infra:
+    name: Create S3 + CloudFront + Route53
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_WEB_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.REGION }}
+
+      - name: Create S3 bucket
+        if: inputs.dry_run == 'false'
+        run: |
+          aws s3api create-bucket \
+            --bucket "$BUCKET" \
+            --region "$REGION"
+
+          # Block all public access (CloudFront will serve via OAC)
+          aws s3api put-public-access-block \
+            --bucket "$BUCKET" \
+            --public-access-block-configuration \
+              "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+
+          echo "✅ S3 bucket created: $BUCKET"
+
+      - name: Create CloudFront distribution
+        id: cf
+        if: inputs.dry_run == 'false'
+        run: |
+          DISTRIBUTION=$(aws cloudfront create-distribution --distribution-config '{
+            "CallerReference": "design-auraxis-'$(date +%s)'",
+            "Comment": "design.auraxis.com.br — Storybook",
+            "DefaultRootObject": "index.html",
+            "Origins": {
+              "Quantity": 1,
+              "Items": [{
+                "Id": "S3-design-auraxis",
+                "DomainName": "'"$BUCKET"'.s3-website-'"$REGION"'.amazonaws.com",
+                "CustomOriginConfig": {
+                  "HTTPPort": 80,
+                  "HTTPSPort": 443,
+                  "OriginProtocolPolicy": "http-only"
+                }
+              }]
+            },
+            "DefaultCacheBehavior": {
+              "TargetOriginId": "S3-design-auraxis",
+              "ViewerProtocolPolicy": "redirect-to-https",
+              "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+              "Compress": true,
+              "AllowedMethods": { "Quantity": 2, "Items": ["GET","HEAD"] },
+              "CachedMethods": { "Quantity": 2, "Items": ["GET","HEAD"] }
+            },
+            "CustomErrorResponses": {
+              "Quantity": 1,
+              "Items": [{
+                "ErrorCode": 404,
+                "ResponseCode": "200",
+                "ResponsePagePath": "/index.html",
+                "ErrorCachingMinTTL": 0
+              }]
+            },
+            "Aliases": { "Quantity": 1, "Items": ["design.auraxis.com.br"] },
+            "ViewerCertificate": {
+              "ACMCertificateArn": "${{ inputs.acm_certificate_arn }}",
+              "SSLSupportMethod": "sni-only",
+              "MinimumProtocolVersion": "TLSv1.2_2021"
+            },
+            "Enabled": true,
+            "HttpVersion": "http2and3",
+            "IsIPV6Enabled": true,
+            "PriceClass": "PriceClass_100"
+          }')
+
+          CF_ID=$(echo "$DISTRIBUTION" | jq -r '.Distribution.Id')
+          CF_DOMAIN=$(echo "$DISTRIBUTION" | jq -r '.Distribution.DomainName')
+          echo "cf_id=$CF_ID" >> "$GITHUB_OUTPUT"
+          echo "cf_domain=$CF_DOMAIN" >> "$GITHUB_OUTPUT"
+          echo "✅ CloudFront distribution created: $CF_ID ($CF_DOMAIN)"
+
+      - name: Create Route53 CNAME record
+        if: inputs.dry_run == 'false'
+        run: |
+          aws route53 change-resource-record-sets \
+            --hosted-zone-id "${{ inputs.hosted_zone_id }}" \
+            --change-batch '{
+              "Changes": [{
+                "Action": "CREATE",
+                "ResourceRecordSet": {
+                  "Name": "design.auraxis.com.br",
+                  "Type": "CNAME",
+                  "TTL": 300,
+                  "ResourceRecords": [{ "Value": "${{ steps.cf.outputs.cf_domain }}" }]
+                }
+              }]
+            }'
+          echo "✅ Route53 CNAME created"
+
+      - name: Enable S3 static website hosting
+        if: inputs.dry_run == 'false'
+        run: |
+          aws s3 website "s3://$BUCKET" \
+            --index-document index.html \
+            --error-document index.html
+          echo "✅ S3 static website hosting enabled"
+
+      - name: Print next steps
+        run: |
+          CF_ID="${{ steps.cf.outputs.cf_id }}"
+          {
+            echo "## ✅ Infra setup complete"
+            echo
+            echo "Add these as repository secrets:"
+            echo ""
+            echo "| Secret | Value |"
+            echo "|--------|-------|"
+            echo "| \`STORYBOOK_DEPLOY_BUCKET\` | \`$BUCKET\` |"
+            echo "| \`STORYBOOK_CF_DISTRIBUTION_ID\` | \`${CF_ID:-<run with dry_run=false to get}\` |"
+            echo
+            echo "DNS propagation may take up to 5 minutes."
+            echo "CloudFront deployment can take 5–15 minutes."
+            echo
+            echo "After secrets are set, the next push to main with component changes"
+            echo "will automatically deploy to https://design.auraxis.com.br"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- **paths filter**: Chromatic e deploy só trigam quando arquivos de componente ou story mudam — nenhum custo em pushes sem alteração de UI
- **TurboSnap** (`onlyChanged: true`): dentro de um build Chromatic, só snapshots das stories cujos arquivos foram alterados
- **deploy-storybook job**: constrói o Storybook estático e faz sync no S3 + invalidação CloudFront para `design.auraxis.com.br` (skipa com aviso enquanto os secrets não estiverem configurados)
- **setup-design-infra.yml**: workflow `workflow_dispatch` para criar a infra AWS one-time (S3 bucket + CloudFront + Route53 CNAME)

## Como funciona o filtro de paths

```
Push/PR sem mudança em componente → workflow não roda
Push/PR com mudança em componente → chromatic job + deploy-storybook (main only)
```

Arquivos monitorados:
- `app/components/**`
- `app/features/**/components/**`
- `app/shared/components/**`
- `**/*.stories.ts|vue|mdx`
- `.storybook/**`

## Próximos passos para `design.auraxis.com.br`

1. Ir em **Actions → Setup design.auraxis.com.br infra** e rodar manualmente (workflow_dispatch)
   - Inputs necessários: `acm_certificate_arn` (o wildcard `*.auraxis.com.br` já existe em us-east-1) e `hosted_zone_id` do Route53
2. Copiar o CloudFront Distribution ID printado no job summary
3. Adicionar dois secrets no repo:
   - `STORYBOOK_DEPLOY_BUCKET` = `design.auraxis.com.br`
   - `STORYBOOK_CF_DISTRIBUTION_ID` = `<id do passo 2>`
4. Próximo push com mudança de componente → Storybook disponível em https://design.auraxis.com.br

## IAM caveat

O role `AWS_WEB_DEPLOY_ROLE_ARN` precisa ter permissões adicionais para o setup one-time:
- `cloudfront:CreateDistribution`
- `route53:ChangeResourceRecordSets`
- `s3:CreateBucket`, `s3:PutPublicAccessBlock`, `s3:PutBucketWebsite`

Após o setup, apenas `s3:PutObject`, `s3:DeleteObject`, `cloudfront:CreateInvalidation` são necessários (já cobertos pelo role existente para o bucket do app).