### PR TITLE
feat(transactions): quick-add income/expense from dashboard

### DIFF
--- a/app/components/dashboard/DashboardQuickAdd.vue
+++ b/app/components/dashboard/DashboardQuickAdd.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { NButton, NSpace } from "naive-ui";
+import type { TransactionTypeDto } from "~/features/transactions/contracts/transaction.dto";
+
+const { t } = useI18n();
+
+/** Which modal is currently open (null = none). */
+const openModal = ref<TransactionTypeDto | null>(null);
+
+/**
+ * Opens the quick-add modal for the given transaction type.
+ *
+ * @param type "income" or "expense".
+ */
+const openForm = (type: TransactionTypeDto): void => {
+  openModal.value = type;
+};
+
+/** Closes any open quick-add modal. */
+const closeForm = (): void => {
+  openModal.value = null;
+};
+</script>
+
+<template>
+  <div class="dashboard-quick-add">
+    <NSpace :size="8">
+      <!-- Income button -->
+      <NButton
+        type="success"
+        size="medium"
+        class="dashboard-quick-add__btn dashboard-quick-add__btn--income"
+        @click="openForm('income')"
+      >
+        <template #icon>
+          <span class="dashboard-quick-add__icon" aria-hidden="true">+</span>
+        </template>
+        {{ t('dashboard.quickAdd.income') }}
+      </NButton>
+
+      <!-- Expense button -->
+      <NButton
+        type="error"
+        size="medium"
+        class="dashboard-quick-add__btn dashboard-quick-add__btn--expense"
+        @click="openForm('expense')"
+      >
+        <template #icon>
+          <span class="dashboard-quick-add__icon" aria-hidden="true">−</span>
+        </template>
+        {{ t('dashboard.quickAdd.expense') }}
+      </NButton>
+    </NSpace>
+
+    <!-- Income modal -->
+    <QuickTransactionForm
+      :visible="openModal === 'income'"
+      type="income"
+      @update:visible="closeForm"
+      @success="closeForm"
+    />
+
+    <!-- Expense modal -->
+    <QuickTransactionForm
+      :visible="openModal === 'expense'"
+      type="expense"
+      @update:visible="closeForm"
+      @success="closeForm"
+    />
+  </div>
+</template>
+
+<style scoped>
+.dashboard-quick-add {
+  display: flex;
+  align-items: center;
+}
+
+.dashboard-quick-add__icon {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  line-height: 1;
+}
+</style>

--- a/app/components/dashboard/__tests__/DashboardQuickAdd.spec.ts
+++ b/app/components/dashboard/__tests__/DashboardQuickAdd.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import DashboardQuickAdd from "../DashboardQuickAdd.vue";
+
+vi.mock(
+  "~/components/transactions/QuickTransactionForm/QuickTransactionForm.vue",
+  () => ({
+    default: {
+      name: "QuickTransactionForm",
+      props: ["visible", "type"],
+      emits: ["update:visible", "success"],
+      template: "<div class=\"stub-form\" :data-type=\"type\" :data-visible=\"visible\" />",
+    },
+  }),
+);
+
+describe("DashboardQuickAdd", () => {
+  it("renders income and expense buttons", () => {
+    const wrapper = mount(DashboardQuickAdd);
+    expect(wrapper.text()).toContain("Nova Receita");
+    expect(wrapper.text()).toContain("Nova Despesa");
+  });
+
+  it("opens income modal when income button is clicked", async () => {
+    const wrapper = mount(DashboardQuickAdd);
+    const incomeBtn = wrapper.findAll("button").find((b) => b.text().includes("Nova Receita"));
+    await incomeBtn?.trigger("click");
+    const form = wrapper.findAll(".stub-form").find(
+      (el) => el.attributes("data-type") === "income",
+    );
+    expect(form?.attributes("data-visible")).toBe("true");
+  });
+
+  it("opens expense modal when expense button is clicked", async () => {
+    const wrapper = mount(DashboardQuickAdd);
+    const expenseBtn = wrapper.findAll("button").find((b) => b.text().includes("Nova Despesa"));
+    await expenseBtn?.trigger("click");
+    const form = wrapper.findAll(".stub-form").find(
+      (el) => el.attributes("data-type") === "expense",
+    );
+    expect(form?.attributes("data-visible")).toBe("true");
+  });
+
+  it("both modals start as not visible", () => {
+    const wrapper = mount(DashboardQuickAdd);
+    const forms = wrapper.findAll(".stub-form");
+    forms.forEach((f) => {
+      expect(f.attributes("data-visible")).toBe("false");
+    });
+  });
+});

--- a/app/components/transactions/QuickTransactionForm/QuickTransactionForm.types.ts
+++ b/app/components/transactions/QuickTransactionForm/QuickTransactionForm.types.ts
@@ -1,0 +1,12 @@
+import type { TransactionTypeDto } from "~/features/transactions/contracts/transaction.dto";
+
+/**
+ * Props accepted by the QuickTransactionForm component.
+ */
+export interface QuickTransactionFormProps {
+  /** Whether the modal is currently visible. */
+  readonly visible: boolean;
+
+  /** Determines the form layout and API payload type. */
+  readonly type: TransactionTypeDto;
+}

