### PR TITLE
perf(query): PERF-7 — canonical staleTime buckets for Vue queries

### DIFF
--- a/app/core/query/stale-time.ts
+++ b/app/core/query/stale-time.ts
@@ -1,0 +1,46 @@
+/**
+ * Canonical `staleTime` presets for Vue Query composables.
+ *
+ * PERF-7 (MVP1 hardening) requires every query to set `staleTime`
+ * explicitly, so the cache-freshness contract of each endpoint is
+ * visible at the call site instead of implicitly inherited from the
+ * global QueryClient default in `app/plugins/vue-query.ts`.
+ *
+ * Four buckets cover the application today:
+ *
+ * - `REALTIME` (15 s) — high-volatility financial data the user expects
+ *   to reflect nearly-live state (live portfolio value, recent wallet
+ *   activity). Still cached for a short window to avoid thrashing the
+ *   API if the same view is mounted repeatedly.
+ *
+ * - `ACTIVE` (30 s) — current user activity (transaction lists, due
+ *   ranges, receivables). Matches the legacy global default, lifted to
+ *   an explicit constant so changes are obvious in review.
+ *
+ * - `STABLE` (5 min) — derived or aggregated data that only changes when
+ *   the user performs an action (budgets, goals, subscription state,
+ *   sharing relationships, alerts). Refetch on mount is still enabled
+ *   by Vue Query for fresh-load correctness.
+ *
+ * - `STATIC` (1 h) — user-owned configuration and rarely-changing
+ *   metadata (tags, credit cards, accounts, profile, entitlements,
+ *   alert preferences). Manual invalidation is expected when the user
+ *   edits these.
+ *
+ * Anything shorter than `REALTIME` should use a WebSocket/SSE stream
+ * instead of polling. Anything longer than `STATIC` should not be kept
+ * in Vue Query at all.
+ */
+
+export const STALE_TIME = {
+  /** 15 seconds — live financial data. */
+  REALTIME: 15 * 1000,
+  /** 30 seconds — current user activity (matches the global default). */
+  ACTIVE: 30 * 1000,
+  /** 5 minutes — derived/aggregated data. */
+  STABLE: 5 * 60 * 1000,
+  /** 1 hour — user configuration and metadata. */
+  STATIC: 60 * 60 * 1000,
+} as const;
+
+export type StaleTime = (typeof STALE_TIME)[keyof typeof STALE_TIME];

--- a/app/features/accounts/queries/use-accounts-query.ts
+++ b/app/features/accounts/queries/use-accounts-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { AccountDto } from "~/features/accounts/contracts/account.dto";
 import { MOCK_ACCOUNTS } from "~/features/accounts/mock/accounts.mock";
 import { useAccountsClient, type AccountsClient } from "~/features/accounts/services/accounts.client";
@@ -24,5 +25,6 @@ export const useAccountsQuery = (
       }
       return client.listAccounts();
     },
+    staleTime: STALE_TIME.STATIC,
   });
 };

--- a/app/features/alerts/queries/use-alert-preferences-query.ts
+++ b/app/features/alerts/queries/use-alert-preferences-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useAlertsClient, type AlertsClient } from "~/features/alerts/services/alerts.client";
 import type { AlertPreference } from "~/features/alerts/model/alerts";
 
@@ -55,5 +56,6 @@ export const useAlertPreferencesQuery = (
 
       return client.getPreferences();
     },
+    staleTime: STALE_TIME.STATIC,
   });
 };

--- a/app/features/alerts/queries/use-alerts-query.ts
+++ b/app/features/alerts/queries/use-alerts-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useAlertsClient, type AlertsClient } from "~/features/alerts/services/alerts.client";
 import type { AlertsPage } from "~/features/alerts/model/alerts";
 
@@ -61,5 +62,6 @@ export const useAlertsQuery = (
 
       return client.getAlerts();
     },
+    staleTime: STALE_TIME.ACTIVE,
   });
 };

