### PR TITLE
refactor(web): split installment-vs-cash page into composable + hero/bridge-modals subcomponents

### DIFF
--- a/app/features/tools/installment-vs-cash/InstallmentVsCashBridgeModals.vue
+++ b/app/features/tools/installment-vs-cash/InstallmentVsCashBridgeModals.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { computed, inject } from "vue";
+import { NButton, NDatePicker, NForm, NFormItem, NInput, NModal, NSpace } from "naive-ui";
+
+import UiSegmentedControl from "~/components/ui/UiSegmentedControl/UiSegmentedControl.vue";
+import {
+  INSTALLMENT_VS_CASH_EXPENSE_FORM_KEY,
+  INSTALLMENT_VS_CASH_GOAL_FORM_KEY,
+  type InstallmentVsCashGoalForm,
+  type InstallmentVsCashPlannedExpenseForm,
+} from "./installment-vs-cash-bridge-modals.types";
+
+defineOptions({ name: "InstallmentVsCashBridgeModals" });
+
+const props = defineProps<{
+  showGoalModal: boolean;
+  showExpenseModal: boolean;
+  feesEnabled: boolean;
+  isCreatingGoal: boolean;
+  isCreatingExpense: boolean;
+  t: (key: string, vars?: Record<string, unknown>) => string;
+}>();
+
+const emit = defineEmits<{
+  "update:showGoalModal": [value: boolean];
+  "update:showExpenseModal": [value: boolean];
+  submitGoal: [];
+  submitExpense: [];
+}>();
+
+const goalForm = inject<InstallmentVsCashGoalForm>(INSTALLMENT_VS_CASH_GOAL_FORM_KEY)!;
+const expenseForm = inject<InstallmentVsCashPlannedExpenseForm>(INSTALLMENT_VS_CASH_EXPENSE_FORM_KEY)!;
+
+const goalShow = computed({
+  get: () => props.showGoalModal,
+  set: (v: boolean) => emit("update:showGoalModal", v),
+});
+const expenseShow = computed({
+  get: () => props.showExpenseModal,
+  set: (v: boolean) => emit("update:showExpenseModal", v),
+});
+</script>
+
+<template>
+  <div class="installment-vs-cash-bridge-modals">
+    <NModal v-model:show="goalShow" preset="card" :title="t('pages.installmentVsCash.goalModal.title')" class="installment-vs-cash-bridge-modals__modal">
+      <NForm label-placement="top">
+        <NFormItem :label="t('pages.installmentVsCash.goalModal.titleLabel')">
+          <NInput v-model:value="goalForm.title" />
+        </NFormItem>
+
+        <NFormItem :label="t('pages.installmentVsCash.goalModal.descriptionLabel')">
+          <NInput v-model:value="goalForm.description" type="textarea" />
+        </NFormItem>
+
+        <NFormItem :label="t('pages.installmentVsCash.goalModal.targetDateLabel')">
+          <NDatePicker v-model:value="goalForm.targetDate" type="date" clearable />
+        </NFormItem>
+
+        <NSpace justify="end">
+          <NButton @click="goalShow = false">{{ t('pages.installmentVsCash.goalModal.cancel') }}</NButton>
+          <NButton type="primary" :loading="isCreatingGoal" @click="emit('submitGoal')">
+            {{ t('pages.installmentVsCash.goalModal.submit') }}
+          </NButton>
+        </NSpace>
+      </NForm>
+    </NModal>
+
+    <NModal v-model:show="expenseShow" preset="card" :title="t('pages.installmentVsCash.expenseModal.title')" class="installment-vs-cash-bridge-modals__modal">
+      <NForm label-placement="top">
+        <NFormItem :label="t('pages.installmentVsCash.expenseModal.titleLabel')">
+          <NInput v-model:value="expenseForm.title" />
+        </NFormItem>
+
+        <NFormItem :label="t('pages.installmentVsCash.expenseModal.descriptionLabel')">
+          <NInput v-model:value="expenseForm.description" type="textarea" />
+        </NFormItem>
+
+        <NFormItem :label="t('pages.installmentVsCash.expenseModal.modeLabel')">
+          <UiSegmentedControl
+            v-model="expenseForm.selectedOption"
+            :options="[
+              { label: t('pages.installmentVsCash.expenseModal.cashLabel'), value: 'cash' },
+              { label: t('pages.installmentVsCash.expenseModal.installmentLabel'), value: 'installment' },
+            ]"
+            :aria-label="t('pages.installmentVsCash.expenseModal.modeAriaLabel')"
+          />
+        </NFormItem>
+
+        <NFormItem
+          v-if="expenseForm.selectedOption === 'cash'"
+          :label="t('pages.installmentVsCash.expenseModal.dueDateLabel')"
+        >
+          <NDatePicker v-model:value="expenseForm.dueDate" type="date" clearable />
+        </NFormItem>
+        <NFormItem v-else :label="t('pages.installmentVsCash.expenseModal.firstDueDateLabel')">
+          <NDatePicker v-model:value="expenseForm.firstDueDate" type="date" clearable />
+        </NFormItem>
+
+        <NFormItem v-if="feesEnabled" :label="t('pages.installmentVsCash.expenseModal.upfrontDateLabel')">
+          <NDatePicker v-model:value="expenseForm.upfrontDueDate" type="date" clearable />
+        </NFormItem>
+
+        <NSpace justify="end">
+          <NButton @click="expenseShow = false">{{ t('pages.installmentVsCash.expenseModal.cancel') }}</NButton>
+          <NButton type="primary" :loading="isCreatingExpense" @click="emit('submitExpense')">
+            {{ t('pages.installmentVsCash.expenseModal.submit') }}
+          </NButton>
+        </NSpace>
+      </NForm>
+    </NModal>
+  </div>
+</template>
+
+<style scoped>
+:deep(.installment-vs-cash-bridge-modals__modal) {
+  width: min(720px, calc(100vw - 32px));
+}
+</style>

