### PR TITLE
perf(ui): PERF-6 add UiImage wrapper as @nuxt/image alternative

### DIFF
--- a/app/components/ui/UiImage.spec.ts
+++ b/app/components/ui/UiImage.spec.ts
@@ -1,0 +1,80 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import UiImage from "./UiImage.vue";
+
+describe("UiImage", () => {
+  it("renders an <img> when src is provided", () => {
+    const wrapper = mount(UiImage, {
+      props: { src: "/avatar.png", alt: "Ana", width: 32, height: 32 },
+    });
+
+    expect(wrapper.find("img").exists()).toBe(true);
+  });
+
+  it("does not render when src is null", () => {
+    const wrapper = mount(UiImage, {
+      props: { src: null, alt: "", width: 32, height: 32 },
+    });
+
+    expect(wrapper.find("img").exists()).toBe(false);
+  });
+
+  it("does not render when src is undefined", () => {
+    const wrapper = mount(UiImage, {
+      props: { src: undefined, alt: "", width: 32, height: 32 },
+    });
+
+    expect(wrapper.find("img").exists()).toBe(false);
+  });
+
+  it("applies loading=lazy by default", () => {
+    const wrapper = mount(UiImage, {
+      props: { src: "/a.png", alt: "a", width: 10, height: 10 },
+    });
+
+    expect(wrapper.find("img").attributes("loading")).toBe("lazy");
+  });
+
+  it("applies decoding=async by default", () => {
+    const wrapper = mount(UiImage, {
+      props: { src: "/a.png", alt: "a", width: 10, height: 10 },
+    });
+
+    expect(wrapper.find("img").attributes("decoding")).toBe("async");
+  });
+
+  it("respects loading=eager override", () => {
+    const wrapper = mount(UiImage, {
+      props: { src: "/a.png", alt: "a", width: 10, height: 10, loading: "eager" },
+    });
+
+    expect(wrapper.find("img").attributes("loading")).toBe("eager");
+  });
+
+  it("respects fetchpriority=high override", () => {
+    const wrapper = mount(UiImage, {
+      props: { src: "/a.png", alt: "a", width: 10, height: 10, fetchpriority: "high" },
+    });
+
+    expect(wrapper.find("img").attributes("fetchpriority")).toBe("high");
+  });
+
+  it("forwards width and height attributes", () => {
+    const wrapper = mount(UiImage, {
+      props: { src: "/a.png", alt: "a", width: 64, height: 48 },
+    });
+
+    const img = wrapper.find("img");
+    expect(img.attributes("width")).toBe("64");
+    expect(img.attributes("height")).toBe("48");
+  });
+
+  it("forwards alt text", () => {
+    const wrapper = mount(UiImage, {
+      props: { src: "/a.png", alt: "profile photo", width: 10, height: 10 },
+    });
+
+    expect(wrapper.find("img").attributes("alt")).toBe("profile photo");
+  });
+});

--- a/app/components/ui/UiImage.vue
+++ b/app/components/ui/UiImage.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+/**
+ * Canonical image wrapper for the Auraxis web app (PERF-6).
+ *
+ * `@nuxt/image` was removed from the module stack because its `sharp`
+ * dependency breaks ARM64 Docker builds. This component is the lightweight
+ * alternative: it forwards to a native `<img>` while setting the defaults
+ * modern browsers need for performant image rendering without a runtime cost.
+ *
+ * Defaults:
+ * - `loading="lazy"` — defer offscreen images to improve LCP on first paint
+ * - `decoding="async"` — off-main-thread decode
+ * - explicit `width`/`height` — reserve layout space to avoid CLS
+ *
+ * Use `eager` priority for above-the-fold hero images that must not be lazy.
+ */
+type Loading = "lazy" | "eager";
+type Decoding = "async" | "sync" | "auto";
+type FetchPriority = "auto" | "high" | "low";
+
+interface Props {
+  /** Image source URL. Required for rendering. */
+  src: string | null | undefined;
+  /** Accessible alt text. Empty string is valid for decorative images. */
+  alt: string;
+  /** Intrinsic width in pixels (prevents layout shift). */
+  width: number | string;
+  /** Intrinsic height in pixels (prevents layout shift). */
+  height: number | string;
+  /** Loading strategy. Defaults to `"lazy"`. */
+  loading?: Loading;
+  /** Decoding strategy. Defaults to `"async"`. */
+  decoding?: Decoding;
+  /** Fetch priority hint. Defaults to `"auto"`. Use `"high"` for LCP hero. */
+  fetchpriority?: FetchPriority;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  loading: "lazy",
+  decoding: "async",
+  fetchpriority: "auto",
+});
+
+const hasSrc = computed<boolean>((): boolean => Boolean(props.src));
+</script>
+
+<template>
+  <img
+    v-if="hasSrc"
+    :src="src ?? ''"
+    :alt="alt"
+    :width="width"
+    :height="height"
+    :loading="loading"
+    :decoding="decoding"
+    :fetchpriority="fetchpriority"
+    class="ui-image"
+  >
+</template>
+
+<style scoped>
+.ui-image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+</style>

--- a/app/components/ui/UiUserMenu/UiUserMenu.vue
+++ b/app/components/ui/UiUserMenu/UiUserMenu.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { Settings, LogOut, ChevronRight } from "lucide-vue-next";
+import UiImage from "~/components/ui/UiImage.vue";
 import type { UiUserMenuProps, UiUserMenuEmits } from "./UiUserMenu.types";
 
 
@@ -48,12 +49,14 @@ onUnmounted(() => document.removeEventListener("mousedown", handleClickOutside))
       aria-haspopup="menu"
       @click="toggle"
     >
-      <img
+      <UiImage
         v-if="avatarUrl"
         :src="avatarUrl"
         :alt="name"
+        :width="32"
+        :height="32"
         class="ui-user-menu__avatar"
-      >
+      />
       <span
         v-else
         class="ui-user-menu__avatar ui-user-menu__avatar--fallback"


### PR DESCRIPTION
## Summary

- Add `UiImage.vue` as the canonical image wrapper for the web app, replacing `@nuxt/image` (which was removed earlier due to `sharp`/ARM64 Docker build conflicts).
- Forwards to a native `<img>` with performance defaults baked in: `loading=\"lazy\"`, `decoding=\"async\"`, explicit `width`/`height` to prevent CLS, and optional `fetchpriority` override for LCP heroes.
- Migrate the only remaining raw `<img>` in the codebase (`UiUserMenu` avatar) to use `UiImage`.

## Why

PERF-6 from MVP1 hardening plan. Re-establishes an image optimization boundary for the app so future images default to lazy + async decoding + reserved layout space, without reintroducing the `@nuxt/image`/`sharp` native dependency that breaks ARM64 container builds.

## Test plan

- [x] `pnpm test:unit` — 2569 tests pass, including new 9-test `UiImage.spec.ts`
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [ ] CI green