### PR TITLE
refactor(web): split QuickTransactionForm [UX-5 2/6]

### DIFF
--- a/app/components/transactions/QuickTransactionForm/QuickTransactionForm.vue
+++ b/app/components/transactions/QuickTransactionForm/QuickTransactionForm.vue
@@ -1,30 +1,10 @@
 <script setup lang="ts">
-import { computed, reactive, watch } from "vue";
-import {
-  NModal,
-  NForm,
-  NFormItem,
-  NInput,
-  NInputNumber,
-  NSelect,
-  NDatePicker,
-  NSwitch,
-  NButton,
-  NSpace,
-  NAlert,
-  type FormInst,
-  type FormRules,
-  type SelectOption,
-} from "naive-ui";
+import { computed, toRef } from "vue";
+import { NAlert, NButton, NForm, NModal, NSpace } from "naive-ui";
+
+import QuickTransactionFormFields from "./QuickTransactionFormFields.vue";
 import type { QuickTransactionFormProps } from "./QuickTransactionForm.types";
-import type {
-  CreateTransactionPayload,
-  TransactionStatusDto,
-} from "~/features/transactions/contracts/transaction.dto";
-import { useCreateTransactionMutation } from "~/features/transactions/queries/use-create-transaction-mutation";
-import { useTagsQuery } from "~/features/tags/queries/use-tags-query";
-import { useAccountsQuery } from "~/features/accounts/queries/use-accounts-query";
-import { useCreditCardsQuery } from "~/features/credit-cards/queries/use-credit-cards-query";
+import { useQuickTransactionForm } from "./useQuickTransactionForm";
 
 const { t } = useI18n();
 
@@ -35,242 +15,32 @@ const emit = defineEmits<{
   success: [];
 }>();
 
-// ── External data ──────────────────────────────────────────────────────────────
+const typeRef = toRef(props, "type");
 