--- a/app/components/transactions/QuickTransactionForm/QuickTransactionForm.vue
+++ b/app/components/transactions/QuickTransactionForm/QuickTransactionForm.vue
@@ -1,0 +1,446 @@
+<script setup lang="ts">
+import { computed, reactive, watch } from "vue";
+import {
+  NModal,
+  NForm,
+  NFormItem,
+  NInput,
+  NInputNumber,
+  NSelect,
+  NDatePicker,
+  NSwitch,
+  NButton,
+  NSpace,
+  NAlert,
+  type FormInst,
+  type FormRules,
+  type SelectOption,
+} from "naive-ui";
+import type { QuickTransactionFormProps } from "./QuickTransactionForm.types";
+import type {
+  CreateTransactionPayload,
+  TransactionStatusDto,
+} from "~/features/transactions/contracts/transaction.dto";
+import { useCreateTransactionMutation } from "~/features/transactions/queries/use-create-transaction-mutation";
+import { useTagsQuery } from "~/features/tags/queries/use-tags-query";
+import { useAccountsQuery } from "~/features/accounts/queries/use-accounts-query";
+import { useCreditCardsQuery } from "~/features/credit-cards/queries/use-credit-cards-query";
+
+const { t } = useI18n();
+
+const props = defineProps<QuickTransactionFormProps>();
+
+const emit = defineEmits<{
+  "update:visible": [value: boolean];
+  success: [];
+}>();
+
+// ── External data ──────────────────────────────────────────────────────────────
+
+const { data: tags } = useTagsQuery();
+const { data: accounts } = useAccountsQuery();
+const { data: creditCards } = useCreditCardsQuery();
+
+const tagOptions = computed((): SelectOption[] =>
+  (tags.value ?? []).map((t) => ({ label: t.name, value: t.id })),
+);
+
+const accountOptions = computed((): SelectOption[] =>
+  (accounts.value ?? []).map((a) => ({ label: a.name, value: a.id })),
+);
+
+const creditCardOptions = computed((): SelectOption[] =>
+  (creditCards.value ?? []).map((c) => ({ label: c.name, value: c.id })),
+);
+
+// ── Form state ─────────────────────────────────────────────────────────────────
+
+const formRef = ref<FormInst | null>(null);
+
+const form = reactive({
+  title: "",
+  amount: null as number | null,
+  due_date: null as number | null,   // NDatePicker timestamp (ms)
+  tag_id: null as string | null,
+  account_id: null as string | null,
+  credit_card_id: null as string | null,
+  status: "pending" as TransactionStatusDto,
+  description: "",
+  is_installment: false,
+  installment_count: null as number | null,
+  is_recurring: false,
+  end_date: null as number | null,
+});
+
+// ── Computed field visibility ──────────────────────────────────────────────────
+
+/** Credit card field is only shown for expense forms. */
+const showCreditCard = computed((): boolean => props.type === "expense");
+
+/** Installment toggle is only for expense. Income has no installment concept. */
+const showInstallment = computed((): boolean => props.type === "expense");
+
+/** Recurring toggle is always shown, but disabled while installment is active. */
+const recurringDisabled = computed((): boolean => form.is_installment);
+
+/** Installment count field only shown when the toggle is on. */
+const showInstallmentCount = computed((): boolean => form.is_installment);
+
+/** End date only shown when recurring is on. */
+const showEndDate = computed((): boolean => form.is_recurring);
+
+// ── Status options ─────────────────────────────────────────────────────────────
+
+const statusOptions = computed((): SelectOption[] => {
+  if (props.type === "income") {
+    return [
+      { label: t("transaction.status.pending"), value: "pending" },
+      { label: t("transaction.status.paid"), value: "paid" },
+    ];
+  }
+  return [
+    { label: t("transaction.status.pending"), value: "pending" },
+    { label: t("transaction.status.paid"), value: "paid" },
+    { label: t("transaction.status.postponed"), value: "postponed" },
+  ];
+});
+
+// ── Watchers ───────────────────────────────────────────────────────────────────
+
+/** When installment is toggled on, disable recurring and vice-versa. */
+watch(
+  () => form.is_installment,
+  (on) => {
+    if (on) { form.is_recurring = false; }
+  },
+);
+
+watch(
+  () => form.is_recurring,
+  (on) => {
+    if (on) { form.is_installment = false; }
+  },
+);
+
+// ── Validation rules ───────────────────────────────────────────────────────────
+
+const rules = computed((): FormRules => ({
+  title: [
+    {
+      required: true,
+      message: t("transaction.form.required.title"),
+      trigger: "blur",
+    },
+  ],
+  amount: [
+    {
+      required: true,
+      type: "number",
+      message: t("transaction.form.required.amount"),
+      trigger: ["blur", "change"],
+    },
+  ],
+  due_date: [
+    {
+      required: true,
+      type: "number",
+      message: t("transaction.form.required.dueDate"),
+      trigger: "change",
+    },
+  ],
+  installment_count: showInstallmentCount.value
+    ? [
+        {
+          required: true,
+          type: "number",
+          message: t("transaction.form.required.installmentCount"),
+          trigger: ["blur", "change"],
+        },
+      ]
+    : [],
+}));
+
+// ── Mutation ───────────────────────────────────────────────────────────────────
+
+const mutation = useCreateTransactionMutation();
+
+/**
+ * Converts a Unix timestamp (ms) produced by NDatePicker to a YYYY-MM-DD string.
+ *
+ * @param ts Unix timestamp in milliseconds.
+ * @returns ISO 8601 date string.
+ */
+const tsToDate = (ts: number): string => {
+  const d = new Date(ts);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+};
+
+/**
+ * Builds the optional installment fields when the toggle is active.
+ *
+ * @returns Partial payload fields for installment mode, or empty object.
+ */
+const buildInstallmentFields = (): Partial<CreateTransactionPayload> => {
+  if (!showInstallment.value || !form.is_installment) { return {}; }
+  return { is_installment: true, installment_count: form.installment_count ?? 2 };
+};
+
+/**
+ * Builds the optional recurrence fields when the toggle is active.
+ *
+ * @returns Partial payload fields for recurring mode, or empty object.
+ */
+const buildRecurringFields = (): Partial<CreateTransactionPayload> => {
+  if (!form.is_recurring) { return {}; }
+  return {
+    is_recurring: true,
+    ...(form.end_date ? { end_date: tsToDate(form.end_date) } : {}),
+  };
+};
+
+/**
+ * Assembles the full CreateTransactionPayload from the current form state.
+ *
+ * @returns Typed payload ready for the mutation.
+ */
+const buildPayload = (): CreateTransactionPayload => ({
+  title: form.title,
+  amount: String(form.amount ?? 0),
+  type: props.type,
+  due_date: form.due_date ? tsToDate(form.due_date) : "",
+  status: form.status,
+  tag_id: form.tag_id ?? null,
+  account_id: form.account_id ?? null,
+  ...(form.description.trim() ? { description: form.description } : {}),
+  ...buildInstallmentFields(),
+  ...buildRecurringFields(),
+  ...(showCreditCard.value && form.credit_card_id
+    ? { credit_card_id: form.credit_card_id }
+    : {}),
+});
+
+/**
+ * Validates and submits the form.
+ * Delegates payload building to {@link buildPayload}.
+ */
+const handleSubmit = async (): Promise<void> => {
+  try {
+    await formRef.value?.validate();
+  } catch {
+    return;
+  }
+
+  mutation.mutate(buildPayload(), {
+    onSuccess: () => {
+      emit("success");
+      emit("update:visible", false);
+      resetForm();
+    },
+  });
+};
+
+/** Resets all form fields to their default values. */
+const resetForm = (): void => {
+  form.title = "";
+  form.amount = null;
+  form.due_date = null;
+  form.tag_id = null;
+  form.account_id = null;
+  form.credit_card_id = null;
+  form.status = "pending" as TransactionStatusDto;
+  form.description = "";
+  form.is_installment = false;
+  form.installment_count = null;
+  form.is_recurring = false;
+  form.end_date = null;
+};
+
+/** Closes the modal without submitting. */
+const handleClose = (): void => {
+  emit("update:visible", false);
+  resetForm();
+};
+
+// ── Computed title / colour ────────────────────────────────────────────────────
+
+const modalTitle = computed((): string =>
+  props.type === "income"
+    ? t("transaction.form.title.income")
+    : t("transaction.form.title.expense"),
+);
+
+const submitButtonType = computed(() =>
+  props.type === "income" ? "success" : "error",
+);
+</script>
+
+<template>
+  <NModal
+    :show="props.visible"
+    preset="card"
+    :title="modalTitle"
+    class="quick-transaction-form-modal"
+    :style="{ maxWidth: '520px', width: '100%' }"
+    @update:show="handleClose"
+  >
+    <!-- Mutation error alert -->
+    <NAlert
+      v-if="mutation.isError.value"
+      type="error"
+      :title="$t('transaction.form.errorTitle')"
+      style="margin-bottom: 16px;"
+    >
+      {{ mutation.error.value?.message ?? $t('transaction.form.errorFallback') }}
+    </NAlert>
+
+    <NForm ref="formRef" :model="form" :rules="rules" label-placement="top">
+
+      <!-- Title -->
+      <NFormItem :label="$t('transaction.form.title.label')" path="title">
+        <NInput
+          v-model:value="form.title"
+          :placeholder="$t('transaction.form.title.placeholder')"
+        />
+      </NFormItem>
+
+      <!-- Amount -->
+      <NFormItem :label="$t('transaction.form.amount.label')" path="amount">
+        <NInputNumber
+          v-model:value="form.amount"
+          :placeholder="$t('transaction.form.amount.placeholder')"
+          :min="0.01"
+          :precision="2"
+          style="width: 100%"
+        />
+      </NFormItem>
+
+      <!-- Due date -->
+      <NFormItem :label="$t('transaction.form.dueDate.label')" path="due_date">
+        <NDatePicker
+          v-model:value="form.due_date"
+          type="date"
+          style="width: 100%"
+        />
+      </NFormItem>
+
+      <!-- Category / tag -->
+      <NFormItem :label="$t('transaction.form.tag.label')" path="tag_id">
+        <NSelect
+          v-model:value="form.tag_id"
+          :options="tagOptions"
+          :placeholder="$t('transaction.form.tag.placeholder')"
+          clearable
+        />
+      </NFormItem>
+
+      <!-- Account -->
+      <NFormItem :label="$t('transaction.form.account.label')" path="account_id">
+        <NSelect
+          v-model:value="form.account_id"
+          :options="accountOptions"
+          :placeholder="$t('transaction.form.account.placeholder')"
+          clearable
+        />
+      </NFormItem>
+
+      <!-- Credit card (expense only) -->
+      <NFormItem
+        v-if="showCreditCard"
+        :label="$t('transaction.form.creditCard.label')"
+        path="credit_card_id"
+      >
+        <NSelect
+          v-model:value="form.credit_card_id"
+          :options="creditCardOptions"
+          :placeholder="$t('transaction.form.creditCard.placeholder')"
+          clearable
+        />
+      </NFormItem>
+
+      <!-- Status -->
+      <NFormItem :label="$t('transaction.form.status.label')" path="status">
+        <NSelect
+          v-model:value="form.status"
+          :options="statusOptions"
+        />
+      </NFormItem>
+
+      <!-- Installment toggle (expense only) -->
+      <NFormItem v-if="showInstallment" :label="$t('transaction.form.installment.label')" path="is_installment">
+        <NSwitch v-model:value="form.is_installment" />
+      </NFormItem>
+
+      <!-- Installment count -->
+      <NFormItem
+        v-if="showInstallmentCount"
+        :label="$t('transaction.form.installmentCount.label')"
+        path="installment_count"
+      >
+        <NInputNumber
+          v-model:value="form.installment_count"
+          :placeholder="$t('transaction.form.installmentCount.placeholder')"
+          :min="2"
+          :max="60"
+          style="width: 100%"
+        />
+      </NFormItem>
+
+      <!-- Recurring toggle -->
+      <NFormItem :label="$t('transaction.form.recurring.label')" path="is_recurring">
+        <NSwitch
+          v-model:value="form.is_recurring"
+          :disabled="recurringDisabled"
+        />
+      </NFormItem>
+
+      <!-- Recurring end date -->
+      <NFormItem
+        v-if="showEndDate"
+        :label="$t('transaction.form.endDate.label')"
+        path="end_date"
+      >
+        <NDatePicker
+          v-model:value="form.end_date"
+          type="date"
+          style="width: 100%"
+          clearable
+        />
+      </NFormItem>
+
+      <!-- Description / notes -->
+      <NFormItem :label="$t('transaction.form.description.label')" path="description">
+        <NInput
+          v-model:value="form.description"
+          type="textarea"
+          :placeholder="$t('transaction.form.description.placeholder')"
+          :rows="2"
+        />
+      </NFormItem>
+
+    </NForm>
+
+    <template #footer>
+      <NSpace justify="end">
+        <NButton :disabled="mutation.isPending.value" @click="handleClose">
+          {{ $t('common.cancel') }}
+        </NButton>
+        <NButton
+          :type="submitButtonType"
+          :loading="mutation.isPending.value"
+          @click="handleSubmit"
+        >
+          {{ $t('common.save') }}
+        </NButton>
+      </NSpace>
+    </template>
+  </NModal>
+</template>
+
+<style scoped>
+.quick-transaction-form-modal {
+  color: var(--color-text-primary);
+}
+</style>

