### PR TITLE
feat(security): SEC-2 — document production CSP as CloudFront custom policy

### DIFF
--- a/app/core/security/__tests__/csp.spec.ts
+++ b/app/core/security/__tests__/csp.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildCsp, resolveCspEnvironment } from "../csp";
+import { PRODUCTION_CSP, buildCsp, resolveCspEnvironment } from "../csp";
 
 describe("resolveCspEnvironment", () => {
   it("resolve 'production' e 'prod' para production", () => {
@@ -30,6 +30,49 @@ describe("resolveCspEnvironment", () => {
 describe("buildCsp — production", () => {
   it("retorna null em production (header vem do CloudFront)", () => {
     expect(buildCsp("production")).toBeNull();
+  });
+});
+
+describe("PRODUCTION_CSP", () => {
+  it("inclui default-src 'self'", () => {
+    expect(PRODUCTION_CSP).toContain("default-src 'self'");
+  });
+
+  it("inclui connect-src com a API do Auraxis e Sentry", () => {
+    expect(PRODUCTION_CSP).toContain("https://api.auraxis.com.br");
+    expect(PRODUCTION_CSP).toContain("https://*.sentry.io");
+  });
+
+  it("NÃO permite unsafe-inline em script-src", () => {
+    const scriptDirective = PRODUCTION_CSP.split(";")
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith("script-src"));
+    expect(scriptDirective).toBeDefined();
+    expect(scriptDirective).not.toContain("'unsafe-inline'");
+    expect(scriptDirective).not.toContain("'unsafe-eval'");
+  });
+
+  it("NÃO permite ws:/wss: em connect-src", () => {
+    const connectDirective = PRODUCTION_CSP.split(";")
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith("connect-src"));
+    expect(connectDirective).toBeDefined();
+    expect(connectDirective).not.toMatch(/\bws:/);
+    expect(connectDirective).not.toMatch(/\bwss:/);
+  });
+
+  it("NÃO permite localhost em connect-src", () => {
+    expect(PRODUCTION_CSP).not.toContain("localhost");
+  });
+
+  it("inclui object-src 'none', base-uri 'self' e form-action 'self'", () => {
+    expect(PRODUCTION_CSP).toContain("object-src 'none'");
+    expect(PRODUCTION_CSP).toContain("base-uri 'self'");
+    expect(PRODUCTION_CSP).toContain("form-action 'self'");
+  });
+
+  it("bloqueia iframes via frame-ancestors 'none'", () => {
+    expect(PRODUCTION_CSP).toContain("frame-ancestors 'none'");
   });
 });
 

--- a/app/core/security/csp.ts
+++ b/app/core/security/csp.ts
@@ -2,9 +2,14 @@
  * Content Security Policy builder for the Auraxis web app.
  *
  * Emits an env-aware CSP string that is baked into a `<meta http-equiv>` tag
- * at SSG time by `nuxt.config.ts`. In production the CSP is set by the
- * CloudFront Response Headers Policy instead, so this module returns `null`
- * for `"production"` and the meta tag is omitted.
+ * at SSG time by `nuxt.config.ts`. In production the CSP is emitted by a
+ * custom CloudFront response headers policy (see
+ * `auraxis-platform/infra/web/main.tf` → `aws_cloudfront_response_headers_policy.web_security`),
+ * so this module returns `null` for `"production"` and no meta tag is
+ * injected.
+ *
+ * `PRODUCTION_CSP` is exported as the canonical source of truth for the
+ * production policy — the terraform module must stay in sync with it (SEC-2).
  *
  * Kept dependency-free so `nuxt.config.ts` can import it at build time and
  * Vitest can cover it without Nuxt runtime.
@@ -17,8 +22,9 @@
  *   for HMR and `http://localhost:*` so Vite dev server works.
  * - `staging`: production-equivalent — no inline scripts, only `self` + API
  *   + Sentry ingest, surfacing any real CSP regression before prod.
- * - `production`: returns `null` — CloudFront emits the CSP header so the
- *   meta tag is omitted to avoid double-specification.
+ * - `production`: returns `null` here — CloudFront emits the CSP header via
+ *   the custom response headers policy documented in
+ *   `auraxis-platform/infra/web/main.tf`.
  */
 export type CspEnvironment = "development" | "staging" | "production";
 
@@ -34,6 +40,29 @@ const DEV_CSP = [
 ].join("; ");
 
 const STAGING_CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "img-src 'self' data: https:",
+  "font-src 'self' https://fonts.gstatic.com",
+  "connect-src 'self' https://api.auraxis.com.br https://*.sentry.io",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "form-action 'self'",
+].join("; ");
+
+/**
+ * Canonical production CSP value.
+ *
+ * Kept byte-identical to the CSP injected by the CloudFront custom
+ * response headers policy in `auraxis-platform/infra/web/main.tf`
+ * (`local.web_csp`). If you change one, change both.
+ *
+ * This constant is exported so integration tests can assert the two
+ * sources stay in sync.
+ */
+export const PRODUCTION_CSP = [
   "default-src 'self'",
   "script-src 'self'",
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
@@ -71,7 +100,8 @@ export const resolveCspEnvironment = (raw: string | undefined): CspEnvironment =
  *
  * @param env Execution environment.
  * @returns CSP directive string, or `null` when the environment emits the
- *          CSP via an HTTP header (production).
+ *          CSP via an HTTP header (production — see
+ *          `aws_cloudfront_response_headers_policy.web_security`).
  */
 export const buildCsp = (env: CspEnvironment): string | null => {
   if (env === "production") {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,8 +4,10 @@ import { buildCsp, resolveCspEnvironment } from "./app/core/security/csp";
 import { TOOL_SLUGS } from "./app/data/tools";
 
 // Resolve Content Security Policy at build time based on NUXT_PUBLIC_APP_ENV.
-// Production returns null because CloudFront emits the CSP header, so no meta
-// tag is injected and there is no duplicate policy.
+// Production returns null because the CSP is emitted by the custom CloudFront
+// response headers policy (auraxis-platform/infra/web/main.tf →
+// aws_cloudfront_response_headers_policy.web_security). No meta tag is
+// injected in production to avoid double-specification.
 const cspEnvironment = resolveCspEnvironment(process.env.NUXT_PUBLIC_APP_ENV);
 const cspPolicy = buildCsp(cspEnvironment);
 


### PR DESCRIPTION
## Summary

Makes the web side's CSP documentation match reality: production CSP is now (per the companion platform PR) emitted by a **custom** CloudFront response headers policy that actually includes Content-Security-Policy.

## Why this matters

The previous comment in \`csp.ts\` and \`nuxt.config.ts\` claimed the production CSP came from CloudFront. In reality the distribution (\`infra/web/main.tf\`) was using the AWS-managed \`SecurityHeadersPolicy\` (\`f56a12bf-5512-4c9f-9f9a-31e79a6c1887\`), which does **not** include CSP. So production was running **without CSP enforcement**, despite all the staging/dev plumbing assuming it was wired up at the edge.

This PR doesn't fix that by itself — it just captures the canonical production CSP value as an exported constant so the two sides (terraform + web) can stay in sync via a clear source of truth. The terraform change lives in:

- https://github.com/italofelipe/auraxis-platform/pull/<platform-pr>

Both PRs should land together.

## Changes

- \`app/core/security/csp.ts\` — new exported \`PRODUCTION_CSP\` constant; docstrings updated to reference the terraform resource.
- \`app/core/security/__tests__/csp.spec.ts\` — 7 new assertions on \`PRODUCTION_CSP\` (no \`unsafe-inline\`, no \`localhost\`, includes API + Sentry, \`object-src 'none'\`, \`frame-ancestors 'none'\`, etc.).
- \`nuxt.config.ts\` — build-time comment updated to point at the custom CloudFront response headers policy.

## Test plan

- [x] \`pnpm vitest run app/core/security\` → 28 passed (was 21; 7 new assertions)
- [x] \`pnpm lint\`
- [x] \`pnpm typecheck\`

Ref: GAPS_MELHORIAS_MVP1.md → Ciclo 1 / SEC-2