### PR TITLE
feat(security): env-aware CSP meta tag for dev/staging (SEC-2)

### DIFF
--- a/app/core/security/__tests__/csp.spec.ts
+++ b/app/core/security/__tests__/csp.spec.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCsp, resolveCspEnvironment } from "../csp";
+
+describe("resolveCspEnvironment", () => {
+  it("resolve 'production' e 'prod' para production", () => {
+    expect(resolveCspEnvironment("production")).toBe("production");
+    expect(resolveCspEnvironment("prod")).toBe("production");
+  });
+
+  it("resolve 'staging' e 'stage' para staging", () => {
+    expect(resolveCspEnvironment("staging")).toBe("staging");
+    expect(resolveCspEnvironment("stage")).toBe("staging");
+  });
+
+  it("cai em development quando valor é undefined", () => {
+    expect(resolveCspEnvironment(undefined)).toBe("development");
+  });
+
+  it("cai em development quando valor é desconhecido", () => {
+    expect(resolveCspEnvironment("qa")).toBe("development");
+    expect(resolveCspEnvironment("")).toBe("development");
+  });
+
+  it("é case-sensitive — 'Production' não mapeia para production", () => {
+    expect(resolveCspEnvironment("Production")).toBe("development");
+  });
+});
+
+describe("buildCsp — production", () => {
+  it("retorna null em production (header vem do CloudFront)", () => {
+    expect(buildCsp("production")).toBeNull();
+  });
+});
+
+describe("buildCsp — development", () => {
+  const csp = buildCsp("development") ?? "";
+
+  it("retorna uma string não-nula", () => {
+    expect(csp).not.toBe("");
+    expect(typeof csp).toBe("string");
+  });
+
+  it("inclui default-src 'self'", () => {
+    expect(csp).toContain("default-src 'self'");
+  });
+
+  it("permite unsafe-inline e unsafe-eval em script-src (HMR/vite)", () => {
+    expect(csp).toMatch(/script-src[^;]*'unsafe-inline'/);
+    expect(csp).toMatch(/script-src[^;]*'unsafe-eval'/);
+  });
+
+  it("permite ws: e wss: em connect-src para HMR", () => {
+    expect(csp).toMatch(/connect-src[^;]*\bws:/);
+    expect(csp).toMatch(/connect-src[^;]*\bwss:/);
+  });
+
+  it("permite http://localhost:* em connect-src", () => {
+    expect(csp).toContain("http://localhost:*");
+  });
+
+  it("inclui a API do Auraxis e o ingest do Sentry", () => {
+    expect(csp).toContain("https://api.auraxis.com.br");
+    expect(csp).toContain("https://*.sentry.io");
+  });
+
+  it("bloqueia iframes via frame-ancestors 'none'", () => {
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+});
+
+describe("buildCsp — staging", () => {
+  const csp = buildCsp("staging") ?? "";
+
+  it("retorna uma string não-nula", () => {
+    expect(csp).not.toBe("");
+  });
+
+  it("NÃO permite 'unsafe-inline' em script-src", () => {
+    const scriptDirective = csp
+      .split(";")
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith("script-src"));
+    expect(scriptDirective).toBeDefined();
+    expect(scriptDirective).not.toContain("'unsafe-inline'");
+    expect(scriptDirective).not.toContain("'unsafe-eval'");
+  });
+
+  it("NÃO permite ws:/wss: em connect-src", () => {
+    const connectDirective = csp
+      .split(";")
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith("connect-src"));
+    expect(connectDirective).toBeDefined();
+    expect(connectDirective).not.toMatch(/\bws:/);
+    expect(connectDirective).not.toMatch(/\bwss:/);
+  });
+
+  it("NÃO permite localhost em connect-src", () => {
+    expect(csp).not.toContain("localhost");
+  });
+
+  it("inclui object-src 'none' e base-uri 'self'", () => {
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'self'");
+  });
+
+  it("inclui form-action 'self'", () => {
+    expect(csp).toContain("form-action 'self'");
+  });
+
+  it("bloqueia iframes via frame-ancestors 'none'", () => {
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+
+  it("inclui a API do Auraxis e o ingest do Sentry", () => {
+    expect(csp).toContain("https://api.auraxis.com.br");
+    expect(csp).toContain("https://*.sentry.io");
+  });
+});

--- a/app/core/security/csp.ts
+++ b/app/core/security/csp.ts
@@ -1,0 +1,84 @@
+/**
+ * Content Security Policy builder for the Auraxis web app.
+ *
+ * Emits an env-aware CSP string that is baked into a `<meta http-equiv>` tag
+ * at SSG time by `nuxt.config.ts`. In production the CSP is set by the
+ * CloudFront Response Headers Policy instead, so this module returns `null`
+ * for `"production"` and the meta tag is omitted.
+ *
+ * Kept dependency-free so `nuxt.config.ts` can import it at build time and
+ * Vitest can cover it without Nuxt runtime.
+ */
+
+/**
+ * Execution environments that drive the CSP shape.
+ *
+ * - `development`: permissive — allows `unsafe-inline`/`unsafe-eval`, `ws:`
+ *   for HMR and `http://localhost:*` so Vite dev server works.
+ * - `staging`: production-equivalent — no inline scripts, only `self` + API
+ *   + Sentry ingest, surfacing any real CSP regression before prod.
+ * - `production`: returns `null` — CloudFront emits the CSP header so the
+ *   meta tag is omitted to avoid double-specification.
+ */
+export type CspEnvironment = "development" | "staging" | "production";
+
+const DEV_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data: https://fonts.gstatic.com",
+  "connect-src 'self' ws: wss: http://localhost:* https://api.auraxis.com.br https://*.sentry.io",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+].join("; ");
+
+const STAGING_CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "img-src 'self' data: https:",
+  "font-src 'self' https://fonts.gstatic.com",
+  "connect-src 'self' https://api.auraxis.com.br https://*.sentry.io",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "form-action 'self'",
+].join("; ");
+
+/**
+ * Normalises an arbitrary runtime string into a known {@link CspEnvironment}.
+ *
+ * Unknown values (including `undefined`) fall back to `"development"` — the
+ * most permissive policy — so local tooling never breaks when the env var is
+ * missing.
+ *
+ * @param raw Raw value from `process.env.NUXT_PUBLIC_APP_ENV` or similar.
+ * @returns Resolved execution environment.
+ */
+export const resolveCspEnvironment = (raw: string | undefined): CspEnvironment => {
+  if (raw === "production" || raw === "prod") {
+    return "production";
+  }
+  if (raw === "staging" || raw === "stage") {
+    return "staging";
+  }
+  return "development";
+};
+
+/**
+ * Builds the CSP string for a given environment.
+ *
+ * @param env Execution environment.
+ * @returns CSP directive string, or `null` when the environment emits the
+ *          CSP via an HTTP header (production).
+ */
+export const buildCsp = (env: CspEnvironment): string | null => {
+  if (env === "production") {
+    return null;
+  }
+  if (env === "staging") {
+    return STAGING_CSP;
+  }
+  return DEV_CSP;
+};

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,13 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 import { visualizer } from "rollup-plugin-visualizer";
+import { buildCsp, resolveCspEnvironment } from "./app/core/security/csp";
 import { TOOL_SLUGS } from "./app/data/tools";
