### PR TITLE
feat(sentry): redact request body on sensitive routes (SEC-3 / Track A2)

### DIFF
--- a/__tests__/plugins/sentry.client.spec.ts
+++ b/__tests__/plugins/sentry.client.spec.ts
@@ -66,3 +66,128 @@ describe("initSentry", () => {
     expect(mockSentryInit).not.toHaveBeenCalled();
   });
 });
+
+describe("scrubPiiFromEvent — request body redaction", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("redacta request.data inteiro quando URL casa /auth/login", async () => {
+    const { scrubPiiFromEvent } = await import("../../app/plugins/sentry.client");
+    const event = {
+      request: {
+        url: "https://api.auraxis.com.br/auth/login",
+        method: "POST",
+        data: { email: "user@example.com", password: "Sup3rS3cret!" },
+      },
+    };
+    const result = scrubPiiFromEvent(
+      event as unknown as Parameters<typeof scrubPiiFromEvent>[0],
+      {} as Parameters<typeof scrubPiiFromEvent>[1],
+    );
+    expect(result.request?.data).toBe("[Filtered]");
+  });
+
+  it("redacta request.data quando URL casa /payments", async () => {
+    const { scrubPiiFromEvent } = await import("../../app/plugins/sentry.client");
+    const event = {
+      request: {
+        url: "https://api.auraxis.com.br/payments",
+        method: "POST",
+        data: {
+          card_number: "4111111111111111",
+          cvv: "123",
+          holder: "Fulano",
+        },
+      },
+    };
+    const result = scrubPiiFromEvent(
+      event as unknown as Parameters<typeof scrubPiiFromEvent>[0],
+      {} as Parameters<typeof scrubPiiFromEvent>[1],
+    );
+    expect(result.request?.data).toBe("[Filtered]");
+  });
+
+  it("redacta request.data quando URL casa /subscriptions", async () => {
+    const { scrubPiiFromEvent } = await import("../../app/plugins/sentry.client");
+    const event = {
+      request: {
+        url: "https://api.auraxis.com.br/subscriptions",
+        method: "POST",
+        data: { plan: "gold", card_token: "tok_abc123" },
+      },
+    };
+    const result = scrubPiiFromEvent(
+      event as unknown as Parameters<typeof scrubPiiFromEvent>[0],
+      {} as Parameters<typeof scrubPiiFromEvent>[1],
+    );
+    expect(result.request?.data).toBe("[Filtered]");
+  });
+
+  it("preserva request.data quando URL não casa nenhuma rota sensível", async () => {
+    const { scrubPiiFromEvent } = await import("../../app/plugins/sentry.client");
+    const event = {
+      request: {
+        url: "https://api.auraxis.com.br/transactions",
+        method: "GET",
+        data: { page: 1, limit: 20 },
+      },
+    };
+    const result = scrubPiiFromEvent(
+      event as unknown as Parameters<typeof scrubPiiFromEvent>[0],
+      {} as Parameters<typeof scrubPiiFromEvent>[1],
+    );
+    expect(result.request?.data).toEqual({ page: 1, limit: 20 });
+  });
+
+  it("redacta breadcrumbs http com URL sensível e data contendo body", async () => {
+    const { scrubPiiFromEvent } = await import("../../app/plugins/sentry.client");
+    const event = {
+      breadcrumbs: [
+        {
+          category: "xhr",
+          data: {
+            url: "https://api.auraxis.com.br/auth/login",
+            method: "POST",
+            request_body: JSON.stringify({ email: "a@b.com", password: "x" }),
+          },
+        },
+        {
+          category: "xhr",
+          data: {
+            url: "https://api.auraxis.com.br/transactions",
+            method: "GET",
+          },
+        },
+      ],
+    };
+    const result = scrubPiiFromEvent(
+      event as unknown as Parameters<typeof scrubPiiFromEvent>[0],
+      {} as Parameters<typeof scrubPiiFromEvent>[1],
+    );
+    const first = result.breadcrumbs?.[0];
+    const second = result.breadcrumbs?.[1];
+    expect(first?.data?.request_body).toBe("[Filtered]");
+    expect(second?.data?.request_body).toBeUndefined();
+    expect(second?.data?.method).toBe("GET");
+  });
+
+  it("redacta extra.body e extra.request quando presentes em rotas sensíveis", async () => {
+    const { scrubPiiFromEvent } = await import("../../app/plugins/sentry.client");
+    const event = {
+      request: { url: "https://api.auraxis.com.br/auth/login", method: "POST" },
+      extra: {
+        body: { email: "u@x.com", password: "secret" },
+        request: { endpoint: "/auth/login", payload: { password: "x" } },
+        unrelated: "keep-me",
+      },
+    };
+    const result = scrubPiiFromEvent(
+      event as unknown as Parameters<typeof scrubPiiFromEvent>[0],
+      {} as Parameters<typeof scrubPiiFromEvent>[1],
+    );
+    expect(result.extra?.body).toBe("[Filtered]");
+    expect(result.extra?.request).toBe("[Filtered]");
+    expect(result.extra?.unrelated).toBe("keep-me");
+  });
+});

