### PR TITLE
feat(seo): seo tecnico v1 — robots.txt, sitemap e meta em paginas legais

### DIFF
--- a/app/middleware/legal-seo.ts
+++ b/app/middleware/legal-seo.ts
@@ -1,0 +1,42 @@
+import { defineNuxtRouteMiddleware, useSeoMeta } from "#app";
+
+/**
+ * Injects SEO meta tags for static legal pages.
+ *
+ * These pages use `definePageMeta({ layout: false })` without i18n, so SEO
+ * is applied here rather than inside the component to keep the component
+ * clean and unit-testable without a Nuxt runtime context.
+ */
+
+const LEGAL_SEO: Record<string, { title: string; description: string }> = {
+  "/privacy-policy": {
+    title: "Política de Privacidade",
+    description: "Saiba como o Auraxis coleta, usa e protege seus dados pessoais em conformidade com a LGPD.",
+  },
+  "/en/privacy-policy": {
+    title: "Privacy Policy",
+    description: "Learn how Auraxis collects, uses and protects your personal data in compliance with LGPD.",
+  },
+  "/terms-of-service": {
+    title: "Termos de Uso",
+    description: "Leia os Termos de Uso do Auraxis — planner financeiro inteligente para gerenciar carteira e metas.",
+  },
+  "/en/terms-of-service": {
+    title: "Terms of Service",
+    description: "Read the Auraxis Terms of Service — smart financial planner for managing your portfolio and goals.",
+  },
+};
+
+export default defineNuxtRouteMiddleware((to) => {
+  const seo = LEGAL_SEO[to.path];
+  if (!seo) {
+    return;
+  }
+
+  useSeoMeta({
+    title: seo.title,
+    description: seo.description,
+    ogTitle: `${seo.title} | Auraxis`,
+    ogDescription: seo.description,
+  });
+});

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -272,6 +272,61 @@ export default defineNuxtConfig({
     enabled: false,
   },
 
+  // ── Sitemap (@nuxtjs/sitemap, bundled in @nuxtjs/seo) ────────────────────
+  // Generated as a static file at build time (prerendered via nitro below).
+  // Only public SSG routes are included — private SPA routes are excluded.
+  // Locale alternates are injected automatically by @nuxtjs/i18n integration.
+  sitemap: {
+    // Explicitly exclude private SPA routes (ssr: false in routeRules).
+    // @nuxtjs/sitemap normally skips them, but listing is belt-and-suspenders.
+    exclude: [
+      "/dashboard",
+      "/portfolio",
+      "/goals",
+      "/transactions",
+      "/alerts",
+      "/simulations",
+      "/shared-entries",
+      "/income",
+      "/subscription",
+      "/budgets",
+      "/investor-profile",
+      "/settings/**",
+      "/checkout/success",
+      "/confirm-email-pending",
+      "/resend-confirmation",
+      "/en/dashboard",
+      "/en/portfolio",
+      "/en/goals",
+      "/en/transactions",
+      "/en/alerts",
+      "/en/simulations",
+      "/en/shared-entries",
+      "/en/income",
+      "/en/subscription",
+      "/en/budgets",
+      "/en/investor-profile",
+      "/en/settings/**",
+      "/en/checkout/success",
+      "/en/confirm-email-pending",
+      "/en/resend-confirmation",
+      // Auth pages — noindex, not useful in search results
+      "/login",
+      "/register",
+      "/forgot-password",
+      "/reset-password",
+      "/confirm-email",
+      "/en/login",
+      "/en/register",
+      "/en/forgot-password",
+      "/en/reset-password",
+      "/en/confirm-email",
+      // Checkout cancel — transactional, not useful in search
+      "/checkout/cancel",
+      "/en/checkout/cancel",
+    ],
+  },
+
   // ── PWA (@vite-pwa/nuxt) ─────────────────────────────────────────────
   //
   // Strategy: generateSW — Workbox generates a service worker at build time.
@@ -453,8 +508,10 @@ export default defineNuxtConfig({
         // ── Tool routes — auto-generated from app/data/tools.ts ────────
         // DO NOT add individual tool routes here. Edit app/data/tools.ts.
         ...toolPrerenderRoutes,
+        // ── SEO assets ────────────────────────────────────────────────
+        "/sitemap.xml",
       ],
-      ignore: ["/sitemap.xml", "/__nuxt_content"],
+      ignore: ["/__nuxt_content"],
     },
   },
 });

--- a/public/_robots.txt
+++ b/public/_robots.txt
@@ -1,2 +1,33 @@
 User-Agent: *
-Disallow:
+
+# Block private authenticated routes — no financial data should be indexed
+Disallow: /dashboard
+Disallow: /portfolio
+Disallow: /goals
+Disallow: /transactions
+Disallow: /alerts
+Disallow: /simulations
+Disallow: /shared-entries
+Disallow: /income
+Disallow: /subscription
+Disallow: /budgets
+Disallow: /investor-profile
+Disallow: /settings/
+Disallow: /checkout/success
+
+# EN locale equivalents
+Disallow: /en/dashboard
+Disallow: /en/portfolio
+Disallow: /en/goals
+Disallow: /en/transactions
+Disallow: /en/alerts
+Disallow: /en/simulations
+Disallow: /en/shared-entries
+Disallow: /en/income
+Disallow: /en/subscription
+Disallow: /en/budgets
+Disallow: /en/investor-profile
+Disallow: /en/settings/
+Disallow: /en/checkout/success
+
+Sitemap: https://app.auraxis.com.br/sitemap.xml

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -70,3 +70,4 @@ config.global.plugins = [
   ...(config.global.plugins ?? []),
   i18n,
 ];
+


### PR DESCRIPTION
## Summary

- `public/_robots.txt`: bloqueia todas as rotas privadas autenticadas (`/dashboard`, `/portfolio`, `/goals`, `/settings/**`, etc.) e locais EN equivalentes; adiciona `Sitemap:` reference
- `nuxt.config.ts`: adiciona bloco `sitemap` excluindo rotas privadas e de auth do sitemap.xml; remove `/sitemap.xml` do prerender ignore list; adiciona ao seed de prerender para geração estática no build S3
- `app/middleware/legal-seo.ts`: route middleware que injeta `useSeoMeta` para `/privacy-policy` e `/terms-of-service` (PT + EN) sem acoplamento ao componente, mantendo testes unitários funcionais sem contexto Nuxt

## Why middleware instead of component

`useSeoMeta` requires `useNuxtApp` at runtime. The legal pages use plain `mount()` in unit tests (without Nuxt context). Moving SEO injection to a route middleware — following the same pattern as `middleware/noindex.ts` — keeps components testable and avoids `[nuxt] instance unavailable` errors.

## Test plan

- [ ] `pnpm quality-check` verde (lint + typecheck + coverage ≥ 85% + build)
- [ ] Sitemap.xml é gerado estaticamente no output (`.output/public/sitemap.xml`)
- [ ] `robots.txt` bloqueia `/dashboard`, `/portfolio`, `/settings/**`
- [ ] `/privacy-policy` tem `<title>Política de Privacidade | Auraxis</title>` no HTML prerendido
- [ ] `/terms-of-service` tem `<title>Termos de Uso | Auraxis</title>` no HTML prerendido

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)