### PR TITLE
docs(web): module CLAUDE.md for app/features + app/core/http

### DIFF
--- a/app/core/http/CLAUDE.md
+++ b/app/core/http/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md — `app/core/http`
+
+Diretiva operacional para agentes trabalhando no cliente HTTP central.
+Complementa `app/core/README.md` com regras específicas de execução.
+
+## Papel
+
+`app/core/http/http-client.ts` é o **único** ponto canônico que cria
+instâncias Axios para falar com `auraxis-api`. Toda feature deve usar este
+cliente — direta ou indiretamente via hook de `app/features/*/queries/`.
+
+Responsabilidades atuais:
+
+- Normalização da base URL (tira trailing slashes).
+- Injeção do header `Authorization: Bearer <token>` via interceptor de request.
+- Injeção do header de contrato v2 global.
+- Registro dos interceptors de response (403 → toast, 5xx → toast/observability).
+- Exposição de hook para o consumer fornecer `getAccessToken()` lazy.
+
+## Regras obrigatórias
+
+- **Um único cliente por runtime.** Não crie novos `axios.create()` em
+  features. Se precisar de comportamento diferente, estenda este arquivo
+  com um parâmetro de opções.
+- **Interceptors ficam em `app/core/api/interceptors.ts`.** Não escreva
+  interceptor dentro de feature — se for transversal, promova aqui.
+- **401 é intencionalmente excluído** do handler global. Endpoints de auth
+  (ex.: `/auth/login`) devolvem 401 como resposta legítima — feature
+  trata localmente.
+- **Sempre devolver `ApiError` normalizado.** Feature `catch` deve poder
+  assumir `error instanceof ApiError`. Não vaze erro cru do Axios.
+- **Sem lógica de cache aqui.** Cache é responsabilidade de Vue Query
+  (camada `queries/` de cada feature).
+
+## O que fazer autonomamente
+
+- Adicionar novos interceptors transversais (observability, trace IDs).
+- Ajustar normalização de URL / headers globais.
+- Estender opções do factory com novos parâmetros opcionais.
+- Criar testes em `__tests__/` para cada interceptor e para o factory.
+
+## O que perguntar antes
+
+- Mudar a política de 401 (afeta fluxo de auth).
+- Mudar o formato do bearer token (afeta backend e todas as features).
+- Substituir Axios por outro client (decisão arquitetural com blast radius total).
+- Adicionar retry automático (pode mascarar idempotência de mutations).
+
+## O que nunca fazer
+
+- Expor tokens em log, console, ou breadcrumb do Sentry.
+- Persistir o token dentro deste módulo — token vive em `app/core/session/`.
+- Injetar dependência concreta de Pinia/Nuxt runtime — passe via argumento.
+- Adicionar fallback silencioso que esconda erro de rede real.
+
+## Testing checklist
+
+Cada mudança neste módulo deve rodar:
+
+```bash
+pnpm test -- app/core/http
+pnpm test -- app/core/api
+pnpm typecheck
+```
+
+Antes de PR:
+
+```bash
+pnpm quality-check
+```
+
+## Referências
+
+- Interceptors: `app/core/api/interceptors.ts`
+- Tipos de opções: `app/core/api/types.ts`
+- Erro normalizado: `app/core/errors/api-error.ts`
+- Sessão e bearer token: `app/core/session/`
+- Observabilidade: `app/core/observability/`