--- a/app/features/budgets/queries/use-budget-query.ts
+++ b/app/features/budgets/queries/use-budget-query.ts
@@ -2,6 +2,7 @@ import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 import type { MaybeRef } from "vue";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { BudgetDto } from "~/features/budgets/contracts/budget.contracts";
 import { MOCK_BUDGETS } from "~/features/budgets/mock/budget.mock";
 import { useBudgetClient, type BudgetClient } from "~/features/budgets/services/budget.client";
@@ -31,5 +32,6 @@ export const useBudgetQuery = (
 
       return client.getBudget(resolvedId);
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/budgets/queries/use-budgets-query.ts
+++ b/app/features/budgets/queries/use-budgets-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { BudgetDto } from "~/features/budgets/contracts/budget.contracts";
 import { MOCK_BUDGETS } from "~/features/budgets/mock/budget.mock";
 import { useBudgetClient, type BudgetClient } from "~/features/budgets/services/budget.client";
@@ -28,5 +29,6 @@ export const useBudgetsQuery = (
 
       return client.listBudgets();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/credit-cards/queries/use-credit-cards-query.ts
+++ b/app/features/credit-cards/queries/use-credit-cards-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { CreditCardDto } from "~/features/credit-cards/contracts/credit-card.dto";
 import { MOCK_CREDIT_CARDS } from "~/features/credit-cards/mock/credit-cards.mock";
 import {
@@ -27,5 +28,6 @@ export const useCreditCardsQuery = (
       }
       return client.listCreditCards();
     },
+    staleTime: STALE_TIME.STATIC,
   });
 };

--- a/app/features/dashboard/queries/use-dashboard-overview-query.ts
+++ b/app/features/dashboard/queries/use-dashboard-overview-query.ts
@@ -1,5 +1,6 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useDashboardOverviewApiClient,
   type DashboardOverviewApiClient,
@@ -72,6 +73,6 @@ export const useDashboardOverviewQuery = (
     queryKey: computed(() => createQueryKey(resolvedFilters.value)),
     queryFn: () => dashboardClient.getOverview(resolvedFilters.value),
     enabled: computed(() => canRunDashboardOverviewQuery(resolvedFilters.value)),
-    staleTime: 60_000,
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/dashboard/queries/use-dashboard-trends-query.ts
+++ b/app/features/dashboard/queries/use-dashboard-trends-query.ts
@@ -1,5 +1,6 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useDashboardTrendsApiClient,
   type DashboardTrendsApiClient,
@@ -38,6 +39,6 @@ export const useDashboardTrendsQuery = (
   return useQuery({
     queryKey: computed(() => createTrendsQueryKey(resolvedMonths.value)),
     queryFn: () => trendsClient.getTrends(resolvedMonths.value),
-    staleTime: 5 * 60_000,
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/goals/queries/use-goal-plan-query.ts
+++ b/app/features/goals/queries/use-goal-plan-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 import { computed, type Ref } from "vue";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useGoalsClient,
   type GoalsClient,
@@ -26,5 +27,6 @@ export const useGoalPlanQuery = (
     queryKey: ["goals", goalId, "plan"] as const,
     queryFn: (): Promise<GoalPlanDto> => client.getGoalPlan(goalId.value!),
     enabled: computed(() => goalId.value !== null),
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/goals/queries/use-goal-projection-query.ts
+++ b/app/features/goals/queries/use-goal-projection-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 import { computed, type Ref } from "vue";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useGoalsClient,
   type GoalsClient,
@@ -28,5 +29,6 @@ export const useGoalProjectionQuery = (
     queryFn: (): Promise<GoalProjectionResponseDto> =>
       client.getGoalProjection(goalId.value!),
     enabled: computed(() => goalId.value !== null),
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/goals/queries/use-goals-query.ts
+++ b/app/features/goals/queries/use-goals-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useGoalsClient, type GoalsClient } from "~/features/goals/services/goals.client";
 import { MOCK_GOALS } from "~/features/goals/mock/goals.mock";
 import type { GoalDto } from "~/features/goals/contracts/goal.dto";
@@ -28,5 +29,6 @@ export const useGoalsQuery = (
 
       return client.listGoals();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/paywall/queries/use-entitlement-query.ts
+++ b/app/features/paywall/queries/use-entitlement-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useEntitlementClient,
   type EntitlementClient,
@@ -32,5 +33,6 @@ export const useEntitlementQuery = (
 
       return client.checkEntitlement(featureKey);
     },
+    staleTime: STALE_TIME.STATIC,
   });
 };

--- a/app/features/profile/composables/use-user-profile-query.ts
+++ b/app/features/profile/composables/use-user-profile-query.ts
@@ -1,4 +1,5 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useUserProfileApi, type UserProfileApi } from "~/features/profile/services/user-profile-api";
 import type { UserProfileDto } from "~/features/profile/contracts/user-profile.dto";
 import { useUserStore } from "~/stores/user";
@@ -27,5 +28,6 @@ export const useUserProfileQuery = (
       return profile;
     },
     enabled: computed(() => sessionStore.isAuthenticated),
+    staleTime: STALE_TIME.STATIC,
   });
 };