--- a/app/components/transactions/QuickTransactionForm/__tests__/QuickTransactionForm.spec.ts
+++ b/app/components/transactions/QuickTransactionForm/__tests__/QuickTransactionForm.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import QuickTransactionForm from "../QuickTransactionForm.vue";
+
+// ── Hoisted stubs ──────────────────────────────────────────────────────────────
+// vi.mock factories are hoisted before module initialisation, so the stubs must
+// be created with vi.hoisted() to avoid temporal dead zone errors.
+
+const { NModalStub } = vi.hoisted(() => ({
+  NModalStub: {
+    name: "NModal",
+    props: { show: Boolean, title: String },
+    template: "<div v-if=\"show\" data-testid=\"n-modal\"><span>{{ title }}</span><slot /><slot name=\"footer\" /></div>",
+  },
+}));
+
+vi.mock("naive-ui", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const actual = await importOriginal<any>();
+  return { ...actual, NModal: NModalStub };
+});
+
+vi.mock("~/features/transactions/queries/use-create-transaction-mutation", () => ({
+  useCreateTransactionMutation: (): object => ({
+    mutate: vi.fn(),
+    isPending: { value: false },
+    isError: { value: false },
+    error: { value: null },
+  }),
+}));
+
+vi.mock("~/features/tags/queries/use-tags-query", () => ({
+  useTagsQuery: (): object => ({ data: { value: [] } }),
+}));
+
+vi.mock("~/features/accounts/queries/use-accounts-query", () => ({
+  useAccountsQuery: (): object => ({ data: { value: [] } }),
+}));
+
+vi.mock("~/features/credit-cards/queries/use-credit-cards-query", () => ({
+  useCreditCardsQuery: (): object => ({ data: { value: [] } }),
+}));
+
+/**
+ * Mounts the QuickTransactionForm with sensible defaults.
+ *
+ * @param type Transaction type — "income" or "expense".
+ * @returns Vue Test Utils wrapper.
+ */
+const mountForm = (type: "income" | "expense" = "expense"): VueWrapper =>
+  mount(QuickTransactionForm, {
+    props: { visible: true, type },
+  });
+
+describe("QuickTransactionForm", () => {
+  it("renders modal content when visible is true", () => {
+    const wrapper = mountForm("expense");
+    expect(wrapper.find("[data-testid='n-modal']").exists()).toBe(true);
+  });
+
+  it("shows 'Nova Receita' title for income type", () => {
+    const wrapper = mountForm("income");
+    expect(wrapper.text()).toContain("Nova Receita");
+  });
+
+  it("shows 'Nova Despesa' title for expense type", () => {
+    const wrapper = mountForm("expense");
+    expect(wrapper.text()).toContain("Nova Despesa");
+  });
+
+  it("renders title input field", () => {
+    const wrapper = mountForm("expense");
+    expect(wrapper.find("input").exists()).toBe(true);
+  });
+
+  it("shows installment toggle for expense type", () => {
+    const wrapper = mountForm("expense");
+    expect(wrapper.text()).toContain("Parcelado?");
+  });
+
+  it("does not show installment toggle for income type", () => {
+    const wrapper = mountForm("income");
+    expect(wrapper.text()).not.toContain("Parcelado?");
+  });
+
+  it("shows recurring toggle for both income and expense", () => {
+    expect(mountForm("income").text()).toContain("Recorrente?");
+    expect(mountForm("expense").text()).toContain("Recorrente?");
+  });
+
+  it("shows credit card field for expense type", () => {
+    const wrapper = mountForm("expense");
+    expect(wrapper.text()).toContain("Cartão de crédito");
+  });
+
+  it("does not show credit card field for income type", () => {
+    const wrapper = mountForm("income");
+    expect(wrapper.text()).not.toContain("Cartão de crédito");
+  });
+
+  it("shows cancel and save buttons", () => {
+    const wrapper = mountForm("expense");
+    expect(wrapper.text()).toContain("Cancelar");
+    expect(wrapper.text()).toContain("Salvar");
+  });
+
+  it("emits update:visible with false when cancel button is clicked", async () => {
+    const wrapper = mountForm("expense");
+    const cancelButton = wrapper.findAll("button").find((b) => b.text() === "Cancelar");
+    await cancelButton?.trigger("click");
+    const emitted = wrapper.emitted("update:visible");
+    expect(emitted).toBeTruthy();
+    expect(emitted?.[0]).toEqual([false]);
+  });
+
+  it("does not render modal content when visible is false", () => {
+    const wrapper = mount(QuickTransactionForm, {
+      props: { visible: false, type: "expense" },
+    });
+    expect(wrapper.find("[data-testid='n-modal']").exists()).toBe(false);
+  });
+});

