### PR TITLE
feat(web): transactions trash page with restore

### DIFF
--- a/app/features/transactions/components/TransactionToolbar.vue
+++ b/app/features/transactions/components/TransactionToolbar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { NButton, NDatePicker, NSelect, type SelectOption } from "naive-ui";
-import { Calendar, GripVertical, List, Tag, TrendingDown, TrendingUp } from "lucide-vue-next";
+import { Calendar, GripVertical, List, Tag, Trash2, TrendingDown, TrendingUp } from "lucide-vue-next";
 
 defineProps<{
   filterType: string;
@@ -28,6 +28,7 @@ const emit = defineEmits<{
   "add-income": [];
   "add-expense": [];
   "create-tag": [];
+  "open-trash": [];
 }>();
 </script>
 
@@ -106,6 +107,16 @@ const emit = defineEmits<{
     <NButton size="small" secondary @click="emit('create-tag')">
       <template #icon><Tag :size="14" /></template>
       {{ $t('transactions.createTag') }}
+    </NButton>
+
+    <NButton
+      size="small"
+      secondary
+      :title="$t('transactions.trash.title')"
+      @click="emit('open-trash')"
+    >
+      <template #icon><Trash2 :size="14" /></template>
+      {{ $t('transactions.trash.link') }}
     </NButton>
 
     <NButton size="small" @click="emit('add-income')">

--- a/app/features/transactions/queries/use-list-deleted-transactions-query.spec.ts
+++ b/app/features/transactions/queries/use-list-deleted-transactions-query.spec.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useListDeletedTransactionsQuery } from "./use-list-deleted-transactions-query";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+
+const useQueryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/vue-query", () => ({
+  useQuery: useQueryMock,
+}));
+
+/**
+ * Builds a minimal TransactionDto fixture for assertions.
+ *
+ * @returns Deleted expense transaction fixture.
+ */
+const makeDeletedTransactionDto = (): TransactionDto => ({
+  id: "txn-del-1",
+  title: "Mercado",
+  amount: "120.00",
+  type: "expense",
+  due_date: "2026-03-20",
+  description: null,
+  observation: null,
+  is_recurring: false,
+  is_installment: false,
+  installment_count: null,
+  currency: "BRL",
+  status: "pending",
+  start_date: null,
+  end_date: null,
+  tag_id: null,
+  account_id: null,
+  credit_card_id: null,
+  installment_group_id: null,
+  paid_at: null,
+  created_at: "2026-03-01T00:00:00.000Z",
+  updated_at: "2026-03-01T00:00:00.000Z",
+});
+
+describe("useListDeletedTransactionsQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useQueryMock.mockImplementation((opts: unknown) => opts);
+  });
+
+  it("uses the ['transactions', 'deleted'] queryKey for cache isolation", () => {
+    const client = { listDeletedTransactions: vi.fn().mockResolvedValue([]) };
+
+    const query = useListDeletedTransactionsQuery(client as never) as unknown as {
+      queryKey: readonly unknown[];
+    };
+
+    expect(query.queryKey).toEqual(["transactions", "deleted"]);
+  });
+
+  it("calls client.listDeletedTransactions and returns the result", async () => {
+    const dto = makeDeletedTransactionDto();
+    const client = { listDeletedTransactions: vi.fn().mockResolvedValue([dto]) };
+
+    const query = useListDeletedTransactionsQuery(client as never) as unknown as {
+      queryFn: () => Promise<TransactionDto[]>;
+    };
+
+    const result = await query.queryFn();
+
+    expect(client.listDeletedTransactions).toHaveBeenCalledWith();
+    expect(result).toEqual([dto]);
+  });
+
+  it("propagates errors from client.listDeletedTransactions without catching", async () => {
+    const client = {
+      listDeletedTransactions: vi.fn().mockRejectedValue(new Error("network error")),
+    };
+
+    const query = useListDeletedTransactionsQuery(client as never) as unknown as {
+      queryFn: () => Promise<TransactionDto[]>;
+    };
+
+    await expect(query.queryFn()).rejects.toThrow("network error");
+  });
+});