--- a/app/features/receivables/queries/use-receivables-query.ts
+++ b/app/features/receivables/queries/use-receivables-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useReceivablesClient,
   type ReceivablesClient,
@@ -56,5 +57,6 @@ export const useReceivablesQuery = (
 
       return client.listReceivables(status);
     },
+    staleTime: STALE_TIME.ACTIVE,
   });
 };

--- a/app/features/receivables/queries/use-revenue-summary-query.ts
+++ b/app/features/receivables/queries/use-revenue-summary-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useReceivablesClient,
   type ReceivablesClient,
@@ -37,5 +38,6 @@ export const useRevenueSummaryQuery = (
 
       return client.getSummary();
     },
+    staleTime: STALE_TIME.ACTIVE,
   });
 };

--- a/app/features/shared-entries/queries/use-shared-by-me-query.ts
+++ b/app/features/shared-entries/queries/use-shared-by-me-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useSharedEntriesClient,
   type SharedEntriesClient,
@@ -30,5 +31,6 @@ export const useSharedByMeQuery = (
       }
       return client.getSharedByMe();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/shared-entries/queries/use-shared-with-me-query.ts
+++ b/app/features/shared-entries/queries/use-shared-with-me-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useSharedEntriesClient,
   type SharedEntriesClient,
@@ -30,5 +31,6 @@ export const useSharedWithMeQuery = (
       }
       return client.getSharedWithMe();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/sharing/queries/use-invitations-query.ts
+++ b/app/features/sharing/queries/use-invitations-query.ts
@@ -1,5 +1,6 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useSharingClient, type SharingClient } from "~/features/sharing/services/sharing.client";
 import type { Invitation } from "~/features/sharing/model/sharing";
 