--- a/app/features/transactions/contracts/transaction.dto.ts
+++ b/app/features/transactions/contracts/transaction.dto.ts
@@ -1,0 +1,97 @@
+/** Status values accepted by the backend for a transaction. */
+export type TransactionStatusDto =
+  | "pending"
+  | "paid"
+  | "cancelled"
+  | "postponed"
+  | "overdue";
+
+/** Transaction type discriminator. */
+export type TransactionTypeDto = "income" | "expense";
+
+/**
+ * Payload sent to POST /transactions.
+ *
+ * `amount` is serialised as a decimal string because the backend uses
+ * `fields.Decimal(as_string=True)` in TransactionSchema.
+ */
+export interface CreateTransactionPayload {
+  /** Short title for the transaction. */
+  readonly title: string;
+
+  /** Positive monetary value as a decimal string (e.g. "150.50"). */
+  readonly amount: string;
+
+  /** Whether this represents revenue or an expenditure. */
+  readonly type: TransactionTypeDto;
+
+  /** Due date in ISO 8601 format (YYYY-MM-DD). */
+  readonly due_date: string;
+
+  /** Optional long-form description. */
+  readonly description?: string;
+
+  /** Optional free-text observation / note. */
+  readonly observation?: string;
+
+  /** Whether this transaction repeats periodically. Mutually exclusive with installment. */
+  readonly is_recurring?: boolean;
+
+  /** Whether this transaction is split into installments. */
+  readonly is_installment?: boolean;
+
+  /** Number of installments (1–60). Required when is_installment is true. */
+  readonly installment_count?: number;
+
+  /** ISO 4217 currency code. Defaults to "BRL" on the backend. */
+  readonly currency?: string;
+
+  /** Current lifecycle status. Defaults to "pending" when omitted. */
+  readonly status?: TransactionStatusDto;
+
+  /** Start date for recurring transactions (YYYY-MM-DD). */
+  readonly start_date?: string;
+
+  /** End date for recurring transactions (YYYY-MM-DD). */
+  readonly end_date?: string;
+
+  /** UUID of the tag/category associated with this transaction. */
+  readonly tag_id?: string | null;
+
+  /** UUID of the bank account associated with this transaction. */
+  readonly account_id?: string | null;
+
+  /** UUID of the credit card associated with this transaction. */
+  readonly credit_card_id?: string | null;
+}
+
+/**
+ * Single transaction item returned by POST /transactions.
+ *
+ * The backend wraps the response in `data: { transactions: [...] }` for
+ * installment transactions and `data: { transaction: [...] }` for single ones.
+ * The service layer normalises both into `TransactionDto[]`.
+ */
+export interface TransactionDto {
+  readonly id: string;
+  readonly title: string;
+  readonly amount: string;
+  readonly type: string;
+  readonly due_date: string;
+  readonly description: string | null;
+  readonly observation: string | null;
+  readonly is_recurring: boolean;
+  readonly is_installment: boolean;
+  readonly installment_count: number | null;
+  readonly currency: string;
+  readonly status: string;
+  readonly start_date: string | null;
+  readonly end_date: string | null;
+  readonly tag_id: string | null;
+  readonly account_id: string | null;
+  readonly credit_card_id: string | null;
+  readonly installment_group_id: string | null;
+  readonly paid_at: string | null;
+  readonly created_at: string | null;
+  readonly updated_at: string | null;
+}

