### PR TITLE
feat(paywall): add UiPaywallGate and UiUpgradePrompt components

### DIFF
--- a/app/components/paywall/UiPaywallGate.spec.ts
+++ b/app/components/paywall/UiPaywallGate.spec.ts
@@ -1,0 +1,119 @@
+import { ref } from "vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+import UiPaywallGate from "./UiPaywallGate.vue";
+
+const useEntitlementQueryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
+  useEntitlementQuery: useEntitlementQueryMock,
+}));
+
+const stubs = {
+  NSkeleton: {
+    template: "<div class='n-skeleton' />",
+  },
+};
+
+const defaultSlotContent = "<span class='default-slot'>Feature content</span>";
+const lockedSlotContent = "<span class='locked-slot'>Upgrade required</span>";
+
+describe("UiPaywallGate", () => {
+  it("renders skeleton when isLoading is true", () => {
+    useEntitlementQueryMock.mockReturnValue({
+      isLoading: ref(true),
+      data: ref(undefined),
+    });
+
+    const wrapper = mount(UiPaywallGate, {
+      props: { feature: "advanced_simulations" },
+      slots: {
+        default: defaultSlotContent,
+        locked: lockedSlotContent,
+      },
+      global: { stubs },
+    });
+
+    expect(wrapper.find(".n-skeleton").exists()).toBe(true);
+    expect(wrapper.find(".default-slot").exists()).toBe(false);
+    expect(wrapper.find(".locked-slot").exists()).toBe(false);
+  });
+
+  it("renders default slot when has_access is true", () => {
+    useEntitlementQueryMock.mockReturnValue({
+      isLoading: ref(false),
+      data: ref(true),
+    });
+
+    const wrapper = mount(UiPaywallGate, {
+      props: { feature: "advanced_simulations" },
+      slots: {
+        default: defaultSlotContent,
+        locked: lockedSlotContent,
+      },
+      global: { stubs },
+    });
+
+    expect(wrapper.find(".default-slot").exists()).toBe(true);
+    expect(wrapper.find(".locked-slot").exists()).toBe(false);
+    expect(wrapper.find(".n-skeleton").exists()).toBe(false);
+  });
+
+  it("renders locked slot when has_access is false", () => {
+    useEntitlementQueryMock.mockReturnValue({
+      isLoading: ref(false),
+      data: ref(false),
+    });
+
+    const wrapper = mount(UiPaywallGate, {
+      props: { feature: "advanced_simulations" },
+      slots: {
+        default: defaultSlotContent,
+        locked: lockedSlotContent,
+      },
+      global: { stubs },
+    });
+
+    expect(wrapper.find(".locked-slot").exists()).toBe(true);
+    expect(wrapper.find(".default-slot").exists()).toBe(false);
+    expect(wrapper.find(".n-skeleton").exists()).toBe(false);
+  });
+
+  it("renders locked slot when data is undefined (not yet resolved)", () => {
+    useEntitlementQueryMock.mockReturnValue({
+      isLoading: ref(false),
+      data: ref(undefined),
+    });
+
+    const wrapper = mount(UiPaywallGate, {
+      props: { feature: "export_pdf" },
+      slots: {
+        default: defaultSlotContent,
+        locked: lockedSlotContent,
+      },
+      global: { stubs },
+    });
+
+    expect(wrapper.find(".locked-slot").exists()).toBe(true);
+    expect(wrapper.find(".default-slot").exists()).toBe(false);
+  });
+
+  it("renders the gate wrapper element", () => {
+    useEntitlementQueryMock.mockReturnValue({
+      isLoading: ref(false),
+      data: ref(false),
+    });
+
+    const wrapper = mount(UiPaywallGate, {
+      props: { feature: "shared_entries" },
+      slots: {
+        default: defaultSlotContent,
+        locked: lockedSlotContent,
+      },
+      global: { stubs },
+    });
+
+    expect(wrapper.find(".ui-paywall-gate").exists()).toBe(true);
+  });
+});

