### PR TITLE
chore(dx): ci-parity — add flags:check + build to quality-check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,13 +41,20 @@ Frontend web do Auraxis.
 
 ## Quality gates obrigatórios
 
+**Canonical CI-parity command** (mirrors GitHub Actions ci.yml exactly):
+
 ```bash
-pnpm lint
-pnpm typecheck
-pnpm test:coverage
-pnpm policy:check
-pnpm contracts:check
-pnpm build
+pnpm quality-check
+```
+
+This runs in order: flags:check → lint → typecheck → test:coverage → policy:check →
+contracts:check → build.
+
+**Full CI parity** (includes audit gate, optional lighthouse/e2e/sonar):
+
+```bash
+bash scripts/run_ci_like_actions_local.sh --local
+# Add --with-e2e --with-lighthouse for complete CI match
 ```
 
 Thresholds:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "contracts:sync": "node scripts/contracts-sync.cjs",
     "contracts:check": "node scripts/contracts-check.cjs",
     "policy:check": "node scripts/check-frontend-governance.cjs",
-    "quality-check": "pnpm lint && pnpm typecheck && pnpm test:coverage && pnpm policy:check && pnpm contracts:check",
+    "quality-check": "pnpm flags:check && pnpm lint && pnpm typecheck && pnpm test:coverage && pnpm policy:check && pnpm contracts:check && pnpm build",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",


### PR DESCRIPTION
## Summary
- `quality-check` script now mirrors `ci.yml` core gates exactly
- Added `flags:check` — feature flag hygiene was running in CI but missing from quality-check
- Added `build` — Nuxt build gate was running in CI but missing from quality-check
- Updated `CLAUDE.md` to reference canonical CI-parity commands

## Context
Gap found during auraxis-platform governance audit: agents were opening PRs without running the full CI pipeline locally, causing predictable CI failures. This ensures fail-fast locally before any push.

## Test plan
- [ ] `pnpm quality-check` runs flags:check, lint, typecheck, test:coverage, policy:check, contracts:check, build
- [ ] CI pipeline passes with no regressions