### PR TITLE
fix(auth): align email confirmation endpoints with backend

### DIFF
--- a/app/features/auth/services/__tests__/auth-email.client.spec.ts
+++ b/app/features/auth/services/__tests__/auth-email.client.spec.ts
@@ -10,22 +10,22 @@ const mockHttp = {
 describe("AuthEmailClient", () => {
   const client = new AuthEmailClient(mockHttp);
 
-  it("calls GET /auth/confirm-email with the token param", async () => {
-    vi.mocked(mockHttp.get).mockResolvedValueOnce({ data: { success: true } });
+  it("calls POST /auth/email/confirm with the token in the JSON body", async () => {
+    vi.mocked(mockHttp.post).mockResolvedValueOnce({ data: { success: true } });
     await client.confirmEmail("abc123");
-    expect(mockHttp.get).toHaveBeenCalledWith("/auth/confirm-email", {
-      params: { token: "abc123" },
+    expect(mockHttp.post).toHaveBeenCalledWith("/auth/email/confirm", {
+      token: "abc123",
     });
   });
 
-  it("calls POST /auth/resend-confirmation", async () => {
+  it("calls POST /auth/email/resend", async () => {
     vi.mocked(mockHttp.post).mockResolvedValueOnce({ data: { success: true } });
     await client.resendConfirmation();
-    expect(mockHttp.post).toHaveBeenCalledWith("/auth/resend-confirmation");
+    expect(mockHttp.post).toHaveBeenCalledWith("/auth/email/resend");
   });
 
   it("propagates errors from confirmEmail", async () => {
-    vi.mocked(mockHttp.get).mockRejectedValueOnce(new Error("Network error"));
+    vi.mocked(mockHttp.post).mockRejectedValueOnce(new Error("Network error"));
     await expect(client.confirmEmail("bad-token")).rejects.toThrow("Network error");
   });
 

--- a/app/features/auth/services/auth-email.client.ts
+++ b/app/features/auth/services/auth-email.client.ts
@@ -27,19 +27,21 @@ export class AuthEmailClient {
   /**
    * Confirms the user's email address using the one-time token sent by email.
    *
+   * Backend: POST /auth/email/confirm — expects `{ token }` as JSON body.
+   *
    * @param token Confirmation token extracted from the URL query param.
    */
   async confirmEmail(token: string): Promise<void> {
-    await this.#http.get<AuthEmailResponse>("/auth/confirm-email", {
-      params: { token },
-    });
+    await this.#http.post<AuthEmailResponse>("/auth/email/confirm", { token });
   }
 
   /**
    * Requests a new confirmation email for the authenticated user.
+   *
+   * Backend: POST /auth/email/resend
    */
   async resendConfirmation(): Promise<void> {
-    await this.#http.post<AuthEmailResponse>("/auth/resend-confirmation");
+    await this.#http.post<AuthEmailResponse>("/auth/email/resend");
   }
 }
 


### PR DESCRIPTION
## Summary

Closes the last remaining frontend-backend contract drift identified in the audit.

- \`confirmEmail\`: was calling \`GET /auth/confirm-email?token=\` → now calls \`POST /auth/email/confirm\` with \`{ token }\` as JSON body
- \`resendConfirmation\`: was calling \`POST /auth/resend-confirmation\` → now calls \`POST /auth/email/resend\`

Both paths and HTTP methods now match the backend routes registered in \`app/controllers/auth/routes.py\`.

## Test plan

- [x] \`auth-email.client.spec.ts\` — all 4 tests updated and passing
- [x] Full \`pnpm quality-check\` passes (lint, typecheck, 1122+ tests, policy, contracts) — EXIT:0

🤖 Generated with [Claude Code](https://claude.com/claude-code)