--- a/app/features/transactions/queries/use-list-deleted-transactions-query.ts
+++ b/app/features/transactions/queries/use-list-deleted-transactions-query.ts
@@ -1,0 +1,29 @@
+import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+
+import { STALE_TIME } from "~/core/query/stale-time";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import {
+  type TransactionsClient,
+  useTransactionsClient,
+} from "~/features/transactions/services/transactions.client";
+
+/**
+ * Vue Query hook for listing the user's soft-deleted transactions.
+ *
+ * Powers the "Lixeira" (trash) view where users can review recently
+ * deleted records and restore individual items.
+ *
+ * @param providedClient Optional injected client for unit tests.
+ * @returns Vue Query state with typed soft-deleted TransactionDto array.
+ */
+export const useListDeletedTransactionsQuery = (
+  providedClient?: TransactionsClient,
+): UseQueryReturnType<TransactionDto[], Error> => {
+  const client = providedClient ?? useTransactionsClient();
+
+  return useQuery({
+    queryKey: ["transactions", "deleted"] as const,
+    queryFn: (): Promise<TransactionDto[]> => client.listDeletedTransactions(),
+    staleTime: STALE_TIME.ACTIVE,
+  });
+};

--- a/app/features/transactions/queries/use-restore-transaction-mutation.spec.ts
+++ b/app/features/transactions/queries/use-restore-transaction-mutation.spec.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRestoreTransactionMutation } from "./use-restore-transaction-mutation";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────────
+
+const { useMutationMock, useQueryClientMock, invalidateQueriesMock } = vi.hoisted(() => {
+  const invalidateQueriesMock = vi.fn().mockResolvedValue(undefined);
+  return {
+    useMutationMock: vi.fn(),
+    useQueryClientMock: vi.fn(() => ({ invalidateQueries: invalidateQueriesMock })),
+    invalidateQueriesMock,
+  };
+});
+
+vi.mock("@tanstack/vue-query", () => ({
+  useMutation: useMutationMock,
+  useQueryClient: useQueryClientMock,
+}));
+
+/**
+ * Builds a minimal TransactionDto fixture for assertions.
+ *
+ * @returns Restored expense transaction fixture.
+ */
+const makeTransactionDto = (): TransactionDto => ({
+  id: "txn-restore-1",
+  title: "Mercado",
+  amount: "120.00",
+  type: "expense",
+  due_date: "2026-03-20",
+  description: null,
+  observation: null,
+  is_recurring: false,
+  is_installment: false,
+  installment_count: null,
+  currency: "BRL",
+  status: "pending",
+  start_date: null,
+  end_date: null,
+  tag_id: null,
+  account_id: null,
+  credit_card_id: null,
+  installment_group_id: null,
+  paid_at: null,
+  created_at: "2026-03-01T00:00:00.000Z",
+  updated_at: "2026-03-10T00:00:00.000Z",
+});
+
+describe("useRestoreTransactionMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useMutationMock.mockImplementation((opts: unknown) => opts);
+  });
+
+  it("calls client.restoreTransaction with the given id", async () => {
+    const dto = makeTransactionDto();
+    const client = { restoreTransaction: vi.fn().mockResolvedValue(dto) };
+
+    const mutation = useRestoreTransactionMutation(client as never) as unknown as {
+      mutationFn: (id: string) => Promise<TransactionDto>;
+    };
+
+    const result = await mutation.mutationFn("txn-restore-1");
+
+    expect(client.restoreTransaction).toHaveBeenCalledWith("txn-restore-1");
+    expect(result).toEqual(dto);
+  });
+
+  it("invalidates both active list and deleted list on success", async () => {
+    const client = { restoreTransaction: vi.fn().mockResolvedValue(makeTransactionDto()) };
+
+    const mutation = useRestoreTransactionMutation(client as never) as unknown as {
+      onSuccess: () => Promise<void>;
+    };
+
+    await mutation.onSuccess();
+
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({ queryKey: ["transactions", "list"] });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({ queryKey: ["transactions", "deleted"] });
+    expect(invalidateQueriesMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates errors from client.restoreTransaction without catching", async () => {
+    const client = {
+      restoreTransaction: vi.fn().mockRejectedValue(new Error("restore failed")),
+    };
+
+    const mutation = useRestoreTransactionMutation(client as never) as unknown as {
+      mutationFn: (id: string) => Promise<TransactionDto>;
+    };
+
+    await expect(mutation.mutationFn("txn-x")).rejects.toThrow("restore failed");
+  });
+});

