### PR TITLE
chore(web): broaden icloud duplicate guards + playwright artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,15 @@ audit.json
 .env
 .env.*
 !.env.example
+
+# iCloud Drive / Finder duplicates (name patterns: "foo 2.ext" and "foo 2")
+# Silently break Nuxt auto-import when they land in app/features, app/composables, etc.
+* 2
+* 2.*
+* 3
+* 3.*
+
+# Playwright / Vitest local artifacts
+playwright-report/
+test-results/
+


### PR DESCRIPTION
## Summary
- Broadens iCloud/Finder duplicate guards from scoped paths to repo-wide patterns (`* 2`, `* 2.*`, `* 3`, `* 3.*`)
- Ignores Playwright/Vitest local artifacts (`playwright-report/`, `test-results/`)

## Why
iCloud Drive syncs folders across devices and silently creates `foo 2.ext` / `foo 2` duplicates. When these land in `app/features/*` or `app/composables/*`, Nuxt auto-import starts pulling in the duplicate, breaking the build with confusing errors. A session audit earlier today flushed 700+ such duplicates — this guard keeps them from recurring in source control.

## Test plan
- [x] `pnpm quality-check` passing locally (coverage 93.12%/87.6%)
- [x] Pre-push checks green