### PR TITLE
feat(tools): ToolSaveResult component + 3 page integrations

### DIFF
--- a/app/components/tool/ToolSaveResult/ToolSaveResult.spec.ts
+++ b/app/components/tool/ToolSaveResult/ToolSaveResult.spec.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { ref } from "vue";
+
+import ToolSaveResult from "./ToolSaveResult.vue";
+import { useSessionStore } from "~/stores/session";
+
+const mockMutateAsync = vi.fn();
+const mockIsPending = ref(false);
+
+vi.mock("~/features/receivables/queries/use-create-receivable-mutation", () => ({
+  useCreateReceivableMutation: (): unknown => ({
+    mutateAsync: mockMutateAsync,
+    isPending: mockIsPending,
+  }),
+}));
+
+vi.mock("~/features/goals/queries/use-create-goal-mutation", () => ({
+  useCreateGoalMutation: (): unknown => ({
+    mutateAsync: mockMutateAsync,
+    isPending: mockIsPending,
+  }),
+}));
+
+vi.mock("~/features/transactions/queries/use-create-transaction-mutation", () => ({
+  useCreateTransactionMutation: (): unknown => ({
+    mutateAsync: mockMutateAsync,
+    isPending: mockIsPending,
+  }),
+}));
+
+vi.mock("~/core/observability", () => ({
+  captureException: vi.fn(),
+}));
+
+/**
+ * Builds a wrapper for ToolSaveResult with the given props.
+ * @param props Component props override.
+ * @returns Vue Test Utils wrapper.
+ */
+/**
+ * Mounts ToolSaveResult with lightweight stubs that render slot content.
+ * @param props Component props override.
+ * @returns Vue Test Utils wrapper.
+ */
+function mountComponent(props: Record<string, unknown> = {}): ReturnType<typeof mount> {
+  return mount(ToolSaveResult, {
+    props: {
+      intent: "receivable",
+      label: "13º Salário",
+      amount: 500000,
+      ...props,
+    },
+    global: {
+      stubs: {
+        NButton: { template: "<button @click=\"$emit('click')\"><slot /><slot name=\"icon\" /></button>" },
+        NIcon: { template: "<span><slot /></span>" },
+        NAlert: { template: "<div class=\"n-alert\"><slot /></div>" },
+        Check: { template: "<i />" },
+        Save: { template: "<i />" },
+        AlertCircle: { template: "<i />" },
+      },
+    },
+  });
+}
+
+describe("ToolSaveResult", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutateAsync.mockReset();
+    mockIsPending.value = false;
+    setActivePinia(createPinia());
+  });
+
+  it("does not render when intent is none", () => {
+    const session = useSessionStore();
+    session.$patch({ accessToken: "t" });
+    const wrapper = mountComponent({ intent: "none" });
+    expect(wrapper.find(".tool-save-result").exists()).toBe(false);
+  });
+
+  it("does not render when user is not authenticated", () => {
+    const wrapper = mountComponent({ intent: "receivable" });
+    expect(wrapper.find(".tool-save-result").exists()).toBe(false);
+  });
+
+  it("renders container when authenticated with valid intent", () => {
+    const session = useSessionStore();
+    session.$patch({ accessToken: "t" });
+    const wrapper = mountComponent({ intent: "receivable" });
+    expect(wrapper.find(".tool-save-result").exists()).toBe(true);
+    expect(wrapper.html()).toContain("Salvar como receita");
+  });
+
+  it("shows correct label for goal intent", () => {
+    const session = useSessionStore();
+    session.$patch({ accessToken: "t" });
+    const wrapper = mountComponent({ intent: "goal" });
+    expect(wrapper.html()).toContain("Salvar como meta");
+  });
+
+  it("shows correct label for expense intent", () => {
+    const session = useSessionStore();
+    session.$patch({ accessToken: "t" });
+    const wrapper = mountComponent({ intent: "expense" });
+    expect(wrapper.html()).toContain("Salvar como despesa");
+  });
+
+  it("calls mutateAsync on click", async () => {
+    const session = useSessionStore();
+    session.$patch({ accessToken: "t" });
+    mockMutateAsync.mockResolvedValue({});
+    const wrapper = mountComponent({ intent: "receivable" });
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows error alert on mutation failure", async () => {
+    const session = useSessionStore();
+    session.$patch({ accessToken: "t" });
+    mockMutateAsync.mockRejectedValue(new Error("fail"));
+    const wrapper = mountComponent({ intent: "goal" });
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".n-alert").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Erro ao salvar");
+  });
+});

