### PR TITLE
fix(ci): upgrade pnpm/action-setup to v5 in deploy workflows

### DIFF
--- a/.github/workflows/deploy-minimum.yml
+++ b/.github/workflows/deploy-minimum.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@6e7bdbda5fe05107efc88b23b7ed00aa05f84ca0 # v4
+        uses: pnpm/action-setup@v5
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@6e7bdbda5fe05107efc88b23b7ed00aa05f84ca0 # v4
+        uses: pnpm/action-setup@v5
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/.github/workflows/pwa-store-artifacts.yml
+++ b/.github/workflows/pwa-store-artifacts.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@6e7bdbda5fe05107efc88b23b7ed00aa05f84ca0 # v4
+        uses: pnpm/action-setup@v5
         with:
           version: ${{ env.PNPM_VERSION }}
 


### PR DESCRIPTION
## Root cause

Dependabot PR #289 bumped `pnpm/action-setup` from v4 → v5 in March 2026, but it only updated `ci.yml`, `chromatic.yml`, and `deploy-staging.yml`. The three deploy workflows were using pinned commit hashes and Dependabot updated those hashes to a **newer v4 commit** (`6e7bdbda`) — not v5. So every deploy after that day triggered:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile is broken: expected a single document in the stream
```

This is a known incompatibility between `pnpm/action-setup@v4` and `pnpm 10.30.1`. The v5 action handles pnpm 10.x correctly.

## Fix

- `deploy.yml` — `pnpm/action-setup@6e7bdbda...` → `@v5`
- `deploy-minimum.yml` — same
- `pwa-store-artifacts.yml` — same

Aligns with `ci.yml` / `chromatic.yml` / `deploy-staging.yml` which already use `@v5` and pass CI without issues.

## Test plan

- [ ] Merge and observe the next `Deploy Official Web (AWS)` run on main — should pass `pnpm install --frozen-lockfile`
- [ ] Verify `Deploy Minimum (Web Baseline)` also recovers

> Deploy pipeline has been broken since 2026-03-31 19:20 (every push to main failed).