--- a/app/plugins/sentry.client.ts
+++ b/app/plugins/sentry.client.ts
@@ -1,4 +1,4 @@
-import type { ErrorEvent, EventHint } from "@sentry/nuxt";
+import type { Breadcrumb, ErrorEvent, EventHint } from "@sentry/nuxt";
 import * as Sentry from "@sentry/nuxt";
 
 /**
@@ -14,6 +14,36 @@ export function normalizeDsn(raw: unknown): string {
 /** HTTP header names that carry credentials and must be stripped. */
 const REDACTED_HEADERS = new Set(["authorization", "cookie"]);
 
+/** Sentinel used by Sentry's own data scrubber for redacted values. */
+const REDACTED_PLACEHOLDER = "[Filtered]";
+
+/** Keys in `event.extra` that frequently carry request payloads. */
+const SENSITIVE_EXTRA_KEYS = new Set(["body", "request", "payload", "form"]);
+
+/**
+ * URL path fragments whose request bodies must never reach Sentry.
+ *
+ * The match is path-based (case-insensitive, substring) so it covers both
+ * absolute URLs (`https://api/.../auth/login`) and relative paths
+ * (`/auth/login`). Matches any sub-route (e.g. `/payments/webhooks`).
+ */
+const SENSITIVE_URL_FRAGMENTS = ["/auth/", "/payments", "/subscriptions"];
+
+/**
+ * Returns true if the URL path matches any route whose body carries secrets
+ * (credentials, card data, billing payloads).
+ *
+ * @param url - URL or path from request/breadcrumb context.
+ * @returns Whether the URL points at a sensitive route.
+ */
+export function isSensitiveUrl(url: string | undefined): boolean {
+  if (!url) {
+    return false;
+  }
+  const lower = url.toLowerCase();
+  return SENSITIVE_URL_FRAGMENTS.some((fragment) => lower.includes(fragment));
+}
+
 /**
  * Returns a copy of the header map with credential headers removed.
  *
@@ -28,6 +58,57 @@ const redactHeaders = (
   );
 
 /**
+ * Redacts breadcrumb payloads when their URL targets a sensitive route.
+ * Preserves unrelated breadcrumbs untouched.
+ *
+ * @param breadcrumbs - Breadcrumb list from the Sentry event.
+ * @returns Breadcrumb list with sensitive bodies replaced by the sentinel.
+ */
+function scrubBreadcrumbs(
+  breadcrumbs: Breadcrumb[] | undefined,
+): Breadcrumb[] | undefined {
+  if (!breadcrumbs) {
+    return breadcrumbs;
+  }
+  return breadcrumbs.map((crumb) => {
+    const data = crumb.data as Record<string, unknown> | undefined;
+    const url = typeof data?.url === "string" ? data.url : undefined;
+    if (!isSensitiveUrl(url)) {
+      return crumb;
+    }
+    return {
+      ...crumb,
+      data: {
+        ...data,
+        request_body: REDACTED_PLACEHOLDER,
+      },
+    };
+  });
+}
+
+/**
+ * Redacts well-known request-payload keys in `event.extra` when the event
+ * was captured against a sensitive route.
+ *
+ * @param extra - Sentry event extra bag.
+ * @returns Extra bag with sensitive keys replaced by the sentinel.
+ */
+function scrubExtra(
+  extra: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!extra) {
+    return extra;
+  }
+  const next: Record<string, unknown> = { ...extra };
+  for (const key of Object.keys(next)) {
+    if (SENSITIVE_EXTRA_KEYS.has(key)) {
+      next[key] = REDACTED_PLACEHOLDER;
+    }
+  }
+  return next;
+}
+
+/**
  * Strips personally identifiable information from a Sentry event before it is
  * transmitted to Sentry servers.
  *
@@ -35,6 +116,9 @@ const redactHeaders = (
  * - `user` object (keeps only the opaque `id`, drops email/username/ip)
  * - `request.cookies` (session tokens)
  * - `request.headers.authorization` and `request.headers.cookie`
+ * - `request.data` on sensitive routes (auth, payments, subscriptions)
+ * - `event.extra.{body,request,payload,form}` on sensitive routes
+ * - Breadcrumb `request_body` on sensitive routes
  *
  * @param event - Sentry error event to sanitize.
  * @param _hint - Event hint (unused but required by the interface).
@@ -43,6 +127,8 @@ const redactHeaders = (
 export function scrubPiiFromEvent(event: ErrorEvent, _hint: EventHint): ErrorEvent {
   const user = event.user ? { id: event.user.id } : undefined;
 
+  const sensitiveRoute = isSensitiveUrl(event.request?.url);
+
   const request = event.request
     ? {
         ...event.request,
@@ -50,10 +136,17 @@ export function scrubPiiFromEvent(event: ErrorEvent, _hint: EventHint): ErrorEve
         headers: event.request.headers
           ? redactHeaders(event.request.headers as Record<string, string>)
           : undefined,
+        data: sensitiveRoute ? REDACTED_PLACEHOLDER : event.request.data,
       }
     : undefined;
 
-  return { ...event, user, request };
+  const extra = sensitiveRoute
+    ? scrubExtra(event.extra as Record<string, unknown> | undefined)
+    : event.extra;
+
+  const breadcrumbs = scrubBreadcrumbs(event.breadcrumbs);
+
+  return { ...event, user, request, extra, breadcrumbs };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Closes gap on Sentry beforeSend scrubber: request bodies for `/auth/*`, `/payments`, `/subscriptions` now never leave the browser inside error events.
- Redacts `request.data`, `event.extra.{body,request,payload,form}`, and breadcrumb `request_body` on any URL matching a sensitive fragment.
- Adds 6 unit tests covering login password, card data, subscription payload, safe routes, breadcrumbs and `extra` bag.

## Why

Issue italofelipe/auraxis-web#632 (Track A2 — pre-beta hardening). Prior scrubber cleaned cookies and Authorization headers but left POST bodies intact — an `event.request.data` with `{ email, password }` would still ship to Sentry on login errors.

## Changes

- `app/plugins/sentry.client.ts`
  - Adds `isSensitiveUrl` helper (path-fragment match, case-insensitive).
  - Adds `scrubBreadcrumbs` + `scrubExtra` helpers.
  - Extends `scrubPiiFromEvent` to set `request.data = "[Filtered]"` when URL is sensitive, clean matching `extra` keys, and filter breadcrumb bodies regardless of surface event URL.
- `__tests__/plugins/sentry.client.spec.ts`
  - 6 new scenarios under `scrubPiiFromEvent — request body redaction`.

## Quality gates

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 249 files / 2532 tests passing
- [x] `pnpm policy:check`
- [x] `pnpm contracts:check`

## Test plan

- [ ] Provocar erro em `/auth/login` em staging, confirmar no Sentry que `request.data` vem `[Filtered]`.
- [ ] Provocar erro em `/payments` (checkout Asaas mock) e confirmar ausência de `card_number`/`cvv`.
- [ ] Verificar que rotas não sensíveis continuam com body estruturado.

Closes italofelipe/auraxis-web#632