--- a/app/features/tools/installment-vs-cash/InstallmentVsCashHero.vue
+++ b/app/features/tools/installment-vs-cash/InstallmentVsCashHero.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { NAlert, NSpace, NTag, NThing } from "naive-ui";
+
+import type { InstallmentVsCashFormState } from "~/features/tools/model/installment-vs-cash";
+
+defineOptions({ name: "InstallmentVsCashHero" });
+
+defineProps<{
+  form: InstallmentVsCashFormState;
+  validationMessage: string | null;
+  isLoading: boolean;
+  isError: boolean;
+  t: (key: string, vars?: Record<string, unknown>) => string;
+}>();
+
+const emit = defineEmits<{
+  "update:form": [value: InstallmentVsCashFormState];
+  submit: [];
+}>();
+</script>
+
+<template>
+  <section class="installment-vs-cash-hero">
+    <div class="installment-vs-cash-hero__copy">
+      <NTag round type="warning">
+        {{ t('pages.installmentVsCash.hero.badge') }}
+      </NTag>
+      <UiPageHeader
+        :title="t('pages.installmentVsCash.hero.title')"
+        :subtitle="t('pages.installmentVsCash.hero.subtitle')"
+      />
+
+      <NSpace vertical :size="16">
+        <NThing
+          :title="t('pages.installmentVsCash.hero.featureBasic')"
+          :description="t('pages.installmentVsCash.hero.featureBasicDesc')"
+        />
+        <NThing
+          :title="t('pages.installmentVsCash.hero.featureAdvanced')"
+          :description="t('pages.installmentVsCash.hero.featureAdvancedDesc')"
+        />
+      </NSpace>
+    </div>
+
+    <UiGlassPanel glow class="installment-vs-cash-hero__panel">
+      <InstallmentVsCashCalculatorForm
+        :model-value="form"
+        :loading="isLoading"
+        @update:model-value="(v: InstallmentVsCashFormState) => emit('update:form', v)"
+        @submit="emit('submit')"
+      />
+
+      <NAlert v-if="validationMessage" type="warning" class="installment-vs-cash-hero__alert">
+        {{ validationMessage }}
+      </NAlert>
+
+      <NAlert v-if="isError" type="error" class="installment-vs-cash-hero__alert">
+        {{ t('pages.installmentVsCash.errors.calculate') }}
+      </NAlert>
+    </UiGlassPanel>
+  </section>
+</template>
+
+<style scoped>
+.installment-vs-cash-hero {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: minmax(0, 1.1fr) minmax(380px, 0.9fr);
+  align-items: start;
+}
+
+.installment-vs-cash-hero__copy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding-top: var(--space-5);
+}
+
+.installment-vs-cash-hero__panel {
+  position: sticky;
+  top: var(--space-3);
+}
+
+.installment-vs-cash-hero__alert {
+  margin-top: var(--space-2);
+}
+
+@media (max-width: 1023px) {
+  .installment-vs-cash-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .installment-vs-cash-hero__copy {
+    padding-top: var(--space-2);
+  }
+
+  .installment-vs-cash-hero__panel {
+    position: static;
+  }
+}
+</style>

--- a/app/features/tools/installment-vs-cash/installment-vs-cash-bridge-modals.types.ts
+++ b/app/features/tools/installment-vs-cash/installment-vs-cash-bridge-modals.types.ts
@@ -1,0 +1,25 @@
+import type { InjectionKey } from "vue";
+
+import type { SelectedPaymentOption } from "~/features/tools/model/installment-vs-cash";
+
+export interface InstallmentVsCashGoalForm {
+  title: string;
+  selectedOption: SelectedPaymentOption;
+  description: string;
+  targetDate: number | null;
+}
+
+export interface InstallmentVsCashPlannedExpenseForm {
+  title: string;
+  selectedOption: SelectedPaymentOption;
+  description: string;
+  dueDate: number | null;
+  firstDueDate: number | null;
+  upfrontDueDate: number | null;
+}
+
+export const INSTALLMENT_VS_CASH_GOAL_FORM_KEY: InjectionKey<InstallmentVsCashGoalForm> =
+  Symbol("InstallmentVsCashGoalForm");
+
+export const INSTALLMENT_VS_CASH_EXPENSE_FORM_KEY: InjectionKey<InstallmentVsCashPlannedExpenseForm> =
+  Symbol("InstallmentVsCashExpenseForm");

--- a/app/features/tools/installment-vs-cash/page.vue
+++ b/app/features/tools/installment-vs-cash/page.vue
@@ -1,679 +1,110 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from "vue";
-import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+import { provide } from "vue";
+import { NSpace, NThing } from "naive-ui";
 
-import {
-  NAlert,
-  NButton,
-  NDatePicker,
-  NForm,
-  NFormItem,
-  NInput,
-  NModal,
-  NSpace,
-  NThing,
-  NTag,
-  useMessage,
-} from "naive-ui";
-
-import { captureException } from "~/core/observability";
-import { STALE_TIME } from "~/core/query/stale-time";
-import { useApiError } from "~/composables/useApiError";
-import { useAuthRedirectContext } from "~/composables/useAuthRedirectContext";
-import { useSessionStore } from "~/stores/session";
-import { useToolContextStore } from "~/stores/toolContext";
-import { useEntitlementClient } from "~/features/paywall/services/entitlement.client";
-import { useCreateGoalFromInstallmentVsCashMutation } from "~/features/tools/queries/use-create-goal-from-installment-vs-cash-mutation";
-import { useCreatePlannedExpenseFromInstallmentVsCashMutation } from "~/features/tools/queries/use-create-planned-expense-from-installment-vs-cash-mutation";
-import { useInstallmentVsCashCalculateMutation } from "~/features/tools/queries/use-installment-vs-cash-calculate-mutation";
-import { useSaveInstallmentVsCashMutation } from "~/features/tools/queries/use-save-installment-vs-cash-mutation";
-import {
-  createDefaultInstallmentVsCashFormState,
-  getRecommendationLabel,
-  INSTALLMENT_VS_CASH_PUBLIC_PATH,
-  INSTALLMENT_VS_CASH_TOOL_ID,
-  isInstallmentVsCashCalculation,
-  isInstallmentVsCashPendingPayload,
-  toInstallmentVsCashCalculationRequest,
-  validateInstallmentVsCashForm,
-  type CreateInstallmentVsCashGoalPayload,
-  type CreateInstallmentVsCashPlannedExpensePayload,
-  type InstallmentVsCashCalculation,
-  type InstallmentVsCashFormState,
-  type InstallmentVsCashSavedSimulation,
-  type SelectedPaymentOption,
-} from "~/features/tools/model/installment-vs-cash";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import { getRecommendationLabel } from "~/features/tools/model/installment-vs-cash";
+
+import InstallmentVsCashHero from "./InstallmentVsCashHero.vue";
+import InstallmentVsCashBridgeModals from "./InstallmentVsCashBridgeModals.vue";
+import {
+  INSTALLMENT_VS_CASH_EXPENSE_FORM_KEY,
+  INSTALLMENT_VS_CASH_GOAL_FORM_KEY,
+} from "./installment-vs-cash-bridge-modals.types";
+import { useInstallmentVsCashPage } from "./useInstallmentVsCashPage";
 
 defineOptions({ name: "InstallmentVsCashPage" });
 
-const { t } = useI18n();
-const message = useMessage();
-const { getErrorMessage } = useApiError();
-const router = useRouter();
-const sessionStore = useSessionStore();
-const toolContextStore = useToolContextStore();
-const { saveRedirect } = useAuthRedirectContext();
-const entitlementClient = useEntitlementClient();
+const page = useInstallmentVsCashPage();
 
