### PR TITLE
feat(ui): UX-3 standardize skeleton loaders via BaseSkeleton

### DIFF
--- a/app/components/alert/AlertPreferencesList.vue
+++ b/app/components/alert/AlertPreferencesList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { NCard, NEmpty, NSkeleton, NSpace } from "naive-ui";
+import { NCard, NEmpty, NSpace } from "naive-ui";
+import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
 
 import type { AlertPreference } from "~/features/alerts/model/alerts";
 
@@ -40,7 +41,7 @@ const onToggle = (category: string, enabled: boolean): void => {
   <NCard :title="$t('alert.preferences.title')">
     <!-- Loading skeletons -->
     <NSpace v-if="isLoading" vertical :size="12">
-      <NSkeleton v-for="n in 4" :key="n" height="52px" :sharp="false" />
+      <BaseSkeleton :repeat="4" height="52px" />
     </NSpace>
 
     <!-- Empty state -->

--- a/app/components/alert/AlertsList.vue
+++ b/app/components/alert/AlertsList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { NCard, NEmpty, NSkeleton, NSpace } from "naive-ui";
+import { NCard, NEmpty, NSpace } from "naive-ui";
+import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
 
 import type { Alert } from "~/features/alerts/model/alerts";
 
@@ -45,7 +46,7 @@ const onDelete = (id: string): void => {
   <NCard :title="$t('alert.list.title')">
     <!-- Loading skeletons -->
     <NSpace v-if="isLoading" vertical :size="12">
-      <NSkeleton v-for="n in 3" :key="n" height="72px" :sharp="false" />
+      <BaseSkeleton :repeat="3" height="72px" />
     </NSpace>
 
     <!-- Empty state -->

--- a/app/components/goal/GoalCard/GoalCard.spec.ts
+++ b/app/components/goal/GoalCard/GoalCard.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from "@vue/test-utils";
 import { describe, it, expect } from "vitest";
-import { NTag, NProgress, NSkeleton } from "naive-ui";
+import { NTag, NProgress } from "naive-ui";
 
 import GoalCard from "./GoalCard.vue";
 import type { GoalDto } from "~/features/goals/contracts/goal.dto";
@@ -114,7 +114,7 @@ describe("GoalCard", () => {
 
   it("shows skeleton elements when loading is true", () => {
     const wrapper = mountGoalCard(makeGoal(), true);
-    expect(wrapper.findAllComponents(NSkeleton).length).toBeGreaterThan(0);
+    expect(wrapper.findAll("[data-testid='base-skeleton']").length).toBeGreaterThan(0);
     expect(wrapper.findComponent(NProgress).exists()).toBe(false);
   });
 

--- a/app/components/goal/GoalCard/GoalCard.vue
+++ b/app/components/goal/GoalCard/GoalCard.vue
@@ -5,10 +5,10 @@ import {
   NProgress,
   NStatistic,
   NButton,
-  NSkeleton,
   NPopconfirm,
   NSpace,
 } from "naive-ui";
+import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
 import { formatCurrency } from "~/utils/currency";
 import type { GoalCardProps } from "./GoalCard.types";
 import type { GoalDto, GoalStatus } from "~/features/goals/contracts/goal.dto";
@@ -139,10 +139,10 @@ const healthLabel = computed((): string => {
     content-style="padding: var(--space-3);"
   >
     <template v-if="props.loading">
-      <NSkeleton height="20px" width="60%" :sharp="false" />
-      <NSkeleton height="14px" width="40%" :sharp="false" style="margin-top: 8px;" />
-      <NSkeleton height="8px" :sharp="false" style="margin-top: 12px;" />
-      <NSkeleton height="40px" :sharp="false" style="margin-top: 12px;" />
+      <BaseSkeleton height="20px" width="60%" />
+      <BaseSkeleton height="14px" width="40%" />
+      <BaseSkeleton height="8px" />
+      <BaseSkeleton height="40px" />
     </template>
 
     <template v-else>

--- a/app/components/paywall/PaywallGate.spec.ts
+++ b/app/components/paywall/PaywallGate.spec.ts
@@ -10,11 +10,7 @@ vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
   useEntitlementQuery: useEntitlementQueryMock,
 }));
 
-const stubs = {
-  NSkeleton: {
-    template: "<div class='n-skeleton' />",
-  },
-};
+const stubs = {};
 
 const defaultSlotContent = "<span class='default-slot'>Feature content</span>";
 const lockedSlotContent = "<span class='locked-slot'>Upgrade required</span>";
@@ -35,7 +31,7 @@ describe("PaywallGate", () => {
       global: { stubs },
     });
 
-    expect(wrapper.find(".n-skeleton").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='base-skeleton']").exists()).toBe(true);
     expect(wrapper.find(".default-slot").exists()).toBe(false);
     expect(wrapper.find(".locked-slot").exists()).toBe(false);
   });
@@ -57,7 +53,7 @@ describe("PaywallGate", () => {
 
     expect(wrapper.find(".default-slot").exists()).toBe(true);
     expect(wrapper.find(".locked-slot").exists()).toBe(false);
-    expect(wrapper.find(".n-skeleton").exists()).toBe(false);
+    expect(wrapper.find("[data-testid='base-skeleton']").exists()).toBe(false);
   });
 
   it("renders locked slot when has_access is false", () => {
@@ -77,7 +73,7 @@ describe("PaywallGate", () => {
 
     expect(wrapper.find(".locked-slot").exists()).toBe(true);
     expect(wrapper.find(".default-slot").exists()).toBe(false);
-    expect(wrapper.find(".n-skeleton").exists()).toBe(false);
+    expect(wrapper.find("[data-testid='base-skeleton']").exists()).toBe(false);
   });
 
   it("renders locked slot when data is undefined (not yet resolved)", () => {

--- a/app/components/paywall/PaywallGate.vue
+++ b/app/components/paywall/PaywallGate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { NSkeleton } from "naive-ui";
+import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
 import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
 import type { FeatureKey } from "~/features/paywall/model/entitlement";
 
@@ -14,7 +14,7 @@ const { isLoading, data: hasAccessData } = useEntitlementQuery(props.feature);
 
 <template>
   <div class="paywall-gate">
-    <NSkeleton v-if="isLoading" height="120px" :sharp="false" />
+    <BaseSkeleton v-if="isLoading" height="120px" />
     <slot v-else-if="hasAccessData === true" />
     <slot v-else name="locked" />
   </div>

--- a/app/components/paywall/UiPaywallGate.spec.ts
+++ b/app/components/paywall/UiPaywallGate.spec.ts
@@ -10,11 +10,7 @@ vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
   useEntitlementQuery: useEntitlementQueryMock,
 }));
 
-const stubs = {
-  NSkeleton: {
-    template: "<div class='n-skeleton' />",
-  },
-};
+const stubs = {};
 
 const defaultSlotContent = "<span class='default-slot'>Feature content</span>";
 const lockedSlotContent = "<span class='locked-slot'>Upgrade required</span>";
@@ -35,7 +31,7 @@ describe("UiPaywallGate", () => {
       global: { stubs },
     });
 
-    expect(wrapper.find(".n-skeleton").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='base-skeleton']").exists()).toBe(true);
     expect(wrapper.find(".default-slot").exists()).toBe(false);
     expect(wrapper.find(".locked-slot").exists()).toBe(false);
   });
