### PR TITLE
test(web): e2e coverage for transactions full CRUD + restore

### DIFF
--- a/e2e/specs/transactions.spec.ts
+++ b/e2e/specs/transactions.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page, type Route } from "@playwright/test";
 import { waitForHydration } from "../helpers/auth";
 
 /**
- * E2E suite: Transactions — MSW-backed flows.
+ * E2E suite: Transactions — MSW-backed CRUD + restore flow.
  *
  * Mirrors the auth/dashboard mock pattern from dashboard.spec.ts so the
  * app lands cleanly on /dashboard before navigating to /transactions.
@@ -37,48 +37,214 @@ const MOCK_OVERVIEW = {
 	portfolio: { currentValue: 25000, costBasis: 20000 },
 };
 
-const MOCK_TRANSACTIONS = {
-	data: {
-		transactions: [
-			{
-				id: "tx-1",
-				title: "Salário Mensal",
-				amount: "10000.00",
-				type: "income",
-				due_date: "2025-12-01",
-				status: "paid",
-				is_recurring: false,
-				is_installment: false,
-				installment_count: null,
-				currency: "BRL",
-				description: null,
-				observation: null,
-				start_date: null,
-				end_date: null,
-				tag_id: null,
-				account_id: null,
-				credit_card_id: null,
-				installment_group_id: null,
-				paid_at: "2025-12-01",
-				created_at: "2025-12-01T10:00:00Z",
-				updated_at: "2025-12-01T10:00:00Z",
-			},
-		],
-	},
+interface MockTransaction {
+	id: string;
+	title: string;
+	amount: string;
+	type: "income" | "expense";
+	due_date: string;
+	status: string;
+	is_recurring: boolean;
+	is_installment: boolean;
+	installment_count: number | null;
+	currency: string;
+	description: string | null;
+	observation: string | null;
+	start_date: string | null;
+	end_date: string | null;
+	tag_id: string | null;
+	account_id: string | null;
+	credit_card_id: string | null;
+	installment_group_id: string | null;
+	paid_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+/**
+ * Builds a minimal transaction mock record.
+ *
+ * @param overrides Partial overrides applied to the default fixture.
+ * @returns Mock transaction payload matching the backend envelope shape.
+ */
+const makeTx = (overrides: Partial<MockTransaction> = {}): MockTransaction => ({
+	id: "tx-1",
+	title: "Salário Mensal",
+	amount: "10000.00",
+	type: "income",
+	due_date: "2025-12-01",
+	status: "paid",
+	is_recurring: false,
+	is_installment: false,
+	installment_count: null,
+	currency: "BRL",
+	description: null,
+	observation: null,
+	start_date: null,
+	end_date: null,
+	tag_id: null,
+	account_id: null,
+	credit_card_id: null,
+	installment_group_id: null,
+	paid_at: "2025-12-01",
+	created_at: "2025-12-01T10:00:00Z",
+	updated_at: "2025-12-01T10:00:00Z",
+	...overrides,
+});
+
+/** In-memory transaction store mutated by route handlers to simulate CRUD. */
+interface TxStore {
+	active: MockTransaction[];
+	deleted: MockTransaction[];
+}
+
+/**
+ * Fulfils a JSON response on the given route with the envelope `{ data: payload }`.
+ *
+ * @param route - Playwright route to fulfil.
+ * @param status - HTTP status code.
+ * @param payload - Object placed under the `data` key.
+ */
+const fulfillJson = async (route: Route, status: number, payload: unknown): Promise<void> => {
+	await route.fulfill({
+		status,
+		contentType: "application/json",
+		body: JSON.stringify({ data: payload }),
+	});
+};
+
+/**
+ * Handles `PATCH /transactions/restore/:id` — moves a transaction from deleted back to active.
+ *
+ * @param route - Playwright route to fulfil.
+ * @param store - Live CRUD store.
+ * @param id - Target transaction id.
+ */
+const handleRestore = async (route: Route, store: TxStore, id: string): Promise<void> => {
+	const target = store.deleted.find((t) => t.id === id);
+	if (target) {
+		store.deleted = store.deleted.filter((t) => t.id !== id);
+		store.active.push(target);
+	}
+	await fulfillJson(route, 200, { transaction: target ?? null });
+};
+
+/**
+ * Handles `DELETE /transactions/:id` — soft-deletes the transaction.
+ *
+ * @param route - Playwright route to fulfil.
+ * @param store - Live CRUD store.
+ * @param id - Target transaction id.
+ */
+const handleDelete = async (route: Route, store: TxStore, id: string): Promise<void> => {
+	const target = store.active.find((t) => t.id === id);
+	if (target) {
+		store.active = store.active.filter((t) => t.id !== id);
+		store.deleted.push(target);
+	}
+	await route.fulfill({ status: 204, body: "" });
+};
+
+/**
+ * Handles `PATCH /transactions/:id` — applies a partial update to an active transaction.
+ *
+ * @param route - Playwright route to fulfil.
+ * @param store - Live CRUD store.
+ * @param id - Target transaction id.
+ */
+const handlePatch = async (route: Route, store: TxStore, id: string): Promise<void> => {
+	const body = route.request().postDataJSON() as Partial<MockTransaction>;
+	const idx = store.active.findIndex((t) => t.id === id);
+	if (idx >= 0) {
+		store.active[idx] = { ...store.active[idx], ...body, id };
+	}
+	await fulfillJson(route, 200, { transaction: idx >= 0 ? store.active[idx] : null });
+};
+
+/**
+ * Handles `POST /transactions` — creates a new active transaction from the request body.
+ *
+ * @param route - Playwright route to fulfil.
+ * @param store - Live CRUD store.
+ */
+const handleCreate = async (route: Route, store: TxStore): Promise<void> => {
+	const body = route.request().postDataJSON() as Partial<MockTransaction>;
+	const newTx = makeTx({
+		id: `tx-${Date.now()}`,
+		title: body.title ?? "New",
+		amount: body.amount ?? "0.00",
+		type: body.type ?? "expense",
+		due_date: body.due_date ?? "2025-12-15",
+		status: "pending",
+		paid_at: null,
+	});
+	store.active.push(newTx);
+	await fulfillJson(route, 201, { transactions: [newTx] });
+};
+
+/**
+ * Dispatches any `/transactions*` request to the matching CRUD handler.
+ *
+ * @param route - Playwright route to fulfil.
+ * @param store - Live CRUD store.
+ */
+const handleTransactionsRoute = async (route: Route, store: TxStore): Promise<void> => {
+	if (route.request().resourceType() === "document") {
+		await route.continue();
+		return;
+	}
+
+	const method = route.request().method();
+	const path = new URL(route.request().url()).pathname;
+
+	if (path.endsWith("/transactions/deleted") && method === "GET") {
+		await fulfillJson(route, 200, { transactions: store.deleted });
+		return;
+	}
+
+	const restoreMatch = path.match(/\/transactions\/restore\/([^/]+)$/);
+	if (restoreMatch && method === "PATCH") {
+		await handleRestore(route, store, restoreMatch[1] ?? "");
+		return;
+	}
+
+	const idMatch = path.match(/\/transactions\/([^/]+)$/);
+	if (idMatch && method === "DELETE") {
+		await handleDelete(route, store, idMatch[1] ?? "");
+		return;
+	}
+	if (idMatch && method === "PATCH") {
+		await handlePatch(route, store, idMatch[1] ?? "");
+		return;
+	}
+
+	if (path.endsWith("/transactions") && method === "POST") {
+		await handleCreate(route, store);
+		return;
+	}
+
+	if (method === "GET") {
+		await fulfillJson(route, 200, { transactions: store.active });
+		return;
+	}
+
+	await route.continue();
 };
 
 /**
  * Sets up all route mocks needed for an authenticated transactions session.
- * Uses the same dashboard mock pattern as dashboard.spec.ts to ensure a
- * clean post-login state before navigating to /transactions.
+ * Returns a live store that tracks active and soft-deleted transactions so
+ * tests can assert on state mutations (create/delete/restore).
  *
  * @param page - Playwright page instance.
+ * @returns The mutable transaction store.
  */