--- a/app/components/paywall/UiPaywallGate.stories.ts
+++ b/app/components/paywall/UiPaywallGate.stories.ts
@@ -1,0 +1,141 @@
+/**
+ * UiPaywallGate stories.
+ *
+ * Each story uses an inline wrapper to simulate a specific entitlement state
+ * (loading / access granted / access denied / unresolved) without requiring
+ * a real authentication context.
+ */
+
+import type { Meta, StoryObj } from "@storybook/vue3";
+import { NSkeleton } from "naive-ui";
+import { type VNode, defineComponent, h } from "vue";
+import UiPaywallGate from "./UiPaywallGate.vue";
+
+/**
+ * Inline simulation components that replicate the three gate states
+ * without hitting the real entitlements API.
+ */
+
+const LoadingDemo = defineComponent({
+  name: "LoadingDemo",
+  components: { NSkeleton },
+  template: `
+    <div class="ui-paywall-gate" style="width:320px">
+      <NSkeleton height="120px" :sharp="false" />
+    </div>
+  `,
+});
+
+const UnlockedDemo = defineComponent({
+  name: "UnlockedDemo",
+  template: `
+    <div class="ui-paywall-gate" style="width:320px;padding:16px;border:1px solid var(--color-outline-soft,#333);border-radius:8px">
+      <p style="margin:0;color:var(--color-text-primary,#fff)">
+        ✅ Conteúdo Premium — acesso liberado
+      </p>
+    </div>
+  `,
+});
+
+const LockedDemo = defineComponent({
+  name: "LockedDemo",
+  template: `
+    <div class="ui-paywall-gate" style="width:320px">
+      <div style="display:flex;flex-direction:column;align-items:center;gap:12px;padding:24px;text-align:center;border:1px dashed var(--color-outline-soft,#555);border-radius:8px">
+        <span style="font-size:14px;color:var(--color-text-secondary,#aaa)">🔒 Conteúdo bloqueado — slot <code>locked</code></span>
+      </div>
+    </div>
+  `,
+});
+
+const meta: Meta<typeof UiPaywallGate> = {
+  title: "Design System/UiPaywallGate",
+  component: UiPaywallGate,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+**UiPaywallGate** envolve conteúdo premium com verificação de entitlement.
+
+Prioridade de renderização:
+1. **Skeleton** enquanto \`isLoading\` for verdadeiro
+2. **\`<slot />\`** quando \`hasAccess === true\`
+3. **\`<slot name="locked" />\`** nos demais casos
+
+A verificação real é feita pelo composable \`useEntitlementQuery\`.
+As stories abaixo mostram cada estado de forma isolada (sem chamada real à API).
+        `.trim(),
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof UiPaywallGate>;
+
+/**
+ * Estado de carregamento — exibe skeleton enquanto o entitlement é verificado.
+ */
+export const Loading: Story = {
+  render: () => ({
+    components: { LoadingDemo },
+    template: "<LoadingDemo />",
+  }),
+};
+
+/**
+ * Acesso liberado — o conteúdo premium é exibido via slot padrão.
+ */
+export const Unlocked: Story = {
+  render: () => ({
+    components: { UnlockedDemo },
+    template: "<UnlockedDemo />",
+  }),
+};
+
+/**
+ * Acesso negado — exibe o slot `locked` (tipicamente UiUpgradePrompt).
+ */
+export const Locked: Story = {
+  render: () => ({
+    components: { LockedDemo },
+    template: "<LockedDemo />",
+  }),
+};
+
+/**
+ * Composição completa — mostra UiPaywallGate com ambos os slots definidos.
+ * Em produção, o estado real virá de useEntitlementQuery.
+ */
+export const ComposedWithSlots: Story = {
+  render: () => ({
+    components: { UiPaywallGate },
+    setup(): () => VNode {
+      return () =>
+        h(
+          "div",
+          { style: "display:flex;flex-direction:column;gap:24px;padding:16px;" },
+          [
+            h("p", { style: "color:var(--color-text-secondary,#aaa);font-size:12px;margin:0" },
+              "Exemplo de composição — o estado final depende da resposta da API de entitlement."),
+            h(
+              UiPaywallGate,
+              { feature: "advanced_simulations" },
+              {
+                default: () =>
+                  h("div", {
+                    style: "padding:16px;background:var(--color-bg-elevated,#1a1a2e);border-radius:8px;color:var(--color-text-primary,#fff)",
+                  }, "Conteúdo premium"),
+                locked: () =>
+                  h("div", {
+                    style: "padding:16px;border:1px dashed var(--color-outline-soft,#555);border-radius:8px;text-align:center;color:var(--color-text-secondary,#aaa)",
+                  }, "🔒 Slot de upgrade"),
+              }
+            ),
+          ]
+        );
+    },
+  }),
+};

--- a/app/components/paywall/UiPaywallGate.vue
+++ b/app/components/paywall/UiPaywallGate.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { NSkeleton } from "naive-ui";
+import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
+import type { FeatureKey } from "~/features/paywall/model/entitlement";
+
+/**
+ * Props for UiPaywallGate.
+ */
+interface Props {
+  /** Feature key to check against the entitlements API. */
+  feature: FeatureKey;
+}
+
+const props = defineProps<Props>();
+
+const { isLoading, data: hasAccessData } = useEntitlementQuery(props.feature);
+</script>
+
+<template>
+  <div class="ui-paywall-gate">
+    <NSkeleton v-if="isLoading" height="120px" :sharp="false" />
+    <slot v-else-if="hasAccessData === true" />
+    <slot v-else name="locked" />
+  </div>
+</template>
+
+<style scoped>
+.ui-paywall-gate {
+  width: 100%;
+}
+</style>

--- a/app/components/paywall/UiUpgradePrompt.spec.ts
+++ b/app/components/paywall/UiUpgradePrompt.spec.ts
@@ -1,0 +1,102 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+import UiUpgradePrompt from "./UiUpgradePrompt.vue";
+
+const pushMock = vi.fn();
+
+vi.mock("#app", () => ({
+  useRouter: (): { push: typeof pushMock } => ({ push: pushMock }),
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: (): { t: (key: string) => string } => ({
+    t: (key: string): string => key,
+  }),
+}));
+
+vi.mock("lucide-vue-next", () => ({
+  Lock: { template: "<span class='lock-icon' />" },
+}));
+
+const stubs = {
+  NButton: {
+    template: "<button class='n-button' @click=\"$emit('click')\"><slot /></button>",
+    emits: ["click"],
+  },
+};
+
+describe("UiUpgradePrompt", () => {
+  it("renders the title and description from i18n keys", () => {
+    const wrapper = mount(UiUpgradePrompt, {
+      global: { stubs },
+    });
+
+    expect(wrapper.text()).toContain("paywall.upgradePrompt.title");
+    expect(wrapper.text()).toContain("paywall.upgradePrompt.description");
+  });
+
+  it("renders featureName badge when provided", () => {
+    const wrapper = mount(UiUpgradePrompt, {
+      props: { featureName: "Simulações Avançadas" },
+      global: { stubs },
+    });
+
+    expect(wrapper.find(".ui-upgrade-prompt__feature-name").text()).toBe("Simulações Avançadas");
+  });
+
+  it("does not render featureName badge when omitted", () => {
+    const wrapper = mount(UiUpgradePrompt, {
+      global: { stubs },
+    });
+
+    expect(wrapper.find(".ui-upgrade-prompt__feature-name").exists()).toBe(false);
+  });
+
+  it("uses custom description when provided", () => {
+    const wrapper = mount(UiUpgradePrompt, {
+      props: { description: "Recurso exclusivo para assinantes Pro." },
+      global: { stubs },
+    });
+
+    expect(wrapper.find(".ui-upgrade-prompt__description").text()).toBe(
+      "Recurso exclusivo para assinantes Pro."
+    );
+  });
+
+  it("uses custom ctaLabel when provided", () => {
+    const wrapper = mount(UiUpgradePrompt, {
+      props: { ctaLabel: "Assinar agora" },
+      global: { stubs },
+    });
+
+    expect(wrapper.find(".n-button").text()).toBe("Assinar agora");
+  });
+
+  it("falls back to i18n ctaLabel when ctaLabel is omitted", () => {
+    const wrapper = mount(UiUpgradePrompt, {
+      global: { stubs },
+    });
+
+    expect(wrapper.find(".n-button").text()).toBe("paywall.upgradePrompt.ctaLabel");
+  });
+
+  it("navigates to /plans when CTA is clicked", async () => {
+    pushMock.mockResolvedValue(undefined);
+
+    const wrapper = mount(UiUpgradePrompt, {
+      global: { stubs },
+    });
+
+    await wrapper.find(".n-button").trigger("click");
+    expect(pushMock).toHaveBeenCalledWith("/plans");
+  });
+
+  it("renders the lock icon", () => {
+    const wrapper = mount(UiUpgradePrompt, {
+      global: { stubs },
+    });
+
+    expect(wrapper.find(".lock-icon").exists()).toBe(true);
+  });
+});

--- a/app/components/paywall/UiUpgradePrompt.stories.ts
+++ b/app/components/paywall/UiUpgradePrompt.stories.ts
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from "@storybook/vue3";
+import UiUpgradePrompt from "./UiUpgradePrompt.vue";
+
+/** Args shape shared by all UiUpgradePrompt stories. */
+interface UiUpgradePromptArgs {
+  featureName?: string;
+  description?: string;
+  ctaLabel?: string;
+}
+
+const meta: Meta<typeof UiUpgradePrompt> = {
+  title: "Design System/UiUpgradePrompt",
+  component: UiUpgradePrompt,
+  tags: ["autodocs"],
+  argTypes: {
+    featureName: { control: "text" },
+    description: { control: "text" },
+    ctaLabel: { control: "text" },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: `
+**UiUpgradePrompt** é o componente de upsell exibido quando o usuário não tem acesso a um recurso premium.
+
+Tipicamente usado como conteúdo do slot \`locked\` do **UiPaywallGate**:
+
+\`\`\`vue
+<UiPaywallGate feature="advanced_simulations">
+  <template #locked>
+    <UiUpgradePrompt feature-name="Simulações Avançadas" />
+  </template>
+  <!-- conteúdo premium aqui -->
+</UiPaywallGate>
+\`\`\`
+        `.trim(),
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof UiUpgradePrompt>;
+
+/**
+ * Estado padrão — usa textos do i18n sem customizações.
+ */
+export const Default: Story = {
+  args: {},
+  render: (args) => ({
+    components: { UiUpgradePrompt },
+    setup(): { args: UiUpgradePromptArgs } {
+      return { args };
+    },
+    template: "<div style=\"width:360px\"><UiUpgradePrompt v-bind=\"args\" /></div>",
+  }),
+};
+
+/**
+ * Com nome do recurso — exibe o badge com o nome da funcionalidade bloqueada.
+ */
+export const WithFeatureName: Story = {
+  args: {
+    featureName: "Simulações Avançadas",
+  },
+  render: (args) => ({
+    components: { UiUpgradePrompt },
+    setup(): { args: UiUpgradePromptArgs } {
+      return { args };
+    },
+    template: "<div style=\"width:360px\"><UiUpgradePrompt v-bind=\"args\" /></div>",
+  }),
+};
+
+/**
+ * Com descrição customizada — sobrescreve o texto padrão do i18n.
+ */
+export const CustomDescription: Story = {
+  args: {
+    featureName: "Exportação PDF",
+    description: "Exporte seus relatórios em PDF com um clique. Disponível no plano Pro.",
+    ctaLabel: "Conhecer o Pro",
+  },
+  render: (args) => ({
+    components: { UiUpgradePrompt },
+    setup(): { args: UiUpgradePromptArgs } {
+      return { args };
+    },
+    template: "<div style=\"width:360px\"><UiUpgradePrompt v-bind=\"args\" /></div>",
+  }),
+};
+
+/**
+ * CLT vs PJ — contexto de ferramenta com badge de produto.
+ */
+export const CltVsPj: Story = {
+  args: {
+    featureName: "CLT vs PJ",
+    description: "Compare o custo-benefício real entre regimes de contratação com análise detalhada.",
+    ctaLabel: "Ver planos",
+  },
+  render: (args) => ({
+    components: { UiUpgradePrompt },
+    setup(): { args: UiUpgradePromptArgs } {
+      return { args };
+    },
+    template: "<div style=\"width:360px\"><UiUpgradePrompt v-bind=\"args\" /></div>",
+  }),
+};

--- a/app/components/paywall/UiUpgradePrompt.vue
+++ b/app/components/paywall/UiUpgradePrompt.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import { NButton } from "naive-ui";
+import { Lock } from "lucide-vue-next";
+import { useRouter } from "#app";
+import { useI18n } from "vue-i18n";
+
+/**
+ * Props for UiUpgradePrompt.
+ */
+interface Props {
+  /**
+   * Name of the gated feature, e.g. "Simulações Avançadas".
+   * Displayed as a subtitle above the main headline.
+   * Falls back to the generic i18n title when omitted.
+   */
+  featureName?: string;
+  /**
+   * Custom description to override the default i18n subtitle.
+   */
+  description?: string;
+  /**
+   * Label for the upgrade CTA button.
+   * Falls back to the i18n value when omitted.
+   */
+  ctaLabel?: string;
+}
+
+defineProps<Props>();
+
+const router = useRouter();
+const { t } = useI18n();
+
+/** Navigates the user to the plans page. */
+const goToPlanos = (): void => {
+  void router.push("/plans");
+};
+</script>
+
+<template>
+  <div class="ui-upgrade-prompt">
+    <span v-if="featureName" class="ui-upgrade-prompt__feature-name">
+      {{ featureName }}
+    </span>
+
+    <Lock class="ui-upgrade-prompt__icon" :size="36" aria-hidden="true" />
+
+    <p class="ui-upgrade-prompt__title">
+      {{ t("paywall.upgradePrompt.title") }}
+    </p>
+
+    <p class="ui-upgrade-prompt__description">
+      {{ description ?? t("paywall.upgradePrompt.description") }}
+    </p>
+
+    <NButton
+      type="primary"
+      size="medium"
+      class="ui-upgrade-prompt__cta"
+      @click="goToPlanos"
+    >
+      {{ ctaLabel ?? t("paywall.upgradePrompt.ctaLabel") }}
+    </NButton>
+  </div>
+</template>
+
+<style scoped>
+.ui-upgrade-prompt {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3, 12px);
+  padding: var(--space-6, 24px) var(--space-4, 16px);
+  text-align: center;
+}
+
+.ui-upgrade-prompt__feature-name {
+  font-size: var(--font-size-body-xs, 11px);
+  font-weight: var(--font-weight-semibold, 600);
+  color: var(--color-warning-dark, #92400e);
+  background-color: var(--color-warning-light, #fef3c7);
+  padding: 2px 10px;
+  border-radius: var(--border-radius-full, 9999px);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ui-upgrade-prompt__icon {
+  color: var(--color-warning, #f59e0b);
+  margin-top: var(--space-1, 4px);
+}
+
+.ui-upgrade-prompt__title {
+  margin: 0;
+  font-size: var(--font-size-body-lg, 18px);
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--color-text-primary, #ffffff);
+  line-height: 1.3;
+}
+
+.ui-upgrade-prompt__description {
+  margin: 0;
+  font-size: var(--font-size-body-sm, 14px);
+  color: var(--color-text-secondary, #9ca3af);
+  max-width: 320px;
+  line-height: 1.5;
+}
+
+.ui-upgrade-prompt__cta {
+  margin-top: var(--space-1, 4px);
+}
+</style>

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -1036,6 +1036,11 @@
       "title": "Premium Feature",
       "subtitle": "Upgrade to access this feature",
       "button": "View plans"
+    },
+    "upgradePrompt": {
+      "title": "Premium Feature",
+      "description": "Upgrade your plan to unlock this feature and get the most out of the platform.",
+      "ctaLabel": "View plans"
     }
   },
   "ui": {

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -1036,6 +1036,11 @@
       "title": "Recurso Premium",
       "subtitle": "Faça upgrade para acessar este recurso",
       "button": "Ver planos"
+    },
+    "upgradePrompt": {
+      "title": "Recurso Premium",
+      "description": "Faça upgrade para desbloquear este recurso e aproveitar todo o potencial da plataforma.",
+      "ctaLabel": "Ver planos"
     }
   },
   "ui": {


### PR DESCRIPTION
Implements MIC-36: renames PaywallGate.vue → UiPaywallGate.vue following the Ui prefix convention, adds UiUpgradePrompt as a configurable upsell prompt with featureName, description and ctaLabel props.

- UiPaywallGate.vue: renamed, updated CSS class to ui-paywall-gate, JSDoc
- UiPaywallGate.spec.ts: full spec (5 tests) covering loading/locked/unlocked states
- UiPaywallGate.stories.ts: 4 stories showing each gate state without real API
- UiUpgradePrompt.vue: new component with featureName badge, lock icon, i18n CTA
- UiUpgradePrompt.spec.ts: 8 tests covering all props and navigation
- UiUpgradePrompt.stories.ts: 4 stories (default, feature name, custom desc, CLT vs PJ)
- i18n pt.json + en.json: added paywall.upgradePrompt keys

Closes #260

## Summary

<!-- What changed and why -->

## Task Reference

- Task ID: `WEBx` / `PLTx` / `DSH-x` / `Bxx` (if integration)
- GitHub Projects / issue updated: [ ] yes

## Validation

- [ ] `pnpm quality-check`
- [ ] `pnpm contracts:check`
- [ ] `pnpm build`

## Frontend Governance (Mandatory)

- [ ] No `.js/.jsx` introduced in product code.
- [ ] Shared/reusable code moved to `app/shared/*` or `app/core/*` when appropriate.
- [ ] Feature-based organization respected.
- [ ] No placeholder masks nominal integration failures.

## Deploy checklist _(preencher apenas se `.github/workflows/deploy*.yml` ou `nuxt.config.ts` foram alterados)_

- [ ] `S3_BUCKET` bate com o origin da distribuição CloudFront? (run `aws cloudfront get-distribution --id <ID> --query '...Origins.Items[0].DomainName'`)
- [ ] `AWS_WEB_CLOUDFRONT_DISTRIBUTION_ID` (secret/var) aponta para a distribuição correta?
- [ ] Smoke test cobre o novo comportamento?
- [ ] Consultar `.context/09_infra_map.md` no `auraxis-platform` antes de alterar qualquer valor de infra.

## Risks / Follow-ups

<!-- Residual risk, technical debt, and next action -->