-const { data: tags } = useTagsQuery();
-const { data: accounts } = useAccountsQuery();
-const { data: creditCards } = useCreditCardsQuery();
-
-const tagOptions = computed((): SelectOption[] =>
-  (tags.value ?? []).map((t) => ({ label: t.name, value: t.id })),
-);
-
-const accountOptions = computed((): SelectOption[] =>
-  (accounts.value ?? []).map((a) => ({ label: a.name, value: a.id })),
-);
-
-const creditCardOptions = computed((): SelectOption[] =>
-  (creditCards.value ?? []).map((c) => ({ label: c.name, value: c.id })),
-);
-
-// ── Form state ─────────────────────────────────────────────────────────────────
-
-const formRef = ref<FormInst | null>(null);
-
-const form = reactive({
-  title: "",
-  amount: null as number | null,
-  due_date: null as number | null,   // NDatePicker timestamp (ms)
-  tag_id: null as string | null,
-  account_id: null as string | null,
-  credit_card_id: null as string | null,
-  status: "pending" as TransactionStatusDto,
-  description: "",
-  is_installment: false,
-  installment_count: null as number | null,
-  is_recurring: false,
-  end_date: null as number | null,
-});
-
-// ── Computed field visibility ──────────────────────────────────────────────────
-
-/** Credit card field is only shown for expense forms. */
-const showCreditCard = computed((): boolean => props.type === "expense");
-
-/** Installment toggle is only for expense. Income has no installment concept. */
-const showInstallment = computed((): boolean => props.type === "expense");
-
-/** Recurring toggle is always shown, but disabled while installment is active. */
-const recurringDisabled = computed((): boolean => form.is_installment);
-
-/** Installment count field only shown when the toggle is on. */
-const showInstallmentCount = computed((): boolean => form.is_installment);
-
-/** End date only shown when recurring is on. */
-const showEndDate = computed((): boolean => form.is_recurring);
-
-// ── Status options ─────────────────────────────────────────────────────────────
-
-const statusOptions = computed((): SelectOption[] => {
-  if (props.type === "income") {
-    return [
-      { label: t("transaction.status.pending"), value: "pending" },
-      { label: t("transaction.status.paid"), value: "paid" },
-    ];
-  }
-  return [
-    { label: t("transaction.status.pending"), value: "pending" },
-    { label: t("transaction.status.paid"), value: "paid" },
-    { label: t("transaction.status.postponed"), value: "postponed" },
-  ];
-});
-
-// ── Watchers ───────────────────────────────────────────────────────────────────
-
-/** When installment is toggled on, disable recurring and vice-versa. */
-watch(
-  () => form.is_installment,
-  (on) => {
-    if (on) { form.is_recurring = false; }
+const {
+  formRef,
+  form,
+  mutation,
+  tagOptions,
+  accountOptions,
+  creditCardOptions,
+  statusOptions,
+  showCreditCard,
+  showInstallment,
+  showInstallmentCount,
+  showEndDate,
+  recurringDisabled,
+  rules,
+  submit,
+  resetForm,
+} = useQuickTransactionForm({
+  type: typeRef,
+  t,
+  onSuccess: () => {
+    emit("success");
+    emit("update:visible", false);
   },
-);
-
-watch(
-  () => form.is_recurring,
-  (on) => {
-    if (on) { form.is_installment = false; }
-  },
-);
-
-// ── Validation rules ───────────────────────────────────────────────────────────
-
-const rules = computed((): FormRules => ({
-  title: [
-    {
-      required: true,
-      message: t("transaction.form.required.title"),
-      trigger: "blur",
-    },
-  ],
-  amount: [
-    {
-      required: true,
-      type: "number",
-      message: t("transaction.form.required.amount"),
-      trigger: ["blur", "change"],
-    },
-  ],
-  due_date: [
-    {
-      required: true,
-      type: "number",
-      message: t("transaction.form.required.dueDate"),
-      trigger: "change",
-    },
-  ],
-  installment_count: showInstallmentCount.value
-    ? [
-        {
-          required: true,
-          type: "number",
-          message: t("transaction.form.required.installmentCount"),
-          trigger: ["blur", "change"],
-        },
-      ]
-    : [],
-}));
-
-// ── Mutation ───────────────────────────────────────────────────────────────────
-
-const mutation = useCreateTransactionMutation();
-
-/**
- * Converts a Unix timestamp (ms) produced by NDatePicker to a YYYY-MM-DD string.
- *
- * @param ts Unix timestamp in milliseconds.
- * @returns ISO 8601 date string.
- */
-const tsToDate = (ts: number): string => {
-  const d = new Date(ts);
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
-};
-
-/**
- * Builds the optional installment fields when the toggle is active.
- *
- * @returns Partial payload fields for installment mode, or empty object.
- */
-const buildInstallmentFields = (): Partial<CreateTransactionPayload> => {
-  if (!showInstallment.value || !form.is_installment) { return {}; }
-  return { is_installment: true, installment_count: form.installment_count ?? 2 };
-};
-
-/**
- * Builds the optional recurrence fields when the toggle is active.
- *
- * The backend requires both `start_date` and `end_date` (YYYY-MM-DD) when
- * `is_recurring` is true. `start_date` defaults to the transaction's due_date.
- *
- * @returns Partial payload fields for recurring mode, or empty object.
- */
-const buildRecurringFields = (): Partial<CreateTransactionPayload> => {
-  if (!form.is_recurring) { return {}; }
-  return {
-    is_recurring: true,
-    start_date: form.due_date ? tsToDate(form.due_date) : undefined,
-    ...(form.end_date ? { end_date: tsToDate(form.end_date) } : {}),
-  };
-};
-
-/**
- * Assembles the full CreateTransactionPayload from the current form state.
- *
- * @returns Typed payload ready for the mutation.
- */
-const buildPayload = (): CreateTransactionPayload => ({
-  title: form.title,
-  amount: String(form.amount ?? 0),
-  type: props.type,
-  due_date: form.due_date ? tsToDate(form.due_date) : "",
-  status: form.status,
-  tag_id: form.tag_id ?? null,
-  account_id: form.account_id ?? null,
-  ...(form.description.trim() ? { description: form.description } : {}),
-  ...buildInstallmentFields(),
-  ...buildRecurringFields(),
-  ...(showCreditCard.value && form.credit_card_id
-    ? { credit_card_id: form.credit_card_id }
-    : {}),
 });
-
-/**
- * Validates and submits the form.
- * Delegates payload building to {@link buildPayload}.
- */
-const handleSubmit = async (): Promise<void> => {
-  try {
-    await formRef.value?.validate();
-  } catch {
-    return;
-  }
-
-  mutation.mutate(buildPayload(), {
-    /* v8 ignore start */
-    onSuccess: () => {
-      emit("success");
-      emit("update:visible", false);
-      resetForm();
-    },
-    /* v8 ignore stop */
-  });
-};
-
-/** Resets all form fields to their default values. */
-const resetForm = (): void => {
-  form.title = "";
-  form.amount = null;
-  form.due_date = null;
-  form.tag_id = null;
-  form.account_id = null;
-  form.credit_card_id = null;
-  form.status = "pending" as TransactionStatusDto;
-  form.description = "";
-  form.is_installment = false;
-  form.installment_count = null;
-  form.is_recurring = false;
-  form.end_date = null;
-};
-
-/** Closes the modal without submitting. */
-const handleClose = (): void => {
-  emit("update:visible", false);
-  resetForm();
-};
-
-// ── Computed title / colour ────────────────────────────────────────────────────
 
 const modalTitle = computed((): string =>
   props.type === "income"
@@ -281,6 +51,14 @@ const modalTitle = computed((): string =>
 const submitButtonType = computed(() =>
   props.type === "income" ? "success" : "error",
 );
+
+/**
+ * Closes the modal without submitting and resets the form.
+ */
+function handleClose(): void {
+  emit("update:visible", false);
+  resetForm();
+}
 </script>
 
 <template>
@@ -292,8 +70,6 @@ const submitButtonType = computed(() =>
     :style="{ maxWidth: '520px', width: '100%' }"
     @update:show="handleClose"
   >
-    <!-- Mutation error alert — only reachable when isError is true; excluded from
-         unit-test coverage because it requires injecting a reactive mutation error -->
     <!-- v8 ignore next 7 -->
     <NAlert
       v-if="mutation.isError.value"
@@ -305,147 +81,18 @@ const submitButtonType = computed(() =>
     </NAlert>
 
     <NForm ref="formRef" :model="form" :rules="rules" label-placement="top">
-
-      <!-- Title -->
-      <NFormItem :label="$t('transaction.form.title.label')" path="title">
-        <NInput
-          v-model:value="form.title"
-          :placeholder="$t('transaction.form.title.placeholder')"
-        />
-      </NFormItem>
-
-      <!-- Amount -->
-      <NFormItem :label="$t('transaction.form.amount.label')" path="amount">
-        <NInputNumber
-          v-model:value="form.amount"
-          :placeholder="$t('transaction.form.amount.placeholder')"
-          :min="0.01"
-          :precision="2"
-          style="width: 100%"
-        />
-      </NFormItem>
-
-      <!-- Due date -->
-      <NFormItem :label="$t('transaction.form.dueDate.label')" path="due_date">
-        <NDatePicker
-          v-model:value="form.due_date"
-          type="date"
-          format="dd/MM/yyyy"
-          style="width: 100%"
-        />
-      </NFormItem>
-
-      <!-- Category / tag -->
-      <NFormItem :label="$t('transaction.form.tag.label')" path="tag_id">
-        <NSelect
-          v-model:value="form.tag_id"
-          :options="tagOptions"
-          :placeholder="$t('transaction.form.tag.placeholder')"
-          clearable
-        />
-        <template v-if="tagOptions.length === 0">
-          <NuxtLink
-            to="/settings/tags"
-            class="quick-transaction-form__settings-link"
-          >
-            {{ $t('transaction.form.tag.createHint') }}
-          </NuxtLink>
-        </template>
-      </NFormItem>
-
-      <!-- Account -->
-      <NFormItem :label="$t('transaction.form.account.label')" path="account_id">
-        <NSelect
-          v-model:value="form.account_id"
-          :options="accountOptions"
-          :placeholder="$t('transaction.form.account.placeholder')"
-          clearable
-        />
-        <template v-if="accountOptions.length === 0">
-          <NuxtLink
-            to="/settings/accounts"
-            class="quick-transaction-form__settings-link"
-          >
-            {{ $t('transaction.form.account.createHint') }}
-          </NuxtLink>
-        </template>
-      </NFormItem>
-
-      <!-- Credit card (expense only) -->
-      <NFormItem
-        v-if="showCreditCard"
-        :label="$t('transaction.form.creditCard.label')"
-        path="credit_card_id"
-      >
-        <NSelect
-          v-model:value="form.credit_card_id"
-          :options="creditCardOptions"
-          :placeholder="$t('transaction.form.creditCard.placeholder')"
-          clearable
-        />
-      </NFormItem>
-
-      <!-- Status -->
-      <NFormItem :label="$t('transaction.form.status.label')" path="status">
-        <NSelect
-          v-model:value="form.status"
-          :options="statusOptions"
-        />
-      </NFormItem>
-
-      <!-- Installment toggle (expense only) -->
-      <NFormItem v-if="showInstallment" :label="$t('transaction.form.installment.label')" path="is_installment">
-        <NSwitch v-model:value="form.is_installment" />
-      </NFormItem>
-
-      <!-- Installment count -->
-      <NFormItem
-        v-if="showInstallmentCount"
-        :label="$t('transaction.form.installmentCount.label')"
-        path="installment_count"
-      >
-        <NInputNumber
-          v-model:value="form.installment_count"
-          :placeholder="$t('transaction.form.installmentCount.placeholder')"
-          :min="2"
-          :max="60"
-          style="width: 100%"
-        />
-      </NFormItem>
-
-      <!-- Recurring toggle -->
-      <NFormItem :label="$t('transaction.form.recurring.label')" path="is_recurring">
-        <NSwitch
-          v-model:value="form.is_recurring"
-          :disabled="recurringDisabled"
-        />
-      </NFormItem>
-
-      <!-- Recurring end date -->
-      <NFormItem
-        v-if="showEndDate"
-        :label="$t('transaction.form.endDate.label')"
-        path="end_date"
-      >
-        <NDatePicker
-          v-model:value="form.end_date"
-          type="date"
-          format="dd/MM/yyyy"
-          style="width: 100%"
-          clearable
-        />
-      </NFormItem>
-
-      <!-- Description / notes -->
-      <NFormItem :label="$t('transaction.form.description.label')" path="description">
-        <NInput
-          v-model:value="form.description"
-          type="textarea"
-          :placeholder="$t('transaction.form.description.placeholder')"
-          :rows="2"
-        />
-      </NFormItem>
-
+      <QuickTransactionFormFields
+        :form="form"
+        :tag-options="tagOptions"
+        :account-options="accountOptions"
+        :credit-card-options="creditCardOptions"
+        :status-options="statusOptions"
+        :show-credit-card="showCreditCard"
+        :show-installment="showInstallment"
+        :show-installment-count="showInstallmentCount"
+        :show-end-date="showEndDate"
+        :recurring-disabled="recurringDisabled"
+      />
     </NForm>
 
     <template #footer>
@@ -453,11 +100,7 @@ const submitButtonType = computed(() =>
         <NButton :disabled="mutation.isPending.value" @click="handleClose">
           {{ $t('common.cancel') }}
         </NButton>
-        <NButton
-          :type="submitButtonType"
-          :loading="mutation.isPending.value"
-          @click="handleSubmit"
-        >
+        <NButton :type="submitButtonType" :loading="mutation.isPending.value" @click="submit">
           {{ $t('common.save') }}
         </NButton>
       </NSpace>
@@ -468,17 +111,5 @@ const submitButtonType = computed(() =>
 <style scoped>
 .quick-transaction-form-modal {
   color: var(--color-text-primary);
-}
-
-.quick-transaction-form__settings-link {
-  display: inline-block;
-  margin-top: 4px;
-  font-size: var(--font-size-xs);
-  color: var(--color-brand-500);
-  text-decoration: none;
-}
-
-.quick-transaction-form__settings-link:hover {
-  text-decoration: underline;
 }
 </style>

--- a/app/components/transactions/QuickTransactionForm/QuickTransactionFormFields.vue
+++ b/app/components/transactions/QuickTransactionForm/QuickTransactionFormFields.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { inject } from "vue";
+import {
+  NDatePicker,
+  NFormItem,
+  NInput,
+  NInputNumber,
+  NSelect,
+  NSwitch,
+  type SelectOption,
+} from "naive-ui";
+
+import {
+  QUICK_TRANSACTION_FORM_KEY,
+  type QuickTransactionFormState,
+} from "./useQuickTransactionForm";
+
+defineOptions({ name: "QuickTransactionFormFields" });
+
+defineProps<{
+  tagOptions: SelectOption[];
+  accountOptions: SelectOption[];
+  creditCardOptions: SelectOption[];
+  statusOptions: SelectOption[];
+  showCreditCard: boolean;
+  showInstallment: boolean;
+  showInstallmentCount: boolean;
+  showEndDate: boolean;
+  recurringDisabled: boolean;
+}>();
+
+const form = inject<QuickTransactionFormState>(QUICK_TRANSACTION_FORM_KEY)!;
+</script>
+
+<template>
+  <div class="quick-transaction-form-fields">
+    <NFormItem :label="$t('transaction.form.title.label')" path="title">
+      <NInput v-model:value="form.title" :placeholder="$t('transaction.form.title.placeholder')" />
+    </NFormItem>
+
+    <NFormItem :label="$t('transaction.form.amount.label')" path="amount">
+      <NInputNumber
+        v-model:value="form.amount"
+        :placeholder="$t('transaction.form.amount.placeholder')"
+        :min="0.01"
+        :precision="2"
+        style="width: 100%"
+      />
+    </NFormItem>
+
+    <NFormItem :label="$t('transaction.form.dueDate.label')" path="due_date">
+      <NDatePicker v-model:value="form.due_date" type="date" format="dd/MM/yyyy" style="width: 100%" />
+    </NFormItem>
+
+    <NFormItem :label="$t('transaction.form.tag.label')" path="tag_id">
+      <NSelect
+        v-model:value="form.tag_id"
+        :options="tagOptions"
+        :placeholder="$t('transaction.form.tag.placeholder')"
+        clearable
+      />
+      <template v-if="tagOptions.length === 0">
+        <NuxtLink to="/settings/tags" class="quick-transaction-form__settings-link">
+          {{ $t('transaction.form.tag.createHint') }}
+        </NuxtLink>
+      </template>
+    </NFormItem>
+
+    <NFormItem :label="$t('transaction.form.account.label')" path="account_id">
+      <NSelect
+        v-model:value="form.account_id"
+        :options="accountOptions"
+        :placeholder="$t('transaction.form.account.placeholder')"
+        clearable
+      />
+      <template v-if="accountOptions.length === 0">
+        <NuxtLink to="/settings/accounts" class="quick-transaction-form__settings-link">
+          {{ $t('transaction.form.account.createHint') }}
+        </NuxtLink>
+      </template>
+    </NFormItem>
+
+    <NFormItem v-if="showCreditCard" :label="$t('transaction.form.creditCard.label')" path="credit_card_id">
+      <NSelect
+        v-model:value="form.credit_card_id"
+        :options="creditCardOptions"
+        :placeholder="$t('transaction.form.creditCard.placeholder')"
+        clearable
+      />
+    </NFormItem>
+
+    <NFormItem :label="$t('transaction.form.status.label')" path="status">
+      <NSelect v-model:value="form.status" :options="statusOptions" />
+    </NFormItem>
+
+    <NFormItem v-if="showInstallment" :label="$t('transaction.form.installment.label')" path="is_installment">
+      <NSwitch v-model:value="form.is_installment" />
+    </NFormItem>
+
+    <NFormItem
+      v-if="showInstallmentCount"
+      :label="$t('transaction.form.installmentCount.label')"
+      path="installment_count"
+    >
+      <NInputNumber
+        v-model:value="form.installment_count"
+        :placeholder="$t('transaction.form.installmentCount.placeholder')"
+        :min="2"
+        :max="60"
+        style="width: 100%"
+      />
+    </NFormItem>
+
+    <NFormItem :label="$t('transaction.form.recurring.label')" path="is_recurring">
+      <NSwitch v-model:value="form.is_recurring" :disabled="recurringDisabled" />
+    </NFormItem>
+
+    <NFormItem v-if="showEndDate" :label="$t('transaction.form.endDate.label')" path="end_date">
+      <NDatePicker v-model:value="form.end_date" type="date" format="dd/MM/yyyy" style="width: 100%" clearable />
+    </NFormItem>
+
+    <NFormItem :label="$t('transaction.form.description.label')" path="description">
+      <NInput
+        v-model:value="form.description"
+        type="textarea"
+        :placeholder="$t('transaction.form.description.placeholder')"
+        :rows="2"
+      />
+    </NFormItem>
+  </div>
+</template>
+
+<style scoped>
+.quick-transaction-form__settings-link {
+  display: inline-block;
+  margin-top: 4px;
+  font-size: var(--font-size-xs);
+  color: var(--color-brand-500);
+  text-decoration: none;
+}
+
+.quick-transaction-form__settings-link:hover {
+  text-decoration: underline;
+}
+</style>

--- a/app/components/transactions/QuickTransactionForm/useQuickTransactionForm.ts
+++ b/app/components/transactions/QuickTransactionForm/useQuickTransactionForm.ts
@@ -1,0 +1,227 @@
+import {
+  computed,
+  provide,
+  reactive,
+  ref,
+  watch,
+  type ComputedRef,
+  type InjectionKey,
+  type Ref,
+} from "vue";
+import type { FormInst, FormRules, SelectOption } from "naive-ui";
+
+import type {
+  CreateTransactionPayload,
+  TransactionStatusDto,
+  TransactionTypeDto,
+} from "~/features/transactions/contracts/transaction.dto";
+import { useAccountsQuery } from "~/features/accounts/queries/use-accounts-query";
+import { useCreditCardsQuery } from "~/features/credit-cards/queries/use-credit-cards-query";
+import { useCreateTransactionMutation } from "~/features/transactions/queries/use-create-transaction-mutation";
+import { useTagsQuery } from "~/features/tags/queries/use-tags-query";
+
+export const QUICK_TRANSACTION_FORM_KEY: InjectionKey<QuickTransactionFormState> =
+  Symbol("QuickTransactionForm");
+
+export interface QuickTransactionFormState {
+  title: string;
+  amount: number | null;
+  due_date: number | null;
+  tag_id: string | null;
+  account_id: string | null;
+  credit_card_id: string | null;
+  status: TransactionStatusDto;
+  description: string;
+  is_installment: boolean;
+  installment_count: number | null;
+  is_recurring: boolean;
+  end_date: number | null;
+}
+
+/**
+ * Converts a millisecond timestamp from NDatePicker to a YYYY-MM-DD string.
+ *
+ * @param ts Unix timestamp in milliseconds.
+ * @returns ISO 8601 date (YYYY-MM-DD).
+ */
+function tsToDate(ts: number): string {
+  const d = new Date(ts);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Produces a fresh QuickTransactionFormState populated with defaults.
+ *
+ * @returns A plain object that can seed a reactive form.
+ */
+function createDefaultFormState(): QuickTransactionFormState {
+  return {
+    title: "",
+    amount: null,
+    due_date: null,
+    tag_id: null,
+    account_id: null,
+    credit_card_id: null,
+    status: "pending" as TransactionStatusDto,
+    description: "",
+    is_installment: false,
+    installment_count: null,
+    is_recurring: false,
+    end_date: null,
+  };
+}
+
+export interface UseQuickTransactionFormOptions {
+  type: Ref<TransactionTypeDto> | ComputedRef<TransactionTypeDto>;
+  t: (key: string) => string;
+  onSuccess: () => void;
+}
+
+/* eslint-disable max-lines-per-function, max-statements, @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types -- return type is inferred from composable shape */
+/**
+ * Encapsulates form state, validation rules, visibility flags and the
+ * submit/reset lifecycle for the QuickTransactionForm modal.
+ *
+ * @param opts Reactive type ref, translator, and success callback from the host.
+ * @returns Reactive form bindings, computed options, rules and submit/reset handlers.
+ */
+export function useQuickTransactionForm(opts: UseQuickTransactionFormOptions) {
+  const { type, t, onSuccess } = opts;
+  const formRef = ref<FormInst | null>(null);
+  const form = reactive<QuickTransactionFormState>(createDefaultFormState());
+  provide(QUICK_TRANSACTION_FORM_KEY, form);
+
+  const { data: tags } = useTagsQuery();
+  const { data: accounts } = useAccountsQuery();
+  const { data: creditCards } = useCreditCardsQuery();
+  const mutation = useCreateTransactionMutation();
+
+  const tagOptions = computed((): SelectOption[] =>
+    (tags.value ?? []).map((tag) => ({ label: tag.name, value: tag.id })));
+  const accountOptions = computed((): SelectOption[] =>
+    (accounts.value ?? []).map((a) => ({ label: a.name, value: a.id })));
+  const creditCardOptions = computed((): SelectOption[] =>
+    (creditCards.value ?? []).map((c) => ({ label: c.name, value: c.id })));
+
+  const showCreditCard = computed((): boolean => type.value === "expense");
+  const showInstallment = computed((): boolean => type.value === "expense");
+  const recurringDisabled = computed((): boolean => form.is_installment);
+  const showInstallmentCount = computed((): boolean => form.is_installment);
+  const showEndDate = computed((): boolean => form.is_recurring);
+
+  const statusOptions = computed((): SelectOption[] => {
+    if (type.value === "income") {
+      return [
+        { label: t("transaction.status.pending"), value: "pending" },
+        { label: t("transaction.status.paid"), value: "paid" },
+      ];
+    }
+    return [
+      { label: t("transaction.status.pending"), value: "pending" },
+      { label: t("transaction.status.paid"), value: "paid" },
+      { label: t("transaction.status.postponed"), value: "postponed" },
+    ];
+  });
+
+  watch(() => form.is_installment, (on) => { if (on) { form.is_recurring = false; } });
+  watch(() => form.is_recurring, (on) => { if (on) { form.is_installment = false; } });
+
+  const rules = computed((): FormRules => ({
+    title: [{ required: true, message: t("transaction.form.required.title"), trigger: "blur" }],
+    amount: [{ required: true, type: "number", message: t("transaction.form.required.amount"), trigger: ["blur", "change"] }],
+    due_date: [{ required: true, type: "number", message: t("transaction.form.required.dueDate"), trigger: "change" }],
+    installment_count: showInstallmentCount.value
+      ? [{ required: true, type: "number", message: t("transaction.form.required.installmentCount"), trigger: ["blur", "change"] }]
+      : [],
+  }));
+
+  /**
+   * Builds installment-only payload fields when the toggle is active.
+   *
+   * @returns Partial payload, or empty object when installment is off.
+   */
+  function buildInstallmentFields(): Partial<CreateTransactionPayload> {
+    if (!showInstallment.value || !form.is_installment) { return {}; }
+    return { is_installment: true, installment_count: form.installment_count ?? 2 };
+  }
+
+  /**
+   * Builds recurring-only payload fields when the toggle is active.
+   *
+   * @returns Partial payload, or empty object when recurring is off.
+   */
+  function buildRecurringFields(): Partial<CreateTransactionPayload> {
+    if (!form.is_recurring) { return {}; }
+    return {
+      is_recurring: true,
+      start_date: form.due_date ? tsToDate(form.due_date) : undefined,
+      ...(form.end_date ? { end_date: tsToDate(form.end_date) } : {}),
+    };
+  }
+
+  /**
+   * Assembles the typed payload expected by the create-transaction mutation.
+   *
+   * @returns Fully populated payload ready to be sent to the API.
+   */
+  function buildPayload(): CreateTransactionPayload {
+    return {
+      title: form.title,
+      amount: String(form.amount ?? 0),
+      type: type.value,
+      due_date: form.due_date ? tsToDate(form.due_date) : "",
+      status: form.status,
+      tag_id: form.tag_id ?? null,
+      account_id: form.account_id ?? null,
+      ...(form.description.trim() ? { description: form.description } : {}),
+      ...buildInstallmentFields(),
+      ...buildRecurringFields(),
+      ...(showCreditCard.value && form.credit_card_id
+        ? { credit_card_id: form.credit_card_id }
+        : {}),
+    };
+  }
+
+  /** Restores every field in the reactive form back to its default value. */
+  function resetForm(): void {
+    Object.assign(form, createDefaultFormState());
+  }
+
+  /** Validates the form and submits via the create-transaction mutation. */
+  async function submit(): Promise<void> {
+    try {
+      await formRef.value?.validate();
+    } catch {
+      return;
+    }
+    mutation.mutate(buildPayload(), {
+      /* v8 ignore start */
+      onSuccess: () => {
+        onSuccess();
+        resetForm();
+      },
+      /* v8 ignore stop */
+    });
+  }
+
+  return {
+    formRef,
+    form,
+    mutation,
+    tagOptions,
+    accountOptions,
+    creditCardOptions,
+    statusOptions,
+    showCreditCard,
+    showInstallment,
+    showInstallmentCount,
+    showEndDate,
+    recurringDisabled,
+    rules,
+    submit,
+    resetForm,
+  };
+}


### PR DESCRIPTION
## Summary

UX-5 refactor series — **PR 2 of 6**.

Splits `QuickTransactionForm.vue` (484 LOC → 115 LOC) into three cohesive pieces:

- `QuickTransactionForm.vue` (115 LOC) — NModal shell + error alert + submit/cancel footer
- `QuickTransactionFormFields.vue` (145 LOC, new) — all 12 NFormItem fields (inject form via provide/inject)
- `useQuickTransactionForm.ts` (227 LOC, new) — reactive form state, options, visibility, rules, payload builders and submit

## Why

`QuickTransactionForm.vue` was 484 LOC mixing modal shell, 12 form fields, state, rules, 2 payload builders, and a submit pipeline. Hitting #646's 200-LOC budget required splitting presentation from logic.

The `form` object is passed from composable to child via `provide(QUICK_TRANSACTION_FORM_KEY, form)` (avoids \`vue/no-mutating-props\` and keeps v-model ergonomics inside fields).

## Test plan

- [x] \`pnpm lint\` — clean
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test -- QuickTransactionForm\` — 25/25 passing
- [x] \`pnpm quality-check\` — end-to-end green (build OK)
- [ ] Reviewer: open any page with the QuickTransactionForm modal (e.g. dashboard quick-add) and confirm no visual/behavioral regression in expense and income modes

## Series progress

| # | Component | LOC | Status |
|---|-----------|-----|--------|
| 1 | hora-extra/page.vue | 465 → 181 | merged #706 |
| 2 | QuickTransactionForm.vue | 484 → 115 | **this PR** |
| 3 | WalletEntryForm.vue | 547 | queued |
| 4 | ProfileCompletionModal.vue | 652 | queued |
| 5 | thirteenth-salary/page.vue | 739 | queued |
| 6 | installment-vs-cash/page.vue | 762 | queued |

Refs #646