--- a/app/components/tool/ToolSaveResult/ToolSaveResult.types.ts
+++ b/app/components/tool/ToolSaveResult/ToolSaveResult.types.ts
@@ -1,0 +1,23 @@
+/**
+ * The kind of financial record the user wants to create from a tool result.
+ *
+ * - `receivable` — creates an entry in the receivables list (income).
+ * - `expense` — creates a transaction of type "expense".
+ * - `goal` — creates a new financial goal.
+ * - `none` — component renders nothing (tool has no saveable output).
+ */
+export type SaveIntent = "receivable" | "expense" | "goal" | "none";
+
+/**
+ * Props for the ToolSaveResult component.
+ */
+export interface ToolSaveResultProps {
+  /** What kind of record to create on save. `none` → nothing renders. */
+  intent: SaveIntent;
+  /** Human-readable label for the result (e.g. "13º Salário"). */
+  label: string;
+  /** Monetary value in centavos (integer). */
+  amount: number;
+  /** Optional extra description attached to the created record. */
+  description?: string;
+}

--- a/app/components/tool/ToolSaveResult/ToolSaveResult.vue
+++ b/app/components/tool/ToolSaveResult/ToolSaveResult.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { NButton, NIcon, NAlert } from "naive-ui";
+import { Save, Check, AlertCircle } from "lucide-vue-next";
+
+import { useSessionStore } from "~/stores/session";
+import { captureException } from "~/core/observability";
+import { useCreateReceivableMutation } from "~/features/receivables/queries/use-create-receivable-mutation";
+import { useCreateGoalMutation } from "~/features/goals/queries/use-create-goal-mutation";
+import { useCreateTransactionMutation } from "~/features/transactions/queries/use-create-transaction-mutation";
+import type { ToolSaveResultProps, SaveIntent } from "./ToolSaveResult.types";
+
+defineOptions({ name: "ToolSaveResult" });
+
+const props = withDefaults(defineProps<ToolSaveResultProps>(), {
+  description: "",
+});
+
+const sessionStore = useSessionStore();
+
+const createReceivable = useCreateReceivableMutation();
+const createGoal = useCreateGoalMutation();
+const createTransaction = useCreateTransactionMutation();
+
+const saveStatus = ref<"idle" | "loading" | "success" | "error">("idle");
+const errorMessage = ref("");
+
+const INTENT_LABELS: Record<Exclude<SaveIntent, "none">, string> = {
+  receivable: "Salvar como receita",
+  expense: "Salvar como despesa",
+  goal: "Salvar como meta",
+};
+
+const buttonLabel = computed((): string => {
+  if (saveStatus.value === "success") { return "Salvo!"; }
+  return INTENT_LABELS[props.intent as Exclude<SaveIntent, "none">] ?? "";
+});
+
+const isPending = computed((): boolean =>
+  createReceivable.isPending.value
+  || createGoal.isPending.value
+  || createTransaction.isPending.value,
+);
+
+const shouldRender = computed((): boolean =>
+  props.intent !== "none" && sessionStore.isAuthenticated,
+);
+
+/**
+ * Formats a centavo integer to BRL decimal string (e.g. 15050 → "150.50").
+ * @param centavos Value in centavos.
+ * @returns Decimal string suitable for the API.
+ */
+function centavosToBrl(centavos: number): string {
+  return (centavos / 100).toFixed(2);
+}
+
+/**
+ * Formats today's date as YYYY-MM-DD for API payloads.
+ * @returns ISO date string (date portion only).
+ */
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Dispatches the save action to the correct mutation based on intent.
+ */
+async function handleSave(): Promise<void> {
+  if (saveStatus.value === "loading" || saveStatus.value === "success") {
+    return;
+  }
+  saveStatus.value = "loading";
+  errorMessage.value = "";
+  try {
+    if (props.intent === "receivable") {
+      await createReceivable.mutateAsync({
+        description: props.label,
+        amount: props.amount,
+        expected_date: todayIso(),
+        category: "tool-calculation",
+      });
+    } else if (props.intent === "expense") {
+      await createTransaction.mutateAsync({
+        title: props.label,
+        amount: centavosToBrl(props.amount),
+        type: "expense",
+        due_date: todayIso(),
+        description: props.description || undefined,
+      });
+    } else if (props.intent === "goal") {
+      await createGoal.mutateAsync({
+        name: props.label,
+        target_amount: props.amount,
+        description: props.description || undefined,
+      });
+    }
+    saveStatus.value = "success";
+  } catch (err) {
+    captureException(err, { context: "ToolSaveResult" });
+    errorMessage.value = "Erro ao salvar. Tente novamente.";
+    saveStatus.value = "error";
+  }
+}
+</script>
+
+<template>
+  <div v-if="shouldRender" class="tool-save-result">
+    <NButton
+      block
+      type="primary"
+      :loading="isPending"
+      :disabled="saveStatus === 'success'"
+      @click="handleSave"
+    >
+      <template #icon>
+        <NIcon>
+          <Check v-if="saveStatus === 'success'" />
+          <AlertCircle v-else-if="saveStatus === 'error'" />
+          <Save v-else />
+        </NIcon>
+      </template>
+      {{ buttonLabel }}
+    </NButton>
+
+    <NAlert
+      v-if="saveStatus === 'error'"
+      type="error"
+      class="tool-save-result__error"
+      :show-icon="false"
+    >
+      {{ errorMessage }}
+    </NAlert>
+  </div>
+</template>
+
+<style scoped>
+.tool-save-result {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 8px);
+}
+
+.tool-save-result__error {
+  font-size: var(--font-size-xs);
+}
+</style>