--- a/app/features/transactions/queries/use-create-transaction-mutation.ts
+++ b/app/features/transactions/queries/use-create-transaction-mutation.ts
@@ -1,0 +1,35 @@
+import type { UseMutationReturnType } from "@tanstack/vue-query";
+
+import type { ApiError } from "~/core/errors";
+import { createApiMutation } from "~/core/query/use-api-mutation";
+import type {
+  CreateTransactionPayload,
+  TransactionDto,
+} from "~/features/transactions/contracts/transaction.dto";
+import {
+  type TransactionsClient,
+  useTransactionsClient,
+} from "~/features/transactions/services/transactions.client";
+
+/**
+ * Vue Query mutation hook for creating a new financial transaction
+ * (income or expense).
+ *
+ * Automatically:
+ * - Shows a success toast after the mutation resolves.
+ * - Invalidates the dashboard overview cache so the summary metrics refresh.
+ *
+ * @param providedClient Optional injected client for unit tests.
+ * @returns Vue Query mutation state: `mutate`, `isPending`, `isError`, etc.
+ */
+export const useCreateTransactionMutation = (
+  providedClient?: TransactionsClient,
+): UseMutationReturnType<TransactionDto[], ApiError, CreateTransactionPayload, unknown> => {
+  const client = providedClient ?? useTransactionsClient();
+  return createApiMutation<TransactionDto[], CreateTransactionPayload>(
+    (payload) => client.createTransaction(payload),
+    {
+      invalidates: [["dashboard", "overview"]],
+    },
+  );
+};