--- a/app/features/CLAUDE.md
+++ b/app/features/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md — `app/features/*`
+
+Diretiva operacional para agentes trabalhando dentro da camada de features.
+Complementa `README.md` (que descreve convenções) com regras de execução.
+
+## Papel da camada
+
+`app/features/*` concentra todo fluxo principal de cada domínio de produto.
+Cada pasta representa uma feature autônoma (ex.: `transactions/`, `goals/`),
+com contratos, queries, componentes e utilitários próprios.
+
+## Estrutura canônica por feature
+
+```
+<feature>/
+  contracts/     # DTOs e tipos alinhados ao contrato REST/GraphQL
+  api/           # API client (classe) + mapper DTO → domínio
+  services/      # Regras de negócio puras (sem Vue)
+  model/         # Tipos de domínio (view model)
+  queries/       # Vue Query hooks (useQuery / useMutation)
+  composables/   # Estado reativo e orquestração fina (hooks Vue)
+  components/    # Componentes Vue exclusivos da feature
+  utils/         # Helpers puros escopados à feature
+```
+
+Não exigido: todos existirem. Criar apenas o que a feature precisa.
+
+## Regras obrigatórias
+
+- **Sem import lateral entre features.** `transactions/` não importa de `goals/`.
+  Se algo for reutilizável, promover para `app/shared/` ou `app/core/`.
+- **Composables são façade fina.** Regras de negócio vão para `services/`
+  ou `queries/`. Não empilhe lógica dentro de `composables/`.
+- **Contratos primeiro.** DTOs em `contracts/` refletem o schema do backend.
+  Nunca manipule payloads crus fora desta pasta — sempre passe pelo mapper.
+- **Mappers são puros.** `api/*.mapper.ts` não conhece Vue, Pinia ou cache.
+  Recebe DTO, devolve domínio.
+- **Queries são os únicos pontos que tocam API + cache.** `queryKey` começa
+  com o nome da feature (ex.: `["transactions", ...]`).
+- **Coverage ≥ 85%.** Cada service, mapper e query deve ter testes unitários.
+  Componentes que renderizam estado derivado também.
+
+## O que fazer autonomamente
+
+- Criar/editar componentes, composables, services, queries, contratos e mappers.
+- Adicionar testes unitários com Vitest no mesmo diretório da unidade.
+- Refatorar dentro da feature sem afetar outras.
+- Estender tipos de domínio em `model/` quando o contrato evoluir.
+
+## O que perguntar antes
+
+- Mover código de uma feature para `app/shared/` ou `app/core/`.
+- Renomear uma pasta de feature (pode quebrar rotas).
+- Introduzir nova biblioteca de estado (preferimos Pinia + Vue Query existentes).
+- Criar um novo endpoint no backend (coordenar com `auraxis-api`).
+
+## O que nunca fazer
+
+- Importar `store` do Pinia diretamente em componentes quando já existe `queries/`.
+- Fazer fetch via `$fetch` / `useFetch` direto — sempre usar `httpClient`
+  do `app/core/http` via hook de feature.
+- Criar `any` explícito; usar tipos do contrato ou `unknown` + narrowing.
+- Duplicar tipos que já existem em `app/shared/types/generated/`.
+- Adicionar comentário JSDoc só para passar lint — escreva código claro.
+
+## Testing checklist
+
+Antes de commitar uma mudança em `app/features/*`:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test -- <pasta-da-feature>
+```
+
+Antes de abrir PR:
+
+```bash
+pnpm quality-check
+```
+
+## Referências rápidas
+
+- Contratos gerados: `app/shared/types/generated/openapi.ts`
+- Infra HTTP: `app/core/http/http-client.ts` (ver CLAUDE.md local)
+- Façades de sessão/observabilidade: `app/core/session/`, `app/core/observability/`
+- Testes E2E relacionados: `e2e/specs/*` (Playwright)


### PR DESCRIPTION
## Summary
Adds operational directive files (CLAUDE.md) to two high-traffic module roots so agents working inside them get localized rules without scanning the repo-wide CLAUDE.md:

- \`app/features/CLAUDE.md\` — canonical feature layout, no-cross-feature-import rule, coverage ≥ 85%, testing checklist, autonomous vs ask-first boundaries.
- \`app/core/http/CLAUDE.md\` — single-client rule, interceptor placement, 401-exclusion rationale, ApiError normalization contract.

## Why
Closes the DX gap identified in the 2026-04 audit: agents hitting module-level work (transactions/goals/http) didn't have a local reference for what's allowed vs forbidden, leading to cross-feature imports and duplicated interceptor logic. This gives them a scoped instruction surface.

## Test plan
- [x] Lint + policy check clean (no code changes)
- [x] Pre-commit hooks green