### PR TITLE
feat(translations): extract hardcoded PT strings to vue-i18n

### DIFF
--- a/app/components/profile/ProfileCompletionModal/ProfileCompletionModal.vue
+++ b/app/components/profile/ProfileCompletionModal/ProfileCompletionModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { NModal, useMessage } from "naive-ui";
+import { useI18n } from "vue-i18n";
 import { toTypedSchema } from "@vee-validate/zod";
 import { useForm } from "vee-validate";
 import {
@@ -20,6 +21,7 @@ import type { UpdateUserProfileRequest } from "~/features/profile/contracts/user
 const props = defineProps<ProfileCompletionModalProps>();
 const emit = defineEmits<ProfileCompletionModalEmits>();
 
+const { t } = useI18n();
 const message = useMessage();
 const userStore = useUserStore();
 const { mutate, isPending } = useUpdateProfileMutation();
@@ -159,26 +161,32 @@ const buildPayload = (values: UserProfileSchema): UpdateUserProfileRequest => ({
 const onSubmit = handleSubmit((values: UserProfileSchema) => {
   mutate(buildPayload(values), {
     onSuccess: () => {
-      message.success("Seus dados foram atualizados", { duration: 3500 });
+      message.success(t("pages.profile.modal.messages.success"), { duration: 3500 });
       emit("saved");
     },
     onError: () => {
-      message.error("Houve um problema ao atualizar os dados", { duration: 4000 });
+      message.error(t("pages.profile.modal.messages.error"), { duration: 4000 });
     },
   });
 });
 
-const GENDER_LABELS: Record<string, string> = {
-  masculino: "Masculino",
-  feminino: "Feminino",
-  outro: "Outro",
-};
+/**
+ * Returns the localized label for a gender option.
+ *
+ * @param opt The gender option key (e.g., "masculino").
+ * @returns Localized label string.
+ */
+const genderLabel = (opt: string): string =>
+  t(`pages.profile.modal.genderOptions.${opt}`, opt);
 
-const INVESTOR_PROFILE_LABELS: Record<string, string> = {
-  conservador: "Conservador",
-  explorador: "Explorador",
-  entusiasta: "Entusiasta",
-};
+/**
+ * Returns the localized label for an investor profile option.
+ *
+ * @param opt The investor profile key (e.g., "conservador").
+ * @returns Localized title string.
+ */
+const investorProfileLabel = (opt: string): string =>
+  t(`investorProfile.result.${opt}.title`, opt);
 </script>
 
 <template>
@@ -193,15 +201,15 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
       <!-- Header -->
       <div class="profile-modal__header">
         <div>
-          <h2 class="profile-modal__title">Complete seu perfil</h2>
+          <h2 class="profile-modal__title">{{ $t('pages.profile.modal.title') }}</h2>
           <p class="profile-modal__subtitle">
-            Preencha seus dados financeiros para personalizar sua experiência no Auraxis.
+            {{ $t('pages.profile.modal.subtitle') }}
           </p>
         </div>
         <button
           class="profile-modal__close"
           type="button"
-          aria-label="Fechar modal"
+          :aria-label="$t('pages.profile.modal.closeAriaLabel')"
           @click="emit('close')"
         >
           ✕
@@ -211,11 +219,11 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
       <!-- Form -->
       <form class="profile-modal__form" novalidate @submit.prevent="onSubmit">
         <!-- Required section -->
-        <div class="profile-modal__section-label">Dados pessoais e financeiros *</div>
+        <div class="profile-modal__section-label">{{ $t('pages.profile.modal.sectionRequired') }}</div>
 
         <div class="profile-modal__grid">
           <!-- Gender -->
-          <UiFormField label="Gênero" field-id="pm-gender" :error="errors.gender" required>
+          <UiFormField :label="$t('pages.profile.modal.labels.gender')" field-id="pm-gender" :error="errors.gender" required>
             <select
               id="pm-gender"
               v-model="gender"
@@ -224,17 +232,17 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
               :disabled="isPending"
               v-bind="genderAttrs"
             >
-              <option value="" disabled>Selecione</option>
+              <option value="" disabled>{{ $t('pages.profile.modal.selectPlaceholder') }}</option>
               <option
                 v-for="opt in GENDER_OPTIONS"
                 :key="opt"
                 :value="opt"
-              >{{ GENDER_LABELS[opt] }}</option>
+              >{{ genderLabel(opt) }}</option>
             </select>
           </UiFormField>
 
           <!-- Birth date -->
-          <UiFormField label="Data de nascimento" field-id="pm-birth-date" :error="errors.birth_date" required>
+          <UiFormField :label="$t('pages.profile.modal.labels.birthDate')" field-id="pm-birth-date" :error="errors.birth_date" required>
             <input
               id="pm-birth-date"
               v-model="birthDate"
@@ -247,7 +255,7 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
           </UiFormField>
 
           <!-- Monthly income -->
-          <UiFormField label="Renda mensal (R$)" field-id="pm-income" :error="errors.monthly_income" required>
+          <UiFormField :label="$t('pages.profile.modal.labels.monthlyIncome')" field-id="pm-income" :error="errors.monthly_income" required>
             <input
               id="pm-income"
               v-model="monthlyIncome"
@@ -263,7 +271,7 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
           </UiFormField>
 
           <!-- Net worth -->
-          <UiFormField label="Patrimônio líquido (R$)" field-id="pm-networth" :error="errors.net_worth" required>
+          <UiFormField :label="$t('pages.profile.modal.labels.netWorth')" field-id="pm-networth" :error="errors.net_worth" required>
             <input
               id="pm-networth"
               v-model="netWorth"
@@ -279,7 +287,7 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
           </UiFormField>
 
           <!-- Monthly expenses -->
-          <UiFormField label="Gastos mensais (R$)" field-id="pm-expenses" :error="errors.monthly_expenses" required>
+          <UiFormField :label="$t('pages.profile.modal.labels.monthlyExpenses')" field-id="pm-expenses" :error="errors.monthly_expenses" required>
             <input
               id="pm-expenses"
               v-model="monthlyExpenses"
@@ -295,7 +303,7 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
           </UiFormField>
 
           <!-- State UF -->
-          <UiFormField label="Estado (UF)" field-id="pm-state" :error="errors.state_uf" required>
+          <UiFormField :label="$t('pages.profile.modal.labels.stateUf')" field-id="pm-state" :error="errors.state_uf" required>
             <select
               id="pm-state"
               v-model="stateUf"
@@ -304,20 +312,20 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
               :disabled="isPending"
               v-bind="stateUfAttrs"
             >
-              <option value="" disabled>Selecione</option>
+              <option value="" disabled>{{ $t('pages.profile.modal.selectPlaceholder') }}</option>
               <option v-for="uf in BRAZIL_UF_OPTIONS" :key="uf" :value="uf">{{ uf }}</option>
             </select>
           </UiFormField>
 
           <!-- Occupation -->
-          <UiFormField label="Profissão" field-id="pm-occupation" :error="errors.occupation" required>
+          <UiFormField :label="$t('pages.profile.modal.labels.occupation')" field-id="pm-occupation" :error="errors.occupation" required>
             <input
               id="pm-occupation"
               v-model="occupation"
               class="profile-modal__input"
               :class="{ 'profile-modal__input--error': !!errors.occupation }"
               type="text"
-              placeholder="Ex.: Engenheiro de Software"
+              :placeholder="$t('pages.profile.modal.placeholders.occupation')"
               maxlength="128"
               :disabled="isPending"
               v-bind="occupationAttrs"
@@ -325,7 +333,7 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
           </UiFormField>
 
           <!-- Investor profile -->
-          <UiFormField label="Perfil de investidor" field-id="pm-inv-profile" :error="errors.investor_profile" required>
+          <UiFormField :label="$t('pages.profile.modal.labels.investorProfile')" field-id="pm-inv-profile" :error="errors.investor_profile" required>
             <select
               id="pm-inv-profile"
               v-model="investorProfile"
@@ -334,19 +342,19 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
               :disabled="isPending"
               v-bind="investorProfileAttrs"
             >
-              <option value="" disabled>Selecione</option>
+              <option value="" disabled>{{ $t('pages.profile.modal.selectPlaceholder') }}</option>
               <option
                 v-for="opt in INVESTOR_PROFILE_OPTIONS"
                 :key="opt"
                 :value="opt"
-              >{{ INVESTOR_PROFILE_LABELS[opt] }}</option>
+              >{{ investorProfileLabel(opt) }}</option>
             </select>
           </UiFormField>
         </div>
 
         <!-- Financial objectives (full width) -->
         <UiFormField
-          label="Objetivos financeiros"
+          :label="$t('pages.profile.modal.labels.financialObjectives')"
           field-id="pm-objectives"
           :error="errors.financial_objectives"
           required
@@ -356,7 +364,7 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
             v-model="financialObjectives"
             class="profile-modal__textarea"
             :class="{ 'profile-modal__input--error': !!errors.financial_objectives }"
-            placeholder="Ex.: Aposentadoria antecipada, compra de imóvel..."
+            :placeholder="$t('pages.profile.modal.placeholders.financialObjectives')"
             rows="3"
             :disabled="isPending"
             v-bind="financialObjectivesAttrs"
@@ -365,12 +373,12 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
 
         <!-- Optional section -->
         <div class="profile-modal__section-label profile-modal__section-label--optional">
-          Informações opcionais
+          {{ $t('pages.profile.modal.sectionOptional') }}
         </div>
 
         <div class="profile-modal__grid">
           <!-- Initial investment -->
-          <UiFormField label="Investimento inicial (R$)" field-id="pm-init-inv" :error="errors.initial_investment">
+          <UiFormField :label="$t('pages.profile.modal.labels.initialInvestment')" field-id="pm-init-inv" :error="errors.initial_investment">
             <input
               id="pm-init-inv"
               v-model="initialInvestment"
@@ -386,7 +394,7 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
           </UiFormField>
 
           <!-- Monthly investment -->
-          <UiFormField label="Aporte mensal (R$)" field-id="pm-monthly-inv" :error="errors.monthly_investment">
+          <UiFormField :label="$t('pages.profile.modal.labels.monthlyInvestment')" field-id="pm-monthly-inv" :error="errors.monthly_investment">
             <input
               id="pm-monthly-inv"
               v-model="monthlyInvestment"
@@ -402,7 +410,7 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
           </UiFormField>
 
           <!-- Investment goal date -->
-          <UiFormField label="Data meta de investimento" field-id="pm-goal-date" :error="errors.investment_goal_date">
+          <UiFormField :label="$t('pages.profile.modal.labels.investmentGoalDate')" field-id="pm-goal-date" :error="errors.investment_goal_date">
             <input
               id="pm-goal-date"
               v-model="investmentGoalDate"
@@ -423,7 +431,7 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
             :disabled="isPending"
             @click="emit('close')"
           >
-            Preencher depois
+            {{ $t('pages.profile.modal.actions.postpone') }}
           </button>
 
           <button
@@ -433,7 +441,7 @@ const INVESTOR_PROFILE_LABELS: Record<string, string> = {
             :aria-busy="isPending"
           >
             <span v-if="isPending" class="profile-modal__spinner" aria-hidden="true" />
-            {{ isPending ? "Salvando..." : "Atualizar dados" }}
+            {{ isPending ? $t('pages.profile.modal.actions.saving') : $t('pages.profile.modal.actions.update') }}
           </button>
         </div>
       </form>

--- a/app/components/tool/InstallmentVsCashCalculatorForm.vue
+++ b/app/components/tool/InstallmentVsCashCalculatorForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import {
   NButton,
   NForm,
@@ -29,30 +30,25 @@ interface Emits {
 
 const props = defineProps<Props>();
 const emit = defineEmits<Emits>();
+const { t } = useI18n();
 
-const opportunityRateOptions = [
-  { label: "Manual", value: "manual" satisfies OpportunityRateType },
-  {
-    label: "Preset do produto",
-    value: "product_default" satisfies OpportunityRateType,
-  },
-  {
-    label: "Usar só inflação",
-    value: "inflation_only" satisfies OpportunityRateType,
-  },
-];
+const opportunityRateOptions = computed(() => [
+  { label: t("pages.installmentVsCash.form.opportunityRateOptions.manual"), value: "manual" satisfies OpportunityRateType },
+  { label: t("pages.installmentVsCash.form.opportunityRateOptions.productDefault"), value: "product_default" satisfies OpportunityRateType },
+  { label: t("pages.installmentVsCash.form.opportunityRateOptions.inflationOnly"), value: "inflation_only" satisfies OpportunityRateType },
+]);
 
-const delayOptions = [
-  { label: "Hoje", value: "today" satisfies InstallmentDelayPreset },
-  { label: "30 dias", value: "30_days" satisfies InstallmentDelayPreset },
-  { label: "45 dias", value: "45_days" satisfies InstallmentDelayPreset },
-  { label: "Personalizar", value: "custom" satisfies InstallmentDelayPreset },
-];
+const delayOptions = computed(() => [
+  { label: t("pages.installmentVsCash.form.delayOptions.today"), value: "today" satisfies InstallmentDelayPreset },
+  { label: t("pages.installmentVsCash.form.delayOptions.thirtyDays"), value: "30_days" satisfies InstallmentDelayPreset },
+  { label: t("pages.installmentVsCash.form.delayOptions.fortyFiveDays"), value: "45_days" satisfies InstallmentDelayPreset },
+  { label: t("pages.installmentVsCash.form.delayOptions.custom"), value: "custom" satisfies InstallmentDelayPreset },
+]);
 
-const installmentInputOptions = [
-  { label: "Informar valor total parcelado", value: "total" satisfies InstallmentInputMode },
-  { label: "Informar valor de cada parcela", value: "amount" satisfies InstallmentInputMode },
-] as const;
+const installmentInputOptions = computed(() => [
+  { label: t("pages.installmentVsCash.form.installmentInputOptions.total"), value: "total" satisfies InstallmentInputMode },
+  { label: t("pages.installmentVsCash.form.installmentInputOptions.amount"), value: "amount" satisfies InstallmentInputMode },
+]);
 
 /**
  * Emits a shallow form patch while preserving the remaining state.
@@ -100,78 +96,78 @@ const shouldShowFeesInput = computed<boolean>(() => {
     label-placement="top"
     @submit.prevent="emit('submit')"
   >
-    <NFormItem label="Compra ou cenário">
+    <NFormItem :label="$t('pages.installmentVsCash.form.labels.scenario')">
       <NInput
         :value="props.modelValue.scenarioLabel"
-        placeholder="Ex.: notebook, geladeira, viagem"
+        :placeholder="$t('pages.installmentVsCash.form.placeholders.scenario')"
         clearable
         @update:value="(value: string) => patchForm({ scenarioLabel: value })"
       />
     </NFormItem>
 
     <div class="installment-vs-cash-form__grid">
-      <NFormItem label="Preço à vista">
+      <NFormItem :label="$t('pages.installmentVsCash.form.labels.cashPrice')">
         <NInputNumber
           :value="props.modelValue.cashPrice"
           :min="0"
           :precision="2"
           :show-button="false"
-          placeholder="900,00"
+          :placeholder="$t('pages.installmentVsCash.form.placeholders.cashPrice')"
           @update:value="(value: number | null) => patchForm({ cashPrice: value })"
         />
       </NFormItem>
 
-      <NFormItem label="Quantidade de parcelas">
+      <NFormItem :label="$t('pages.installmentVsCash.form.labels.installmentCount')">
         <NInputNumber
           :value="props.modelValue.installmentCount"
           :min="1"
           :max="60"
           :show-button="false"
-          placeholder="6"
+          :placeholder="$t('pages.installmentVsCash.form.placeholders.installmentCount')"
           @update:value="(value: number | null) => patchForm({ installmentCount: value })"
         />
       </NFormItem>
     </div>
 
-    <NFormItem label="Como você quer informar o parcelado">
+    <NFormItem :label="$t('pages.installmentVsCash.form.labels.installmentInputMode')">
       <UiSegmentedControl
         :model-value="props.modelValue.installmentInputMode"
-        :options="[...installmentInputOptions]"
-        aria-label="Modo do parcelamento"
-        @update:model-value="(value: InstallmentInputMode) => patchForm({ installmentInputMode: value })"
+        :options="installmentInputOptions"
+        :aria-label="$t('pages.installmentVsCash.form.labels.installmentInputAriaLabel')"
+        @update:model-value="(value: string) => patchForm({ installmentInputMode: value as InstallmentInputMode })"
       />
     </NFormItem>
 
     <NFormItem
       v-if="props.modelValue.installmentInputMode === 'total'"
-      label="Valor total parcelado"
+      :label="$t('pages.installmentVsCash.form.labels.installmentTotal')"
     >
       <NInputNumber
         :value="props.modelValue.installmentTotal"
         :min="0"
         :precision="2"
         :show-button="false"
-        placeholder="990,00"
+        :placeholder="$t('pages.installmentVsCash.form.placeholders.installmentTotal')"
         @update:value="(value: number | null) => patchForm({ installmentTotal: value })"
       />
     </NFormItem>
 
     <NFormItem
       v-else
-      label="Valor de cada parcela"
+      :label="$t('pages.installmentVsCash.form.labels.installmentAmount')"
     >
       <NInputNumber
         :value="props.modelValue.installmentAmount"
         :min="0"
         :precision="2"
         :show-button="false"
-        placeholder="165,00"
+        :placeholder="$t('pages.installmentVsCash.form.placeholders.installmentAmount')"
         @update:value="(value: number | null) => patchForm({ installmentAmount: value })"
       />
     </NFormItem>
 
     <div class="installment-vs-cash-form__grid">
-      <NFormItem label="Primeira parcela">
+      <NFormItem :label="$t('pages.installmentVsCash.form.labels.firstPayment')">
         <NSelect
           :value="props.modelValue.firstPaymentDelayPreset"
           :options="delayOptions"
@@ -179,20 +175,20 @@ const shouldShowFeesInput = computed<boolean>(() => {
         />
       </NFormItem>
 
-      <NFormItem v-if="shouldShowCustomDelay" label="Dias até a primeira parcela">
+      <NFormItem v-if="shouldShowCustomDelay" :label="$t('pages.installmentVsCash.form.labels.customDelay')">
         <NInputNumber
           :value="props.modelValue.customFirstPaymentDelayDays"
           :min="0"
           :max="3650"
           :show-button="false"
-          placeholder="75"
+          :placeholder="$t('pages.installmentVsCash.form.placeholders.customDelay')"
           @update:value="(value: number | null) => patchForm({ customFirstPaymentDelayDays: value })"
         />
       </NFormItem>
     </div>
 
     <div class="installment-vs-cash-form__grid">
-      <NFormItem label="Taxa de oportunidade">
+      <NFormItem :label="$t('pages.installmentVsCash.form.labels.opportunityRate')">
         <NSelect
           :value="props.modelValue.opportunityRateType"
           :options="opportunityRateOptions"
@@ -200,30 +196,30 @@ const shouldShowFeesInput = computed<boolean>(() => {
         />
       </NFormItem>
 
-      <NFormItem label="Inflação anual (%)">
+      <NFormItem :label="$t('pages.installmentVsCash.form.labels.inflationRate')">
         <NInputNumber
           :value="props.modelValue.inflationRateAnnual"
           :min="0"
           :precision="2"
           :show-button="false"
-          placeholder="4,50"
+          :placeholder="$t('pages.installmentVsCash.form.placeholders.inflationRate')"
           @update:value="(value: number | null) => patchForm({ inflationRateAnnual: value })"
         />
       </NFormItem>
     </div>
 
-    <NFormItem v-if="shouldShowManualOpportunityRate" label="Taxa de oportunidade anual (%)">
+    <NFormItem v-if="shouldShowManualOpportunityRate" :label="$t('pages.installmentVsCash.form.labels.manualRate')">
       <NInputNumber
         :value="props.modelValue.opportunityRateAnnual"
         :min="0"
         :precision="2"
         :show-button="false"
-        placeholder="12,00"
+        :placeholder="$t('pages.installmentVsCash.form.placeholders.manualRate')"
         @update:value="(value: number | null) => patchForm({ opportunityRateAnnual: value })"
       />
     </NFormItem>
 
-    <NFormItem label="Custos extras iniciais">
+    <NFormItem :label="$t('pages.installmentVsCash.form.labels.fees')">
       <div class="installment-vs-cash-form__fees">
         <NSwitch
           :value="props.modelValue.feesEnabled"
@@ -236,7 +232,7 @@ const shouldShowFeesInput = computed<boolean>(() => {
           :min="0"
           :precision="2"
           :show-button="false"
-          placeholder="60,00"
+          :placeholder="$t('pages.installmentVsCash.form.placeholders.fees')"
           @update:value="(value: number | null) => patchForm({ feesUpfront: value })"
         />
       </div>
@@ -250,7 +246,7 @@ const shouldShowFeesInput = computed<boolean>(() => {
       :disabled="props.loading"
       class="installment-vs-cash-form__submit"
     >
-      Calcular agora
+      {{ $t('pages.installmentVsCash.form.actions.calculate') }}
     </NButton>
   </NForm>
 </template>

--- a/app/components/tool/InstallmentVsCashResults.vue
+++ b/app/components/tool/InstallmentVsCashResults.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import {
   NCollapse,
   NCollapseItem,
@@ -21,6 +22,7 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+const { t } = useI18n();
 
 /**
  * Chart option derived from the current calculation.
@@ -37,42 +39,47 @@ const chartOption = computed(() => {
  * The render callbacks are called by NDataTable at runtime. In unit tests
  * NDataTable is stubbed and never invokes them, so they are excluded from
  * coverage to avoid false negatives.
+ *
+ * Wrapped in computed so column titles react to locale changes.
  */
 /* v8 ignore start */
-const scheduleColumns = [
+const scheduleColumns = computed(() => [
   {
     key: "installmentNumber",
-    title: "Parcela",
+    title: t("pages.installmentVsCash.schedule.columns.installment"),
     render: (row: InstallmentVsCashScheduleItem): string => {
-      return row.installmentNumber === 0 ? "Hoje" : `${row.installmentNumber}ª`;
+      return row.installmentNumber === 0
+        ? t("pages.installmentVsCash.schedule.today")
+        : `${row.installmentNumber}${t("pages.installmentVsCash.schedule.ordinalSuffix")}`;
     },
   },
   {
     key: "dueInDays",
-    title: "Vence em",
-    render: (row: InstallmentVsCashScheduleItem): string => `${row.dueInDays} dias`,
+    title: t("pages.installmentVsCash.schedule.columns.dueDate"),
+    render: (row: InstallmentVsCashScheduleItem): string =>
+      `${row.dueInDays} ${t("pages.installmentVsCash.schedule.daysUnit")}`,
   },
   {
     key: "amount",
-    title: "Valor",
+    title: t("pages.installmentVsCash.schedule.columns.amount"),
     render: (row: InstallmentVsCashScheduleItem): string => formatCurrency(row.amount),
   },
   {
     key: "presentValue",
-    title: "Valor presente",
+    title: t("pages.installmentVsCash.schedule.columns.presentValue"),
     render: (row: InstallmentVsCashScheduleItem): string => formatCurrency(row.presentValue),
   },
   {
     key: "cumulativeNominal",
-    title: "Acumulado nominal",
+    title: t("pages.installmentVsCash.schedule.columns.cumulativeNominal"),
     render: (row: InstallmentVsCashScheduleItem): string => formatCurrency(row.cumulativeNominal),
   },
   {
     key: "cashCumulative",
-    title: "Acumulado à vista",
+    title: t("pages.installmentVsCash.schedule.columns.cashCumulative"),
     render: (row: InstallmentVsCashScheduleItem): string => formatCurrency(row.cashCumulative),
   },
-];
+]);
 /* v8 ignore stop */
 
 /**
@@ -112,15 +119,15 @@ const recommendationTagType = computed<
 
       <div class="installment-vs-cash-results__metrics">
         <UiMetricCard
-          label="Preço à vista"
+          :label="$t('pages.installmentVsCash.breakdown.metrics.cashPrice')"
           :value="formatCurrency(props.calculation.result.comparison.cashOptionTotal)"
         />
         <UiMetricCard
-          label="Parcelado nominal"
+          :label="$t('pages.installmentVsCash.breakdown.metrics.installmentNominal')"
           :value="formatCurrency(props.calculation.result.comparison.installmentOptionTotal)"
         />
         <UiMetricCard
-          label="Parcelado em valor presente"
+          :label="$t('pages.installmentVsCash.breakdown.metrics.installmentPv')"
           :value="formatCurrency(props.calculation.result.comparison.installmentPresentValue)"
           :trend="props.calculation.result.comparison.relativeDeltaVsCashPercent"
         />
@@ -129,8 +136,8 @@ const recommendationTagType = computed<
 
     <UiSurfaceCard class="installment-vs-cash-results__chart-card">
       <NThing
-        title="Comparação mês a mês"
-        description="Veja o desembolso acumulado e o valor presente do parcelamento ao longo do tempo."
+        :title="$t('pages.installmentVsCash.breakdown.monthlyComparison.title')"
+        :description="$t('pages.installmentVsCash.breakdown.monthlyComparison.description')"
       />
       <UiChart
         :option="chartOption"
@@ -140,50 +147,50 @@ const recommendationTagType = computed<
     </UiSurfaceCard>
 
     <NCollapse arrow-placement="right">
-      <NCollapseItem title="Entenda o cálculo" name="formula">
+      <NCollapseItem :title="$t('pages.installmentVsCash.breakdown.formula.collapseTitle')" name="formula">
         <NThing
-          title="Fórmula e premissas"
+          :title="$t('pages.installmentVsCash.breakdown.formula.title')"
           :description="props.calculation.result.formulaExplainer"
         >
           <template #default>
             <div class="installment-vs-cash-results__assumptions">
               <span>
-                Taxa de oportunidade:
-                <strong>{{ props.calculation.result.assumptions.opportunityRateAnnualPercent.toFixed(2).replace(".", ",") }}% a.a.</strong>
+                {{ $t('pages.installmentVsCash.breakdown.formula.opportunityRateLabel') }}
+                <strong>{{ props.calculation.result.assumptions.opportunityRateAnnualPercent.toFixed(2).replace(".", ",") }}{{ $t('pages.installmentVsCash.breakdown.formula.rateAnnualSuffix') }}</strong>
               </span>
               <span>
-                Inflação:
-                <strong>{{ props.calculation.result.assumptions.inflationRateAnnualPercent.toFixed(2).replace(".", ",") }}% a.a.</strong>
+                {{ $t('pages.installmentVsCash.breakdown.formula.inflationLabel') }}
+                <strong>{{ props.calculation.result.assumptions.inflationRateAnnualPercent.toFixed(2).replace(".", ",") }}{{ $t('pages.installmentVsCash.breakdown.formula.rateAnnualSuffix') }}</strong>
               </span>
               <span>
-                Faixa de neutralidade:
+                {{ $t('pages.installmentVsCash.breakdown.formula.neutralityBandLabel') }}
                 <strong>{{ formatCurrency(props.calculation.result.neutralityBand.absoluteBrl) }}</strong>
-                ou
-                <strong>{{ props.calculation.result.neutralityBand.relativePercent.toFixed(2).replace(".", ",") }}%</strong>
+                {{ $t('pages.installmentVsCash.breakdown.formula.or') }}
+                <strong>{{ props.calculation.result.neutralityBand.relativePercent.toFixed(2).replace(".", ",") }}{{ $t('pages.installmentVsCash.breakdown.formula.percentSuffix') }}</strong>
               </span>
             </div>
           </template>
         </NThing>
       </NCollapseItem>
 
-      <NCollapseItem title="Break-even e comparação detalhada" name="break-even">
+      <NCollapseItem :title="$t('pages.installmentVsCash.breakdown.breakEven.collapseTitle')" name="break-even">
         <div class="installment-vs-cash-results__details-grid">
           <UiMetricCard
-            label="Diferença vs à vista"
+            :label="$t('pages.installmentVsCash.breakdown.metrics.difference')"
             :value="formatCurrency(props.calculation.result.comparison.absoluteDeltaVsCash)"
           />
           <UiMetricCard
-            label="Desconto à vista para empatar"
+            :label="$t('pages.installmentVsCash.breakdown.metrics.breakEvenDiscount')"
             :value="`${props.calculation.result.comparison.breakEvenDiscountPercent.toFixed(2).replace('.', ',')}%`"
           />
           <UiMetricCard
-            label="Taxa mínima para o parcelado empatar"
+            :label="$t('pages.installmentVsCash.breakdown.metrics.breakEvenRate')"
             :value="`${props.calculation.result.comparison.breakEvenOpportunityRateAnnual.toFixed(2).replace('.', ',')}% a.a.`"
           />
         </div>
       </NCollapseItem>
 
-      <NCollapseItem title="Cronograma mês a mês" name="schedule">
+      <NCollapseItem :title="$t('pages.installmentVsCash.breakdown.scheduleSection.collapseTitle')" name="schedule">
         <NDataTable
           :columns="scheduleColumns"
           :data="props.calculation.result.schedule"

--- a/app/components/tool/TaxBracketTable/TaxBracketTable.vue
+++ b/app/components/tool/TaxBracketTable/TaxBracketTable.vue
@@ -7,6 +7,11 @@
  * formatting logic) and remains reusable for both INSS and IRRF tables.
  */
 
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
+
 /** A single row in the bracket table. */
 export interface TaxBracketRow {
   /** Unique key used as the v-for key. */
@@ -41,14 +46,19 @@ interface Props {
   totalValue?: string
 }
 
-withDefaults(defineProps<Props>(), {
-  rangeHeader: "Faixa",
-  rateHeader: "Alíquota",
-  baseHeader: "Base",
-  taxHeader: "Desconto",
+const props = withDefaults(defineProps<Props>(), {
+  rangeHeader: undefined,
+  rateHeader: undefined,
+  baseHeader: undefined,
+  taxHeader: undefined,
   totalLabel: undefined,
   totalValue: undefined,
 });
+
+const resolvedRangeHeader = computed(() => props.rangeHeader ?? t("components.taxBracketTable.rangeHeader"));
+const resolvedRateHeader = computed(() => props.rateHeader ?? t("components.taxBracketTable.rateHeader"));
+const resolvedBaseHeader = computed(() => props.baseHeader ?? t("components.taxBracketTable.baseHeader"));
+const resolvedTaxHeader = computed(() => props.taxHeader ?? t("components.taxBracketTable.taxHeader"));
 </script>
 
 <template>
@@ -57,16 +67,16 @@ withDefaults(defineProps<Props>(), {
       <thead>
         <tr class="tax-bracket-table__header-row">
           <th class="tax-bracket-table__th tax-bracket-table__th--range">
-            {{ rangeHeader }}
+            {{ resolvedRangeHeader }}
           </th>
           <th class="tax-bracket-table__th tax-bracket-table__th--rate">
-            {{ rateHeader }}
+            {{ resolvedRateHeader }}
           </th>
           <th class="tax-bracket-table__th tax-bracket-table__th--base">
-            {{ baseHeader }}
+            {{ resolvedBaseHeader }}
           </th>
           <th class="tax-bracket-table__th tax-bracket-table__th--tax">
-            {{ taxHeader }}
+            {{ resolvedTaxHeader }}
           </th>
         </tr>
       </thead>

--- a/app/components/tool/ToolCard.vue
+++ b/app/components/tool/ToolCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { NButton, NCard, NTag } from "naive-ui";
 import { useRouter } from "#app";
+import { useI18n } from "vue-i18n";
 import type { Tool, ToolAccessLevel } from "~/features/tools/model/tools";
 
 interface Props {
@@ -14,6 +15,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const router = useRouter();
+const { t } = useI18n();
 
 /**
  * Returns the label for the access badge based on access level.
@@ -22,12 +24,12 @@ const router = useRouter();
  */
 const accessBadgeLabel = (accessLevel: ToolAccessLevel): string => {
   if (accessLevel === "premium") {
-    return "Premium";
+    return t("pages.tools.card.badgeLabels.premium");
   }
   if (accessLevel === "authenticated") {
-    return "Login necessário";
+    return t("pages.tools.card.badgeLabels.loginRequired");
   }
-  return "Público";
+  return t("pages.tools.card.badgeLabels.public");
 };
 
 /**
@@ -73,15 +75,15 @@ const handleCtaClick = (): void => {
  */
 const ctaLabel = (): string => {
   if (!props.tool.enabled) {
-    return "Em breve";
+    return t("pages.tools.card.disabled");
   }
   if (props.tool.accessLevel === "premium" && !props.isPremium) {
-    return "Ver planos";
+    return t("pages.tools.card.viewPlans");
   }
   if (props.tool.accessLevel === "authenticated" && !props.isAuthenticated) {
-    return "Fazer login para usar";
+    return t("pages.tools.card.loginToUse");
   }
-  return "Usar ferramenta";
+  return t("pages.tools.card.use");
 };
 </script>
 

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -113,7 +113,15 @@
       },
       "card": {
         "open": "Open tool",
-        "disabled": "Coming soon"
+        "disabled": "Coming soon",
+        "use": "Use tool",
+        "viewPlans": "View plans",
+        "loginToUse": "Log in to use",
+        "badgeLabels": {
+          "premium": "Premium",
+          "loginRequired": "Login required",
+          "public": "Public"
+        }
       },
       "empty": "No tools available at this time."
     },
@@ -638,6 +646,95 @@
         "registerCta": "Create free account",
         "loginCta": "I already have an account",
         "trust": "Free forever · No credit card · Cancel anytime"
+      },
+      "form": {
+        "labels": {
+          "scenario": "Purchase or scenario",
+          "cashPrice": "Cash price",
+          "installmentCount": "Number of installments",
+          "installmentInputMode": "How do you want to enter the installment value",
+          "installmentInputAriaLabel": "Installment mode",
+          "installmentTotal": "Total installment amount",
+          "installmentAmount": "Amount per installment",
+          "firstPayment": "First payment",
+          "customDelay": "Days until first payment",
+          "opportunityRate": "Opportunity rate",
+          "inflationRate": "Annual inflation (%)",
+          "manualRate": "Annual opportunity rate (%)",
+          "fees": "Upfront extra costs"
+        },
+        "placeholders": {
+          "scenario": "E.g.: laptop, fridge, trip",
+          "cashPrice": "900.00",
+          "installmentCount": "6",
+          "installmentTotal": "990.00",
+          "installmentAmount": "165.00",
+          "customDelay": "75",
+          "inflationRate": "4.50",
+          "manualRate": "12.00",
+          "fees": "60.00"
+        },
+        "opportunityRateOptions": {
+          "manual": "Manual",
+          "productDefault": "Product preset",
+          "inflationOnly": "Inflation only"
+        },
+        "delayOptions": {
+          "today": "Today",
+          "thirtyDays": "30 days",
+          "fortyFiveDays": "45 days",
+          "custom": "Custom"
+        },
+        "installmentInputOptions": {
+          "total": "Enter total installment amount",
+          "amount": "Enter amount per installment"
+        },
+        "actions": {
+          "calculate": "Calculate now"
+        }
+      },
+      "schedule": {
+        "columns": {
+          "installment": "Installment",
+          "dueDate": "Due in",
+          "amount": "Amount",
+          "presentValue": "Present value",
+          "cumulativeNominal": "Cumulative nominal",
+          "cashCumulative": "Cash cumulative"
+        },
+        "today": "Today",
+        "daysUnit": "days",
+        "ordinalSuffix": "st"
+      },
+      "breakdown": {
+        "metrics": {
+          "cashPrice": "Cash price",
+          "installmentNominal": "Installment nominal",
+          "installmentPv": "Installment present value",
+          "difference": "Difference vs cash",
+          "breakEvenDiscount": "Cash discount to break even",
+          "breakEvenRate": "Min rate for installment to break even"
+        },
+        "monthlyComparison": {
+          "title": "Month-by-month comparison",
+          "description": "See cumulative outflow and present value of installments over time."
+        },
+        "formula": {
+          "collapseTitle": "Understand the calculation",
+          "title": "Formula and assumptions",
+          "opportunityRateLabel": "Opportunity rate:",
+          "rateAnnualSuffix": "% p.a.",
+          "inflationLabel": "Inflation:",
+          "neutralityBandLabel": "Neutrality band:",
+          "or": "or",
+          "percentSuffix": "%"
+        },
+        "breakEven": {
+          "collapseTitle": "Break-even and detailed comparison"
+        },
+        "scheduleSection": {
+          "collapseTitle": "Month-by-month schedule"
+        }
       }
     },
     "home": {
@@ -685,6 +782,48 @@
         "subtitle": "Create your free account and take full control of your finances.",
         "button": "Create free account",
         "login": "I already have an account"
+      }
+    },
+    "profile": {
+      "modal": {
+        "title": "Complete your profile",
+        "subtitle": "Fill in your financial data to personalize your Auraxis experience.",
+        "closeAriaLabel": "Close modal",
+        "sectionRequired": "Personal and financial details *",
+        "sectionOptional": "Optional information",
+        "selectPlaceholder": "Select",
+        "labels": {
+          "gender": "Gender",
+          "birthDate": "Date of birth",
+          "monthlyIncome": "Monthly income (R$)",
+          "netWorth": "Net worth (R$)",
+          "monthlyExpenses": "Monthly expenses (R$)",
+          "stateUf": "State (UF)",
+          "occupation": "Occupation",
+          "investorProfile": "Investor profile",
+          "financialObjectives": "Financial objectives",
+          "initialInvestment": "Initial investment (R$)",
+          "monthlyInvestment": "Monthly contribution (R$)",
+          "investmentGoalDate": "Investment goal date"
+        },
+        "placeholders": {
+          "occupation": "E.g.: Software Engineer",
+          "financialObjectives": "E.g.: Early retirement, buying a property..."
+        },
+        "genderOptions": {
+          "masculino": "Male",
+          "feminino": "Female",
+          "outro": "Other"
+        },
+        "actions": {
+          "postpone": "Fill in later",
+          "saving": "Saving...",
+          "update": "Update profile"
+        },
+        "messages": {
+          "success": "Your data has been updated",
+          "error": "There was a problem updating your data"
+        }
       }
     }
   },
@@ -2986,6 +3125,12 @@
         }
       },
       "copyright": "© {year} Auraxis. All rights reserved."
+    },
+    "taxBracketTable": {
+      "rangeHeader": "Bracket",
+      "rateHeader": "Rate",
+      "baseHeader": "Base",
+      "taxHeader": "Deduction"
     }
   },
   "onboarding": {

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -113,7 +113,15 @@
       },
       "card": {
         "open": "Abrir ferramenta",
-        "disabled": "Em breve"
+        "disabled": "Em breve",
+        "use": "Usar ferramenta",
+        "viewPlans": "Ver planos",
+        "loginToUse": "Fazer login para usar",
+        "badgeLabels": {
+          "premium": "Premium",
+          "loginRequired": "Login necessário",
+          "public": "Público"
+        }
       },
       "empty": "Nenhuma ferramenta disponível no momento."
     },
@@ -638,6 +646,95 @@
         "registerCta": "Criar conta grátis",
         "loginCta": "Já tenho conta",
         "trust": "Gratuito para sempre · Sem cartão de crédito · Cancele quando quiser"
+      },
+      "form": {
+        "labels": {
+          "scenario": "Compra ou cenário",
+          "cashPrice": "Preço à vista",
+          "installmentCount": "Quantidade de parcelas",
+          "installmentInputMode": "Como você quer informar o parcelado",
+          "installmentInputAriaLabel": "Modo do parcelamento",
+          "installmentTotal": "Valor total parcelado",
+          "installmentAmount": "Valor de cada parcela",
+          "firstPayment": "Primeira parcela",
+          "customDelay": "Dias até a primeira parcela",
+          "opportunityRate": "Taxa de oportunidade",
+          "inflationRate": "Inflação anual (%)",
+          "manualRate": "Taxa de oportunidade anual (%)",
+          "fees": "Custos extras iniciais"
+        },
+        "placeholders": {
+          "scenario": "Ex.: notebook, geladeira, viagem",
+          "cashPrice": "900,00",
+          "installmentCount": "6",
+          "installmentTotal": "990,00",
+          "installmentAmount": "165,00",
+          "customDelay": "75",
+          "inflationRate": "4,50",
+          "manualRate": "12,00",
+          "fees": "60,00"
+        },
+        "opportunityRateOptions": {
+          "manual": "Manual",
+          "productDefault": "Preset do produto",
+          "inflationOnly": "Usar só inflação"
+        },
+        "delayOptions": {
+          "today": "Hoje",
+          "thirtyDays": "30 dias",
+          "fortyFiveDays": "45 dias",
+          "custom": "Personalizar"
+        },
+        "installmentInputOptions": {
+          "total": "Informar valor total parcelado",
+          "amount": "Informar valor de cada parcela"
+        },
+        "actions": {
+          "calculate": "Calcular agora"
+        }
+      },
+      "schedule": {
+        "columns": {
+          "installment": "Parcela",
+          "dueDate": "Vence em",
+          "amount": "Valor",
+          "presentValue": "Valor presente",
+          "cumulativeNominal": "Acumulado nominal",
+          "cashCumulative": "Acumulado à vista"
+        },
+        "today": "Hoje",
+        "daysUnit": "dias",
+        "ordinalSuffix": "ª"
+      },
+      "breakdown": {
+        "metrics": {
+          "cashPrice": "Preço à vista",
+          "installmentNominal": "Parcelado nominal",
+          "installmentPv": "Parcelado em valor presente",
+          "difference": "Diferença vs à vista",
+          "breakEvenDiscount": "Desconto à vista para empatar",
+          "breakEvenRate": "Taxa mínima para o parcelado empatar"
+        },
+        "monthlyComparison": {
+          "title": "Comparação mês a mês",
+          "description": "Veja o desembolso acumulado e o valor presente do parcelamento ao longo do tempo."
+        },
+        "formula": {
+          "collapseTitle": "Entenda o cálculo",
+          "title": "Fórmula e premissas",
+          "opportunityRateLabel": "Taxa de oportunidade:",
+          "rateAnnualSuffix": "% a.a.",
+          "inflationLabel": "Inflação:",
+          "neutralityBandLabel": "Faixa de neutralidade:",
+          "or": "ou",
+          "percentSuffix": "%"
+        },
+        "breakEven": {
+          "collapseTitle": "Break-even e comparação detalhada"
+        },
+        "scheduleSection": {
+          "collapseTitle": "Cronograma mês a mês"
+        }
       }
     },
     "home": {
@@ -685,6 +782,48 @@
         "subtitle": "Crie sua conta gratuita e tenha controle total sobre suas finanças.",
         "button": "Criar conta gratuita",
         "login": "Já tenho uma conta"
+      }
+    },
+    "profile": {
+      "modal": {
+        "title": "Complete seu perfil",
+        "subtitle": "Preencha seus dados financeiros para personalizar sua experiência no Auraxis.",
+        "closeAriaLabel": "Fechar modal",
+        "sectionRequired": "Dados pessoais e financeiros *",
+        "sectionOptional": "Informações opcionais",
+        "selectPlaceholder": "Selecione",
+        "labels": {
+          "gender": "Gênero",
+          "birthDate": "Data de nascimento",
+          "monthlyIncome": "Renda mensal (R$)",
+          "netWorth": "Patrimônio líquido (R$)",
+          "monthlyExpenses": "Gastos mensais (R$)",
+          "stateUf": "Estado (UF)",
+          "occupation": "Profissão",
+          "investorProfile": "Perfil de investidor",
+          "financialObjectives": "Objetivos financeiros",
+          "initialInvestment": "Investimento inicial (R$)",
+          "monthlyInvestment": "Aporte mensal (R$)",
+          "investmentGoalDate": "Data meta de investimento"
+        },
+        "placeholders": {
+          "occupation": "Ex.: Engenheiro de Software",
+          "financialObjectives": "Ex.: Aposentadoria antecipada, compra de imóvel..."
+        },
+        "genderOptions": {
+          "masculino": "Masculino",
+          "feminino": "Feminino",
+          "outro": "Outro"
+        },
+        "actions": {
+          "postpone": "Preencher depois",
+          "saving": "Salvando...",
+          "update": "Atualizar dados"
+        },
+        "messages": {
+          "success": "Seus dados foram atualizados",
+          "error": "Houve um problema ao atualizar os dados"
+        }
       }
     }
   },
