### PR TITLE
feat(web): goals module + tag color badges on transactions

### DIFF
--- a/app/components/tag/CreateTagModal/CreateTagModal.vue
+++ b/app/components/tag/CreateTagModal/CreateTagModal.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import {
+  NButton,
+  NColorPicker,
+  NForm,
+  NFormItem,
+  NInput,
+  NModal,
+  NSpace,
+} from "naive-ui";
+import { useCreateTagMutation } from "~/features/tags/queries/use-create-tag-mutation";
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  visible: boolean;
+}>();
+
+const emit = defineEmits<{
+  "update:visible": [value: boolean];
+}>();
+
+const createMutation = useCreateTagMutation();
+
+const formName = ref("");
+const formColor = ref<string | null>(null);
+const formIcon = ref("");
+
+const TAG_COLOR_SWATCHES = [
+  "#FF6B6B",
+  "#E67E22",
+  "#F1C40F",
+  "#2ECC71",
+  "#4ECDC4",
+  "#3498DB",
+  "#9B59B6",
+  "#DDA0DD",
+  "#96CEB4",
+  "#D3D3D3",
+];
+
+/** Resets the form to its initial state. */
+function resetForm(): void {
+  formName.value = "";
+  formColor.value = null;
+  formIcon.value = "";
+}
+
+/** Closes the modal. */
+function close(): void {
+  emit("update:visible", false);
+  resetForm();
+}
+
+/** Submits the tag creation. */
+async function onSubmit(): Promise<void> {
+  const name = formName.value.trim();
+  if (!name) { return; }
+
+  await createMutation.mutateAsync({
+    name,
+    color: formColor.value || null,
+    icon: formIcon.value.trim() || null,
+  });
+
+  close();
+}
+</script>
+
+<template>
+  <NModal
+    :show="props.visible"
+    preset="card"
+    :title="t('transactions.tagModal.title')"
+    class="create-tag-modal"
+    :mask-closable="true"
+    @update:show="(v) => emit('update:visible', v)"
+  >
+    <NForm label-placement="top">
+      <NFormItem :label="t('transactions.tagModal.name')">
+        <NInput
+          v-model:value="formName"
+          :placeholder="t('transactions.tagModal.namePlaceholder')"
+          maxlength="50"
+          show-count
+        />
+      </NFormItem>
+
+      <NFormItem :label="t('transactions.tagModal.color')">
+        <div class="create-tag-modal__color-section">
+          <NColorPicker
+            v-model:value="formColor"
+            :swatches="TAG_COLOR_SWATCHES"
+            :modes="['hex']"
+            size="small"
+          />
+          <div v-if="formColor" class="create-tag-modal__preview">
+            <span
+              class="create-tag-modal__preview-badge"
+              :style="{
+                backgroundColor: `${formColor}20`,
+                border: `1px solid ${formColor}`,
+                color: formColor,
+              }"
+            >
+              {{ formName || t('transactions.tagModal.previewLabel') }}
+            </span>
+          </div>
+        </div>
+      </NFormItem>
+
+      <NFormItem :label="t('transactions.tagModal.icon')">
+        <NInput
+          v-model:value="formIcon"
+          :placeholder="t('transactions.tagModal.iconPlaceholder')"
+          maxlength="10"
+        />
+      </NFormItem>
+    </NForm>
+
+    <template #footer>
+      <NSpace justify="end">
+        <NButton @click="close">{{ t('common.cancel') }}</NButton>
+        <NButton
+          type="primary"
+          :loading="createMutation.isPending.value"
+          :disabled="!formName.trim()"
+          @click="onSubmit"
+        >
+          {{ t('transactions.tagModal.create') }}
+        </NButton>
+      </NSpace>
+    </template>
+  </NModal>
+</template>
+
+<style scoped>
+.create-tag-modal {
+  width: min(420px, 95vw);
+}
+
+.create-tag-modal__color-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.create-tag-modal__preview {
+  padding: var(--space-1) 0;
+}
+
+.create-tag-modal__preview-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: var(--radius-full, 9999px);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium, 500);
+  line-height: 1.5;
+}
+</style>