@@ -57,7 +53,7 @@ describe("UiPaywallGate", () => {
 
     expect(wrapper.find(".default-slot").exists()).toBe(true);
     expect(wrapper.find(".locked-slot").exists()).toBe(false);
-    expect(wrapper.find(".n-skeleton").exists()).toBe(false);
+    expect(wrapper.find("[data-testid='base-skeleton']").exists()).toBe(false);
   });
 
   it("renders locked slot when has_access is false", () => {
@@ -77,7 +73,7 @@ describe("UiPaywallGate", () => {
 
     expect(wrapper.find(".locked-slot").exists()).toBe(true);
     expect(wrapper.find(".default-slot").exists()).toBe(false);
-    expect(wrapper.find(".n-skeleton").exists()).toBe(false);
+    expect(wrapper.find("[data-testid='base-skeleton']").exists()).toBe(false);
   });
 
   it("renders locked slot when data is undefined (not yet resolved)", () => {

--- a/app/components/paywall/UiPaywallGate.stories.ts
+++ b/app/components/paywall/UiPaywallGate.stories.ts
@@ -7,8 +7,8 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/vue3";
-import { NSkeleton } from "naive-ui";
 import { type VNode, defineComponent, h } from "vue";
+import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
 import UiPaywallGate from "./UiPaywallGate.vue";
 
 /**
@@ -18,10 +18,10 @@ import UiPaywallGate from "./UiPaywallGate.vue";
 
 const LoadingDemo = defineComponent({
   name: "LoadingDemo",
-  components: { NSkeleton },
+  components: { BaseSkeleton },
   template: `
     <div class="ui-paywall-gate" style="width:320px">
-      <NSkeleton height="120px" :sharp="false" />
+      <BaseSkeleton height="120px" />
     </div>
   `,
 });

--- a/app/components/paywall/UiPaywallGate.vue
+++ b/app/components/paywall/UiPaywallGate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { NSkeleton } from "naive-ui";
+import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
 import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
 import type { FeatureKey } from "~/features/paywall/model/entitlement";
 
@@ -18,7 +18,7 @@ const { isLoading, data: hasAccessData } = useEntitlementQuery(props.feature);
 
 <template>
   <div class="ui-paywall-gate">
-    <NSkeleton v-if="isLoading" height="120px" :sharp="false" />
+    <BaseSkeleton v-if="isLoading" height="120px" />
     <slot v-else-if="hasAccessData === true" />
     <slot v-else name="locked" />
   </div>

--- a/app/components/portfolio/PortfolioSummaryBar/PortfolioSummaryBar.spec.ts
+++ b/app/components/portfolio/PortfolioSummaryBar/PortfolioSummaryBar.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from "@vue/test-utils";
 import { describe, it, expect } from "vitest";
-import { NStatistic, NSkeleton } from "naive-ui";
+import { NStatistic } from "naive-ui";
 
 import PortfolioSummaryBar from "./PortfolioSummaryBar.vue";
 import type { PortfolioSummaryDto } from "~/features/portfolio/contracts/portfolio.dto";
@@ -39,7 +39,7 @@ describe("PortfolioSummaryBar", () => {
 
   it("shows 4 skeleton elements when loading is true", () => {
     const wrapper = mountBar(mockSummary, true);
-    expect(wrapper.findAllComponents(NSkeleton)).toHaveLength(4);
+    expect(wrapper.findAll("[data-testid='base-skeleton']")).toHaveLength(4);
     expect(wrapper.findAllComponents(NStatistic)).toHaveLength(0);
   });
 

--- a/app/components/portfolio/PortfolioSummaryBar/PortfolioSummaryBar.vue
+++ b/app/components/portfolio/PortfolioSummaryBar/PortfolioSummaryBar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { NCard, NStatistic, NSkeleton } from "naive-ui";
+import { NCard, NStatistic } from "naive-ui";
+import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
 import { formatCurrency } from "~/utils/currency";
 import type { PortfolioSummaryBarProps } from "./PortfolioSummaryBar.types";
 
@@ -35,11 +36,10 @@ const percentColor = (value: number | null): string => {
   <NCard :bordered="true" class="portfolio-summary-bar">
     <template v-if="props.loading">
       <div class="portfolio-summary-bar__grid">
-        <NSkeleton
+        <BaseSkeleton
           v-for="i in 4"
           :key="i"
           height="56px"
-          :sharp="false"
           class="portfolio-summary-bar__skeleton"
         />
       </div>

--- a/app/components/simulation/SimulationCard/SimulationCard.spec.ts
+++ b/app/components/simulation/SimulationCard/SimulationCard.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from "@vue/test-utils";
 import { describe, it, expect } from "vitest";
-import { NTag, NSkeleton } from "naive-ui";
+import { NTag } from "naive-ui";
 
 import SimulationCard from "./SimulationCard.vue";
 import type { SimulationCardDto } from "~/features/simulations/contracts/simulation-card.dto";
@@ -84,9 +84,9 @@ describe("SimulationCard", () => {
     expect(wrapper.emitted("delete")![0]).toEqual(["sim-delete-01"]);
   });
 
-  it("shows NSkeleton elements when loading is true", () => {
+  it("shows BaseSkeleton elements when loading is true", () => {
     const wrapper = mountSimulationCard(makeSimulation(), true);
-    expect(wrapper.findAllComponents(NSkeleton).length).toBeGreaterThan(0);
+    expect(wrapper.findAll("[data-testid='base-skeleton']").length).toBeGreaterThan(0);
   });
 
   it("hides simulation name when loading is true", () => {

--- a/app/components/simulation/SimulationCard/SimulationCard.vue
+++ b/app/components/simulation/SimulationCard/SimulationCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { NCard, NTag, NText, NStatistic, NButton, NSkeleton } from "naive-ui";
+import { NCard, NTag, NText, NStatistic, NButton } from "naive-ui";
+import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
 import { Trash2Icon } from "lucide-vue-next";
 import { formatCurrency } from "~/utils/currency";
 import type { SimulationCardProps, SimulationCardEmits } from "./SimulationCard.types";
@@ -66,10 +67,10 @@ const onDelete = (): void => {
     content-style="padding: var(--space-3);"
   >
     <template v-if="props.loading">
-      <NSkeleton height="16px" width="70%" :sharp="false" />
-      <NSkeleton height="14px" width="40%" :sharp="false" style="margin-top: 8px;" />
-      <NSkeleton height="14px" width="55%" :sharp="false" style="margin-top: 6px;" />
-      <NSkeleton height="36px" :sharp="false" style="margin-top: 12px;" />
+      <BaseSkeleton height="16px" width="70%" />
+      <BaseSkeleton variant="text" width="40%" />
+      <BaseSkeleton variant="text" width="55%" />
+      <BaseSkeleton variant="button" />
     </template>
 
     <template v-else>

--- a/app/components/subscription/PlanCard/PlanCard.spec.ts
+++ b/app/components/subscription/PlanCard/PlanCard.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from "@vue/test-utils";
 import { describe, it, expect } from "vitest";
-import { NTag, NButton, NSkeleton } from "naive-ui";
+import { NTag, NButton } from "naive-ui";
 
 import PlanCard from "./PlanCard.vue";
 import type { BillingCycle, PlanDto } from "~/features/subscription/contracts/subscription.dto";
@@ -158,7 +158,7 @@ describe("PlanCard", () => {
 
   it("shows skeleton elements when loading is true", () => {
     const wrapper = mountPlanCard({ loading: true });
-    expect(wrapper.findAllComponents(NSkeleton).length).toBeGreaterThan(0);
+    expect(wrapper.findAll("[data-testid='base-skeleton']").length).toBeGreaterThan(0);
   });
 
   it("hides plan name when loading is true", () => {

--- a/app/components/subscription/PlanCard/PlanCard.vue
+++ b/app/components/subscription/PlanCard/PlanCard.vue
@@ -6,8 +6,8 @@ import {
   NButton,
   NList,
   NListItem,
-  NSkeleton,
 } from "naive-ui";
+import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
 import { CheckIcon, XIcon } from "lucide-vue-next";
 import { formatCurrency } from "~/utils/currency";
 import type { PlanCardProps, PlanCardEmits } from "./PlanCard.types";
@@ -55,12 +55,12 @@ const onSelect = (): void => {
     content-style="padding: var(--space-3);"
   >
     <template v-if="props.loading">
-      <NSkeleton height="16px" width="50%" :sharp="false" />
-      <NSkeleton height="20px" width="65%" :sharp="false" style="margin-top: 8px;" />
-      <NSkeleton height="14px" width="80%" :sharp="false" style="margin-top: 12px;" />
-      <NSkeleton height="14px" width="75%" :sharp="false" style="margin-top: 6px;" />
-      <NSkeleton height="14px" width="70%" :sharp="false" style="margin-top: 6px;" />
-      <NSkeleton type="button" :sharp="false" style="margin-top: 16px; width: 100%;" />
+      <BaseSkeleton height="16px" width="50%" />
+      <BaseSkeleton height="20px" width="65%" />
+      <BaseSkeleton variant="text" width="80%" />
+      <BaseSkeleton variant="text" width="75%" />
+      <BaseSkeleton variant="text" width="70%" />
+      <BaseSkeleton variant="button" />
     </template>
 
     <template v-else>

--- a/app/components/ui/BaseSkeleton.spec.ts
+++ b/app/components/ui/BaseSkeleton.spec.ts
@@ -7,6 +7,61 @@ describe("BaseSkeleton", () => {
   it("renderiza placeholder com classe base", () => {
     const wrapper = mount(BaseSkeleton);
 
-    expect(wrapper.classes()).toContain("base-skeleton");
+    expect(wrapper.get("[data-testid='base-skeleton']").classes()).toContain("base-skeleton");
+  });
+
+  it("aplica variante padrão 'line'", () => {
+    const wrapper = mount(BaseSkeleton);
+
+    expect(wrapper.get("[data-testid='base-skeleton']").classes()).toContain("base-skeleton--line");
+  });
+
+  it("respeita height e width customizados", () => {
+    const wrapper = mount(BaseSkeleton, {
+      props: { height: "72px", width: "50%" },
+    });
+
+    const style = wrapper.get("[data-testid='base-skeleton']").attributes("style") ?? "";
+    expect(style).toContain("height: 72px");
+    expect(style).toContain("width: 50%");
+  });
+
+  it("aplica preset de altura para variante text", () => {
+    const wrapper = mount(BaseSkeleton, { props: { variant: "text" } });
+
+    const style = wrapper.get("[data-testid='base-skeleton']").attributes("style") ?? "";
+    expect(style).toContain("height: 14px");
+  });
+
+  it("aplica preset de altura para variante button", () => {
+    const wrapper = mount(BaseSkeleton, { props: { variant: "button" } });
+
+    const style = wrapper.get("[data-testid='base-skeleton']").attributes("style") ?? "";
+    expect(style).toContain("height: 36px");
+  });
+
+  it("renderiza círculo com size", () => {
+    const wrapper = mount(BaseSkeleton, {
+      props: { variant: "circle", size: "32px" },
+    });
+
+    const style = wrapper.get("[data-testid='base-skeleton']").attributes("style") ?? "";
+    expect(style).toContain("height: 32px");
+    expect(style).toContain("width: 32px");
+    expect(style).toContain("border-radius: 9999px");
+  });
+
+  it("repete N elementos quando repeat > 1", () => {
+    const wrapper = mount(BaseSkeleton, { props: { repeat: 4 } });
+
+    expect(wrapper.findAll("[data-testid='base-skeleton']")).toHaveLength(4);
+  });
+
+  it("marca todos os placeholders como aria-hidden", () => {
+    const wrapper = mount(BaseSkeleton, { props: { repeat: 2 } });
+
+    for (const el of wrapper.findAll("[data-testid='base-skeleton']")) {
+      expect(el.attributes("aria-hidden")).toBe("true");
+    }
   });
 });

--- a/app/components/ui/BaseSkeleton.vue
+++ b/app/components/ui/BaseSkeleton.vue
@@ -1,11 +1,85 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+/**
+ * Canonical loading skeleton for the Auraxis web app (UX-3).
+ *
+ * Wraps a small shimmer block with a few well-bounded variants so every
+ * feature uses the same visual rhythm. Prefer this over direct `NSkeleton`
+ * imports — it lets us tune the animation, color, and radius in one place.
+ */
+type SkeletonVariant = "text" | "line" | "block" | "button" | "circle";
+
+interface Props {
+  /** Visual shape. Defaults to "line" (a horizontal bar). */
+  variant?: SkeletonVariant;
+  /** CSS height (e.g. `"20px"`, `"4rem"`). Ignored for `circle`. */
+  height?: string;
+  /** CSS width (e.g. `"60%"`, `"120px"`). Ignored for `circle`. */
+  width?: string;
+  /** Diameter for `circle` variant. */
+  size?: string;
+  /** Repeat the skeleton N times (useful for list placeholders). */
+  repeat?: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  variant: "line",
+  height: undefined,
+  width: undefined,
+  size: "40px",
+  repeat: 1,
+});
+
+const computedHeight = computed<string>((): string => {
+  if (props.variant === "circle") { return props.size; }
+  if (props.height) { return props.height; }
+  if (props.variant === "text") { return "14px"; }
+  if (props.variant === "button") { return "36px"; }
+  if (props.variant === "block") { return "80px"; }
+  return "20px";
+});
+
+const computedWidth = computed<string>((): string => {
+  if (props.variant === "circle") { return props.size; }
+  return props.width ?? "100%";
+});
+
+const radiusToken = computed<string>((): string => {
+  if (props.variant === "circle") { return "9999px"; }
+  if (props.variant === "button") { return "var(--radius-md, 8px)"; }
+  return "var(--radius-sm, 4px)";
+});
+
+const count = computed<number>((): number => Math.max(1, props.repeat));
+</script>
+
 <template>
-  <div class="base-skeleton" aria-hidden="true" />
+  <template v-if="count === 1">
+    <div
+      class="base-skeleton"
+      :class="`base-skeleton--${variant}`"
+      :style="{ height: computedHeight, width: computedWidth, borderRadius: radiusToken }"
+      aria-hidden="true"
+      data-testid="base-skeleton"
+    />
+  </template>
+  <template v-else>
+    <div
+      v-for="n in count"
+      :key="n"
+      class="base-skeleton"
+      :class="`base-skeleton--${variant}`"
+      :style="{ height: computedHeight, width: computedWidth, borderRadius: radiusToken }"
+      aria-hidden="true"
+      data-testid="base-skeleton"
+    />
+  </template>
 </template>
 
 <style scoped>
 .base-skeleton {
-  height: 24px;
-  border-radius: var(--radius-sm);
+  display: block;
   background: linear-gradient(
     90deg,
     rgba(65, 57, 57, 0.12) 0%,
@@ -13,10 +87,24 @@
     rgba(65, 57, 57, 0.12) 100%
   );
   background-size: 200% 100%;
-  animation: shimmer 1.6s infinite;
+  animation: base-skeleton-shimmer 1.6s infinite;
 }
 
-@keyframes shimmer {
+.base-skeleton + .base-skeleton {
+  margin-top: 8px;
+}
+
+.base-skeleton--circle {
+  display: inline-block;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .base-skeleton {
+    animation: none;
+  }
+}
+
+@keyframes base-skeleton-shimmer {
   from {
     background-position: 200% 0;
   }

--- a/app/components/ui/UiPageLoader/UiPageLoader.vue
+++ b/app/components/ui/UiPageLoader/UiPageLoader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { NSkeleton } from "naive-ui";
+import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
 import type { UiPageLoaderProps } from "./UiPageLoader.types";
 
 withDefaults(defineProps<UiPageLoaderProps>(), {
@@ -10,18 +10,16 @@ withDefaults(defineProps<UiPageLoaderProps>(), {
 
 <template>
   <div class="ui-page-loader" role="status" aria-label="Carregando…" aria-busy="true">
-    <NSkeleton
+    <BaseSkeleton
       v-if="withTitle"
       class="ui-page-loader__title"
-      :sharp="false"
       height="28px"
       width="40%"
     />
-    <NSkeleton
+    <BaseSkeleton
       v-for="n in rows"
       :key="n"
       class="ui-page-loader__row"
-      :sharp="false"
       :height="n === 1 ? '72px' : '56px'"
     />
   </div>

--- a/app/components/ui/UiPageLoader/__tests__/UiPageLoader.spec.ts
+++ b/app/components/ui/UiPageLoader/__tests__/UiPageLoader.spec.ts
@@ -1,14 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { mount } from "@vue/test-utils";
 import UiPageLoader from "../UiPageLoader.vue";
-
-vi.mock("naive-ui", () => ({
-  NSkeleton: {
-    name: "NSkeleton",
-    props: ["sharp", "height", "width"],
-    template: "<div class=\"n-skeleton\" :style=\"{ height, width }\" />",
-  },
-}));
 
 describe("UiPageLoader", () => {
   it("renders with role=status and aria-busy", () => {

--- a/app/components/ui/UiPageLoader/__tests__/__snapshots__/UiPageLoader.spec.ts.snap
+++ b/app/components/ui/UiPageLoader/__tests__/__snapshots__/UiPageLoader.spec.ts.snap
@@ -3,18 +3,18 @@
 exports[`UiPageLoader > matches snapshot with defaults 1`] = `
 "<div data-v-0e53768c="" class="ui-page-loader" role="status" aria-label="Carregando…" aria-busy="true">
   <!--v-if-->
-  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 72px;"></div>
-  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 56px;"></div>
-  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 56px;"></div>
+  <div data-v-fab834c6="" data-v-0e53768c="" class="base-skeleton base-skeleton--line ui-page-loader__row" style="height: 72px; width: 100%;" aria-hidden="true" data-testid="base-skeleton"></div>
+  <div data-v-fab834c6="" data-v-0e53768c="" class="base-skeleton base-skeleton--line ui-page-loader__row" style="height: 56px; width: 100%;" aria-hidden="true" data-testid="base-skeleton"></div>
+  <div data-v-fab834c6="" data-v-0e53768c="" class="base-skeleton base-skeleton--line ui-page-loader__row" style="height: 56px; width: 100%;" aria-hidden="true" data-testid="base-skeleton"></div>
 </div>"
 `;
 
 exports[`UiPageLoader > matches snapshot with title and custom row count 1`] = `
 "<div data-v-0e53768c="" class="ui-page-loader" role="status" aria-label="Carregando…" aria-busy="true">
-  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__title" style="height: 28px; width: 40%;"></div>
-  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 72px;"></div>
-  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 56px;"></div>
-  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 56px;"></div>
-  <div data-v-0e53768c="" class="n-skeleton ui-page-loader__row" style="height: 56px;"></div>
+  <div data-v-fab834c6="" data-v-0e53768c="" class="base-skeleton base-skeleton--line ui-page-loader__title" style="height: 28px; width: 40%;" aria-hidden="true" data-testid="base-skeleton"></div>
+  <div data-v-fab834c6="" data-v-0e53768c="" class="base-skeleton base-skeleton--line ui-page-loader__row" style="height: 72px; width: 100%;" aria-hidden="true" data-testid="base-skeleton"></div>
+  <div data-v-fab834c6="" data-v-0e53768c="" class="base-skeleton base-skeleton--line ui-page-loader__row" style="height: 56px; width: 100%;" aria-hidden="true" data-testid="base-skeleton"></div>
+  <div data-v-fab834c6="" data-v-0e53768c="" class="base-skeleton base-skeleton--line ui-page-loader__row" style="height: 56px; width: 100%;" aria-hidden="true" data-testid="base-skeleton"></div>
+  <div data-v-fab834c6="" data-v-0e53768c="" class="base-skeleton base-skeleton--line ui-page-loader__row" style="height: 56px; width: 100%;" aria-hidden="true" data-testid="base-skeleton"></div>
 </div>"
 `;

--- a/app/core/query/stale-time.ts
+++ b/app/core/query/stale-time.ts
@@ -1,0 +1,46 @@
+/**
+ * Canonical `staleTime` presets for Vue Query composables.
+ *
+ * PERF-7 (MVP1 hardening) requires every query to set `staleTime`
+ * explicitly, so the cache-freshness contract of each endpoint is
+ * visible at the call site instead of implicitly inherited from the
+ * global QueryClient default in `app/plugins/vue-query.ts`.
+ *
+ * Four buckets cover the application today:
+ *
+ * - `REALTIME` (15 s) — high-volatility financial data the user expects
+ *   to reflect nearly-live state (live portfolio value, recent wallet
+ *   activity). Still cached for a short window to avoid thrashing the
+ *   API if the same view is mounted repeatedly.
+ *
+ * - `ACTIVE` (30 s) — current user activity (transaction lists, due
+ *   ranges, receivables). Matches the legacy global default, lifted to
+ *   an explicit constant so changes are obvious in review.
+ *
+ * - `STABLE` (5 min) — derived or aggregated data that only changes when
+ *   the user performs an action (budgets, goals, subscription state,
+ *   sharing relationships, alerts). Refetch on mount is still enabled
+ *   by Vue Query for fresh-load correctness.
+ *
+ * - `STATIC` (1 h) — user-owned configuration and rarely-changing
+ *   metadata (tags, credit cards, accounts, profile, entitlements,
+ *   alert preferences). Manual invalidation is expected when the user
+ *   edits these.
+ *
+ * Anything shorter than `REALTIME` should use a WebSocket/SSE stream
+ * instead of polling. Anything longer than `STATIC` should not be kept
+ * in Vue Query at all.
+ */
+
+export const STALE_TIME = {
+  /** 15 seconds — live financial data. */
+  REALTIME: 15 * 1000,
+  /** 30 seconds — current user activity (matches the global default). */
+  ACTIVE: 30 * 1000,
+  /** 5 minutes — derived/aggregated data. */
+  STABLE: 5 * 60 * 1000,
+  /** 1 hour — user configuration and metadata. */
+  STATIC: 60 * 60 * 1000,
+} as const;
+
+export type StaleTime = (typeof STALE_TIME)[keyof typeof STALE_TIME];

--- a/app/features/accounts/queries/use-accounts-query.ts
+++ b/app/features/accounts/queries/use-accounts-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { AccountDto } from "~/features/accounts/contracts/account.dto";
 import { MOCK_ACCOUNTS } from "~/features/accounts/mock/accounts.mock";
 import { useAccountsClient, type AccountsClient } from "~/features/accounts/services/accounts.client";
@@ -24,5 +25,6 @@ export const useAccountsQuery = (
       }
       return client.listAccounts();
     },
+    staleTime: STALE_TIME.STATIC,
   });
 };

--- a/app/features/alerts/queries/use-alert-preferences-query.ts
+++ b/app/features/alerts/queries/use-alert-preferences-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useAlertsClient, type AlertsClient } from "~/features/alerts/services/alerts.client";
 import type { AlertPreference } from "~/features/alerts/model/alerts";
 
@@ -55,5 +56,6 @@ export const useAlertPreferencesQuery = (
 
       return client.getPreferences();
     },
+    staleTime: STALE_TIME.STATIC,
   });
 };

--- a/app/features/alerts/queries/use-alerts-query.ts
+++ b/app/features/alerts/queries/use-alerts-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useAlertsClient, type AlertsClient } from "~/features/alerts/services/alerts.client";
 import type { AlertsPage } from "~/features/alerts/model/alerts";
 
@@ -61,5 +62,6 @@ export const useAlertsQuery = (
 
       return client.getAlerts();
     },
+    staleTime: STALE_TIME.ACTIVE,
   });
 };

--- a/app/features/budgets/queries/use-budget-query.ts
+++ b/app/features/budgets/queries/use-budget-query.ts
@@ -2,6 +2,7 @@ import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 import type { MaybeRef } from "vue";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { BudgetDto } from "~/features/budgets/contracts/budget.contracts";
 import { MOCK_BUDGETS } from "~/features/budgets/mock/budget.mock";
 import { useBudgetClient, type BudgetClient } from "~/features/budgets/services/budget.client";
@@ -31,5 +32,6 @@ export const useBudgetQuery = (
 
       return client.getBudget(resolvedId);
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/budgets/queries/use-budgets-query.ts
+++ b/app/features/budgets/queries/use-budgets-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { BudgetDto } from "~/features/budgets/contracts/budget.contracts";
 import { MOCK_BUDGETS } from "~/features/budgets/mock/budget.mock";
 import { useBudgetClient, type BudgetClient } from "~/features/budgets/services/budget.client";
@@ -28,5 +29,6 @@ export const useBudgetsQuery = (
 
       return client.listBudgets();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/credit-cards/queries/use-credit-cards-query.ts
+++ b/app/features/credit-cards/queries/use-credit-cards-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { CreditCardDto } from "~/features/credit-cards/contracts/credit-card.dto";
 import { MOCK_CREDIT_CARDS } from "~/features/credit-cards/mock/credit-cards.mock";
 import {
@@ -27,5 +28,6 @@ export const useCreditCardsQuery = (
       }
       return client.listCreditCards();
     },
+    staleTime: STALE_TIME.STATIC,
   });
 };