+
+// Resolve Content Security Policy at build time based on NUXT_PUBLIC_APP_ENV.
+// Production returns null because CloudFront emits the CSP header, so no meta
+// tag is injected and there is no duplicate policy.
+const cspEnvironment = resolveCspEnvironment(process.env.NUXT_PUBLIC_APP_ENV);
+const cspPolicy = buildCsp(cspEnvironment);
 
 /**
  * Generates routeRules entries for all tool slugs (PT + EN locales).
@@ -92,6 +99,11 @@ export default defineNuxtConfig({
         // serving the current build and not a cached stale snapshot.
         // Empty string in local dev — harmless.
         { name: "x-build-id", content: process.env.NUXT_PUBLIC_BUILD_ID ?? "" },
+        // Env-aware CSP. In production the header comes from CloudFront, so
+        // `cspPolicy` is null and this entry is filtered out.
+        ...(cspPolicy
+          ? [{ "http-equiv": "Content-Security-Policy", content: cspPolicy }]
+          : []),
       ],
     },
   },


### PR DESCRIPTION
## Summary
- Adds `app/core/security/csp.ts` — dependency-free CSP builder with per-env policies (dev/staging/production).
- Wires it into `nuxt.config.ts` so `app.head.meta` emits a `<meta http-equiv=\"Content-Security-Policy\">` tag at SSG time when not in production.
- 21 new unit tests cover env resolution and directive shape.

**Policies:**
- `development`: permissive (`unsafe-inline` + `unsafe-eval` for Vite HMR, `ws:`/`wss:`/`http://localhost:*` for dev server, Sentry + Auraxis API).
- `staging`: production-equivalent — no inline scripts, no eval, no localhost; only `self`, Auraxis API and Sentry ingest. Surfaces any real CSP regression before prod.
- `production`: builder returns `null` — CloudFront Response Headers Policy emits the CSP header, so the meta tag is omitted to avoid double-specification.

Environment is resolved from `NUXT_PUBLIC_APP_ENV` at build time with a safe fallback to `development` on unknown values.

## Closes
- auraxis-web#634 (SEC-2 — CSP dev/staging)
- Track A4 of the Pre-Beta MVP1 Execution Plan

## Test plan
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm test` — 2553 passed (21 new CSP tests)
- [x] `pnpm test:coverage` — all thresholds held
- [x] `pnpm policy:check` — OK
- [x] `pnpm contracts:check` — OK
- [x] `pnpm build` — OK (pre-push hook)
- [ ] Manual: inspect built `index.html` in dev/staging and confirm CSP meta tag is present; confirm it is absent in production build