-const form = ref<InstallmentVsCashFormState>(
-  createDefaultInstallmentVsCashFormState(),
-);
-const calculation = ref<InstallmentVsCashCalculation | null>(null);
-const savedSimulation = ref<InstallmentVsCashSavedSimulation | null>(null);
-const validationMessage = ref<string | null>(null);
-const showGoalModal = ref(false);
-const showExpenseModal = ref(false);
-
-const goalForm = reactive<{
-  title: string;
-  selectedOption: SelectedPaymentOption;
-  description: string;
-  targetDate: number | null;
-}>({
-  title: "",
-  selectedOption: "cash",
-  description: "",
-  targetDate: null,
-});
-
-const plannedExpenseForm = reactive<{
-  title: string;
-  selectedOption: SelectedPaymentOption;
-  description: string;
-  dueDate: number | null;
-  firstDueDate: number | null;
-  upfrontDueDate: number | null;
-}>({
-  title: "",
-  selectedOption: "installment",
-  description: "",
-  dueDate: null,
-  firstDueDate: null,
-  upfrontDueDate: null,
-});
-
-const calculateMutation = useInstallmentVsCashCalculateMutation();
-const saveMutation = useSaveInstallmentVsCashMutation();
-const createGoalMutation = useCreateGoalFromInstallmentVsCashMutation();
-const createPlannedExpenseMutation =
-  useCreatePlannedExpenseFromInstallmentVsCashMutation();
-
-sessionStore.restore();
-
-const premiumAccessQuery: UseQueryReturnType<boolean, Error> = useQuery({
-  queryKey: ["entitlements", "advanced_simulations", INSTALLMENT_VS_CASH_TOOL_ID],
-  enabled: computed<boolean>(() => sessionStore.isAuthenticated),
-  queryFn: (): Promise<boolean> => {
-    return entitlementClient.checkEntitlement("advanced_simulations");
-  },
-  staleTime: STALE_TIME.STATIC,
-});
-
-const isAuthenticated = computed<boolean>(() => {
-  sessionStore.restore();
-  return sessionStore.isAuthenticated;
-});
-
-const hasPremiumAccess = computed<boolean>(() => {
-  return premiumAccessQuery.data.value === true;
-});
-
-const isBridging = computed<boolean>(() => {
-  return createGoalMutation.isPending.value
-    || createPlannedExpenseMutation.isPending.value;
-});
+provide(INSTALLMENT_VS_CASH_GOAL_FORM_KEY, page.goalForm);
+provide(INSTALLMENT_VS_CASH_EXPENSE_FORM_KEY, page.plannedExpenseForm);
 
 /**
- * Reports an operational error to observability and shows a user-friendly message.
+ * Adapts ref write-back from v-model on InstallmentVsCashHero.
  *
- * @param error The original runtime error.
- * @param context Stable context label for observability.
- * @returns void
+ * @param value New form state emitted by the hero component.
  */