--- a/app/features/transactions/queries/use-restore-transaction-mutation.ts
+++ b/app/features/transactions/queries/use-restore-transaction-mutation.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "@tanstack/vue-query";
+
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import {
+  type TransactionsClient,
+  useTransactionsClient,
+} from "~/features/transactions/services/transactions.client";
+
+/**
+ * Vue Query mutation hook for restoring a soft-deleted transaction.
+ *
+ * Invalidates both the active transactions list and the deleted list
+ * on success so list views re-sync without a manual refresh.
+ *
+ * @param providedClient Optional injected client for unit tests.
+ * @returns Mutation object with `mutate(id)` and standard state fields.
+ */
+export const useRestoreTransactionMutation = (
+  providedClient?: TransactionsClient,
+): ReturnType<typeof useMutation<TransactionDto, Error, string>> => {
+  const client = providedClient ?? useTransactionsClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string): Promise<TransactionDto> => client.restoreTransaction(id),
+
+    onSuccess: async (): Promise<void> => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["transactions", "list"] }),
+        queryClient.invalidateQueries({ queryKey: ["transactions", "deleted"] }),
+      ]);
+    },
+  });
+};

--- a/app/features/transactions/services/transactions.client.spec.ts
+++ b/app/features/transactions/services/transactions.client.spec.ts
@@ -53,13 +53,19 @@ const makePayload = (): CreateTransactionPayload => ({
 describe("TransactionsClient", () => {
   let httpPostMock: ReturnType<typeof vi.fn>;
   let httpGetMock: ReturnType<typeof vi.fn>;
+  let httpPatchMock: ReturnType<typeof vi.fn>;
   let client: TransactionsClient;
 
   beforeEach(() => {
     vi.clearAllMocks();
     httpPostMock = vi.fn();
     httpGetMock = vi.fn();
-    mockedAxiosCreate.mockReturnValue({ post: httpPostMock, get: httpGetMock } as never);
+    httpPatchMock = vi.fn();
+    mockedAxiosCreate.mockReturnValue({
+      post: httpPostMock,
+      get: httpGetMock,
+      patch: httpPatchMock,
+    } as never);
     client = new TransactionsClient(axios.create());
   });
 
@@ -180,6 +186,101 @@ describe("TransactionsClient", () => {
       const result = await client.listTransactions();
 
       expect(result).toEqual([txn]);
+    });
+  });
+
+  describe("listDeletedTransactions", () => {
+    it("gets /transactions/deleted", async () => {
+      httpGetMock.mockResolvedValueOnce({ data: { data: { transactions: [] } } });
+
+      await client.listDeletedTransactions();
+
+      expect(httpGetMock).toHaveBeenCalledWith("/transactions/deleted");
+    });
+
+    it("unwraps transactions from the v2 envelope shape", async () => {
+      const txn = makeTransaction();
+      httpGetMock.mockResolvedValueOnce({ data: { data: { transactions: [txn] } } });
+
+      const result = await client.listDeletedTransactions();
+
+      expect(result).toEqual([txn]);
+    });
+
+    it("falls back to the root-level transactions key", async () => {
+      const txn = makeTransaction();
+      httpGetMock.mockResolvedValueOnce({ data: { transactions: [txn] } });
+
+      const result = await client.listDeletedTransactions();
+
+      expect(result).toEqual([txn]);
+    });
+
+    it("returns a bare array response directly", async () => {
+      const txn = makeTransaction();
+      httpGetMock.mockResolvedValueOnce({ data: [txn] });
+
+      const result = await client.listDeletedTransactions();
+
+      expect(result).toEqual([txn]);
+    });
+
+    it("returns empty array when envelope is empty", async () => {
+      httpGetMock.mockResolvedValueOnce({ data: {} });
+
+      const result = await client.listDeletedTransactions();
+
+      expect(result).toEqual([]);
+    });
+
+    it("propagates network errors without catching", async () => {
+      httpGetMock.mockRejectedValueOnce(new Error("network error"));
+
+      await expect(client.listDeletedTransactions()).rejects.toThrow("network error");
+    });
+  });
+
+  describe("restoreTransaction", () => {
+    it("patches /transactions/restore/:id", async () => {
+      const txn = makeTransaction({ id: "txn-restore-1" });
+      httpPatchMock.mockResolvedValueOnce({ data: { data: { transaction: txn } } });
+
+      await client.restoreTransaction("txn-restore-1");
+
+      expect(httpPatchMock).toHaveBeenCalledWith("/transactions/restore/txn-restore-1");
+    });
+
+    it("unwraps transaction from the v2 envelope shape", async () => {
+      const txn = makeTransaction();
+      httpPatchMock.mockResolvedValueOnce({ data: { data: { transaction: txn } } });
+
+      const result = await client.restoreTransaction(txn.id);
+
+      expect(result).toEqual(txn);
+    });
+
+    it("falls back to the root-level transaction key", async () => {
+      const txn = makeTransaction();
+      httpPatchMock.mockResolvedValueOnce({ data: { transaction: txn } });
+
+      const result = await client.restoreTransaction(txn.id);
+
+      expect(result).toEqual(txn);
+    });
+
+    it("accepts a flat TransactionDto response shape", async () => {
+      const txn = makeTransaction();
+      httpPatchMock.mockResolvedValueOnce({ data: txn });
+
+      const result = await client.restoreTransaction(txn.id);
+
+      expect(result).toEqual(txn);
+    });
+
+    it("propagates network errors without catching", async () => {
+      httpPatchMock.mockRejectedValueOnce(new Error("restore failed"));
+
+      await expect(client.restoreTransaction("txn-x")).rejects.toThrow("restore failed");
     });
   });
 });