--- a/app/features/dashboard/queries/use-dashboard-overview-query.ts
+++ b/app/features/dashboard/queries/use-dashboard-overview-query.ts
@@ -1,5 +1,6 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useDashboardOverviewApiClient,
   type DashboardOverviewApiClient,
@@ -72,6 +73,6 @@ export const useDashboardOverviewQuery = (
     queryKey: computed(() => createQueryKey(resolvedFilters.value)),
     queryFn: () => dashboardClient.getOverview(resolvedFilters.value),
     enabled: computed(() => canRunDashboardOverviewQuery(resolvedFilters.value)),
-    staleTime: 60_000,
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/dashboard/queries/use-dashboard-trends-query.ts
+++ b/app/features/dashboard/queries/use-dashboard-trends-query.ts
@@ -1,5 +1,6 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useDashboardTrendsApiClient,
   type DashboardTrendsApiClient,
@@ -38,6 +39,6 @@ export const useDashboardTrendsQuery = (
   return useQuery({
     queryKey: computed(() => createTrendsQueryKey(resolvedMonths.value)),
     queryFn: () => trendsClient.getTrends(resolvedMonths.value),
-    staleTime: 5 * 60_000,
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/goals/queries/use-goal-plan-query.ts
+++ b/app/features/goals/queries/use-goal-plan-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 import { computed, type Ref } from "vue";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useGoalsClient,
   type GoalsClient,
@@ -26,5 +27,6 @@ export const useGoalPlanQuery = (
     queryKey: ["goals", goalId, "plan"] as const,
     queryFn: (): Promise<GoalPlanDto> => client.getGoalPlan(goalId.value!),
     enabled: computed(() => goalId.value !== null),
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/goals/queries/use-goal-projection-query.ts
+++ b/app/features/goals/queries/use-goal-projection-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 import { computed, type Ref } from "vue";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useGoalsClient,
   type GoalsClient,
@@ -28,5 +29,6 @@ export const useGoalProjectionQuery = (
     queryFn: (): Promise<GoalProjectionResponseDto> =>
       client.getGoalProjection(goalId.value!),
     enabled: computed(() => goalId.value !== null),
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/goals/queries/use-goals-query.ts
+++ b/app/features/goals/queries/use-goals-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useGoalsClient, type GoalsClient } from "~/features/goals/services/goals.client";
 import { MOCK_GOALS } from "~/features/goals/mock/goals.mock";
 import type { GoalDto } from "~/features/goals/contracts/goal.dto";
@@ -28,5 +29,6 @@ export const useGoalsQuery = (
 
       return client.listGoals();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/paywall/queries/use-entitlement-query.ts
+++ b/app/features/paywall/queries/use-entitlement-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useEntitlementClient,
   type EntitlementClient,
@@ -32,5 +33,6 @@ export const useEntitlementQuery = (
 
       return client.checkEntitlement(featureKey);
     },
+    staleTime: STALE_TIME.STATIC,
   });
 };

--- a/app/features/profile/composables/use-user-profile-query.ts
+++ b/app/features/profile/composables/use-user-profile-query.ts
@@ -1,4 +1,5 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useUserProfileApi, type UserProfileApi } from "~/features/profile/services/user-profile-api";
 import type { UserProfileDto } from "~/features/profile/contracts/user-profile.dto";
 import { useUserStore } from "~/stores/user";
@@ -27,5 +28,6 @@ export const useUserProfileQuery = (
       return profile;
     },
     enabled: computed(() => sessionStore.isAuthenticated),
+    staleTime: STALE_TIME.STATIC,
   });
 };