-const mockAuthAndTransactions = async (page: Page): Promise<void> => {
-	// Tracks whether POST /auth/login has succeeded. The session-restore plugin
-	// calls POST /auth/refresh on every full page load (split-token pattern, SEC-GAP-01):
-	// before login the refresh cookie doesn't exist → 401; after login the cookie
-	// is set by the server → 200 (simulated here so page.goto("/transactions") re-authenticates).
+const mockAuthAndTransactions = async (page: Page): Promise<TxStore> => {
+	const store: TxStore = {
+		active: [makeTx()],
+		deleted: [],
+	};
+
 	let sessionEstablished = false;
 
 	await page.route("**/auth/refresh", (route) => {
@@ -119,7 +285,6 @@ const mockAuthAndTransactions = async (page: Page): Promise<void> => {
 		});
 	});
 
-	// Provide proper-shaped dashboard responses so the app lands cleanly.
 	await page.route("**/dashboard/overview", (route) => {
 		route.fulfill({
 			status: 200,
@@ -141,20 +306,9 @@ const mockAuthAndTransactions = async (page: Page): Promise<void> => {
 		});
 	});
 
-	await page.route("**/transactions**", async (route) => {
-		// Skip page navigation requests — only intercept API (fetch/xhr) calls.
-		// Without this check, the pattern also matches the /transactions page URL,
-		// returning JSON where the browser expects HTML and breaking the render.
-		if (route.request().resourceType() === "document") {
-			await route.continue();
-			return;
-		}
-		await route.fulfill({
-			status: 200,
-			contentType: "application/json",
-			body: JSON.stringify(MOCK_TRANSACTIONS),
-		});
-	});
+	await page.route("**/transactions**", (route: Route) =>
+		handleTransactionsRoute(route, store),
+	);
 
 	await page.route("**/tags**", (route) => {
 		route.fulfill({
@@ -171,6 +325,16 @@ const mockAuthAndTransactions = async (page: Page): Promise<void> => {
 			body: JSON.stringify({ data: { accounts: [] } }),
 		});
 	});
+
+	await page.route("**/credit-cards**", (route) => {
+		route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({ data: { credit_cards: [] } }),
+		});
+	});
+
+	return store;
 };
 
 /**
@@ -188,7 +352,6 @@ const loginAndGoToTransactions = async (page: Page): Promise<void> => {
 	await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 });
 	await page.goto("/transactions");
 	await expect(page).toHaveURL(/\/transactions/);
-	// Wait for Vue to hydrate the transactions page before asserting on UI elements.
 	await waitForHydration(page);
 };
 
@@ -217,5 +380,102 @@ test.describe("Transactions — MSW-backed flows", () => {
 		await loginAndGoToTransactions(page);
 
 		await expect(page.getByText("Salário Mensal")).toBeVisible({ timeout: 10_000 });
+	});
+
+	test("clicking Nova Receita opens the income form modal", async ({ page }) => {
+		await mockAuthAndTransactions(page);
+		await loginAndGoToTransactions(page);
+
+		await page.getByRole("button", { name: /nova receita/i }).click();
+
+		await expect(
+			page.getByRole("dialog").getByText(/nova receita/i).first(),
+		).toBeVisible({ timeout: 5_000 });
+	});
+
+	test("clicking Nova Despesa opens the expense form modal", async ({ page }) => {
+		await mockAuthAndTransactions(page);
+		await loginAndGoToTransactions(page);
+
+		await page.getByRole("button", { name: /nova despesa/i }).click();
+
+		await expect(
+			page.getByRole("dialog").getByText(/nova despesa/i).first(),
+		).toBeVisible({ timeout: 5_000 });
+	});
+
+	test("clicking edit on a row opens the edit modal", async ({ page }) => {
+		await mockAuthAndTransactions(page);
+		await loginAndGoToTransactions(page);
+
+		await expect(page.getByText("Salário Mensal")).toBeVisible({ timeout: 10_000 });
+		await page.getByRole("button", { name: /^editar$/i }).first().click();
+
+		await expect(page.getByRole("dialog").first()).toBeVisible({ timeout: 5_000 });
+	});
+
+	test("duplicating a row triggers POST /transactions and shows the copy", async ({ page }) => {
+		const store = await mockAuthAndTransactions(page);
+		await loginAndGoToTransactions(page);
+
+		await expect(page.getByText("Salário Mensal")).toBeVisible({ timeout: 10_000 });
+
+		const postRequest = page.waitForRequest(
+			(req) => req.url().includes("/transactions") && req.method() === "POST",
+			{ timeout: 10_000 },
+		);
+		await page.getByRole("button", { name: /^duplicar$/i }).first().click();
+		await postRequest;
+
+		await expect.poll(() => store.active.length, { timeout: 5_000 }).toBeGreaterThan(1);
+	});
+
+	test("deleting a row asks for confirmation then calls DELETE", async ({ page }) => {
+		const store = await mockAuthAndTransactions(page);
+		await loginAndGoToTransactions(page);
+
+		await expect(page.getByText("Salário Mensal")).toBeVisible({ timeout: 10_000 });
+
+		await page.getByRole("button", { name: /^excluir$/i }).first().click();
+
+		const deleteRequest = page.waitForRequest(
+			(req) => req.url().includes("/transactions/tx-1") && req.method() === "DELETE",
+			{ timeout: 10_000 },
+		);
+		await page
+			.getByRole("dialog")
+			.getByRole("button", { name: /^excluir$/i })
+			.click();
+		await deleteRequest;
+
+		await expect.poll(() => store.active.length, { timeout: 5_000 }).toBe(0);
+		await expect.poll(() => store.deleted.length, { timeout: 5_000 }).toBe(1);
+	});
+
+	test("trash page lists soft-deleted transactions and restores them", async ({ page }) => {
+		const store = await mockAuthAndTransactions(page);
+		// Pre-populate the trash so we can focus the scenario on the restore flow.
+		store.deleted.push(makeTx({ id: "tx-trashed", title: "Mercado", amount: "120.00", type: "expense" }));
+		store.active = [];
+
+		await loginAndGoToTransactions(page);
+		await page.getByRole("button", { name: /lixeira/i }).click();
+		await expect(page).toHaveURL(/\/transactions\/trash/, { timeout: 10_000 });
+
+		await expect(page.getByText("Mercado")).toBeVisible({ timeout: 10_000 });
+
+		const restoreRequest = page.waitForRequest(
+			(req) => req.url().includes("/transactions/restore/tx-trashed") && req.method() === "PATCH",
+			{ timeout: 10_000 },
+		);
+		await page.getByRole("button", { name: /^restaurar$/i }).first().click();
+		await page
+			.getByRole("dialog")
+			.getByRole("button", { name: /^restaurar$/i })
+			.click();
+		await restoreRequest;
+
+		await expect.poll(() => store.deleted.length, { timeout: 5_000 }).toBe(0);
+		await expect.poll(() => store.active.length, { timeout: 5_000 }).toBe(1);
 	});
 });


### PR DESCRIPTION
## Summary
- Expands `e2e/specs/transactions.spec.ts` with an MSW-style `page.route()` mock that shares a live in-memory store between the handlers and the assertions — tests can verify create/update/delete/restore transitions end-to-end without a real backend.
- Adds 6 new scenarios on top of the existing 3: open income/expense modals, edit modal, duplicate triggers `POST /transactions`, delete asks for confirm → `DELETE` → store moves to trash, trash page lists soft-deleted rows and restores them.
- Handler is factored into small helpers (`handleCreate`, `handleDelete`, `handlePatch`, `handleRestore`, `fulfillJson`) so each stays below the ESLint complexity / max-statements caps.

Closes #700.

## Test plan
- [x] `pnpm test:e2e e2e/specs/transactions.spec.ts --project=chromium` — 9 passed (12.5s)
- [x] `pnpm quality-check` — flags, lint, typecheck, coverage (92.3% / 85.95% / 87.6% / 93.12%), policy, contracts, build all green
- [ ] CI e2e job green