### PR TITLE
chore(security): SEC-2 — reconcile PRODUCTION_CSP with deployed policy

### DIFF
--- a/app/core/security/__tests__/csp.spec.ts
+++ b/app/core/security/__tests__/csp.spec.ts
@@ -38,18 +38,10 @@ describe("PRODUCTION_CSP", () => {
     expect(PRODUCTION_CSP).toContain("default-src 'self'");
   });
 
-  it("inclui connect-src com a API do Auraxis e Sentry", () => {
+  it("inclui connect-src com a API do Auraxis, Sentry e PostHog", () => {
     expect(PRODUCTION_CSP).toContain("https://api.auraxis.com.br");
     expect(PRODUCTION_CSP).toContain("https://*.sentry.io");
-  });
-
-  it("NÃO permite unsafe-inline em script-src", () => {
-    const scriptDirective = PRODUCTION_CSP.split(";")
-      .map((directive) => directive.trim())
-      .find((directive) => directive.startsWith("script-src"));
-    expect(scriptDirective).toBeDefined();
-    expect(scriptDirective).not.toContain("'unsafe-inline'");
-    expect(scriptDirective).not.toContain("'unsafe-eval'");
+    expect(PRODUCTION_CSP).toContain("https://*.posthog.com");
   });
 
   it("NÃO permite ws:/wss: em connect-src", () => {
@@ -65,8 +57,7 @@ describe("PRODUCTION_CSP", () => {
     expect(PRODUCTION_CSP).not.toContain("localhost");
   });
 
-  it("inclui object-src 'none', base-uri 'self' e form-action 'self'", () => {
-    expect(PRODUCTION_CSP).toContain("object-src 'none'");
+  it("inclui base-uri 'self' e form-action 'self'", () => {
     expect(PRODUCTION_CSP).toContain("base-uri 'self'");
     expect(PRODUCTION_CSP).toContain("form-action 'self'");
   });

--- a/app/core/security/csp.ts
+++ b/app/core/security/csp.ts
@@ -55,23 +55,23 @@ const STAGING_CSP = [
 /**
  * Canonical production CSP value.
  *
- * Kept byte-identical to the CSP injected by the CloudFront custom
- * response headers policy in `auraxis-platform/infra/web/main.tf`
- * (`local.web_csp`). If you change one, change both.
+ * Byte-identical to the CSP currently served by CloudFront distribution
+ * E38WVQOCDQADWB (custom response headers policy
+ * `8078897a-1312-4e87-8730-4c959789ecde`), and to `local.web_csp` in
+ * `auraxis-platform/infra/web/main.tf`. If you change one, change all three.
  *
- * This constant is exported so integration tests can assert the two
- * sources stay in sync.
+ * This constant is exported so integration tests can assert the sources
+ * stay in sync.
  */
 export const PRODUCTION_CSP = [
   "default-src 'self'",
-  "script-src 'self'",
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-  "img-src 'self' data: https:",
-  "font-src 'self' https://fonts.gstatic.com",
-  "connect-src 'self' https://api.auraxis.com.br https://*.sentry.io",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self'",
+  "connect-src 'self' https://api.auraxis.com.br https://*.sentry.io https://*.posthog.com",
   "frame-ancestors 'none'",
   "base-uri 'self'",
-  "object-src 'none'",
   "form-action 'self'",
 ].join("; ");
 


### PR DESCRIPTION
## Summary

During SEC-2 validation against production, discovered that `PRODUCTION_CSP` in `app/core/security/csp.ts` had **drifted** from the CSP actually served by CloudFront (`E38WVQOCDQADWB`, custom response headers policy `8078897a-1312-4e87-8730-4c959789ecde`). The code claimed a stricter CSP than production was enforcing.

**Before (code — incorrect)**
```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.auraxis.com.br https://*.sentry.io; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'
```

**After (byte-identical to deployed)**
```
default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://api.auraxis.com.br https://*.sentry.io https://*.posthog.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
```

Key differences versus previous code:
- script-src now includes `'unsafe-inline' 'unsafe-eval'` (required by current inline scripts and/or PostHog)
- connect-src now includes `https://*.posthog.com` (analytics endpoint)
- dropped `object-src 'none'` (not in deployed policy)
- dropped `https://fonts.googleapis.com`/`https://fonts.gstatic.com` (not in deployed policy)
- img-src uses `data: blob:` instead of `data: https:`

## Why not tighten instead?

Tightening is still the right long-term direction, but flipping CloudFront to the stricter CSP without auditing production consumers is risky (would block PostHog analytics and inline scripts). The paired platform PR documents this as follow-up work. This PR aligns code with reality so future readers are not misled.

## Sibling PR

Platform: `chore/sec-2-reconcile-csp-drift` — updates `infra/web/main.tf` `local.web_csp` and the terraform docstring to the same byte-identical value.

## Test plan
- [x] `pnpm vitest run app/core/security/__tests__/csp.spec.ts` — 27 passed
- [x] `pnpm lint app/core/security/` — clean
- [x] `pnpm typecheck` — clean