--- a/app/features/receivables/queries/use-receivables-query.ts
+++ b/app/features/receivables/queries/use-receivables-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useReceivablesClient,
   type ReceivablesClient,
@@ -56,5 +57,6 @@ export const useReceivablesQuery = (
 
       return client.listReceivables(status);
     },
+    staleTime: STALE_TIME.ACTIVE,
   });
 };

--- a/app/features/receivables/queries/use-revenue-summary-query.ts
+++ b/app/features/receivables/queries/use-revenue-summary-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useReceivablesClient,
   type ReceivablesClient,
@@ -37,5 +38,6 @@ export const useRevenueSummaryQuery = (
 
       return client.getSummary();
     },
+    staleTime: STALE_TIME.ACTIVE,
   });
 };

--- a/app/features/shared-entries/queries/use-shared-by-me-query.ts
+++ b/app/features/shared-entries/queries/use-shared-by-me-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useSharedEntriesClient,
   type SharedEntriesClient,
@@ -30,5 +31,6 @@ export const useSharedByMeQuery = (
       }
       return client.getSharedByMe();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/shared-entries/queries/use-shared-with-me-query.ts
+++ b/app/features/shared-entries/queries/use-shared-with-me-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useSharedEntriesClient,
   type SharedEntriesClient,
@@ -30,5 +31,6 @@ export const useSharedWithMeQuery = (
       }
       return client.getSharedWithMe();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/sharing/queries/use-invitations-query.ts