--- a/app/components/tag/CreateTagModal/__tests__/CreateTagModal.spec.ts
+++ b/app/components/tag/CreateTagModal/__tests__/CreateTagModal.spec.ts
@@ -1,0 +1,129 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { ref } from "vue";
+import { describe, expect, it, vi } from "vitest";
+import { NButton, NInput, NModal } from "naive-ui";
+
+import CreateTagModal from "../CreateTagModal.vue";
+
+const mutateAsyncMock = vi.fn().mockResolvedValue({ id: "t-new", name: "Urgent", color: "#FF0000", icon: null });
+const isPending = ref(false);
+
+vi.mock("~/features/tags/queries/use-create-tag-mutation", () => ({
+  useCreateTagMutation: (): { mutateAsync: typeof mutateAsyncMock; isPending: typeof isPending } => ({
+    mutateAsync: mutateAsyncMock,
+    isPending,
+  }),
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: (): { t: (key: string) => string } => ({ t: (key: string): string => key }),
+}));
+
+/**
+ * Mounts the CreateTagModal with a stubbed NModal so its content renders
+ * inline and is reachable via `wrapper.find`.
+ *
+ * @param visible - Initial modal visibility.
+ * @returns VueWrapper around the mounted component.
+ */
+function mountModal(visible = true): ReturnType<typeof mount> {
+  return mount(CreateTagModal, {
+    props: { visible },
+    global: {
+      stubs: {
+        Modal: {
+          name: "Modal",
+          props: { show: Boolean },
+          emits: ["update:show"],
+          template: "<div v-if=\"show\"><slot /><slot name=\"footer\" /></div>",
+        },
+        NColorPicker: {
+          name: "NColorPicker",
+          props: { value: String },
+          emits: ["update:value"],
+          template: "<div class=\"color-picker-stub\" />",
+        },
+      },
+    },
+  });
+}
+
+describe("CreateTagModal", () => {
+  it("renders the NModal when visible is true", () => {
+    const wrapper = mountModal(true);
+    expect(wrapper.findComponent(NModal).exists()).toBe(true);
+  });
+
+  it("does not render content when visible is false", () => {
+    const wrapper = mountModal(false);
+    // Modal stub uses v-if, so content is absent when show is false
+    expect(wrapper.find(".color-picker-stub").exists()).toBe(false);
+  });
+
+  it("disables the primary action when the name is empty", () => {
+    const wrapper = mountModal(true);
+    const primary = wrapper.findAllComponents(NButton).find((b) => b.props("type") === "primary");
+    expect(primary?.props("disabled")).toBe(true);
+  });
+
+  it("enables the primary action when a name is entered", async () => {
+    const wrapper = mountModal(true);
+    const nameInput = wrapper.findAllComponents(NInput)[0];
+    await nameInput?.vm.$emit("update:value", "Urgente");
+    const primary = wrapper.findAllComponents(NButton).find((b) => b.props("type") === "primary");
+    expect(primary?.props("disabled")).toBe(false);
+  });
+
+  it("calls createMutation.mutateAsync with trimmed name on submit", async () => {
+    mutateAsyncMock.mockClear();
+    const wrapper = mountModal(true);
+    const nameInput = wrapper.findAllComponents(NInput)[0];
+    await nameInput?.vm.$emit("update:value", "  Urgente  ");
+    const primary = wrapper.findAllComponents(NButton).find((b) => b.props("type") === "primary");
+    await primary?.trigger("click");
+    await flushPromises();
+    expect(mutateAsyncMock).toHaveBeenCalledWith({ name: "Urgente", color: null, icon: null });
+  });
+
+  it("skips submission when name is only whitespace", async () => {
+    mutateAsyncMock.mockClear();
+    const wrapper = mountModal(true);
+    const nameInput = wrapper.findAllComponents(NInput)[0];
+    await nameInput?.vm.$emit("update:value", "   ");
+    const primary = wrapper.findAllComponents(NButton).find((b) => b.props("type") === "primary");
+    // Button is disabled, so triggering its click still skips — assert the mutation is not called.
+    await primary?.trigger("click");
+    await flushPromises();
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("emits update:visible=false when the modal requests to close", async () => {
+    const wrapper = mountModal(true);
+    await wrapper.findComponent(NModal).vm.$emit("update:show", false);
+    const emitted = wrapper.emitted("update:visible");
+    expect(emitted).toBeDefined();
+    expect(emitted?.[0]).toEqual([false]);
+  });
+
+  it("emits update:visible=false and resets state when the Cancel button is clicked", async () => {
+    const wrapper = mountModal(true);
+    const buttons = wrapper.findAllComponents(NButton);
+    const cancel = buttons.find((b) => b.props("type") !== "primary");
+    await cancel?.trigger("click");
+    expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
+  });
+
+  it("sends trimmed icon when provided (null color defaults when picker untouched)", async () => {
+    mutateAsyncMock.mockClear();
+    const wrapper = mountModal(true);
+    const inputs = wrapper.findAllComponents(NInput);
+    await inputs[0]?.vm.$emit("update:value", "Saúde");
+    // Icon is the second NInput — whitespace should be stripped
+    await inputs[1]?.vm.$emit("update:value", "  🏥  ");
+    const primary = wrapper.findAllComponents(NButton).find((b) => b.props("type") === "primary");
+    await primary?.trigger("click");
+    await flushPromises();
+    expect(mutateAsyncMock).toHaveBeenCalledWith({ name: "Saúde", color: null, icon: "🏥" });
+  });
+
+});

--- a/app/features/transactions/components/TransactionToolbar.vue
+++ b/app/features/transactions/components/TransactionToolbar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { NButton, NDatePicker, NSelect, type SelectOption } from "naive-ui";
-import { Calendar, GripVertical, List, TrendingDown, TrendingUp } from "lucide-vue-next";
+import { Calendar, GripVertical, List, Tag, TrendingDown, TrendingUp } from "lucide-vue-next";
 
 defineProps<{
   filterType: string;
@@ -27,6 +27,7 @@ const emit = defineEmits<{
   "exit-reorder": [];
   "add-income": [];
   "add-expense": [];
+  "create-tag": [];
 }>();
 </script>
 
@@ -100,6 +101,11 @@ const emit = defineEmits<{
     >
       <template #icon><GripVertical :size="14" /></template>
       {{ reorderMode ? $t('transactions.reorder.exit') : $t('transactions.reorder.enter') }}
+    </NButton>
+
+    <NButton size="small" secondary @click="emit('create-tag')">
+      <template #icon><Tag :size="14" /></template>
+      {{ $t('transactions.createTag') }}
     </NButton>
 
     <NButton size="small" @click="emit('add-income')">

--- a/app/features/transactions/composables/__tests__/useTransactionFilters.spec.ts
+++ b/app/features/transactions/composables/__tests__/useTransactionFilters.spec.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import { useTransactionFilters } from "../useTransactionFilters";
 
 vi.mock("~/features/tags/queries/use-tags-query", () => ({
-  useTagsQuery: (): { data: { value: { id: string; name: string }[] } } => ({ data: { value: [{ id: "t1", name: "Food" }] } }),
+  useTagsQuery: (): { data: { value: { id: string; name: string; color: string | null }[] } } => ({
+    data: { value: [{ id: "t1", name: "Food", color: "#FF6B6B" }, { id: "t2", name: "Travel", color: null }] },
+  }),
 }));
 
 vi.mock("~/features/accounts/queries/use-accounts-query", () => ({
@@ -62,6 +64,16 @@ describe("useTransactionFilters", () => {
   it("tagMap contains entries from loaded tags", () => {
     const { tagMap } = useTransactionFilters();
     expect(tagMap.value.get("t1")).toBe("Food");
+  });
+
+  it("tagDetailMap exposes both name and colour for a tag with a colour", () => {
+    const { tagDetailMap } = useTransactionFilters();
+    expect(tagDetailMap.value.get("t1")).toStrictEqual({ name: "Food", color: "#FF6B6B" });
+  });
+
+  it("tagDetailMap returns null colour for tags without a colour", () => {
+    const { tagDetailMap } = useTransactionFilters();
+    expect(tagDetailMap.value.get("t2")).toStrictEqual({ name: "Travel", color: null });
   });
 
   it("accountMap contains entries from loaded accounts", () => {

--- a/app/features/transactions/composables/__tests__/useTransactionTable.spec.ts
+++ b/app/features/transactions/composables/__tests__/useTransactionTable.spec.ts
@@ -1,5 +1,8 @@
+import { computed } from "vue";
 import { describe, expect, it } from "vitest";
-import { formatTransactionDate, isTransactionNearDue, isTransactionOverdue } from "../useTransactionTable";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import { darkenHex, formatTransactionDate, isTransactionNearDue, isTransactionOverdue, renderTagBadge } from "../useTransactionTable";
+import type { TagLookup } from "../useTransactionFilters";
 
 describe("formatTransactionDate", () => {
   it("formats YYYY-MM-DD as dd/MM/yyyy", () => {
@@ -49,5 +52,65 @@ describe("isTransactionNearDue", () => {
 
   it("returns false for overdue (past) transactions", () => {
     expect(isTransactionNearDue("2020-01-01", "pending")).toBe(false);
+  });
+});
+
+describe("darkenHex", () => {
+  it("returns pure black when factor is 1", () => {
+    expect(darkenHex("#FF6B6B", 1)).toBe("#000000");
+  });
+
+  it("returns original colour when factor is 0", () => {
+    expect(darkenHex("#ff6b6b", 0)).toBe("#ff6b6b");
+  });
+
+  it("darkens each channel by the factor (mix with black)", () => {
+    // 0xFF (255) * (1 - 0.5) = 127.5 → rounds to 128 → 0x80
+    expect(darkenHex("#FF6B6B", 0.5)).toBe("#803636");
+  });
+
+  it("pads single-hex-digit channels to two characters", () => {
+    // 0x11 * 0.5 = 8.5 → rounds to 9 → must be "09", not "9"
+    expect(darkenHex("#111111", 0.5)).toBe("#090909");
+  });
+});
+
+describe("renderTagBadge", () => {
+  /**
+   * Builds a minimal transaction fixture for tag-badge tests.
+   *
+   * @param tagId - Optional tag id to assign to the row.
+   * @returns A TransactionDto with the given tag id.
+   */
+  function buildTx(tagId: string | null): TransactionDto {
+    return {
+      id: "tx-1",
+      title: "Payment",
+      amount: "10.00",
+      type: "expense",
+      status: "pending",
+      due_date: "2026-01-01",
+      tag_id: tagId,
+    } as unknown as TransactionDto;
+  }
+
+  it("returns em-dash placeholder when tag is not in the map", () => {
+    const map = computed(() => new Map<string, TagLookup>());
+    expect(renderTagBadge(buildTx(null), map)).toBe("—");
+  });
+
+  it("returns plain tag name when tag exists but has no colour", () => {
+    const map = computed(() => new Map<string, TagLookup>([["t1", { name: "Food", color: null }]]));
+    expect(renderTagBadge(buildTx("t1"), map)).toBe("Food");
+  });
+
+  it("returns a styled VNode when tag has a colour", () => {
+    const map = computed(() => new Map<string, TagLookup>([["t1", { name: "Urgent", color: "#FF6B6B" }]]));
+    const result = renderTagBadge(buildTx("t1"), map);
+    expect(typeof result).toBe("object");
+    // VNode children contain the tag name
+    expect(JSON.stringify(result)).toContain("Urgent");
+    // Style string includes the background colour + 20 alpha suffix
+    expect(JSON.stringify(result)).toContain("#FF6B6B20");
   });
 });

--- a/app/features/transactions/composables/useTransactionFilters.ts
+++ b/app/features/transactions/composables/useTransactionFilters.ts
@@ -26,12 +26,22 @@ function useLookupQueries(): { tags: ReturnType<typeof useTagsQuery>["data"]; ac
  * @param accounts Reactive account list.
  * @returns ComputedRef maps for fast id → name resolution.
  */
+export type TagLookup = { name: string; color: string | null };
+
+/**
+ * Builds reactive lookup maps from tag and account query data.
+ *
+ * @param tags     Reactive tag list.
+ * @param accounts Reactive account list.
+ * @returns ComputedRef maps for fast id → name/color resolution.
+ */
 function buildLookupMaps(
   tags: ReturnType<typeof useTagsQuery>["data"],
   accounts: ReturnType<typeof useAccountsQuery>["data"],
-): { tagMap: ComputedRef<Map<string, string>>; accountMap: ComputedRef<Map<string, string>> } {
+): { tagMap: ComputedRef<Map<string, string>>; tagDetailMap: ComputedRef<Map<string, TagLookup>>; accountMap: ComputedRef<Map<string, string>> } {
   return {
     tagMap: computed(() => new Map((tags.value ?? []).map((tg: { id: string; name: string }) => [tg.id, tg.name]))),
+    tagDetailMap: computed(() => new Map((tags.value ?? []).map((tg: { id: string; name: string; color: string | null }) => [tg.id, { name: tg.name, color: tg.color }]))),
     accountMap: computed(() => new Map((accounts.value ?? []).map((ac: { id: string; name: string }) => [ac.id, ac.name]))),
   };
 }
@@ -51,6 +61,7 @@ export type UseTransactionFiltersReturn = {
   STATUS_OPTIONS: ComputedRef<SelectOption[]>;
   tagOptions: ComputedRef<SelectOption[]>;
   tagMap: ComputedRef<Map<string, string>>;
+  tagDetailMap: ComputedRef<Map<string, TagLookup>>;
   accountMap: ComputedRef<Map<string, string>>;
   clearFilters: () => void;
 };
@@ -143,7 +154,7 @@ export function useTransactionFilters(): UseTransactionFiltersReturn {
     ...(tags.value ?? []).map((tg: { id: string; name: string }) => ({ label: tg.name, value: tg.id })),
   ]);
 
-  const { tagMap, accountMap } = buildLookupMaps(tags, accounts);
+  const { tagMap, tagDetailMap, accountMap } = buildLookupMaps(tags, accounts);
 
   /**
    * Resets all active filters back to their default (unfiltered) state.
@@ -171,6 +182,7 @@ export function useTransactionFilters(): UseTransactionFiltersReturn {
     STATUS_OPTIONS,
     tagOptions,
     tagMap,
+    tagDetailMap,
     accountMap,
     clearFilters,
   };

--- a/app/features/transactions/composables/useTransactionTable.ts
+++ b/app/features/transactions/composables/useTransactionTable.ts
@@ -237,7 +237,7 @@ function renderActions(
  * @param factor 0-1 where 0 = original, 1 = fully black.
  * @returns Darkened hex string.
  */
-function darkenHex(hex: string, factor: number): string {
+export function darkenHex(hex: string, factor: number): string {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);
   const b = parseInt(hex.slice(5, 7), 16);
@@ -257,7 +257,7 @@ function darkenHex(hex: string, factor: number): string {
  * @param tagDetailMap Reactive map of tag id → {name, color}.
  * @returns VNode or plain string.
  */
-function renderTagBadge(
+export function renderTagBadge(
   row: TransactionDto,
   tagDetailMap: ComputedRef<Map<string, TagLookup>>,
 ): ReturnType<typeof h> | string {

--- a/app/features/transactions/composables/useTransactionTable.ts
+++ b/app/features/transactions/composables/useTransactionTable.ts
@@ -17,6 +17,7 @@ import {
   Trash2,
 } from "lucide-vue-next";
 import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import type { TagLookup } from "./useTransactionFilters";
 import { formatCurrency } from "~/utils/currency";
 
 const SWIPE_THRESHOLD = 72;
@@ -64,6 +65,7 @@ export function isTransactionNearDue(dueDate: string, status: string): boolean {
 export type UseTransactionTableOptions = {
   data: Ref<TransactionDto[] | undefined> | ComputedRef<TransactionDto[] | undefined>;
   tagMap: ComputedRef<Map<string, string>>;
+  tagDetailMap: ComputedRef<Map<string, TagLookup>>;
   accountMap: ComputedRef<Map<string, string>>;
   filterType: Ref<string>;
   filterStatus: Ref<string>;
@@ -229,6 +231,50 @@ function renderActions(
 }
 
 /**
+ * Darkens a hex colour by mixing it with black.
+ *
+ * @param hex    7-char hex string like "#FF6B6B".
+ * @param factor 0-1 where 0 = original, 1 = fully black.
+ * @returns Darkened hex string.
+ */
+function darkenHex(hex: string, factor: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  /**
+   * @param v - Channel value (0-255).
+   * @returns Hex pair string.
+   */
+  const d = (v: number): string => Math.round(v * (1 - factor)).toString(16).padStart(2, "0");
+  return `#${d(r)}${d(g)}${d(b)}`;
+}
+
+/**
+ * Renders the tag column as a coloured badge when the tag has a colour,
+ * or as plain text when it does not.
+ *
+ * @param row          Transaction row.
+ * @param tagDetailMap Reactive map of tag id → {name, color}.
+ * @returns VNode or plain string.
+ */
+function renderTagBadge(
+  row: TransactionDto,
+  tagDetailMap: ComputedRef<Map<string, TagLookup>>,
+): ReturnType<typeof h> | string {
+  const tag = tagDetailMap.value.get(row.tag_id ?? "");
+  if (!tag) { return "—"; }
+  if (!tag.color) { return tag.name; }
+  return h("span", {
+    class: "tx-tag-badge",
+    style: {
+      backgroundColor: `${tag.color}20`,
+      border: `1px solid ${darkenHex(tag.color, 0.25)}`,
+      color: darkenHex(tag.color, 0.4),
+    },
+  }, tag.name);
+}
+
+/**
  * Manages table columns, drag-and-drop reorder, touch swipe gestures,
  * row props, pagination and summary totals for the transactions page.
  *
@@ -287,7 +333,7 @@ export function useTransactionTable(opts: UseTransactionTableOptions): UseTransa
       { key: "status" as DataTableRowKey, title: t("transactions.table.status"), width: 64, render: (row: TransactionDto) => renderStatusIcon(row, t) },
       { key: "due_date" as DataTableRowKey, title: t("transactions.table.date"), width: 108, defaultSortOrder: "descend" as const, sorter: withSort ? (a: TransactionDto, b: TransactionDto): number => a.due_date.localeCompare(b.due_date) : undefined, render: (row: TransactionDto): string => formatTransactionDate(row.due_date) },
       { key: "title" as DataTableRowKey, title: t("transactions.table.description"), ellipsis: { tooltip: true }, sorter: withSort ? (a: TransactionDto, b: TransactionDto): number => a.title.localeCompare(b.title, "pt-BR") : undefined, render: (row: TransactionDto) => renderTitle(row, t) },
-      { key: "tag_id" as DataTableRowKey, title: t("transactions.table.category"), width: 130, ellipsis: { tooltip: true }, render: (row: TransactionDto): string => opts.tagMap.value.get(row.tag_id ?? "") ?? "—" },
+      { key: "tag_id" as DataTableRowKey, title: t("transactions.table.category"), width: 150, ellipsis: { tooltip: true }, render: (row: TransactionDto) => renderTagBadge(row, opts.tagDetailMap) },
       { key: "account_id" as DataTableRowKey, title: t("transactions.table.account"), width: 120, ellipsis: { tooltip: true }, render: (row: TransactionDto): string => opts.accountMap.value.get(row.account_id ?? "") ?? "—" },
       { key: "amount" as DataTableRowKey, title: t("transactions.table.amount"), width: 138, sorter: withSort ? (a: TransactionDto, b: TransactionDto): number => parseFloat(a.amount) - parseFloat(b.amount) : undefined, render: (row: TransactionDto) => renderAmount(row) },
       { key: "__actions" as DataTableRowKey, title: t("transactions.table.actions"), width: 108, render: (row: TransactionDto) => renderActions(row, opts, t) },

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -1554,17 +1554,6 @@
     "subtitle": "Recorded income and expenses",
     "addIncome": "New Income",
     "addExpense": "New Expense",
-    "createTag": "Create Tag",
-    "tagModal": {
-      "title": "New Tag",
-      "name": "Tag name",
-      "namePlaceholder": "e.g. Urgent, Investment...",
-      "color": "Color",
-      "icon": "Icon (emoji)",
-      "iconPlaceholder": "🏷️",
-      "previewLabel": "Preview",
-      "create": "Create tag"
-    },
     "recurring": "Recurring",
     "installment": "{count}x",
     "count": "{n} transactions",

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -1554,6 +1554,17 @@
     "subtitle": "Recorded income and expenses",
     "addIncome": "New Income",
     "addExpense": "New Expense",
+    "createTag": "Create Tag",
+    "tagModal": {
+      "title": "New Tag",
+      "name": "Tag name",
+      "namePlaceholder": "e.g. Urgent, Investment...",
+      "color": "Color",
+      "icon": "Icon (emoji)",
+      "iconPlaceholder": "🏷️",
+      "previewLabel": "Preview",
+      "create": "Create tag"
+    },
     "recurring": "Recurring",
     "installment": "{count}x",
     "count": "{n} transactions",

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -1554,6 +1554,17 @@
     "subtitle": "Receitas e despesas registradas",
     "addIncome": "Nova Receita",
     "addExpense": "Nova Despesa",
+    "createTag": "Criar Tag",
+    "tagModal": {
+      "title": "Nova Tag",
+      "name": "Nome da tag",
+      "namePlaceholder": "Ex: Urgência, Investimento...",
+      "color": "Cor",
+      "icon": "Ícone (emoji)",
+      "iconPlaceholder": "🏷️",
+      "previewLabel": "Exemplo",
+      "create": "Criar tag"
+    },
     "recurring": "Recorrente",
     "installment": "{count}x",
     "count": "{n} transação | {n} transações",

--- a/app/pages/goals.vue
+++ b/app/pages/goals.vue
@@ -15,7 +15,7 @@ import type { GoalDto, GoalStatus, CreateGoalPayload } from "~/features/goals/co
 const { t } = useI18n();
 
 definePageMeta({
-  middleware: ["authenticated", "coming-soon"],
+  middleware: ["authenticated"],
   pageTitle: "Metas",
   pageSubtitle: "Acompanhe suas metas financeiras",
 });

--- a/app/pages/settings/tags.vue
+++ b/app/pages/settings/tags.vue
@@ -3,6 +3,7 @@ import { h, type VNodeChild } from "vue";
 import {
   NButton,
   NCard,
+  NColorPicker,
   NDataTable,
   NFormItem,
   NInput,
@@ -22,7 +23,7 @@ import { useDeleteTagMutation } from "~/features/tags/queries/use-delete-tag-mut
 const { t } = useI18n();
 
 definePageMeta({
-  middleware: ["authenticated", "coming-soon"],
+  middleware: ["authenticated"],
   pageTitle: "Tags",
   pageSubtitle: "Gerencie suas tags de categorização",
 });
@@ -210,18 +211,12 @@ const columns = computed((): DataTableColumns<TagDto> => [
           />
         </NFormItem>
         <NFormItem :label="$t('pages.settings.tags.fields.color')">
-          <div class="color-field">
-            <NInput
-              v-model:value="formColor"
-              :placeholder="$t('pages.settings.tags.fields.colorPlaceholder')"
-              maxlength="7"
-            />
-            <span
-              v-if="formColor"
-              class="color-preview"
-              :style="{ background: formColor }"
-            />
-          </div>
+          <NColorPicker
+            v-model:value="formColor"
+            :swatches="['#FF6B6B','#E67E22','#F1C40F','#2ECC71','#4ECDC4','#3498DB','#9B59B6','#DDA0DD','#96CEB4','#D3D3D3']"
+            :modes="['hex']"
+            size="small"
+          />
         </NFormItem>
         <NFormItem :label="$t('pages.settings.tags.fields.icon')">
           <NInput

--- a/app/pages/transactions.vue
+++ b/app/pages/transactions.vue
@@ -23,8 +23,10 @@ useHead({ title: "Transações | Auraxis" });
 const {
   filterType, filterStatus, filterStartDate, filterEndDate, filterTagId,
   viewMode, selectedDay, showDayDetail, onDayClick,
-  filters, TYPE_OPTIONS, STATUS_OPTIONS, tagOptions, tagMap, accountMap, clearFilters,
+  filters, TYPE_OPTIONS, STATUS_OPTIONS, tagOptions, tagMap, tagDetailMap, accountMap, clearFilters,
 } = useTransactionFilters();
+
+const showCreateTag = ref(false);
 
 // ── Query ─────────────────────────────────────────────────────────────────────
 
@@ -53,6 +55,7 @@ const {
 } = useTransactionTable({
   data,
   tagMap,
+  tagDetailMap,
   accountMap,
   filterType,
   filterStatus,
@@ -77,6 +80,9 @@ const {
 
     <!-- ── Edit modal ──────────────────────────────────────────────────────── -->
     <EditTransactionModal :visible="showEditModal" :transaction="editTarget" @update:visible="showEditModal = $event" @success="onTransactionCreated" />
+
+    <!-- ── Create tag modal ───────────────────────────────────────────────── -->
+    <CreateTagModal :visible="showCreateTag" @update:visible="showCreateTag = $event" />
 
     <!-- ── Delete confirmation ─────────────────────────────────────────────── -->
     <NModal :show="showDeleteConfirm" preset="dialog" type="error" :title="$t('transactions.action.delete')" :content="$t('transactions.action.deleteConfirm')" :positive-text="$t('transactions.action.deleteConfirmYes')" :negative-text="$t('transactions.action.deleteConfirmNo')" :loading="deleteMutation.isPending.value" @positive-click="confirmDelete" @negative-click="showDeleteConfirm = false" @close="showDeleteConfirm = false" />
@@ -127,6 +133,7 @@ const {
       @exit-reorder="exitReorderMode"
       @add-income="showIncome = true"
       @add-expense="showExpense = true"
+      @create-tag="showCreateTag = true"
     />
 
     <!-- ── Reorder / swipe hints ───────────────────────────────────────────── -->
@@ -227,6 +234,7 @@ const {
 :deep(.tx-badge) { display: inline-flex; align-items: center; gap: 3px; font-size: var(--font-size-xs); color: var(--color-text-muted); }
 :deep(.tx-drag-handle) { display: flex; align-items: center; justify-content: center; cursor: grab; color: var(--color-text-muted); }
 :deep(.tx-drag-handle):active { cursor: grabbing; }
+:deep(.tx-tag-badge) { display: inline-block; padding: 2px 8px; border-radius: var(--radius-full, 9999px); font-size: var(--font-size-xs); font-weight: var(--font-weight-medium, 500); line-height: 1.4; white-space: nowrap; }
 
 @media (max-width: 640px) {
   .transactions-page__summary { grid-template-columns: 1fr; }


### PR DESCRIPTION
Closes #670.

## Summary
- **Goals module unlocked**: removed `coming-soon` middleware from `/goals`. Page, cards (GoalCard), form (GoalForm), plan/projection/simulate panels were already fully implemented — just needed the gate removed. Feature flag `web.pages.goals` already `enabled-prod`.
- **Create Tag from transactions**: new "Criar Tag" button on the toolbar opens a `CreateTagModal` with `NColorPicker` (hex + 10 preset swatches), name, and icon fields.
- **Colored tag badges**: tag column in the transactions table now renders a pill badge — light tinted background (`color` at 12% opacity), darker border (`darkenHex 25%`), dark text (`darkenHex 40%`). Falls back to plain text when tag has no color.
- **Settings tags page**: upgraded color input to `NColorPicker` for consistency; removed `coming-soon` middleware.

## Files changed
- `app/pages/goals.vue` — removed coming-soon middleware
- `app/pages/settings/tags.vue` — NColorPicker + removed coming-soon
- `app/pages/transactions.vue` — CreateTagModal integration + tag badge styles
- `app/features/transactions/composables/useTransactionFilters.ts` — tagDetailMap
- `app/features/transactions/composables/useTransactionTable.ts` — renderTagBadge + darkenHex
- `app/features/transactions/components/TransactionToolbar.vue` — create-tag event + button
- `app/components/tag/CreateTagModal/CreateTagModal.vue` — new component
- `app/i18n/locales/{pt,en}.json` — tagModal keys

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run` green — coverage ≥ 85%
- [ ] Manual: navigate to /goals — cards render with progress bar, form creates/edits/deletes
- [ ] Manual: transactions page → "Criar Tag" → pick color → create → tag badge appears with chosen color
- [ ] Manual: settings/tags — color picker works