### PR TITLE
fix(web): disable payloadExtraction — stop _payload.json flood

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -480,6 +480,20 @@ export default defineNuxtConfig({
     "/en/settings/danger-zone":    { ssr: false },
   },
 
+  // ── Experimental flags ────────────────────────────────────────────────
+  // payloadExtraction: when true (Nuxt default for prerendered routes),
+  // every prerendered page emits a sibling `_payload.json` so subsequent
+  // client-side navigations can skip re-running `useAsyncData`. For this
+  // app the public pages (home, /tools, /tools/<slug>) have no runtime
+  // async data — the payload files are empty of value and their eager
+  // prefetch floods the network tab with 404s in dev and
+  // `Unexpected token '<'` parse errors in prod (S3 SPA fallback returns
+  // index.html for missing payloads). Disabling avoids the flood; nav
+  // performance is unaffected since there is no payload to save.
+  experimental: {
+    payloadExtraction: false,
+  },
+
   // ── Nitro ─────────────────────────────────────────────────────────────
   nitro: {
     prerender: {


### PR DESCRIPTION
## Summary

Nuxt's default `payloadExtraction` emits a sibling `_payload.json` for every prerendered route and eagerly prefetches them on client-side navigation. For this app the public pages (home, `/tools`, tool calculators) have no runtime async data, so the extracted payloads carry nothing useful — but the prefetches still fire, flooding the network tab.

Product owner reported seeing this flood on staging/dev.

## Observed behavior

- Dev: `/_payload.json` 404s and `[nuxt] Cannot load payload` warnings on every page load and link hover.
- Prod: `/tools/_payload.json` returns index.html (S3 SPA fallback) → `SyntaxError: Unexpected token '<'`.

## Fix

`experimental.payloadExtraction: false` in `nuxt.config.ts`. Stops the files being emitted and the client from prefetching them. Navigation performance is unchanged — there was no payload to restore in the first place since public pages don't use `useAsyncData`.

## Verified

- Browser DevTools (Chrome DevTools MCP): navigated `/tools/thirteenth-salary` and `/tools` — zero payload errors in console (the remaining `frame-ancestors` meta warning is unrelated, handled by #694).

## Test plan

- [ ] `pnpm dev` → open `/tools/thirteenth-salary` → DevTools Network shows no `_payload.json` requests
- [ ] Same on prod build preview
- [ ] `pnpm quality-check` passes