--- a/app/features/transactions/services/transactions.client.spec.ts
+++ b/app/features/transactions/services/transactions.client.spec.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
+import { TransactionsClient } from "./transactions.client";
+import type { CreateTransactionPayload, TransactionDto } from "../contracts/transaction.dto";
+
+vi.mock("axios");
+
+const mockedAxiosCreate = vi.mocked(axios.create) as ReturnType<typeof vi.fn>;
+
+/**
+ * Builds a minimal TransactionDto fixture.
+ *
+ * @param overrides Partial overrides applied to the default fixture.
+ * @returns A TransactionDto with sensible defaults.
+ */
+const makeTransaction = (overrides: Partial<TransactionDto> = {}): TransactionDto => ({
+  id: "txn-001",
+  title: "Test",
+  amount: "150.00",
+  type: "expense",
+  due_date: "2024-06-01",
+  description: null,
+  observation: null,
+  is_recurring: false,
+  is_installment: false,
+  installment_count: null,
+  currency: "BRL",
+  status: "pending",
+  start_date: null,
+  end_date: null,
+  tag_id: null,
+  account_id: null,
+  credit_card_id: null,
+  installment_group_id: null,
+  paid_at: null,
+  created_at: "2024-06-01T00:00:00Z",
+  updated_at: null,
+  ...overrides,
+});
+
+/**
+ * Minimal valid create payload.
+ *
+ * @returns A CreateTransactionPayload fixture.
+ */
+const makePayload = (): CreateTransactionPayload => ({
+  title: "Test",
+  amount: "150.00",
+  type: "expense",
+  due_date: "2024-06-01",
+});
+
+describe("TransactionsClient", () => {
+  let httpPostMock: ReturnType<typeof vi.fn>;
+  let client: TransactionsClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    httpPostMock = vi.fn();
+    mockedAxiosCreate.mockReturnValue({ post: httpPostMock } as never);
+    client = new TransactionsClient(axios.create());
+  });
+
+  describe("createTransaction", () => {
+    it("posts to /transactions with the payload", async () => {
+      const txn = makeTransaction();
+      httpPostMock.mockResolvedValueOnce({
+        data: { data: { transaction: [txn] } },
+      });
+
+      await client.createTransaction(makePayload());
+
+      expect(httpPostMock).toHaveBeenCalledWith("/transactions", makePayload());
+    });
+
+    it("returns array from data.transactions envelope", async () => {
+      const txn = makeTransaction();
+      httpPostMock.mockResolvedValueOnce({
+        data: { data: { transactions: [txn] } },
+      });
+
+      const result = await client.createTransaction(makePayload());
+
+      expect(result).toEqual([txn]);
+    });
+
+    it("returns array from data.transaction envelope", async () => {
+      const txn = makeTransaction();
+      httpPostMock.mockResolvedValueOnce({
+        data: { data: { transaction: [txn] } },
+      });
+
+      const result = await client.createTransaction(makePayload());
+
+      expect(result).toEqual([txn]);
+    });
+
+    it("normalises a single object (non-array) to a one-element array", async () => {
+      const txn = makeTransaction();
+      httpPostMock.mockResolvedValueOnce({
+        data: { data: { transaction: txn } },
+      });
+
+      const result = await client.createTransaction(makePayload());
+
+      expect(result).toEqual([txn]);
+    });
+
+    it("returns flat legacy shape from root-level transactions key", async () => {
+      const txn = makeTransaction();
+      httpPostMock.mockResolvedValueOnce({
+        data: { transactions: [txn] },
+      });
+
+      const result = await client.createTransaction(makePayload());
+
+      expect(result).toEqual([txn]);
+    });
+
+    it("propagates network errors without catching them", async () => {
+      httpPostMock.mockRejectedValueOnce(new Error("network error"));
+
+      await expect(client.createTransaction(makePayload())).rejects.toThrow("network error");
+    });
+  });
+});