+++ b/app/features/sharing/queries/use-invitations-query.ts
@@ -1,5 +1,6 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useSharingClient, type SharingClient } from "~/features/sharing/services/sharing.client";
 import type { Invitation } from "~/features/sharing/model/sharing";
 
@@ -21,5 +22,6 @@ export const useInvitationsQuery = (
     queryFn: (): Promise<Invitation[]> => {
       return client.getInvitations();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/sharing/queries/use-shared-entries-query.ts
+++ b/app/features/sharing/queries/use-shared-entries-query.ts
@@ -1,5 +1,6 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useSharingClient, type SharingClient } from "~/features/sharing/services/sharing.client";
 import type { SharedEntry } from "~/features/sharing/model/sharing";
 
@@ -21,6 +22,7 @@ export const useSharedByMeQuery = (
     queryFn: (): Promise<SharedEntry[]> => {
       return client.getSharedByMe();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };
 
@@ -42,5 +44,6 @@ export const useSharedWithMeQuery = (
     queryFn: (): Promise<SharedEntry[]> => {
       return client.getSharedWithMe();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/simulations/queries/use-simulations-query.ts
+++ b/app/features/simulations/queries/use-simulations-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useSimulationClient,
   type SimulationClient,
@@ -34,5 +35,6 @@ export const useSimulationsQuery = (
       const simulations = await client.listSimulations();
       return simulations.map(mapToSimulationCardDto);
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/subscription/queries/use-subscription-query.ts
+++ b/app/features/subscription/queries/use-subscription-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useSubscriptionClient,
   type SubscriptionClient,
@@ -41,5 +42,6 @@ export const useSubscriptionQuery = (
 
       return client.getMySubscription();
     },
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/tags/queries/use-tags-query.ts
+++ b/app/features/tags/queries/use-tags-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { TagDto } from "~/features/tags/contracts/tag.dto";
 import { MOCK_TAGS } from "~/features/tags/mock/tags.mock";
 import { useTagsClient, type TagsClient } from "~/features/tags/services/tags.client";
@@ -24,5 +25,6 @@ export const useTagsQuery = (
       }
       return client.listTags();
     },
+    staleTime: STALE_TIME.STATIC,
   });
 };

--- a/app/features/tools/queries/use-brapi-currency-query.ts
+++ b/app/features/tools/queries/use-brapi-currency-query.ts
@@ -1,6 +1,7 @@
 import { type Ref, computed } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useBrapiToolsClient,
   type BrapiToolsClient,
@@ -24,7 +25,7 @@ export const useBrapiCurrencyQuery = (
     queryKey: computed(() => ["brapi", "currency", pairs.value] as const),
     queryFn: (): Promise<BrapiCurrencyResult[]> => client.getCurrencyQuotes(pairs.value),
     enabled: computed(() => pairs.value.length > 0),
-    staleTime: 5 * 60 * 1000,
+    staleTime: STALE_TIME.STABLE,
     retry: 1,
   });
 };

