### PR TITLE
perf(ci): enable Lighthouse perf metrics as warn baseline (PERF-GAP-08)

### DIFF
--- a/.lighthouserc.yml
+++ b/.lighthouserc.yml
@@ -54,14 +54,29 @@ ci:
       unused-javascript:                   { severity: off }
       unused-css-rules:                    { severity: off }
 
-      # Performance metrics: too noisy on shared CI runners (no throttling
-      # consistency, no CDN, no HTTP/2 push). Tracked separately via RUM.
+      # Performance metrics: warn-only (non-blocking) to establish a Phase 0 baseline.
+      # Thresholds are generous — goal is visibility, not enforcement yet.
+      # Tighten after Phase 2 (PERF-GAP-01/02/06/07) improvements land.
+      # Note: CI runners have no throttling consistency; treat absolute numbers
+      # as relative indicators only. RUM in prod is the authoritative source.
+      'categories:performance':
+        - warn
+        - minScore: 0.5
+
+      largest-contentful-paint:
+        - warn
+        - maxNumericValue: 5000   # warn if LCP > 5s (CI runner, no CDN)
+
+      total-blocking-time:
+        - warn
+        - maxNumericValue: 1500   # warn if TBT > 1.5s
+
+      cumulative-layout-shift:
+        - warn
+        - maxNumericValue: 0.25   # warn if CLS > 0.25
+
       first-contentful-paint:              { severity: off }
-      largest-contentful-paint:            { severity: off }
-      total-blocking-time:                 { severity: off }
-      cumulative-layout-shift:             { severity: off }
       speed-index:                         { severity: off }
-      'categories:performance':            { severity: off }
       'categories:best-practices':         { severity: off }
 
   upload:

--- a/docs/PERF-lighthouse-ci.md
+++ b/docs/PERF-lighthouse-ci.md
@@ -1,0 +1,66 @@
+# Lighthouse CI — Setup e Baseline de Métricas
+
+## Como funciona
+
+O job `lighthouse` em `.github/workflows/ci.yml` executa após o `build` job em todo PR e push para `main`.
+
+Fluxo:
+
+1. `pnpm build` — build de produção (Nuxt generate/SSR)
+2. `lhci autorun` (via `treosh/lighthouse-ci-action@v12`) — lê `.lighthouserc.yml`
+3. `.lighthouserc.yml` inicia `pnpm preview` como servidor e roda 3 coletas contra `http://localhost:3000/`
+4. Resultados são enviados para `temporary-public-storage` (13 dias de retenção)
+5. O link para o relatório aparece no log do job
+
+> O Lighthouse roda contra o **build real** (`pnpm build` + `pnpm preview`), não contra o dev server.
+> Isso garante que otimizações de produção (tree-shaking, minificação, etc.) sejam consideradas.
+
+## Thresholds atuais
+
+| Métrica           | Nível                   | Threshold |
+| ----------------- | ----------------------- | --------- |
+| Accessibility     | **error** (bloqueia CI) | ≥ 0.90    |
+| SEO               | warn                    | ≥ 0.85    |
+| Performance score | warn                    | ≥ 0.50    |
+| LCP               | warn                    | ≤ 5000ms  |
+| TBT               | warn                    | ≤ 1500ms  |
+| CLS               | warn                    | ≤ 0.25    |
+
+**Nota:** Performance metrics são `warn` (não bloqueiam CI). Os valores são generosos propositalmente — o objetivo é capturar o baseline antes de apertar. Após a Fase 2 de hardening (PERF-GAP-01/02/06/07), apertar para:
+
+- Performance ≥ 0.80
+- LCP ≤ 2500ms
+- TBT ≤ 600ms
+- CLS ≤ 0.10
+
+## Como interpretar os resultados
+
+O link para o relatório aparece no output do step "Run Lighthouse CI". Exemplo:
+
+```
+✅ https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/...
+```
+
+Métricas com `⚠ warn` aparecem no log mas **não bloqueiam o merge**.
+Métricas com `✖ error` bloqueiam o merge.
+
+## Rodar localmente
+
+```bash
+# Build primeiro
+pnpm build
+
+# Rodar lhci localmente (abre relatório no browser)
+pnpm dlx @lhci/cli autorun
+```
+
+## Desabilitar temporariamente um threshold
+
+Caso uma métrica esteja failing por razão conhecida, mover de `error` para `warn` em `.lighthouserc.yml` enquanto o fix não vai para prod.
+
+## Referência
+
+- Issue: [PERF-GAP-08](https://github.com/italofelipe/auraxis-web/issues/613)
+- Próximas etapas: PERF-GAP-06 (#611), PERF-GAP-07 (#612), HARD-10 (#597)
+- Config: `.lighthouserc.yml`
+- Job: `.github/workflows/ci.yml` → job `lighthouse` (linha ~362)


### PR DESCRIPTION
## Summary

- Confirms Lighthouse CI job (`.github/workflows/ci.yml` line 362) already runs against **real build** (`pnpm build` + `pnpm preview`) — not dev server
- Enables perf metrics as `warn`-only to capture Phase 0 baseline (non-blocking):
  - Performance score ≥ 0.50 (warn)
  - LCP ≤ 5000ms (warn, generous for CI runner without CDN)
  - TBT ≤ 1500ms (warn)
  - CLS ≤ 0.25 (warn)
- Accessibility ≥ 0.90 remains **error** (blocks CI)
- Documents setup, thresholds, local run instructions and tighten-after-Phase2 plan in `docs/PERF-lighthouse-ci.md`

## Why

Fase 0 do hardening: capturar baseline de métricas antes de atacar PERF-GAP-06/07 (image opt, staleTime) e HARD-10 (bundle size). Thresholds frouxos intencionalmente — apertar após Fase 2.

## Test plan

- [ ] CI passa (perf metrics são warn, não error)
- [ ] Report URL aparece no log do step "Run Lighthouse CI"
- [ ] `pnpm dlx @lhci/cli autorun` roda localmente após `pnpm build`

Closes #613