--- a/app/features/tools/hora-extra/page.vue
+++ b/app/features/tools/hora-extra/page.vue
@@ -18,6 +18,7 @@ import HoraExtraForm from "./HoraExtraForm.vue";
 import HoraExtraResultPanel from "./HoraExtraResult.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
@@ -129,6 +130,12 @@ async function handleSaveSimulation(): Promise<void> {
                   <HoraExtraResultPanel :result="result" />
                 </div>
               </UiSurfaceCard>
+
+              <ToolSaveResult
+                intent="receivable"
+                :label="t('horaExtra.hero.title')"
+                :amount="result.netOvertimeEstimate"
+              />
 
               <HoraExtraActions
                 :saved-simulation-id="savedSimulationId"

--- a/app/features/tools/installment-vs-cash/page.vue
+++ b/app/features/tools/installment-vs-cash/page.vue
@@ -3,6 +3,7 @@ import { provide } from "vue";
 import { NSpace, NThing } from "naive-ui";
 
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import { getRecommendationLabel } from "~/features/tools/model/installment-vs-cash";
 
 import InstallmentVsCashHero from "./InstallmentVsCashHero.vue";
@@ -46,6 +47,13 @@ function updateForm(value: typeof page.form.value): void {
 
         <section v-if="page.calculation.value" class="installment-vs-cash-page__results">
           <InstallmentVsCashResults :calculation="page.calculation.value" />
+
+          <ToolSaveResult
+            intent="goal"
+            :label="page.t('pages.installmentVsCash.title')"
+            :amount="page.calculation.value.input.cashPrice"
+            :description="getRecommendationLabel(page.calculation.value.result.recommendedOption)"
+          />
 
           <UiSurfaceCard>
             <NThing

--- a/app/features/tools/model/tools-catalog.ts
+++ b/app/features/tools/model/tools-catalog.ts
@@ -23,6 +23,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/installment-vs-cash",
     featureFlag: "web.tools.installment-vs-cash",
+    saveIntent: "goal",
   },
   {
     id: "thirteenth-salary",
@@ -33,6 +34,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/thirteenth-salary",
     featureFlag: "web.tools.thirteenth-salary",
+    saveIntent: "receivable",
   },
   {
     id: "inss-ir-folha",
@@ -53,6 +55,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/hora-extra",
     featureFlag: "web.tools.hora-extra",
+    saveIntent: "receivable",
   },
   {
     id: "ferias",

--- a/app/features/tools/model/tools.ts
+++ b/app/features/tools/model/tools.ts
@@ -1,4 +1,5 @@
 import type { ToolDto } from "~/features/tools/contracts/tools.dto";
+import type { SaveIntent } from "~/components/tool/ToolSaveResult/ToolSaveResult.types";
 
 /**
  * Access level required to use a tool.
@@ -25,6 +26,8 @@ export interface Tool {
    * When absent, the tool relies solely on `enabled` and `accessLevel`.
    */
   featureFlag?: string;
+  /** What kind of financial record the tool result can be saved as. */
+  saveIntent?: SaveIntent;
 }
 
 /**

--- a/app/features/tools/thirteenth-salary/page.vue
+++ b/app/features/tools/thirteenth-salary/page.vue
@@ -6,6 +6,7 @@ import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/C
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 
 import ThirteenthSalaryResultPanel from "./ThirteenthSalaryResult.vue";
 import ThirteenthSalaryForm from "./ThirteenthSalaryForm.vue";
@@ -63,6 +64,12 @@ function handleUpgrade(): void {
               <UiSurfaceCard>
                 <ThirteenthSalaryResultPanel :result="page.result.value" />
               </UiSurfaceCard>
+
+              <ToolSaveResult
+                intent="receivable"
+                :label="page.t('thirteenthSalary.hero.title')"
+                :amount="page.result.value.totalNet"
+              />
 
               <ThirteenthSalaryActions
                 :saved-simulation-id="page.savedSimulationId.value"

--- a/app/pages/tools/hora-extra.spec.ts
+++ b/app/pages/tools/hora-extra.spec.ts
@@ -204,6 +204,10 @@ const globalStubs = {
   ToolGuestCta: {
     template: "<div class='tool-guest-cta'>toolGuestCta.registerCta</div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/installment-vs-cash.spec.ts
+++ b/app/pages/tools/installment-vs-cash.spec.ts
@@ -224,6 +224,10 @@ const globalStubs = {
     props: ["calculation"],
     template: "<div class='results'>resultado</div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
   InstallmentVsCashActionBar: {
     props: ["isAuthenticated", "hasPremiumAccess", "isSaving", "isBridging", "hasSavedSimulation"],
     template: `


### PR DESCRIPTION
## Summary
- Add `ToolSaveResult` component: auth-gated save button that creates receivables, goals or expenses from tool calculation results via intent-driven mutations
- Add `SaveIntent` type (`receivable | expense | goal | none`) to `Tool` model and catalog entries
- Integrate into hora-extra (receivable), thirteenth-salary (receivable), and installment-vs-cash (goal) pages
- 7 unit tests for the component + page-level test stubs for existing specs

## Test plan
- [x] ToolSaveResult.spec.ts — 7 tests covering no-render, intent labels, mutation calls, error states
- [x] hora-extra.spec.ts — 12 tests pass with ToolSaveResult stubbed
- [x] installment-vs-cash.spec.ts — 10 tests pass with ToolSaveResult stubbed
- [x] Full quality-check green (lint, typecheck, coverage ≥ 85%, build)

Closes #689