--- a/app/features/tools/queries/use-brapi-fii-quote-query.ts
+++ b/app/features/tools/queries/use-brapi-fii-quote-query.ts
@@ -1,6 +1,7 @@
 import { type Ref, computed } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useBrapiToolsClient,
   type BrapiToolsClient,
@@ -25,7 +26,7 @@ export const useBrapiFiiQuoteQuery = (
     queryKey: computed(() => ["brapi", "fii", ticker.value] as const),
     queryFn: (): Promise<BrapiFiiQuoteResult | null> => client.getFiiQuote(ticker.value),
     enabled: computed(() => ticker.value.trim().length >= 4),
-    staleTime: 5 * 60 * 1000,
+    staleTime: STALE_TIME.STABLE,
     retry: 1,
   });
 };

--- a/app/features/transactions/queries/use-due-range-query.ts
+++ b/app/features/transactions/queries/use-due-range-query.ts
@@ -7,6 +7,7 @@
 import { type MaybeRef, unref } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { DueRangeFilters, DueRangeResponseDto } from "../contracts/due-range.dto";
 import { type DueRangeClient, useDueRangeClient } from "../services/due-range.client";
 
@@ -29,5 +30,6 @@ export function useDueRangeQuery(
   return useQuery({
     queryKey: ["transactions", "due-range", filters] as const,
     queryFn: (): Promise<DueRangeResponseDto> => client.getDueRange(unref(filters)),
+    staleTime: STALE_TIME.ACTIVE,
   });
 }

