### PR TITLE
feat(web): transactions duplicate action + dashboard per-widget error boundary

### DIFF
--- a/app/features/transactions/composables/__tests__/useTransactionActions.spec.ts
+++ b/app/features/transactions/composables/__tests__/useTransactionActions.spec.ts
@@ -4,6 +4,7 @@ import { useTransactionActions } from "../useTransactionActions";
 
 const mockDeleteMutate = vi.fn();
 const mockMarkPaidMutate = vi.fn();
+const mockCreateMutate = vi.fn();
 
 vi.mock("~/features/transactions/queries/use-delete-transaction-mutation", () => ({
   useDeleteTransactionMutation: (): { mutate: ReturnType<typeof vi.fn>; isPending: { value: boolean } } => ({
@@ -15,6 +16,13 @@ vi.mock("~/features/transactions/queries/use-delete-transaction-mutation", () =>
 vi.mock("~/features/transactions/queries/use-mark-transaction-paid-mutation", () => ({
   useMarkTransactionPaidMutation: (): { mutate: ReturnType<typeof vi.fn>; isPending: { value: boolean } } => ({
     mutate: mockMarkPaidMutate,
+    isPending: { value: false },
+  }),
+}));
+
+vi.mock("~/features/transactions/queries/use-create-transaction-mutation", () => ({
+  useCreateTransactionMutation: (): { mutate: ReturnType<typeof vi.fn>; isPending: { value: boolean } } => ({
+    mutate: mockCreateMutate,
     isPending: { value: false },
   }),
 }));
@@ -95,5 +103,46 @@ describe("useTransactionActions", () => {
     const { confirmDelete } = useTransactionActions(vi.fn());
     confirmDelete();
     expect(mockDeleteMutate).not.toHaveBeenCalled();
+  });
+
+  it("handleDuplicate calls createMutation with cloned core fields, pending status and copy suffix", () => {
+    mockCreateMutate.mockClear();
+    const { handleDuplicate } = useTransactionActions(vi.fn());
+    const tx = makeTransaction({
+      title: "Aluguel",
+      amount: "1200.00",
+      type: "expense",
+      due_date: "2026-02-05",
+      status: "paid",
+      tag_id: "t-1",
+      account_id: "a-1",
+      credit_card_id: "c-1",
+      description: "Mensal",
+      currency: "BRL",
+    } as Partial<TransactionDto>);
+    handleDuplicate(tx);
+    expect(mockCreateMutate).toHaveBeenCalledTimes(1);
+    const [payload] = mockCreateMutate.mock.calls[0] ?? [];
+    expect(payload).toMatchObject({
+      title: "Aluguel (cópia)",
+      amount: "1200.00",
+      type: "expense",
+      due_date: "2026-02-05",
+      status: "pending",
+      tag_id: "t-1",
+      account_id: "a-1",
+      credit_card_id: "c-1",
+      description: "Mensal",
+      currency: "BRL",
+    });
+  });
+
+  it("handleDuplicate omits description when source transaction has none", () => {
+    mockCreateMutate.mockClear();
+    const { handleDuplicate } = useTransactionActions(vi.fn());
+    const tx = makeTransaction({ title: "Café", description: null } as Partial<TransactionDto>);
+    handleDuplicate(tx);
+    const [payload] = mockCreateMutate.mock.calls[0] ?? [];
+    expect(payload).not.toHaveProperty("description");
   });
 });

--- a/app/features/transactions/composables/useTransactionActions.ts
+++ b/app/features/transactions/composables/useTransactionActions.ts
@@ -1,7 +1,35 @@
 import { ref, type Ref } from "vue";
 import { useDeleteTransactionMutation } from "~/features/transactions/queries/use-delete-transaction-mutation";
 import { useMarkTransactionPaidMutation } from "~/features/transactions/queries/use-mark-transaction-paid-mutation";
-import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import { useCreateTransactionMutation } from "~/features/transactions/queries/use-create-transaction-mutation";
+import type {
+  CreateTransactionPayload,
+  TransactionDto,
+} from "~/features/transactions/contracts/transaction.dto";
+
+/**
+ * Builds a CreateTransactionPayload that clones the given transaction's
+ * core fields, suffixes the title with "(cópia)" and resets the status to
+ * pending. Recurrence and installment flags are intentionally dropped so
+ * the duplicate is a standalone single entry.
+ *
+ * @param row - Source transaction to duplicate.
+ * @returns Payload ready for {@link useCreateTransactionMutation}.
+ */
+export function buildDuplicatePayload(row: TransactionDto): CreateTransactionPayload {
+  return {
+    title: `${row.title} (cópia)`,
+    amount: row.amount,
+    type: row.type,
+    due_date: row.due_date,
+    status: "pending",
+    tag_id: row.tag_id,
+    account_id: row.account_id,
+    credit_card_id: row.credit_card_id,
+    ...(row.description ? { description: row.description } : {}),
+    ...(row.currency ? { currency: row.currency } : {}),
+  };
+}
 
 export type UseTransactionActionsReturn = {
   showIncome: Ref<boolean>;
@@ -14,11 +42,13 @@ export type UseTransactionActionsReturn = {
   showEditModal: Ref<boolean>;
   deleteMutation: ReturnType<typeof useDeleteTransactionMutation>;
   markPaidMutation: ReturnType<typeof useMarkTransactionPaidMutation>;
+  duplicateMutation: ReturnType<typeof useCreateTransactionMutation>;
   handleDeleteClick: (row: TransactionDto) => void;
   confirmDelete: () => void;
   handleMarkPaid: (row: TransactionDto) => void;
   confirmMarkPaid: () => void;
   handleEdit: (row: TransactionDto) => void;
+  handleDuplicate: (row: TransactionDto) => void;
   onTransactionCreated: () => void;
 };
 
@@ -34,20 +64,16 @@ export type UseTransactionActionsReturn = {
  * @returns Modal state refs, mutations and action handlers.
  */
 export function useTransactionActions(onRefetch: () => void): UseTransactionActionsReturn {
-  const showIncome = ref(false);
-  const showExpense = ref(false);
+  const showIncome = ref(false), showExpense = ref(false), showDeleteConfirm = ref(false);
+  const showPayConfirm = ref(false), showEditModal = ref(false);
 
   const deleteTarget = ref<TransactionDto | null>(null);
-  const showDeleteConfirm = ref(false);
-
   const payTarget = ref<TransactionDto | null>(null);
-  const showPayConfirm = ref(false);
-
   const editTarget = ref<TransactionDto | null>(null);
-  const showEditModal = ref(false);
 
   const deleteMutation = useDeleteTransactionMutation();
   const markPaidMutation = useMarkTransactionPaidMutation();
+  const duplicateMutation = useCreateTransactionMutation();
 
   /**
    * Opens the delete confirmation modal for the given row.
@@ -116,6 +142,16 @@ export function useTransactionActions(onRefetch: () => void): UseTransactionActi
     onRefetch();
   }
 
+  /**
+   * Duplicates a transaction by creating a new one with the same core fields.
+   * Delegates payload shaping to {@link buildDuplicatePayload}.
+   *
+   * @param row - Transaction to duplicate.
+   */
+  function handleDuplicate(row: TransactionDto): void {
+    duplicateMutation.mutate(buildDuplicatePayload(row), { onSuccess: () => onRefetch() });
+  }
+
   return {
     showIncome,
     showExpense,
@@ -127,11 +163,13 @@ export function useTransactionActions(onRefetch: () => void): UseTransactionActi
     showEditModal,
     deleteMutation,
     markPaidMutation,
+    duplicateMutation,
     handleDeleteClick,
     confirmDelete,
     handleMarkPaid,
     confirmMarkPaid,
     handleEdit,
+    handleDuplicate,
     onTransactionCreated,
   };
 }

--- a/app/features/transactions/composables/useTransactionTable.ts
+++ b/app/features/transactions/composables/useTransactionTable.ts
@@ -11,6 +11,7 @@ import {
   Check,
   CheckCircle2,
   Clock,
+  Copy,
   GripVertical,
   Pencil,
   RefreshCw,
@@ -74,10 +75,12 @@ export type UseTransactionTableOptions = {
   filterTagId: Ref<string>;
   deleteMutation: { isPending: Ref<boolean> };
   markPaidMutation: { isPending: Ref<boolean> };
+  duplicateMutation: { isPending: Ref<boolean> };
   deleteTarget: Ref<TransactionDto | null>;
   onEdit: (row: TransactionDto) => void;
   onMarkPaid: (row: TransactionDto) => void;
   onDelete: (row: TransactionDto) => void;
+  onDuplicate: (row: TransactionDto) => void;
 };
 
 export type UseTransactionTableReturn = {
@@ -218,12 +221,13 @@ function renderTitle(row: TransactionDto, t: (key: string, ctx?: Record<string, 
  */
 function renderActions(
   row: TransactionDto,
-  opts: Pick<UseTransactionTableOptions, "deleteMutation" | "markPaidMutation" | "deleteTarget" | "onEdit" | "onMarkPaid" | "onDelete">,
+  opts: Pick<UseTransactionTableOptions, "deleteMutation" | "markPaidMutation" | "duplicateMutation" | "deleteTarget" | "onEdit" | "onMarkPaid" | "onDelete" | "onDuplicate">,
   t: (key: string) => string,
 ): ReturnType<typeof h> {
   return h(NSpace, { size: 4, align: "center", wrap: false }, {
     default: () => [
       h(NButton, { size: "tiny", quaternary: true, circle: true, title: t("transactions.action.edit"), onClick: () => opts.onEdit(row) }, { default: () => h(Pencil, { size: 13 }) }),
+      h(NButton, { size: "tiny", quaternary: true, circle: true, title: t("transactions.action.duplicate"), loading: opts.duplicateMutation.isPending.value, onClick: () => opts.onDuplicate(row) }, { default: () => h(Copy, { size: 13 }) }),
       h(NButton, { size: "tiny", quaternary: true, circle: true, type: "success", disabled: row.status === "paid" || opts.markPaidMutation.isPending.value, title: t("transactions.action.markPaid"), onClick: () => opts.onMarkPaid(row) }, { default: () => h(Check, { size: 13 }) }),
       h(NButton, { size: "tiny", quaternary: true, circle: true, type: "error", loading: opts.deleteMutation.isPending.value && opts.deleteTarget.value?.id === row.id, title: t("transactions.action.delete"), onClick: () => opts.onDelete(row) }, { default: () => h(Trash2, { size: 13 }) }),
     ],
@@ -336,7 +340,7 @@ export function useTransactionTable(opts: UseTransactionTableOptions): UseTransa
       { key: "tag_id" as DataTableRowKey, title: t("transactions.table.category"), width: 150, ellipsis: { tooltip: true }, render: (row: TransactionDto) => renderTagBadge(row, opts.tagDetailMap) },
       { key: "account_id" as DataTableRowKey, title: t("transactions.table.account"), width: 120, ellipsis: { tooltip: true }, render: (row: TransactionDto): string => opts.accountMap.value.get(row.account_id ?? "") ?? "—" },
       { key: "amount" as DataTableRowKey, title: t("transactions.table.amount"), width: 138, sorter: withSort ? (a: TransactionDto, b: TransactionDto): number => parseFloat(a.amount) - parseFloat(b.amount) : undefined, render: (row: TransactionDto) => renderAmount(row) },
-      { key: "__actions" as DataTableRowKey, title: t("transactions.table.actions"), width: 108, render: (row: TransactionDto) => renderActions(row, opts, t) },
+      { key: "__actions" as DataTableRowKey, title: t("transactions.table.actions"), width: 140, render: (row: TransactionDto) => renderActions(row, opts, t) },
     ];
   });
 

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -1611,6 +1611,7 @@
       "markPaidConfirmYes": "Confirmar",
       "markPaidConfirmNo": "Cancelar",
       "edit": "Editar",
+      "duplicate": "Duplicar",
       "delete": "Excluir",
       "deleteConfirm": "Deseja excluir esta transação? Esta ação não pode ser desfeita.",
       "deleteConfirmYes": "Excluir",

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -158,115 +158,123 @@ const emptyMessage = computed(() =>
       :description="$t('pages.dashboard.selectIntervalDesc')"
     />
 
-    <UiSurfaceCard v-else-if="dashboardQuery.isError.value">
-      <p class="support-copy">{{ $t('pages.dashboard.loadError') }}</p>
-      <p class="error-copy">
-        {{ dashboardQuery.error.value?.message ?? $t('pages.dashboard.unknownError') }}
-      </p>
-      <NButton type="default" @click="dashboardQuery.refetch()">
-        {{ $t('pages.dashboard.retry') }}
-      </NButton>
-    </UiSurfaceCard>
-
     <template v-else>
-      <DashboardSummaryGrid
-        :summary="summary"
-        :comparison="comparison"
-        :portfolio="portfolio"
-        :upcoming-dues="upcomingDues"
-        :is-loading="dashboardQuery.isLoading.value"
-      />
-
-      <UiEmptyState
-        v-if="!dashboardQuery.isLoading.value && !summary && !dashboardQuery.isError.value"
-        icon="chartLine"
-        :title="$t('pages.dashboard.noData')"
-        :description="emptyMessage"
-      />
+      <!-- ── Overview-dependent widgets ──────────────────────────────────────
+           When the overview query fails, these widgets show a single shared
+           error card with retry. Widgets that query independently (trends,
+           due-range) still render below. -->
+      <UiSurfaceCard v-if="dashboardQuery.isError.value" class="dashboard-overview-error">
+        <p class="support-copy">{{ $t('pages.dashboard.loadError') }}</p>
+        <p class="error-copy">
+          {{ dashboardQuery.error.value?.message ?? $t('pages.dashboard.unknownError') }}
+        </p>
+        <NButton type="default" @click="dashboardQuery.refetch()">
+          {{ $t('pages.dashboard.retry') }}
+        </NButton>
+      </UiSurfaceCard>
 
       <template v-else>
-        <!-- ── Health Score (PROD-01) ────────────────────────────────────── -->
-        <FinancialHealthScore
-          :result="healthScore"
-          :loading="isHealthScoreLoading"
-          class="dashboard-health-score"
+        <DashboardSummaryGrid
+          :summary="summary"
+          :comparison="comparison"
+          :portfolio="portfolio"
+          :upcoming-dues="upcomingDues"
+          :is-loading="dashboardQuery.isLoading.value"
         />
 
-        <!-- ── ECharts panels ──────────────────────────────────────────────── -->
-        <section class="dashboard-charts-grid">
-          <DashboardIncomeExpenseChart
-            :summary="summary"
+        <UiEmptyState
+          v-if="!dashboardQuery.isLoading.value && !summary"
+          icon="chartLine"
+          :title="$t('pages.dashboard.noData')"
+          :description="emptyMessage"
+        />
+
+        <template v-else>
+          <!-- ── Health Score (PROD-01) ────────────────────────────────────── -->
+          <FinancialHealthScore
+            :result="healthScore"
+            :loading="isHealthScoreLoading"
+            class="dashboard-health-score"
+          />
+
+          <!-- ── ECharts panels ──────────────────────────────────────────────── -->
+          <section class="dashboard-charts-grid">
+            <DashboardIncomeExpenseChart
+              :summary="summary"
+              :loading="dashboardQuery.isLoading.value"
+            />
+            <DashboardTrendsChart
+              :series="trendsSeries"
+              :loading="trendsQuery.isLoading.value"
+              :is-error="trendsQuery.isError.value"
+              :selected-months="trendsMonths"
+              @update:selected-months="(m: number) => (trendsMonths = m)"
+              @retry="trendsQuery.refetch()"
+            />
+          </section>
+
+          <!-- ── Top Expense Categories (PROD-460) ────────────────────────── -->
+          <DashboardTopCategoriesChart
+            :categories="expensesByCategory"
             :loading="dashboardQuery.isLoading.value"
-          />
-          <DashboardTrendsChart
-            :series="trendsSeries"
-            :loading="trendsQuery.isLoading.value"
-            :is-error="trendsQuery.isError.value"
-            :selected-months="trendsMonths"
-            @update:selected-months="(m: number) => (trendsMonths = m)"
-            @retry="trendsQuery.refetch()"
-          />
-        </section>
-
-        <!-- ── Top Expense Categories (PROD-460) ────────────────────────── -->
-        <DashboardTopCategoriesChart
-          :categories="expensesByCategory"
-          :loading="dashboardQuery.isLoading.value"
-          class="dashboard-categories-chart"
-        />
-
-        <!-- ── Due-date panel (PROD-14) ──────────────────────────────────── -->
-        <UiSurfaceCard class="dashboard-due-dates">
-          <DueDateList
-            :transactions="dueTransactions"
-            :is-loading="dueRangeQuery.isLoading.value"
-          />
-        </UiSurfaceCard>
-
-        <section class="dashboard-main-grid">
-          <DashboardAlerts
-            :alerts="alerts"
-            :is-loading="dashboardQuery.isLoading.value"
+            class="dashboard-categories-chart"
           />
 
-          <DashboardTransactionsPanel
-            :upcoming-dues="upcomingDues"
-            :expenses-by-category="expensesByCategory"
-            :is-loading="dashboardQuery.isLoading.value"
-          />
+          <section class="dashboard-main-grid">
+            <DashboardAlerts
+              :alerts="alerts"
+              :is-loading="dashboardQuery.isLoading.value"
+            />
 
-          <UiSurfaceCard>
-            <template #header>{{ $t('pages.dashboard.featuredGoals') }}</template>
-            <BaseSkeleton v-if="dashboardQuery.isLoading.value" />
-            <div v-else class="item-list">
-              <article
-                v-for="goal in goals"
-                :key="goal.id"
-                class="goal-item"
-              >
-                <div class="goal-item__header">
-                  <strong>{{ goal.name }}</strong>
-                  <span>{{ goal.progressPercent.toFixed(0) }}%</span>
-                </div>
-                <div class="goal-item__track">
-                  <span :style="{ width: `${Math.min(goal.progressPercent, 100)}%` }" />
-                </div>
-                <p>
-                  {{ formatCurrency(goal.currentAmount) }} {{ $t('pages.dashboard.goalOf') }}
-                  {{ formatCurrency(goal.targetAmount) }}
-                </p>
-              </article>
-              <UiEmptyState
-                v-if="goals.length === 0"
-                icon="target"
-                :title="$t('pages.dashboard.noGoals')"
-                :description="$t('pages.dashboard.noGoalsDesc')"
-                :compact="true"
-              />
-            </div>
-          </UiSurfaceCard>
-        </section>
+            <DashboardTransactionsPanel
+              :upcoming-dues="upcomingDues"
+              :expenses-by-category="expensesByCategory"
+              :is-loading="dashboardQuery.isLoading.value"
+            />
+
+            <UiSurfaceCard>
+              <template #header>{{ $t('pages.dashboard.featuredGoals') }}</template>
+              <BaseSkeleton v-if="dashboardQuery.isLoading.value" />
+              <div v-else class="item-list">
+                <article
+                  v-for="goal in goals"
+                  :key="goal.id"
+                  class="goal-item"
+                >
+                  <div class="goal-item__header">
+                    <strong>{{ goal.name }}</strong>
+                    <span>{{ goal.progressPercent.toFixed(0) }}%</span>
+                  </div>
+                  <div class="goal-item__track">
+                    <span :style="{ width: `${Math.min(goal.progressPercent, 100)}%` }" />
+                  </div>
+                  <p>
+                    {{ formatCurrency(goal.currentAmount) }} {{ $t('pages.dashboard.goalOf') }}
+                    {{ formatCurrency(goal.targetAmount) }}
+                  </p>
+                </article>
+                <UiEmptyState
+                  v-if="goals.length === 0"
+                  icon="target"
+                  :title="$t('pages.dashboard.noGoals')"
+                  :description="$t('pages.dashboard.noGoalsDesc')"
+                  :compact="true"
+                />
+              </div>
+            </UiSurfaceCard>
+          </section>
+        </template>
       </template>
+
+      <!-- ── Due-date panel (PROD-14) ──────────────────────────────────────
+           Independent of `dashboardQuery` — always renders when the period is
+           valid, with its own loading + error states. -->
+      <UiSurfaceCard class="dashboard-due-dates">
+        <DueDateList
+          :transactions="dueTransactions"
+          :is-loading="dueRangeQuery.isLoading.value"
+        />
+      </UiSurfaceCard>
     </template>
   </div>
 </template>

--- a/app/pages/transactions.vue
+++ b/app/pages/transactions.vue
@@ -37,8 +37,8 @@ const { data, isLoading, isError, refetch } = useListTransactionsQuery(filters);
 const {
   showIncome, showExpense,
   deleteTarget, showDeleteConfirm, payTarget, showPayConfirm, editTarget, showEditModal,
-  deleteMutation, markPaidMutation,
-  handleDeleteClick, confirmDelete, handleMarkPaid, confirmMarkPaid, handleEdit, onTransactionCreated,
+  deleteMutation, markPaidMutation, duplicateMutation,
+  handleDeleteClick, confirmDelete, handleMarkPaid, confirmMarkPaid, handleEdit, handleDuplicate, onTransactionCreated,
 } = useTransactionActions(() => void refetch());
 
 // ── Recurrence ────────────────────────────────────────────────────────────────
@@ -64,10 +64,12 @@ const {
   filterTagId,
   deleteMutation,
   markPaidMutation,
+  duplicateMutation,
   deleteTarget,
   onEdit: handleEdit,
   onMarkPaid: handleMarkPaid,
   onDelete: handleDeleteClick,
+  onDuplicate: handleDuplicate,
 });
 </script>
 


### PR DESCRIPTION
## Summary

Closes #671 and #674 in a single delivery, finalizing all transaction-related MVP scope.

### Transactions CRUD (#674)
- New **Duplicate** action on each row (Copy icon) between Edit and Mark-Paid.
- Clones core fields (title, amount, type, due_date, tag, account, credit_card, description, currency) with `"(cópia)"` suffix and resets status to `pending`.
- Drops recurrence/installment flags — duplicate is always a standalone single entry.
- Actions column widened 108 → 140 px to fit the new button.

### Dashboard real data (#671)
- Per-widget error boundary replaces the previous top-level error card that hid the whole page.
- `DueDateList` now renders **independently** of `dashboardQuery` — when overview fails, due dates still load via their own query.
- Overview-dependent widgets (SummaryGrid, HealthScore, charts, Alerts, TransactionsPanel, goals) share a single retry card when overview fails.
- TrendsChart already had its own retry via `@retry="trendsQuery.refetch()"`.

### i18n
- `pt.json`: `transactions.action.duplicate: "Duplicar"`.
- `en.json` untouched (MVP1 freeze per DEC-186).

### Tests
- 2 new cases in `useTransactionActions.spec.ts`:
  - `handleDuplicate` clones core fields with `(cópia)` suffix and `pending` status.
  - `handleDuplicate` omits `description` when source has none.

## Quality gates

- ✅ `pnpm quality-check` — flags:check → lint → typecheck → test:coverage → policy:check → contracts:check → build
- ✅ 259 test files, 2704 tests
- ✅ Coverage: 92.3% stmts / 85.95% branches / 87.6% funcs / 93.12% lines (all ≥ 85%)
- ✅ Build complete

## Test plan
- [ ] Transactions page: Duplicate button creates a copy with `(cópia)` suffix and `pending` status; list refetches.
- [ ] Transactions page: duplicating an expense with a tag preserves `tag_id` and `account_id`.
- [ ] Dashboard: when overview endpoint fails, due-date panel still renders with the next-30-days data.
- [ ] Dashboard: when overview endpoint fails, retry card restores widgets on click.
- [ ] i18n: Duplicate button shows "Duplicar" in pt; en unchanged.