### PR TITLE
feat(http): dedupe concurrent 401 refreshes (SEC-4 / Track A3)

### DIFF
--- a/app/core/api/__tests__/interceptors.spec.ts
+++ b/app/core/api/__tests__/interceptors.spec.ts
@@ -257,3 +257,93 @@ describe("registerResponseInterceptors — onUnauthorized (token refresh)", () =
     expect(onUnauthorized).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// 401 — concurrent refresh deduplication (stampede guard)
+// ---------------------------------------------------------------------------
+
+describe("registerResponseInterceptors — refresh stampede dedup", () => {
+  it("dez 401 concorrentes compartilham o mesmo refresh in-flight", async () => {
+    let resolveRefresh: ((token: string | null) => void) | null = null;
+    const onUnauthorized = vi.fn<() => Promise<string | null>>().mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+    // Mock the client so the retry path doesn't attempt a real network call.
+    const retryCalls: Array<Record<string, unknown>> = [];
+    const baseClient = axios.create({ baseURL: "http://localhost" });
+    const clientAsFn = baseClient as unknown as ((
+      config: unknown,
+    ) => Promise<unknown>) & { interceptors: typeof baseClient.interceptors };
+    const proxyHandler: ProxyHandler<typeof clientAsFn> = {
+      apply: (_target, _this, args: unknown[]) => {
+        retryCalls.push(args[0] as Record<string, unknown>);
+        return Promise.resolve({ data: "ok" });
+      },
+    };
+    const proxied = new Proxy(clientAsFn, proxyHandler);
+    registerResponseInterceptors(
+      proxied as unknown as ReturnType<typeof axios.create>,
+      { onUnauthorized },
+    );
+    const proxiedHandler = (
+      (proxied as unknown as typeof clientAsFn).interceptors.response as unknown as {
+        handlers: Array<{ rejected: (e: unknown) => Promise<never> }>;
+      }
+    ).handlers[0]!.rejected;
+
+    const failures = Array.from({ length: 10 }, (_, i) =>
+      Object.assign(new Error("Unauthorized"), {
+        isAxiosError: true,
+        response: { status: 401, data: { message: "Unauthorized" } },
+        config: { headers: {}, _retry: false, url: `/res/${i}` },
+      }),
+    );
+
+    const results = failures.map((err) =>
+      proxiedHandler(err).catch((e: unknown) => e),
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+
+    if (!resolveRefresh) {
+      throw new Error("refresh was never scheduled");
+    }
+    (resolveRefresh as (token: string | null) => void)("new-token");
+
+    await Promise.all(results);
+    expect(retryCalls.length).toBe(10);
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it("libera a promise cacheada após a resolução para permitir novos refreshes", async () => {
+    const onUnauthorized = vi.fn<() => Promise<string | null>>().mockResolvedValue(null);
+    const refreshClient = axios.create({ baseURL: "http://localhost" });
+    registerResponseInterceptors(refreshClient, { onUnauthorized });
+    const handler = getRejectedHandler(refreshClient);
+
+    /**
+     * Creates a fresh axios-like error object with `_retry: false` so each
+     * invocation passes the retry-guard and exercises the shared-refresh path.
+     *
+     * @returns Axios-shaped 401 error ready to hand to the interceptor.
+     */
+    const makeErr = (): Error => Object.assign(new Error("Unauthorized"), {
+      isAxiosError: true,
+      response: { status: 401, data: { message: "Unauthorized" } },
+      config: { headers: {}, _retry: false },
+    });
+
+    await handler(makeErr()).catch(() => undefined);
+    await handler(makeErr()).catch(() => undefined);
+
+    // Each sequential 401 (with its own config) must trigger a fresh refresh
+    // once the previous one has settled, even though it returned null.
+    expect(onUnauthorized).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/core/api/interceptors.ts
+++ b/app/core/api/interceptors.ts
@@ -68,11 +68,38 @@ export const toApiError = (error: unknown): ApiError => {
 };
 
 /**
+ * Deduplicates concurrent refresh calls triggered by parallel 401 responses.
+ *
+ * When N requests fail with 401 before any refresh has completed, the first
+ * one kicks off `onUnauthorized()` and the others await the same in-flight
+ * promise. Once the promise settles, the cache is cleared so subsequent
+ * 401s can trigger a fresh refresh.
+ *
+ * @param onUnauthorized Underlying refresh handler.
+ * @returns A wrapped handler that collapses concurrent calls into one.
+ */
+const createSharedRefresh = (
+  onUnauthorized: () => Promise<string | null>,
+): (() => Promise<string | null>) => {
+  let inflight: Promise<string | null> | null = null;
+  return (): Promise<string | null> => {
+    if (inflight) {
+      return inflight;
+    }
+    inflight = onUnauthorized().finally(() => {
+      inflight = null;
+    });
+    return inflight;
+  };
+};
+
+/**
  * Registers a response interceptor on the provided Axios instance.
  *
  * Behaviour by HTTP status:
  * - **401**: When `options.onUnauthorized` is provided, calls it to refresh
- *   tokens and retries the original request once. If the refresh fails or no
+ *   tokens and retries the original request once. Concurrent 401s share a
+ *   single in-flight refresh (stampede guard). If the refresh fails or no
  *   handler is configured, re-throws the 401 as an {@link ApiError}.
  * - **403**: Calls `options.onForbidden` with the localised message, then re-throws.
  * - **5xx**: Calls `options.onServerError` with the localised message, then re-throws.
@@ -88,19 +115,23 @@ export const registerResponseInterceptors = (
   client: AxiosInstance,
   options: ResponseInterceptorOptions,
 ): void => {
+  const sharedRefresh = options.onUnauthorized
+    ? createSharedRefresh(options.onUnauthorized)
+    : null;
+
   client.interceptors.response.use(
     (response) => response,
     async (error: unknown): Promise<never> => {
       const apiError = toApiError(error);
 
-      if (apiError.status === 401 && options.onUnauthorized) {
+      if (apiError.status === 401 && sharedRefresh) {
         const config = axios.isAxiosError(error)
           ? (error.config as RetryableConfig | undefined)
           : undefined;
 
         if (config && !config._retry) {
           config._retry = true;
-          const newToken = await options.onUnauthorized();
+          const newToken = await sharedRefresh();
 
           if (newToken) {
             config.headers.Authorization = `Bearer ${newToken}`;


### PR DESCRIPTION
## Summary

- Adds shared in-flight refresh promise to the Axios response interceptor so N parallel 401s collapse into a single `POST /auth/refresh`.
- Prevents refresh stampedes under Vue Query parallel fan-out (dashboard load, batch fetches).
- Complements the 401 handler already implemented in `useHttp/useHttp.ts` — no call-site changes required.

## Problem

Previously every 401 invoked `onUnauthorized()` independently: 10 parallel requests meant 10 refresh calls. Side effects:

1. Backend rate-limit (`429`) kicked in, logging the user out of their own session.
2. Refresh rotation on the server could invalidate earlier-issued access tokens mid-retry.
3. Dialog "session expired" could flash multiple times under failure.

## Fix

`createSharedRefresh(onUnauthorized)` wraps the handler so the first 401 stores the pending promise; subsequent 401s await it. `finally` clears the cache so future expirations still trigger a fresh refresh.

```ts
let inflight: Promise<string | null> | null = null;
return () => {
  if (inflight) return inflight;
  inflight = onUnauthorized().finally(() => { inflight = null; });
  return inflight;
};
```

## Tests

- `dez 401 concorrentes compartilham o mesmo refresh in-flight` — 10 parallel 401s → 1 refresh call, 10 retries.
- `libera a promise cacheada após a resolução` — 2 sequential 401s → 2 refresh calls.
- Existing 19 test suite continues green (loop guard, null refresh, 403, 5xx, ApiError normalisation).

## Quality gates

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (interceptors: 19/19)
- [x] `pnpm policy:check`
- [x] `pnpm contracts:check`

## Test plan

- [ ] Abrir dashboard com 5+ queries paralelas expiradas; observar 1 refresh apenas no DevTools Network.
- [ ] Forçar 401 → refresh 401 → confirmar dialog + redirect /login (sem flash múltiplo).

Closes italofelipe/auraxis-web#633