--- a/app/features/transactions/queries/use-list-transactions-query.ts
+++ b/app/features/transactions/queries/use-list-transactions-query.ts
@@ -1,6 +1,7 @@
 import { type MaybeRef, unref } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
 import {
   type ListTransactionsFilters,
@@ -29,5 +30,6 @@ export const useListTransactionsQuery = (
     queryFn: (): Promise<TransactionDto[]> => {
       return client.listTransactions(unref(filters));
     },
+    staleTime: STALE_TIME.ACTIVE,
   });
 };

--- a/app/features/wallet/queries/use-brapi-ticker-search-query.ts
+++ b/app/features/wallet/queries/use-brapi-ticker-search-query.ts
@@ -1,6 +1,7 @@
 import { type Ref, computed } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   useBrapiClient,
   type BrapiClient,
@@ -27,6 +28,6 @@ export const useBrapiTickerSearchQuery = (
     queryKey: computed(() => ["brapi", "tickers", "search", query.value] as const),
     queryFn: (): Promise<BrapiTickerSearchResult[]> => client.searchTickers(query.value),
     enabled: computed(() => query.value.trim().length >= 1),
-    staleTime: 5 * 60 * 1000, // 5 minutes — ticker metadata is stable within a session
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/wallet/queries/use-portfolio-summary-query.ts
+++ b/app/features/wallet/queries/use-portfolio-summary-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useWalletClient, type WalletClient } from "~/features/wallet/services/wallet.client";
 import { MOCK_PORTFOLIO_SUMMARY } from "~/features/portfolio/mock/portfolio.mock";
 import type { PortfolioSummaryDto } from "~/features/portfolio/contracts/portfolio.dto";