-const handleOperationalError = (
-  error: unknown,
-  context: string,
-): void => {
-  captureException(error, {
-    context,
-    extra: {
-      toolId: INSTALLMENT_VS_CASH_TOOL_ID,
-    },
-  });
-  message.error(getErrorMessage(error));
-};
-
-/**
- * Builds a YYYY-MM-DD string from a date-picker timestamp.
- *
- * @param value Epoch milliseconds from Naive UI.
- * @returns ISO calendar string or undefined.
- */
-const toIsoDate = (value: number | null): string | undefined => {
-  if (value === null) {
-    return undefined;
-  }
-
-  const date = new Date(value);
-  const year = date.getUTCFullYear();
-  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(date.getUTCDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-};
-
-/**
- * Persists the current page state before redirecting the user to login.
- *
- * @returns void
- */
-const persistContextAndRedirectToLogin = (): void => {
-  if (calculation.value === null) {
-    return;
-  }
-
-  toolContextStore.save(
-    INSTALLMENT_VS_CASH_TOOL_ID,
-    calculation.value,
-    { form: form.value },
-  );
-  saveRedirect(INSTALLMENT_VS_CASH_PUBLIC_PATH);
-  void router.push("/login");
-};
-
-/**
- * Ensures a saved simulation exists before a premium bridge action.
- *
- * @returns The saved simulation reference.
- */
-const ensureSavedSimulation = async (): Promise<InstallmentVsCashSavedSimulation> => {
-  if (savedSimulation.value !== null) {
-    return savedSimulation.value;
-  }
-
-  const currentCalculation = calculation.value;
-  if (currentCalculation === null) {
-    throw new Error(t("pages.installmentVsCash.errors.noSimulation"));
-  }
-
-  const response = await saveMutation.mutateAsync(
-    toInstallmentVsCashCalculationRequest(form.value),
-  );
-  savedSimulation.value = response.simulation;
-  return response.simulation;
-};
-
-/**
- * Runs the public calculation using the current form values.
- *
- * @returns void
- */
-const handleCalculate = async (): Promise<void> => {
-  const errors = validateInstallmentVsCashForm(form.value);
-  if (errors.length > 0) {
-    validationMessage.value = errors[0]?.message ?? t("pages.installmentVsCash.errors.validateForm");
-    return;
-  }
-
-  validationMessage.value = null;
-  savedSimulation.value = null;
-  try {
-    calculation.value = await calculateMutation.mutateAsync(
-      toInstallmentVsCashCalculationRequest(form.value),
-    );
-  } catch (error: unknown) {
-    handleOperationalError(
-      error,
-      "tools.installment_vs_cash.calculate",
-    );
-  }
-};
-
-/**
- * Saves the current calculation or redirects the visitor to login first.
- *
- * @returns void
- */
-const handleSave = async (): Promise<void> => {
-  if (calculation.value === null) {
-    return;
-  }
-
-  if (!isAuthenticated.value) {
-    persistContextAndRedirectToLogin();
-    return;
-  }
-
-  try {
-    const response = await saveMutation.mutateAsync(
-      toInstallmentVsCashCalculationRequest(form.value),
-    );
-    savedSimulation.value = response.simulation;
-    message.success(t("pages.installmentVsCash.success.saved"));
-  } catch (error: unknown) {
-    handleOperationalError(
-      error,
-      "tools.installment_vs_cash.save",
-    );
-  }
-};
-
-/**
- * Opens the goal bridge or routes the user to the appropriate gate.
- *
- * @returns void
- */
-const handleGoalAction = async (): Promise<void> => {
-  if (calculation.value === null) {
-    return;
-  }
-
-  if (!isAuthenticated.value) {
-    persistContextAndRedirectToLogin();
-    return;
-  }
-
-  if (!hasPremiumAccess.value) {
-    void router.push("/plans");
-    return;
-  }
-
-  try {
-    await ensureSavedSimulation();
-    goalForm.title = form.value.scenarioLabel.trim() || t("pages.installmentVsCash.goalModal.defaultTitle");
-    goalForm.selectedOption = calculation.value.result.recommendedOption === "installment"
-      ? "installment"
-      : "cash";
-    showGoalModal.value = true;
-  } catch (error: unknown) {
-    handleOperationalError(
-      error,
-      "tools.installment_vs_cash.goal.prefill",
-    );
-  }
-};
-
-/**
- * Opens the planned-expense bridge or routes the user to the appropriate gate.
- *
- * @returns void
- */
-const handleExpenseAction = async (): Promise<void> => {
-  if (calculation.value === null) {
-    return;
-  }
-
-  if (!isAuthenticated.value) {
-    persistContextAndRedirectToLogin();
-    return;
-  }
-
-  if (!hasPremiumAccess.value) {
-    void router.push("/plans");
-    return;
-  }
-
-  try {
-    await ensureSavedSimulation();
-    plannedExpenseForm.title = form.value.scenarioLabel.trim() || t("pages.installmentVsCash.expenseModal.defaultTitle");
-    plannedExpenseForm.selectedOption =
-      calculation.value.result.recommendedOption === "cash" ? "cash" : "installment";
-    showExpenseModal.value = true;
-  } catch (error: unknown) {
-    handleOperationalError(
-      error,
-      "tools.installment_vs_cash.expense.prefill",
-    );
-  }
-};
-
-/**
- * Submits the goal bridge modal.
- *
- * @returns void
- */
-const submitGoalBridge = async (): Promise<void> => {
-  const simulation = savedSimulation.value;
-  if (simulation === null) {
-    message.error(t("pages.installmentVsCash.errors.saveBeforeGoal"));
-    return;
-  }
-
-  const payload: CreateInstallmentVsCashGoalPayload = {
-    title: goalForm.title.trim(),
-    selectedOption: goalForm.selectedOption,
-    description: goalForm.description.trim() || undefined,
-    targetDate: toIsoDate(goalForm.targetDate),
-  };
-
-  try {
-    const response = await createGoalMutation.mutateAsync({
-      simulationId: simulation.id,
-      payload,
-    });
-
-    savedSimulation.value = response.simulation;
-    showGoalModal.value = false;
-    message.success(t("pages.installmentVsCash.success.goalCreated"));
-  } catch (error: unknown) {
-    handleOperationalError(
-      error,
-      "tools.installment_vs_cash.goal.submit",
-    );
-  }
-};
-
-/**
- * Submits the planned-expense bridge modal.
- *
- * @returns void
- */
-const submitExpenseBridge = async (): Promise<void> => {
-  const simulation = savedSimulation.value;
-  if (simulation === null) {
-    message.error(t("pages.installmentVsCash.errors.saveBeforeExpense"));
-    return;
-  }
-
-  const payload: CreateInstallmentVsCashPlannedExpensePayload = {
-    title: plannedExpenseForm.title.trim(),
-    selectedOption: plannedExpenseForm.selectedOption,
-    description: plannedExpenseForm.description.trim() || undefined,
-    dueDate: plannedExpenseForm.selectedOption === "cash"
-      ? toIsoDate(plannedExpenseForm.dueDate)
-      : undefined,
-    firstDueDate: plannedExpenseForm.selectedOption === "installment"
-      ? toIsoDate(plannedExpenseForm.firstDueDate)
-      : undefined,
-    upfrontDueDate: toIsoDate(plannedExpenseForm.upfrontDueDate),
-  };
-
-  try {
-    const response = await createPlannedExpenseMutation.mutateAsync({
-      simulationId: simulation.id,
-      payload,
-    });
-
-    savedSimulation.value = response.simulation;
-    showExpenseModal.value = false;
-    message.success(
-      t("pages.installmentVsCash.success.expensesCreated", { count: response.transactions.length }),
-    );
-  } catch (error: unknown) {
-    handleOperationalError(
-      error,
-      "tools.installment_vs_cash.expense.submit",
-    );
-  }
-};
-
-onMounted((): void => {
-  toolContextStore.restore();
-
-  if (toolContextStore.pendingToolId !== INSTALLMENT_VS_CASH_TOOL_ID) {
-    return;
-  }
-
-  if (isInstallmentVsCashPendingPayload(toolContextStore.pendingPayload)) {
-    form.value = toolContextStore.pendingPayload.form;
-  }
-
-  if (isInstallmentVsCashCalculation(toolContextStore.pendingResult)) {
-    calculation.value = toolContextStore.pendingResult;
-  }
-
-  toolContextStore.clear();
-});
+function updateForm(value: typeof page.form.value): void {
+  page.form.value = value;
+}
 </script>
 
 <template>
-  <!-- Transparent root wrapper required by vue/no-multiple-template-root. -->
   <div class="installment-vs-cash-root">
-  <!-- ═══ AUTHENTICATED VIEW ════════════════════════════════════════════════ -->
-  <NuxtLayout :name="isAuthenticated ? 'default' : 'tools-public'">
-    <main class="installment-vs-cash-page__content installment-vs-cash-page__content--in-app">
-      <section class="installment-vs-cash-page__hero">
-        <div class="installment-vs-cash-page__hero-copy">
-          <NTag round type="warning">
-            {{ t('pages.installmentVsCash.hero.badge') }}
-          </NTag>
-          <UiPageHeader
-            :title="t('pages.installmentVsCash.hero.title')"
-            :subtitle="t('pages.installmentVsCash.hero.subtitle')"
-          />
-
-          <NSpace vertical :size="16">
-            <NThing
-              :title="t('pages.installmentVsCash.hero.featureBasic')"
-              :description="t('pages.installmentVsCash.hero.featureBasicDesc')"
-            />
-            <NThing
-              :title="t('pages.installmentVsCash.hero.featureAdvanced')"
-              :description="t('pages.installmentVsCash.hero.featureAdvancedDesc')"
-            />
-          </NSpace>
-        </div>
-
-        <UiGlassPanel glow class="installment-vs-cash-page__hero-panel">
-          <InstallmentVsCashCalculatorForm
-            v-model="form"
-            :loading="calculateMutation.isPending.value"
-            @submit="handleCalculate"
-          />
-
-          <NAlert
-            v-if="validationMessage"
-            type="warning"
-            class="installment-vs-cash-page__alert"
-          >
-            {{ validationMessage }}
-          </NAlert>
-
-          <NAlert
-            v-if="calculateMutation.isError.value"
-            type="error"
-            class="installment-vs-cash-page__alert"
-          >
-            {{ t('pages.installmentVsCash.errors.calculate') }}
-          </NAlert>
-        </UiGlassPanel>
-      </section>
-
-      <section v-if="calculation" class="installment-vs-cash-page__results">
-        <InstallmentVsCashResults :calculation="calculation" />
-
-        <UiSurfaceCard>
-          <NThing
-            :title="t('pages.installmentVsCash.results.nextStep')"
-            :description="`${getRecommendationLabel(calculation.result.recommendedOption)}.`"
-          />
-
-          <InstallmentVsCashActionBar
-            class="installment-vs-cash-page__actions"
-            :is-authenticated="isAuthenticated"
-            :has-premium-access="hasPremiumAccess"
-            :is-saving="saveMutation.isPending.value"
-            :is-bridging="isBridging"
-            :has-saved-simulation="savedSimulation !== null"
-            @save="handleSave"
-            @goal="handleGoalAction"
-            @expense="handleExpenseAction"
-          />
-        </UiSurfaceCard>
-      </section>
-
-      <section class="installment-vs-cash-page__seo">
-        <UiSurfaceCard>
-          <NSpace vertical :size="16">
-            <NThing
-              :title="t('pages.installmentVsCash.seoSection.considers')"
-              :description="t('pages.installmentVsCash.seoSection.considersDesc')"
-            />
-            <NThing
-              :title="t('pages.installmentVsCash.seoSection.notReplaces')"
-              :description="t('pages.installmentVsCash.seoSection.notReplacesDesc')"
-            />
-            <NThing
-              :title="t('pages.installmentVsCash.seoSection.howToUse')"
-              :description="t('pages.installmentVsCash.seoSection.howToUseDesc')"
-            />
-          </NSpace>
-        </UiSurfaceCard>
-      </section>
-    </main>
-      <ToolGuestCta v-if="!isAuthenticated" />
-  </NuxtLayout>
-
-    <!-- ─── Modals ─────────────────────────────────────────────────────────── -->
-  <NModal
-    v-model:show="showGoalModal"
-    preset="card"
-    :title="t('pages.installmentVsCash.goalModal.title')"
-    class="installment-vs-cash-page__modal"
-  >
-    <NForm label-placement="top">
-      <NFormItem :label="t('pages.installmentVsCash.goalModal.titleLabel')">
-        <NInput v-model:value="goalForm.title" />
-      </NFormItem>
-
-      <NFormItem :label="t('pages.installmentVsCash.goalModal.descriptionLabel')">
-        <NInput v-model:value="goalForm.description" type="textarea" />
-      </NFormItem>
-
-      <NFormItem :label="t('pages.installmentVsCash.goalModal.targetDateLabel')">
-        <NDatePicker
-          v-model:value="goalForm.targetDate"
-          type="date"
-          clearable
+    <NuxtLayout :name="page.isAuthenticated.value ? 'default' : 'tools-public'">
+      <main class="installment-vs-cash-page__content installment-vs-cash-page__content--in-app">
+        <InstallmentVsCashHero
+          :form="page.form.value"
+          :validation-message="page.validationMessage.value"
+          :is-loading="page.calculateMutation.isPending.value"
+          :is-error="page.calculateMutation.isError.value"
+          :t="page.t"
+          @update:form="updateForm"
+          @submit="page.handleCalculate"
         />
-      </NFormItem>
 
-      <NSpace justify="end">
-        <NButton @click="showGoalModal = false">{{ t('pages.installmentVsCash.goalModal.cancel') }}</NButton>
-        <NButton
-          type="primary"
-          :loading="createGoalMutation.isPending.value"
-          @click="submitGoalBridge"
-        >
-          {{ t('pages.installmentVsCash.goalModal.submit') }}
-        </NButton>
-      </NSpace>
-    </NForm>
-  </NModal>
+        <section v-if="page.calculation.value" class="installment-vs-cash-page__results">
+          <InstallmentVsCashResults :calculation="page.calculation.value" />
 
-  <NModal
-    v-model:show="showExpenseModal"
-    preset="card"
-    :title="t('pages.installmentVsCash.expenseModal.title')"
-    class="installment-vs-cash-page__modal"
-  >
-    <NForm label-placement="top">
-      <NFormItem :label="t('pages.installmentVsCash.expenseModal.titleLabel')">
-        <NInput v-model:value="plannedExpenseForm.title" />
-      </NFormItem>
+          <UiSurfaceCard>
+            <NThing
+              :title="page.t('pages.installmentVsCash.results.nextStep')"
+              :description="`${getRecommendationLabel(page.calculation.value.result.recommendedOption)}.`"
+            />
 
-      <NFormItem :label="t('pages.installmentVsCash.expenseModal.descriptionLabel')">
-        <NInput v-model:value="plannedExpenseForm.description" type="textarea" />
-      </NFormItem>
+            <InstallmentVsCashActionBar
+              class="installment-vs-cash-page__actions"
+              :is-authenticated="page.isAuthenticated.value"
+              :has-premium-access="page.hasPremiumAccess.value"
+              :is-saving="page.saveMutation.isPending.value"
+              :is-bridging="page.isBridging.value"
+              :has-saved-simulation="page.savedSimulation.value !== null"
+              @save="page.handleSave"
+              @goal="page.handleGoalAction"
+              @expense="page.handleExpenseAction"
+            />
+          </UiSurfaceCard>
+        </section>
 
-      <NFormItem :label="t('pages.installmentVsCash.expenseModal.modeLabel')">
-        <UiSegmentedControl
-          v-model="plannedExpenseForm.selectedOption"
-          :options="[
-            { label: t('pages.installmentVsCash.expenseModal.cashLabel'), value: 'cash' },
-            { label: t('pages.installmentVsCash.expenseModal.installmentLabel'), value: 'installment' },
-          ]"
-          :aria-label="t('pages.installmentVsCash.expenseModal.modeAriaLabel')"
-        />
-      </NFormItem>
+        <section class="installment-vs-cash-page__seo">
+          <UiSurfaceCard>
+            <NSpace vertical :size="16">
+              <NThing
+                :title="page.t('pages.installmentVsCash.seoSection.considers')"
+                :description="page.t('pages.installmentVsCash.seoSection.considersDesc')"
+              />
+              <NThing
+                :title="page.t('pages.installmentVsCash.seoSection.notReplaces')"
+                :description="page.t('pages.installmentVsCash.seoSection.notReplacesDesc')"
+              />
+              <NThing
+                :title="page.t('pages.installmentVsCash.seoSection.howToUse')"
+                :description="page.t('pages.installmentVsCash.seoSection.howToUseDesc')"
+              />
+            </NSpace>
+          </UiSurfaceCard>
+        </section>
+      </main>
+      <ToolGuestCta v-if="!page.isAuthenticated.value" />
+    </NuxtLayout>
 