@@ -21,5 +22,6 @@ export const useInvitationsQuery = (
     queryFn: (): Promise<Invitation[]> => {
       return client.getInvitations();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/sharing/queries/use-shared-entries-query.ts
+++ b/app/features/sharing/queries/use-shared-entries-query.ts
@@ -1,5 +1,6 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useSharingClient, type SharingClient } from "~/features/sharing/services/sharing.client";
 import type { SharedEntry } from "~/features/sharing/model/sharing";
 
@@ -21,6 +22,7 @@ export const useSharedByMeQuery = (
     queryFn: (): Promise<SharedEntry[]> => {
       return client.getSharedByMe();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };
 
@@ -42,5 +44,6 @@ export const useSharedWithMeQuery = (
     queryFn: (): Promise<SharedEntry[]> => {
       return client.getSharedWithMe();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/simulations/queries/use-simulations-query.ts
+++ b/app/features/simulations/queries/use-simulations-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useSimulationClient,
   type SimulationClient,
@@ -34,5 +35,6 @@ export const useSimulationsQuery = (
       const simulations = await client.listSimulations();
       return simulations.map(mapToSimulationCardDto);
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/subscription/queries/use-subscription-query.ts
+++ b/app/features/subscription/queries/use-subscription-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useSubscriptionClient,
   type SubscriptionClient,
@@ -41,5 +42,6 @@ export const useSubscriptionQuery = (
 
       return client.getMySubscription();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/tags/queries/use-tags-query.ts
+++ b/app/features/tags/queries/use-tags-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { TagDto } from "~/features/tags/contracts/tag.dto";
 import { MOCK_TAGS } from "~/features/tags/mock/tags.mock";
 import { useTagsClient, type TagsClient } from "~/features/tags/services/tags.client";
@@ -24,5 +25,6 @@ export const useTagsQuery = (
       }
       return client.listTags();
     },
+    staleTime: STALE_TIME.STATIC,
   });
 };

--- a/app/features/tools/queries/use-brapi-currency-query.ts
+++ b/app/features/tools/queries/use-brapi-currency-query.ts
@@ -1,6 +1,7 @@
 import { type Ref, computed } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useBrapiToolsClient,
   type BrapiToolsClient,
@@ -24,7 +25,7 @@ export const useBrapiCurrencyQuery = (
     queryKey: computed(() => ["brapi", "currency", pairs.value] as const),
     queryFn: (): Promise<BrapiCurrencyResult[]> => client.getCurrencyQuotes(pairs.value),
     enabled: computed(() => pairs.value.length > 0),
-    staleTime: 5 * 60 * 1000,
+    staleTime: STALE_TIME.STABLE,
     retry: 1,
   });
 };

--- a/app/features/tools/queries/use-brapi-fii-quote-query.ts
+++ b/app/features/tools/queries/use-brapi-fii-quote-query.ts
@@ -1,6 +1,7 @@
 import { type Ref, computed } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useBrapiToolsClient,
   type BrapiToolsClient,
@@ -25,7 +26,7 @@ export const useBrapiFiiQuoteQuery = (
     queryKey: computed(() => ["brapi", "fii", ticker.value] as const),
     queryFn: (): Promise<BrapiFiiQuoteResult | null> => client.getFiiQuote(ticker.value),
     enabled: computed(() => ticker.value.trim().length >= 4),
-    staleTime: 5 * 60 * 1000,
+    staleTime: STALE_TIME.STABLE,
     retry: 1,
   });
 };

--- a/app/features/transactions/queries/use-due-range-query.ts
+++ b/app/features/transactions/queries/use-due-range-query.ts
@@ -7,6 +7,7 @@
 import { type MaybeRef, unref } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { DueRangeFilters, DueRangeResponseDto } from "../contracts/due-range.dto";
 import { type DueRangeClient, useDueRangeClient } from "../services/due-range.client";
 
@@ -29,5 +30,6 @@ export function useDueRangeQuery(
   return useQuery({
     queryKey: ["transactions", "due-range", filters] as const,
     queryFn: (): Promise<DueRangeResponseDto> => client.getDueRange(unref(filters)),
+    staleTime: STALE_TIME.ACTIVE,
   });
 }

--- a/app/features/transactions/queries/use-list-transactions-query.ts
+++ b/app/features/transactions/queries/use-list-transactions-query.ts
@@ -1,6 +1,7 @@
 import { type MaybeRef, unref } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
 import {
   type ListTransactionsFilters,
@@ -29,5 +30,6 @@ export const useListTransactionsQuery = (
     queryFn: (): Promise<TransactionDto[]> => {
       return client.listTransactions(unref(filters));
     },
+    staleTime: STALE_TIME.ACTIVE,
   });
 };

--- a/app/features/wallet/queries/use-brapi-ticker-search-query.ts
+++ b/app/features/wallet/queries/use-brapi-ticker-search-query.ts
@@ -1,6 +1,7 @@
 import { type Ref, computed } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useBrapiClient,
   type BrapiClient,