--- a/app/features/transactions/services/transactions.client.ts
+++ b/app/features/transactions/services/transactions.client.ts
@@ -1,0 +1,78 @@
+import type { AxiosInstance } from "axios";
+
+import { useHttp } from "~/composables/useHttp";
+import type {
+  CreateTransactionPayload,
+  TransactionDto,
+} from "~/features/transactions/contracts/transaction.dto";
+
+/**
+ * Raw envelope returned by the backend for a successful transaction creation.
+ *
+ * The backend's `_compat_success` helper always wraps the data object, and the
+ * key inside `data` is dynamic ("transaction" for single, "transactions" for
+ * installments). We accept both shapes here.
+ */
+interface TransactionCreateResponseEnvelope {
+  readonly message?: string;
+  readonly data?: {
+    readonly transaction?: TransactionDto | TransactionDto[];
+    readonly transactions?: TransactionDto | TransactionDto[];
+  };
+  // Legacy flat shape (no envelope) — kept for backward compat:
+  readonly transaction?: TransactionDto | TransactionDto[];
+  readonly transactions?: TransactionDto | TransactionDto[];
+}
+
+/**
+ * API client for the transactions feature.
+ *
+ * Encapsulates HTTP calls to the `/transactions` endpoints.
+ */
+export class TransactionsClient {
+  readonly #http: AxiosInstance;
+
+  /**
+   * @param http Axios instance already configured for the Auraxis API.
+   */
+  constructor(http: AxiosInstance) {
+    this.#http = http;
+  }
+
+  /**
+   * Creates one or more transaction entries.
+   *
+   * When `payload.is_installment` is true the backend generates
+   * `payload.installment_count` individual transaction records and returns
+   * them all in the response array.
+   *
+   * @param payload Transaction creation payload.
+   * @returns Array of created TransactionDto records (one per installment).
+   */
+  async createTransaction(payload: CreateTransactionPayload): Promise<TransactionDto[]> {
+    const response = await this.#http.post<TransactionCreateResponseEnvelope>(
+      "/transactions",
+      payload,
+    );
+
+    const raw = response.data;
+
+    // Unwrap both envelope shapes the backend may return.
+    const items =
+      raw.data?.transactions
+      ?? raw.data?.transaction
+      ?? raw.transactions
+      ?? raw.transaction
+      ?? [];
+
+    return Array.isArray(items) ? items : [items];
+  }
+}
+
+/**
+ * Resolves the canonical transactions API client using the shared HTTP layer.
+ *
+ * @returns TransactionsClient instance bound to the application HTTP adapter.
+ */
+export const useTransactionsClient = (): TransactionsClient =>
+  new TransactionsClient(useHttp());

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -346,6 +346,70 @@
       "sending": "Sending…"
     }
   },
+  "transaction": {
+    "form": {
+      "title": {
+        "income": "New Income",
+        "expense": "New Expense",
+        "label": "Title",
+        "placeholder": "E.g. March salary"
+      },
+      "amount": {
+        "label": "Amount",
+        "placeholder": "0.00"
+      },
+      "dueDate": {
+        "label": "Due date"
+      },
+      "tag": {
+        "label": "Category",
+        "placeholder": "Select a category"
+      },
+      "account": {
+        "label": "Account",
+        "placeholder": "Select an account"
+      },
+      "creditCard": {
+        "label": "Credit card",
+        "placeholder": "Select a card"
+      },
+      "status": {
+        "label": "Status"
+      },
+      "installment": {
+        "label": "Split into installments?"
+      },
+      "installmentCount": {
+        "label": "Number of installments",
+        "placeholder": "E.g. 12"
+      },
+      "recurring": {
+        "label": "Recurring?"
+      },
+      "endDate": {
+        "label": "Repeat until (optional)"
+      },
+      "description": {
+        "label": "Notes",
+        "placeholder": "Additional notes about this entry"
+      },
+      "errorTitle": "Save failed",
+      "errorFallback": "Could not save the entry. Please try again.",
+      "required": {
+        "title": "Please enter a title",
+        "amount": "Please enter an amount",
+        "dueDate": "Please select a date",
+        "installmentCount": "Please enter the number of installments"
+      }
+    },
+    "status": {
+      "pending": "Pending",
+      "paid": "Paid / Received",
+      "cancelled": "Cancelled",
+      "postponed": "Postponed",
+      "overdue": "Overdue"
+    }
+  },
   "wallet": {
     "form": {
       "title": "Add asset",
@@ -593,6 +657,10 @@
     },
     "periodSelector": {
       "ariaLabel": "Select period"
+    },
+    "quickAdd": {
+      "income": "New Income",
+      "expense": "New Expense"
     }
   },
   "receivable": {

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -346,6 +346,70 @@
       "sending": "Enviando…"
     }
   },