-      <NFormItem
-        v-if="plannedExpenseForm.selectedOption === 'cash'"
-        :label="t('pages.installmentVsCash.expenseModal.dueDateLabel')"
-      >
-        <NDatePicker
-          v-model:value="plannedExpenseForm.dueDate"
-          type="date"
-          clearable
-        />
-      </NFormItem>
-
-      <NFormItem
-        v-else
-        :label="t('pages.installmentVsCash.expenseModal.firstDueDateLabel')"
-      >
-        <NDatePicker
-          v-model:value="plannedExpenseForm.firstDueDate"
-          type="date"
-          clearable
-        />
-      </NFormItem>
-
-      <NFormItem v-if="form.feesEnabled" :label="t('pages.installmentVsCash.expenseModal.upfrontDateLabel')">
-        <NDatePicker
-          v-model:value="plannedExpenseForm.upfrontDueDate"
-          type="date"
-          clearable
-        />
-      </NFormItem>
-
-      <NSpace justify="end">
-        <NButton @click="showExpenseModal = false">{{ t('pages.installmentVsCash.expenseModal.cancel') }}</NButton>
-        <NButton
-          type="primary"
-          :loading="createPlannedExpenseMutation.isPending.value"
-          @click="submitExpenseBridge"
-        >
-          {{ t('pages.installmentVsCash.expenseModal.submit') }}
-        </NButton>
-      </NSpace>
-    </NForm>
-  </NModal>
+    <InstallmentVsCashBridgeModals
+      v-model:show-goal-modal="page.showGoalModal.value"
+      v-model:show-expense-modal="page.showExpenseModal.value"
+      :fees-enabled="page.form.value.feesEnabled"
+      :is-creating-goal="page.createGoalMutation.isPending.value"
+      :is-creating-expense="page.createPlannedExpenseMutation.isPending.value"
+      :t="page.t"
+      @submit-goal="page.submitGoalBridge"
+      @submit-expense="page.submitExpenseBridge"
+    />
   </div>
 </template>
 
 <style scoped>
 .installment-vs-cash-root {
   display: contents;
-}
-
-.installment-vs-cash-page {
-  min-height: 100dvh;
-  background:
-    radial-gradient(circle at top right, var(--color-brand-glow-xs), transparent 28%),
-    linear-gradient(180deg, var(--color-bg-surface) 0%, var(--color-bg-base) 100%);
-  color: var(--color-text-primary);
-}
-
-.installment-vs-cash-page__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-3) var(--space-4);
-}
-
-.installment-vs-cash-page__brand {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.installment-vs-cash-page__brand-mark {
-  font-family: var(--font-heading);
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-bold);
-}
-
-.installment-vs-cash-page__brand-copy {
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-}
-
-.installment-vs-cash-page__header-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
 }
 
 .installment-vs-cash-page__content {
@@ -685,27 +116,8 @@ onMounted((): void => {
   gap: var(--space-5);
 }
 
-.installment-vs-cash-page__hero {
-  display: grid;
-  gap: var(--space-4);
-  grid-template-columns: minmax(0, 1.1fr) minmax(380px, 0.9fr);
-  align-items: start;
-}
-
-.installment-vs-cash-page__hero-copy {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  padding-top: var(--space-5);
-}
-
-.installment-vs-cash-page__hero-panel {
-  position: sticky;
-  top: var(--space-3);
-}
-
-.installment-vs-cash-page__alert {
-  margin-top: var(--space-2);
+.installment-vs-cash-page__content--in-app {
+  padding: var(--space-4) var(--space-4) var(--space-6);
 }
 
 .installment-vs-cash-page__results {
@@ -722,41 +134,9 @@ onMounted((): void => {
   padding-bottom: var(--space-4);
 }
 
-:deep(.installment-vs-cash-page__modal) {
-  width: min(720px, calc(100vw - 32px));
-}
-
-@media (max-width: 1023px) {
-  .installment-vs-cash-page__hero {
-    grid-template-columns: 1fr;
-  }
-
-  .installment-vs-cash-page__hero-copy {
-    padding-top: var(--space-2);
-  }
-
-  .installment-vs-cash-page__hero-panel {
-    position: static;
-  }
-}
-
 @media (max-width: 767px) {
-  .installment-vs-cash-page__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
   .installment-vs-cash-page__content {
     padding-inline: var(--space-2);
   }
-}
-
-.installment-vs-cash-page__content--in-app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: var(--space-4) var(--space-4) var(--space-6);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-5);
 }
 </style>

--- a/app/features/tools/installment-vs-cash/useInstallmentVsCashPage.ts
+++ b/app/features/tools/installment-vs-cash/useInstallmentVsCashPage.ts
@@ -1,0 +1,282 @@
+import { computed, onMounted, reactive, ref } from "vue";
+import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+import { useMessage } from "naive-ui";
+
+import { captureException } from "~/core/observability";
+import { STALE_TIME } from "~/core/query/stale-time";
+import { useApiError } from "~/composables/useApiError";
+import { useAuthRedirectContext } from "~/composables/useAuthRedirectContext";
+import { useSessionStore } from "~/stores/session";
+import { useToolContextStore } from "~/stores/toolContext";
+import { useEntitlementClient } from "~/features/paywall/services/entitlement.client";
+import { useCreateGoalFromInstallmentVsCashMutation } from "~/features/tools/queries/use-create-goal-from-installment-vs-cash-mutation";
+import { useCreatePlannedExpenseFromInstallmentVsCashMutation } from "~/features/tools/queries/use-create-planned-expense-from-installment-vs-cash-mutation";
+import { useInstallmentVsCashCalculateMutation } from "~/features/tools/queries/use-installment-vs-cash-calculate-mutation";
+import { useSaveInstallmentVsCashMutation } from "~/features/tools/queries/use-save-installment-vs-cash-mutation";
+import {
+  createDefaultInstallmentVsCashFormState,
+  INSTALLMENT_VS_CASH_PUBLIC_PATH,
+  INSTALLMENT_VS_CASH_TOOL_ID,
+  isInstallmentVsCashCalculation,
+  isInstallmentVsCashPendingPayload,
+  toInstallmentVsCashCalculationRequest,
+  validateInstallmentVsCashForm,
+  type CreateInstallmentVsCashGoalPayload,
+  type CreateInstallmentVsCashPlannedExpensePayload,
+  type InstallmentVsCashCalculation,
+  type InstallmentVsCashFormState,
+  type InstallmentVsCashSavedSimulation,
+  type SelectedPaymentOption,
+} from "~/features/tools/model/installment-vs-cash";
+
+/**
+ * Builds a YYYY-MM-DD string from a date-picker timestamp.
+ *
+ * @param value Epoch milliseconds from Naive UI.
+ * @returns ISO calendar string or undefined.
+ */
+function toIsoDate(value: number | null): string | undefined {
+  if (value === null) { return undefined; }
+  const date = new Date(value);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/* eslint-disable max-lines-per-function, max-statements, @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types -- return type inferred from composable shape */
+/**
+ * Orchestrates state, queries, mutations, and handlers for the
+ * Installment vs Cash calculator page.
+ *
+ * @returns Reactive bindings, computed flags, mutation handlers and modal state.
+ */
+export function useInstallmentVsCashPage() {
+  const { t } = useI18n();
+  const message = useMessage();
+  const { getErrorMessage } = useApiError();
+  const router = useRouter();
+  const sessionStore = useSessionStore();
+  const toolContextStore = useToolContextStore();
+  const { saveRedirect } = useAuthRedirectContext();
+  const entitlementClient = useEntitlementClient();
+
+  const form = ref<InstallmentVsCashFormState>(createDefaultInstallmentVsCashFormState());
+  const calculation = ref<InstallmentVsCashCalculation | null>(null);
+  const savedSimulation = ref<InstallmentVsCashSavedSimulation | null>(null);
+  const validationMessage = ref<string | null>(null);
+  const showGoalModal = ref(false);
+  const showExpenseModal = ref(false);
+
+  const goalForm = reactive<{
+    title: string;
+    selectedOption: SelectedPaymentOption;
+    description: string;
+    targetDate: number | null;
+  }>({ title: "", selectedOption: "cash", description: "", targetDate: null });
+
+  const plannedExpenseForm = reactive<{
+    title: string;
+    selectedOption: SelectedPaymentOption;
+    description: string;
+    dueDate: number | null;
+    firstDueDate: number | null;
+    upfrontDueDate: number | null;
+  }>({
+    title: "", selectedOption: "installment", description: "",
+    dueDate: null, firstDueDate: null, upfrontDueDate: null,
+  });
+
+  const calculateMutation = useInstallmentVsCashCalculateMutation();
+  const saveMutation = useSaveInstallmentVsCashMutation();
+  const createGoalMutation = useCreateGoalFromInstallmentVsCashMutation();
+  const createPlannedExpenseMutation = useCreatePlannedExpenseFromInstallmentVsCashMutation();
+
+  sessionStore.restore();
+
+  const premiumAccessQuery: UseQueryReturnType<boolean, Error> = useQuery({
+    queryKey: ["entitlements", "advanced_simulations", INSTALLMENT_VS_CASH_TOOL_ID],
+    enabled: computed<boolean>(() => sessionStore.isAuthenticated),
+    queryFn: (): Promise<boolean> => entitlementClient.checkEntitlement("advanced_simulations"),
+    staleTime: STALE_TIME.STATIC,
+  });
+
+  const isAuthenticated = computed<boolean>(() => {
+    sessionStore.restore();
+    return sessionStore.isAuthenticated;
+  });
+  const hasPremiumAccess = computed<boolean>(() => premiumAccessQuery.data.value === true);
+  const isBridging = computed<boolean>(() =>
+    createGoalMutation.isPending.value || createPlannedExpenseMutation.isPending.value,
+  );
+
+  /**
+   * Reports an operational error to observability and surfaces a friendly toast.
+   *
+   * @param error Original runtime error.
+   * @param context Stable context label used by observability tooling.
+   */
+  function handleOperationalError(error: unknown, context: string): void {
+    captureException(error, { context, extra: { toolId: INSTALLMENT_VS_CASH_TOOL_ID } });
+    message.error(getErrorMessage(error));
+  }
+
+  /**
+   * Persists the current page state before redirecting the user to login.
+   *
+   * @returns void
+   */
+  function persistContextAndRedirectToLogin(): void {
+    if (calculation.value === null) { return; }
+    toolContextStore.save(INSTALLMENT_VS_CASH_TOOL_ID, calculation.value, { form: form.value });
+    saveRedirect(INSTALLMENT_VS_CASH_PUBLIC_PATH);
+    void router.push("/login");
+  }
+
+  /**
+   * Ensures a saved simulation exists before a premium bridge action.
+   *
+   * @returns The saved simulation reference.
+   */
+  async function ensureSavedSimulation(): Promise<InstallmentVsCashSavedSimulation> {
+    if (savedSimulation.value !== null) { return savedSimulation.value; }
+    if (calculation.value === null) {
+      throw new Error(t("pages.installmentVsCash.errors.noSimulation"));
+    }
+    const response = await saveMutation.mutateAsync(toInstallmentVsCashCalculationRequest(form.value));
+    savedSimulation.value = response.simulation;
+    return response.simulation;
+  }
+
+  /** Runs the public calculation using the current form values. */
+  async function handleCalculate(): Promise<void> {
+    const errors = validateInstallmentVsCashForm(form.value);
+    if (errors.length > 0) {
+      validationMessage.value = errors[0]?.message ?? t("pages.installmentVsCash.errors.validateForm");
+      return;
+    }
+    validationMessage.value = null;
+    savedSimulation.value = null;
+    try {
+      calculation.value = await calculateMutation.mutateAsync(toInstallmentVsCashCalculationRequest(form.value));
+    } catch (error: unknown) {
+      handleOperationalError(error, "tools.installment_vs_cash.calculate");
+    }
+  }
+
+  /** Saves the current calculation or redirects the visitor to login first. */
+  async function handleSave(): Promise<void> {
+    if (calculation.value === null) { return; }
+    if (!isAuthenticated.value) { persistContextAndRedirectToLogin(); return; }
+    try {
+      const response = await saveMutation.mutateAsync(toInstallmentVsCashCalculationRequest(form.value));
+      savedSimulation.value = response.simulation;
+      message.success(t("pages.installmentVsCash.success.saved"));
+    } catch (error: unknown) {
+      handleOperationalError(error, "tools.installment_vs_cash.save");
+    }
+  }
+
+  /** Opens the goal bridge or routes the user to the appropriate gate. */
+  async function handleGoalAction(): Promise<void> {
+    if (calculation.value === null) { return; }
+    if (!isAuthenticated.value) { persistContextAndRedirectToLogin(); return; }
+    if (!hasPremiumAccess.value) { void router.push("/plans"); return; }
+    try {
+      await ensureSavedSimulation();
+      goalForm.title = form.value.scenarioLabel.trim() || t("pages.installmentVsCash.goalModal.defaultTitle");
+      goalForm.selectedOption = calculation.value.result.recommendedOption === "installment" ? "installment" : "cash";
+      showGoalModal.value = true;
+    } catch (error: unknown) {
+      handleOperationalError(error, "tools.installment_vs_cash.goal.prefill");
+    }
+  }
+
+  /** Opens the planned-expense bridge or routes the user to the appropriate gate. */
+  async function handleExpenseAction(): Promise<void> {
+    if (calculation.value === null) { return; }
+    if (!isAuthenticated.value) { persistContextAndRedirectToLogin(); return; }
+    if (!hasPremiumAccess.value) { void router.push("/plans"); return; }
+    try {
+      await ensureSavedSimulation();
+      plannedExpenseForm.title = form.value.scenarioLabel.trim() || t("pages.installmentVsCash.expenseModal.defaultTitle");
+      plannedExpenseForm.selectedOption = calculation.value.result.recommendedOption === "cash" ? "cash" : "installment";
+      showExpenseModal.value = true;
+    } catch (error: unknown) {
+      handleOperationalError(error, "tools.installment_vs_cash.expense.prefill");
+    }
+  }
+
+  /** Submits the goal bridge modal. */
+  async function submitGoalBridge(): Promise<void> {
+    const simulation = savedSimulation.value;
+    if (simulation === null) {
+      message.error(t("pages.installmentVsCash.errors.saveBeforeGoal"));
+      return;
+    }
+    const payload: CreateInstallmentVsCashGoalPayload = {
+      title: goalForm.title.trim(),
+      selectedOption: goalForm.selectedOption,
+      description: goalForm.description.trim() || undefined,
+      targetDate: toIsoDate(goalForm.targetDate),
+    };
+    try {
+      const response = await createGoalMutation.mutateAsync({ simulationId: simulation.id, payload });
+      savedSimulation.value = response.simulation;
+      showGoalModal.value = false;
+      message.success(t("pages.installmentVsCash.success.goalCreated"));
+    } catch (error: unknown) {
+      handleOperationalError(error, "tools.installment_vs_cash.goal.submit");
+    }
+  }
+
+  /** Submits the planned-expense bridge modal. */
+  async function submitExpenseBridge(): Promise<void> {
+    const simulation = savedSimulation.value;
+    if (simulation === null) {
+      message.error(t("pages.installmentVsCash.errors.saveBeforeExpense"));
+      return;
+    }
+    const payload: CreateInstallmentVsCashPlannedExpensePayload = {
+      title: plannedExpenseForm.title.trim(),
+      selectedOption: plannedExpenseForm.selectedOption,
+      description: plannedExpenseForm.description.trim() || undefined,
+      dueDate: plannedExpenseForm.selectedOption === "cash" ? toIsoDate(plannedExpenseForm.dueDate) : undefined,
+      firstDueDate: plannedExpenseForm.selectedOption === "installment" ? toIsoDate(plannedExpenseForm.firstDueDate) : undefined,
+      upfrontDueDate: toIsoDate(plannedExpenseForm.upfrontDueDate),
+    };
+    try {
+      const response = await createPlannedExpenseMutation.mutateAsync({ simulationId: simulation.id, payload });
+      savedSimulation.value = response.simulation;
+      showExpenseModal.value = false;
+      message.success(
+        t("pages.installmentVsCash.success.expensesCreated", { count: response.transactions.length }),
+      );
+    } catch (error: unknown) {
+      handleOperationalError(error, "tools.installment_vs_cash.expense.submit");
+    }
+  }
+
+  onMounted((): void => {
+    toolContextStore.restore();
+    if (toolContextStore.pendingToolId !== INSTALLMENT_VS_CASH_TOOL_ID) { return; }
+    if (isInstallmentVsCashPendingPayload(toolContextStore.pendingPayload)) {
+      form.value = toolContextStore.pendingPayload.form;
+    }
+    if (isInstallmentVsCashCalculation(toolContextStore.pendingResult)) {
+      calculation.value = toolContextStore.pendingResult;
+    }
+    toolContextStore.clear();
+  });
+
+  return {
+    t, router,
+    form, calculation, savedSimulation, validationMessage,
+    showGoalModal, showExpenseModal, goalForm, plannedExpenseForm,
+    calculateMutation, saveMutation, createGoalMutation, createPlannedExpenseMutation,
+    isAuthenticated, hasPremiumAccess, isBridging,
+    handleCalculate, handleSave, handleGoalAction, handleExpenseAction,
+    submitGoalBridge, submitExpenseBridge,
+  };
+}
+/* eslint-enable max-lines-per-function, max-statements, @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types */


### PR DESCRIPTION
## Summary

**Final PR (6 of 6)** in the UX-5 refactor series (Refs #646) — closes the last remaining page >250 LOC with the same composable + subcomponent + provide/inject pattern used across the series.

Before: `app/features/tools/installment-vs-cash/page.vue` — **762 LOC**
After: `page.vue` — **141 LOC** thin orchestrator

## What changed

- **New composable** `useInstallmentVsCashPage.ts` — form state, session/entitlement queries, all mutations (calculate/save/goal/planned-expense), all bridge handlers, and the onMounted tool-context restore
- **`InstallmentVsCashHero.vue`** — badge + page header + feature list + the sticky glass-panel hosting the calculator form and its alerts
- **`InstallmentVsCashBridgeModals.vue`** — goal + planned-expense modals; both forms shared with the orchestrator via `provide`/`inject` (keys in a companion `.types.ts` because `<script setup>` forbids ES exports)
- **`page.vue`** — slim orchestrator that wires the composable to hero / results / action bar / bridge modals, keeping only the layout CSS still referenced (removed `__header`, `__brand*`, `__hero*` dead selectors — they were replaced by the hero subcomponent's own scoped styles)

## LOC budget (all under 200 per SFC)

| File | LOC |
|---|---|
| `page.vue` | 141 |
| `InstallmentVsCashHero.vue` | 101 |
| `InstallmentVsCashBridgeModals.vue` | 119 |
| `useInstallmentVsCashPage.ts` | 281 |
| `installment-vs-cash-bridge-modals.types.ts` | 25 |

No behavior change — same UI, same validation, same calculate/save flow, same goal & planned-expense bridge flows, same login-redirect & entitlement gates.

## Series progress (Refs #646 — UX-5) — complete ✅

| # | PR | Target | Status |
|---|---|---|---|
| 1 | #706 | hora-extra/page.vue 465→181 | ✅ merged |
| 2 | #707 | QuickTransactionForm 484→115 | ✅ merged |
| 3 | #708 | WalletEntryForm 547→96 | ✅ merged |
| 4 | #709 | ProfileCompletionModal 652→77 | ✅ merged |
| 5 | #710 | thirteenth-salary/page.vue 739→149 | 🟡 open |
| 6 | **this PR** | installment-vs-cash/page.vue 762→141 | 🟡 open |

## Test plan

- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `pnpm typecheck` — passes
- [x] `pnpm quality-check` (flags → lint → typecheck → test:coverage → policy → contracts → build) — passes
- [x] Coverage: Statements 92.18% · Branches 85.75% · Functions 87.25% · Lines 93.15% (all ≥ 85%)
- [ ] Smoke test authenticated: calculate → save → create goal modal → create planned-expense modal (both cash and installment modes, with upfront date when feesEnabled)
- [ ] Smoke test public: calculate → handleSave redirects to login and restores context on return