@@ -2986,6 +3125,12 @@
         }
       },
       "copyright": "© {year} Auraxis. Todos os direitos reservados."
+    },
+    "taxBracketTable": {
+      "rangeHeader": "Faixa",
+      "rateHeader": "Alíquota",
+      "baseHeader": "Base",
+      "taxHeader": "Desconto"
     }
   },
   "onboarding": {


### PR DESCRIPTION
## Summary

- Migrates all hardcoded Portuguese strings from 5 components to vue-i18n keys
- Adds new locale entries to pt.json and en.json for pages.installmentVsCash.{form,schedule,breakdown}, pages.profile.modal, pages.tools.card, and components.taxBracketTable
- Wraps option arrays in computed() so labels react to locale changes at runtime
- Fixes type error in InstallmentVsCashCalculatorForm (UiSegmentedControl emit cast)

## Components updated

| Component | Changes |
|:---|:---|
| ToolCard.vue | accessBadgeLabel(), ctaLabel() to t() |
| InstallmentVsCashCalculatorForm.vue | All labels, placeholders, and option arrays to computed + t() |
| InstallmentVsCashResults.vue | scheduleColumns to computed, all template strings to t() |
| ProfileCompletionModal.vue | GENDER_LABELS, INVESTOR_PROFILE_LABELS, toasts, and all template labels to t() |
| TaxBracketTable.vue | Prop defaults to undefined; column headers fall back to t() when not provided |

## Test plan

- [x] pnpm lint - no errors
- [x] pnpm typecheck - no errors
- [x] pnpm test:coverage - all files >= 85%
- [x] pnpm policy:check - OK
- [x] pnpm contracts:check - OK
- [ ] Manual: switch locale and verify all labels update correctly

Closes #478