+  "transaction": {
+    "form": {
+      "title": {
+        "income": "Nova Receita",
+        "expense": "Nova Despesa",
+        "label": "Título",
+        "placeholder": "Ex: Salário de março"
+      },
+      "amount": {
+        "label": "Valor",
+        "placeholder": "0,00"
+      },
+      "dueDate": {
+        "label": "Data de vencimento"
+      },
+      "tag": {
+        "label": "Categoria",
+        "placeholder": "Selecione uma categoria"
+      },
+      "account": {
+        "label": "Conta",
+        "placeholder": "Selecione uma conta"
+      },
+      "creditCard": {
+        "label": "Cartão de crédito",
+        "placeholder": "Selecione um cartão"
+      },
+      "status": {
+        "label": "Status"
+      },
+      "installment": {
+        "label": "Parcelado?"
+      },
+      "installmentCount": {
+        "label": "Número de parcelas",
+        "placeholder": "Ex: 12"
+      },
+      "recurring": {
+        "label": "Recorrente?"
+      },
+      "endDate": {
+        "label": "Repetir até (opcional)"
+      },
+      "description": {
+        "label": "Observações",
+        "placeholder": "Notas adicionais sobre este lançamento"
+      },
+      "errorTitle": "Erro ao salvar",
+      "errorFallback": "Não foi possível salvar o lançamento. Tente novamente.",
+      "required": {
+        "title": "Informe o título",
+        "amount": "Informe o valor",
+        "dueDate": "Selecione a data",
+        "installmentCount": "Informe o número de parcelas"
+      }
+    },
+    "status": {
+      "pending": "Pendente",
+      "paid": "Pago / Recebido",
+      "cancelled": "Cancelado",
+      "postponed": "Adiado",
+      "overdue": "Vencido"
+    }
+  },
   "wallet": {
     "form": {
       "title": "Adicionar ativo",
@@ -593,6 +657,10 @@
     },
     "periodSelector": {
       "ariaLabel": "Selecionar período"
+    },
+    "quickAdd": {
+      "income": "Nova Receita",
+      "expense": "Nova Despesa"
     }
   },
   "receivable": {

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -55,6 +55,13 @@ const emptyMessage = computed(() =>
 
 <template>
   <div class="dashboard-page">
+
+    <!-- ── Quick-add bar ──────────────────────────────────────────────────── -->
+    <div class="dashboard-page__topbar">
+      <DashboardQuickAdd />
+    </div>
+
+    <!-- ── Period controls ────────────────────────────────────────────────── -->
     <div class="dashboard-page__controls">
       <DashboardPeriodSelector
         v-if="isQuickSelectPeriod"
@@ -178,6 +185,13 @@ const emptyMessage = computed(() =>
 .dashboard-page {
   display: grid;
   gap: var(--space-3);
+}
+
+.dashboard-page__topbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
 }
 
 .dashboard-page__controls {


### PR DESCRIPTION
## Summary

- Adds **"Nova Receita"** (green) and **"Nova Despesa"** (red) buttons to the top-right of the dashboard, always visible regardless of the period filter state.
- Each button opens a **`QuickTransactionForm`** modal with all relevant fields:
  - Title, amount, due date
  - Category (tag select), account select
  - Credit card select (expense only)
  - Status (pending / paid / postponed)
  - **Installment toggle** (expense only) → number of parcels (2–60)
  - **Recurring toggle** (mutually exclusive with installment) → optional end date
  - Free-text notes
- On submit: calls `POST /transactions`, shows success toast via `createApiMutation`, and invalidates the dashboard overview query so the summary metrics refresh immediately.
- All strings go through `vue-i18n` (`pt.json` / `en.json`).

## New files

| File | Purpose |
|---|---|
| `app/features/transactions/contracts/transaction.dto.ts` | `CreateTransactionPayload` + `TransactionDto` matching `TransactionSchema` |
| `app/features/transactions/services/transactions.client.ts` | `POST /transactions` + envelope normalisation (single vs installment) |
| `app/features/transactions/queries/use-create-transaction-mutation.ts` | Vue Query mutation hook |
| `app/components/transactions/QuickTransactionForm/` | Modal form component + types |
| `app/components/dashboard/DashboardQuickAdd.vue` | Two-button quick-add bar |

## Test plan

- [ ] All 1093 tests pass (`pnpm test:coverage`)
- [ ] `pnpm lint` and `pnpm typecheck` clean
- [ ] Open dashboard → "Nova Receita" button visible top-right
- [ ] Click "Nova Receita" → modal opens with correct title, no installment toggle, no credit card field
- [ ] Click "Nova Despesa" → modal opens with installment and credit card fields visible
- [ ] Enable installment → recurring toggle becomes disabled
- [ ] Submit valid expense → toast appears, modal closes, dashboard summary updates
- [ ] Submit with missing required field → validation error shown inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)