--- a/app/features/transactions/services/transactions.client.ts
+++ b/app/features/transactions/services/transactions.client.ts
@@ -156,6 +156,46 @@ export class TransactionsClient {
   }
 
   /**
+   * Lists the authenticated user's soft-deleted transactions.
+   *
+   * These are records still retained in the database after DELETE
+   * (soft delete) and can be restored individually.
+   *
+   * @returns Array of soft-deleted TransactionDto records.
+   */
+  async listDeletedTransactions(): Promise<TransactionDto[]> {
+    const response = await this.#http.get<TransactionListResponseEnvelope | TransactionDto[]>(
+      "/transactions/deleted",
+    );
+
+    const raw = response.data;
+    if (Array.isArray(raw)) { return raw; }
+    return (raw as TransactionListResponseEnvelope).data?.transactions
+      ?? (raw as TransactionListResponseEnvelope).transactions
+      ?? [];
+  }
+
+  /**
+   * Restores a previously soft-deleted transaction.
+   *
+   * @param id UUID of the transaction to restore.
+   * @returns The restored TransactionDto.
+   */
+  async restoreTransaction(id: string): Promise<TransactionDto> {
+    const response = await this.#http.patch<
+      | { data?: { transaction?: TransactionDto }; transaction?: TransactionDto }
+      | TransactionDto
+    >(`/transactions/restore/${id}`);
+
+    const raw = response.data as {
+      data?: { transaction?: TransactionDto };
+      transaction?: TransactionDto;
+    } & Partial<TransactionDto>;
+
+    return raw.data?.transaction ?? raw.transaction ?? (raw as unknown as TransactionDto);
+  }
+
+  /**
    * Lists the authenticated user's transactions, optionally filtered by
    * type, status and date range.
    *

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -1632,6 +1632,25 @@
     "view": {
       "list": "Vista de lista",
       "calendar": "Vista de calendário"
+    },
+    "trash": {
+      "link": "Lixeira",
+      "title": "Lixeira de transações",
+      "subtitle": "Transações excluídas recentemente — restaure a qualquer momento",
+      "backToList": "Voltar para transações",
+      "empty": {
+        "title": "Nenhuma transação na lixeira",
+        "description": "Transações que você excluir aparecerão aqui."
+      },
+      "loadError": "Não foi possível carregar a lixeira",
+      "loadErrorMessage": "Tente recarregar a página.",
+      "restore": "Restaurar",
+      "restoreConfirm": "Restaurar transação",
+      "restoreConfirmDesc": "Restaurar \"{title}\" ({amount}) para a lista de transações?",
+      "restoreConfirmYes": "Restaurar",
+      "restoreConfirmNo": "Cancelar",
+      "restoreSuccess": "Transação restaurada",
+      "restoreError": "Não foi possível restaurar a transação"
     }
   },
   "thirteenthSalary": {

--- a/app/pages/transactions/index.vue
+++ b/app/pages/transactions/index.vue
@@ -136,6 +136,7 @@ const {
       @add-income="showIncome = true"
       @add-expense="showExpense = true"
       @create-tag="showCreateTag = true"
+      @open-trash="navigateTo('/transactions/trash')"
     />
 
     <!-- ── Reorder / swipe hints ───────────────────────────────────────────── -->

--- a/app/pages/transactions/trash.vue
+++ b/app/pages/transactions/trash.vue
@@ -1,0 +1,197 @@
+<script setup lang="ts">
+import { computed, h, ref, type VNode } from "vue";
+import { NButton, NDataTable, NModal, useMessage, type DataTableColumns } from "naive-ui";
+import { ArrowLeft, RotateCcw, TrendingDown, TrendingUp } from "lucide-vue-next";
+import { formatTransactionDate } from "~/features/transactions/composables/useTransactionTable";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import { useListDeletedTransactionsQuery } from "~/features/transactions/queries/use-list-deleted-transactions-query";
+import { useRestoreTransactionMutation } from "~/features/transactions/queries/use-restore-transaction-mutation";
+import { formatCurrency } from "~/utils/currency";
+
+definePageMeta({
+  middleware: ["authenticated"],
+  pageTitle: "Lixeira de transações",
+  pageSubtitle: "Transações excluídas recentemente",
+});
+
+useHead({ title: "Lixeira | Auraxis" });
+
+const { t } = useI18n();
+const message = useMessage();
+
+const { data, isLoading, isError } = useListDeletedTransactionsQuery();
+const restoreMutation = useRestoreTransactionMutation();
+
+const restoreTarget = ref<TransactionDto | null>(null);
+const showRestoreConfirm = ref(false);
+
+const tableData = computed<TransactionDto[]>(() => data.value ?? []);
+
+/**
+ * Prompts for confirmation before restoring the given transaction.
+ *
+ * @param row Transaction to restore.
+ */
+function onRestoreClick(row: TransactionDto): void {
+  restoreTarget.value = row;
+  showRestoreConfirm.value = true;
+}
+
+/** Executes the restore once the user confirms. */
+function onConfirmRestore(): void {
+  const target = restoreTarget.value;
+  if (!target) { return; }
+  restoreMutation.mutate(target.id, {
+    onSuccess: (): void => {
+      message.success(t("transactions.trash.restoreSuccess"));
+      showRestoreConfirm.value = false;
+      restoreTarget.value = null;
+    },
+    onError: (): void => {
+      message.error(t("transactions.trash.restoreError"));
+    },
+  });
+}
+
+/** Closes the confirmation modal without restoring. */
+function onCancelRestore(): void {
+  showRestoreConfirm.value = false;
+  restoreTarget.value = null;
+}
+
+const columns = computed<DataTableColumns<TransactionDto>>(() => [
+  {
+    key: "type",
+    title: "",
+    width: 40,
+    render: (row): VNode =>
+      row.type === "income"
+        ? h(TrendingUp, { size: 16, class: "tx-amount--income" })
+        : h(TrendingDown, { size: 16, class: "tx-amount--expense" }),
+  },
+  {
+    key: "title",
+    title: t("transactions.table.description"),
+    render: (row): string => row.title,
+  },
+  {
+    key: "due_date",
+    title: t("transactions.table.date"),
+    width: 120,
+    render: (row): string => formatTransactionDate(row.due_date),
+  },
+  {
+    key: "amount",
+    title: t("transactions.table.amount"),
+    width: 140,
+    align: "right",
+    render: (row): VNode =>
+      h(
+        "span",
+        { class: ["tx-amount", row.type === "income" ? "tx-amount--income" : "tx-amount--expense"] },
+        formatCurrency(parseFloat(row.amount)),
+      ),
+  },
+  {
+    key: "actions",
+    title: t("transactions.table.actions"),
+    width: 140,
+    align: "right",
+    render: (row): VNode =>
+      h(
+        NButton,
+        {
+          size: "small",
+          type: "primary",
+          secondary: true,
+          loading: restoreMutation.isPending.value && restoreTarget.value?.id === row.id,
+          onClick: (): void => onRestoreClick(row),
+        },
+        {
+          icon: (): VNode => h(RotateCcw, { size: 14 }),
+          default: (): string => t("transactions.trash.restore"),
+        },
+      ),
+  },
+]);
+
+const restoreConfirmDesc = computed((): string => {
+  if (!restoreTarget.value) { return ""; }
+  return t("transactions.trash.restoreConfirmDesc", {
+    title: restoreTarget.value.title,
+    amount: formatCurrency(parseFloat(restoreTarget.value.amount)),
+  });
+});
+</script>
+
+<template>
+  <div class="trash-page">
+    <div class="trash-page__header">
+      <NButton size="small" secondary @click="navigateTo('/transactions')">
+        <template #icon><ArrowLeft :size="14" /></template>
+        {{ $t('transactions.trash.backToList') }}
+      </NButton>
+    </div>
+
+    <NModal
+      :show="showRestoreConfirm"
+      preset="dialog"
+      type="success"
+      :title="$t('transactions.trash.restoreConfirm')"
+      :content="restoreConfirmDesc"
+      :positive-text="$t('transactions.trash.restoreConfirmYes')"
+      :negative-text="$t('transactions.trash.restoreConfirmNo')"
+      :loading="restoreMutation.isPending.value"
+      @positive-click="onConfirmRestore"
+      @negative-click="onCancelRestore"
+      @close="onCancelRestore"
+    />
+
+    <UiInlineError
+      v-if="isError"
+      :title="$t('transactions.trash.loadError')"
+      :message="$t('transactions.trash.loadErrorMessage')"
+    />
+    <UiPageLoader v-else-if="isLoading" :rows="5" />
+    <UiEmptyState
+      v-else-if="tableData.length === 0"
+      icon="transactions"
+      :title="$t('transactions.trash.empty.title')"
+      :description="$t('transactions.trash.empty.description')"
+    />
+    <NDataTable
+      v-else
+      :columns="columns"
+      :data="tableData"
+      :row-key="(row: TransactionDto) => row.id"
+      :scroll-x="720"
+      size="small"
+      class="trash-page__table"
+    />
+  </div>
+</template>
+
+<style scoped>
+.trash-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-3);
+}
+
+.trash-page__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.trash-page__table {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-outline-soft);
+  overflow: hidden;
+}
+
+:deep(.tx-amount) { font-weight: var(--font-weight-semibold); white-space: nowrap; }
+:deep(.tx-amount--income) { color: var(--color-positive); }
+:deep(.tx-amount--expense) { color: var(--color-negative); }
+</style>


### PR DESCRIPTION
## Summary

- New `/transactions/trash` page listing soft-deleted transactions with a per-row **Restore** action
- `TransactionsClient.listDeletedTransactions` and `.restoreTransaction` wrapping `GET /transactions/deleted` and `PATCH /transactions/restore/:id`
- `useListDeletedTransactionsQuery` and `useRestoreTransactionMutation` — restore invalidates both `["transactions", "list"]` and `["transactions", "deleted"]` so the main list re-syncs automatically
- Confirmation modal before restoring; success/error toast via `NaiveUI` message
- Trash link in `TransactionToolbar`; back link on the trash page
- pt i18n under `transactions.trash.*`
- Unit tests covering client, query, mutation

Closes #699

## Test plan

- [x] `pnpm quality-check` — 262 files / 2726 tests pass, coverage ≥85%, typecheck clean, build green
- [ ] Manual: delete a transaction → open Lixeira → restore → verify it reappears in main list