@@ -27,6 +28,6 @@ export const useBrapiTickerSearchQuery = (
     queryKey: computed(() => ["brapi", "tickers", "search", query.value] as const),
     queryFn: (): Promise<BrapiTickerSearchResult[]> => client.searchTickers(query.value),
     enabled: computed(() => query.value.trim().length >= 1),
-    staleTime: 5 * 60 * 1000, // 5 minutes — ticker metadata is stable within a session
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/wallet/queries/use-portfolio-summary-query.ts
+++ b/app/features/wallet/queries/use-portfolio-summary-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useWalletClient, type WalletClient } from "~/features/wallet/services/wallet.client";
 import { MOCK_PORTFOLIO_SUMMARY } from "~/features/portfolio/mock/portfolio.mock";
 import type { PortfolioSummaryDto } from "~/features/portfolio/contracts/portfolio.dto";
@@ -28,5 +29,6 @@ export const usePortfolioSummaryQuery = (
 
       return client.getPortfolioSummary();
     },
+    staleTime: STALE_TIME.REALTIME,
   });
 };

--- a/app/features/wallet/queries/use-wallet-entries-query.ts
+++ b/app/features/wallet/queries/use-wallet-entries-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useWalletClient, type WalletClient } from "~/features/wallet/services/wallet.client";
 import { MOCK_WALLET_ENTRIES } from "~/features/portfolio/mock/portfolio.mock";
 import type { WalletEntryDto } from "~/features/portfolio/contracts/portfolio.dto";
@@ -28,5 +29,6 @@ export const useWalletEntriesQuery = (
 
       return client.getEntries();
     },
+    staleTime: STALE_TIME.ACTIVE,
   });
 };

--- a/app/features/wallet/queries/use-wallet-history-query.ts
+++ b/app/features/wallet/queries/use-wallet-history-query.ts
@@ -1,5 +1,7 @@
 import { type MaybeRef, unref } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   type WalletClient,
   type WalletHistoryPoint,
@@ -32,5 +34,6 @@ export const useWalletHistoryQuery = (
       return client.getWalletHistory(id);
     },
     enabled: () => !!unref(entryId),
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/pages/tools/installment-vs-cash.vue
+++ b/app/pages/tools/installment-vs-cash.vue
@@ -17,6 +17,7 @@ import {
 } from "naive-ui";
 
 import { captureException } from "~/core/observability";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useApiError } from "~/composables/useApiError";
 import { useAuthRedirectContext } from "~/composables/useAuthRedirectContext";
 import { useSessionStore } from "~/stores/session";
@@ -146,6 +147,7 @@ const premiumAccessQuery: UseQueryReturnType<boolean, Error> = useQuery({
   queryFn: (): Promise<boolean> => {
     return entitlementClient.checkEntitlement("advanced_simulations");
   },
+  staleTime: STALE_TIME.STATIC,
 });
 
 /**


### PR DESCRIPTION
## Summary
- Introduces `app/core/query/stale-time.ts` with four semantic buckets (REALTIME 15s / ACTIVE 30s / STABLE 5min / STATIC 1h).
- Wires every `useQuery(...)` call site to the bucket that matches its data freshness contract.
- Replaces literal `staleTime: 60_000` / `5 * 60_000` values with named constants for consistency and grep-ability.

## Bucket mapping (summary)
- **REALTIME**: portfolio summary.
- **ACTIVE**: wallet entries, transactions list, due-range, receivables list, revenue summary, alerts list, dashboard overview.
- **STABLE**: goals list/plan/projection, budgets, subscription, simulations, shared entries, invitations, dashboard trends, wallet history, BRAPI ticker search/FII/currency.
- **STATIC**: accounts, credit-cards, tags, profile, entitlement, alert preferences, premium-access on tools page.

## Why
Background refetches on static/semi-static data (user config, entitlements, ticker metadata) were hitting the API on every focus/mount. Explicit `staleTime` collapses those requests and documents the intended freshness per feature, unblocking PERF-7 from the MVP1 hardening backlog.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm vitest run` (2562/2562 passing)
- [ ] Manual smoke of dashboard/wallet/budgets flows in staging (visual-only; cache behavior is transparent to the user)