@@ -28,5 +29,6 @@ export const usePortfolioSummaryQuery = (
 
       return client.getPortfolioSummary();
     },
+    staleTime: STALE_TIME.REALTIME,
   });
 };

--- a/app/features/wallet/queries/use-wallet-entries-query.ts
+++ b/app/features/wallet/queries/use-wallet-entries-query.ts
@@ -1,6 +1,7 @@
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useWalletClient, type WalletClient } from "~/features/wallet/services/wallet.client";
 import { MOCK_WALLET_ENTRIES } from "~/features/portfolio/mock/portfolio.mock";
 import type { WalletEntryDto } from "~/features/portfolio/contracts/portfolio.dto";
@@ -28,5 +29,6 @@ export const useWalletEntriesQuery = (
 
       return client.getEntries();
     },
+    staleTime: STALE_TIME.ACTIVE,
   });
 };

--- a/app/features/wallet/queries/use-wallet-history-query.ts
+++ b/app/features/wallet/queries/use-wallet-history-query.ts
@@ -1,5 +1,7 @@
 import { type MaybeRef, unref } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+
+import { STALE_TIME } from "~/core/query/stale-time";
 import {
   type WalletClient,
   type WalletHistoryPoint,
@@ -32,5 +34,6 @@ export const useWalletHistoryQuery = (
       return client.getWalletHistory(id);
     },
     enabled: () => !!unref(entryId),
+    staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/pages/income.vue
+++ b/app/pages/income.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { NCard, NEmpty, NSkeleton, NSpace, NTabPane, NTabs } from "naive-ui";
+import { NCard, NEmpty, NSpace, NTabPane, NTabs } from "naive-ui";
 import { ref } from "vue";
+import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
 
 import { useConfirmImportMutation } from "~/features/receivables/queries/use-confirm-import-mutation";
 import { useCsvUploadMutation } from "~/features/receivables/queries/use-csv-upload-mutation";
@@ -92,10 +93,9 @@ const handleDelete = (id: string): void => {
 
 <template>
   <div class="income-page">
-    <NSkeleton
+    <BaseSkeleton
       v-if="summaryQuery.isLoading.value"
       height="100px"
-      :sharp="false"
     />
 
     <UiBaseCard
@@ -121,10 +121,9 @@ const handleDelete = (id: string): void => {
             v-if="csvUploadMutation.isPending.value || previewRows.length > 0 || createdCount !== null"
             :title="t('pages.income.preview')"
           >
-            <NSkeleton
+            <BaseSkeleton
               v-if="csvUploadMutation.isPending.value"
               height="120px"
-              :sharp="false"
             />
 
             <p
@@ -147,9 +146,7 @@ const handleDelete = (id: string): void => {
 
       <NTabPane name="list" :tab="t('pages.income.tabs.list')">
         <NSpace v-if="receivablesQuery.isLoading.value" vertical :size="8">
-          <NSkeleton height="72px" :sharp="false" />
-          <NSkeleton height="72px" :sharp="false" />
-          <NSkeleton height="72px" :sharp="false" />
+          <BaseSkeleton height="72px" :repeat="3" />
         </NSpace>
 
         <UiBaseCard

--- a/app/pages/tools/installment-vs-cash.vue
+++ b/app/pages/tools/installment-vs-cash.vue
@@ -17,6 +17,7 @@ import {
 } from "naive-ui";
 
 import { captureException } from "~/core/observability";
+import { STALE_TIME } from "~/core/query/stale-time";
 import { useApiError } from "~/composables/useApiError";
 import { useAuthRedirectContext } from "~/composables/useAuthRedirectContext";
 import { useSessionStore } from "~/stores/session";
@@ -146,6 +147,7 @@ const premiumAccessQuery: UseQueryReturnType<boolean, Error> = useQuery({
   queryFn: (): Promise<boolean> => {
     return entitlementClient.checkEntitlement("advanced_simulations");
   },
+  staleTime: STALE_TIME.STATIC,
 });
 
 /**


### PR DESCRIPTION
## Summary
- Promotes `BaseSkeleton` to the canonical skeleton primitive (UX-3): adds `variant` (`text|line|block|button|circle`), `height`, `width`, `size`, `repeat` props plus `prefers-reduced-motion` opt-out.
- Migrates every remaining direct `NSkeleton` consumer (`UiPageLoader`, `PaywallGate`, `UiPaywallGate`, `GoalCard`, `PlanCard`, `SimulationCard`, `PortfolioSummaryBar`, `AlertsList`, `AlertPreferencesList`, `pages/income.vue`, `UiPaywallGate` story) to `BaseSkeleton`, unifying radius, shimmer cadence and dark-mode colors in one file.
- Refreshes unit tests and Vue-Test-Utils selectors to query `[data-testid='base-skeleton']`, regenerates `UiPageLoader` snapshots.

## Why
Fragmented skeletons (naive-ui `NSkeleton` + handcrafted `BaseSkeleton`) caused inconsistent visual rhythm, conflicting colors, and made dark-mode tuning brittle. Centralizing on `BaseSkeleton` lets us tune motion/color once and gives every feature the same loading idiom.

## Test plan
- [x] `pnpm vitest run` — 2569 tests passing
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] visual smoke via Storybook (`UiPaywallGate > Loading` story)