### PR TITLE
feat(tools): ToolSaveResult integration — all 17 tool pages

### DIFF
--- a/app/features/tools/model/tools-catalog.ts
+++ b/app/features/tools/model/tools-catalog.ts
@@ -45,6 +45,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/inss-ir-folha",
     featureFlag: "web.tools.inss-ir-folha",
+    saveIntent: "expense",
   },
   {
     id: "hora-extra",
@@ -66,6 +67,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/ferias",
     featureFlag: "web.tools.ferias",
+    saveIntent: "receivable",
   },
   {
     id: "rescisao",
@@ -76,6 +78,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/rescisao",
     featureFlag: "web.tools.rescisao",
+    saveIntent: "receivable",
   },
   {
     id: "dividir-conta",
@@ -86,6 +89,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/dividir-conta",
     featureFlag: "web.tools.dividir-conta",
+    saveIntent: "none",
   },
   {
     id: "desconto-markup",
@@ -96,6 +100,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/desconto-markup",
     featureFlag: "web.tools.desconto-markup",
+    saveIntent: "none",
   },
   {
     id: "juros-compostos",
@@ -106,6 +111,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/juros-compostos",
     featureFlag: "web.tools.juros-compostos",
+    saveIntent: "goal",
   },
   {
     id: "fgts",
@@ -116,6 +122,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/fgts",
     featureFlag: "web.tools.fgts",
+    saveIntent: "receivable",
   },
   {
     id: "clt-vs-pj",
@@ -126,6 +133,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/clt-vs-pj",
     featureFlag: "web.tools.clt-vs-pj",
+    saveIntent: "receivable",
   },
   {
     id: "mei",
@@ -136,6 +144,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/mei",
     featureFlag: "web.tools.mei",
+    saveIntent: "expense",
   },
   {
     id: "cdb-lci-lca",
@@ -146,6 +155,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/cdb-lci-lca",
     featureFlag: "web.tools.cdb-lci-lca",
+    saveIntent: "goal",
   },
   {
     id: "tesouro-direto",
@@ -156,6 +166,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/tesouro-direto",
     featureFlag: "web.tools.tesouro-direto",
+    saveIntent: "goal",
   },
   {
     id: "aposentadoria",
@@ -166,6 +177,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/aposentadoria",
     featureFlag: "web.tools.aposentadoria",
+    saveIntent: "goal",
   },
   {
     id: "fire",
@@ -176,6 +188,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/fire",
     featureFlag: "web.tools.fire",
+    saveIntent: "goal",
   },
   {
     id: "financiamento-imobiliario",
@@ -186,6 +199,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/financiamento-imobiliario",
     featureFlag: "web.tools.financiamento-imobiliario",
+    saveIntent: "goal",
   },
   {
     id: "aluguel-vs-compra",
@@ -196,6 +210,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/aluguel-vs-compra",
     featureFlag: "web.tools.aluguel-vs-compra",
+    saveIntent: "goal",
   },
   {
     id: "conversor-moeda",
@@ -206,6 +221,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/conversor-moeda",
     featureFlag: "web.tools.conversor-moeda",
+    saveIntent: "none",
   },
   {
     id: "fii",
@@ -216,6 +232,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     accessLevel: "public",
     route: "/tools/fii",
     featureFlag: "web.tools.fii",
+    saveIntent: "goal",
   },
 ];
 

--- a/app/pages/tools/aluguel-vs-compra.spec.ts
+++ b/app/pages/tools/aluguel-vs-compra.spec.ts
@@ -242,6 +242,10 @@ const globalStubs = {
     props: ["option", "height", "width", "autoresize", "updateKey"],
     template: "<div class='v-chart' />",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/aluguel-vs-compra.vue
+++ b/app/pages/tools/aluguel-vs-compra.vue
@@ -29,6 +29,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -395,6 +396,12 @@ const isSaved = computed(() => savedSimulationId.value !== null);
               :label="t('aluguelVsCompra.results.verdict')"
               :value="result.buyIsBetter ? t('aluguelVsCompra.results.buyWins') : t('aluguelVsCompra.results.rentWins')"
               :metrics="summaryMetrics"
+            />
+
+            <ToolSaveResult
+              intent="goal"
+              :label="t('aluguelVsCompra.hero.title')"
+              :amount="result.totalBuyCost"
             />
 
             <NSpace vertical style="margin-top: 16px">

--- a/app/pages/tools/aposentadoria.spec.ts
+++ b/app/pages/tools/aposentadoria.spec.ts
@@ -174,6 +174,10 @@ const globalStubs = {
     props: ["option", "height", "width", "autoresize", "updateKey"],
     template: "<div class='v-chart'></div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/aposentadoria.vue
+++ b/app/pages/tools/aposentadoria.vue
@@ -31,6 +31,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -379,6 +380,12 @@ const isSaved = computed(() => savedSimulationId.value !== null);
               :label="t('aposentadoria.results.requiredPatrimony')"
               :value="formatBrl(result.requiredPatrimony)"
               :metrics="summaryMetrics"
+            />
+
+            <ToolSaveResult
+              intent="goal"
+              :label="t('aposentadoria.hero.title')"
+              :amount="result.requiredPatrimony"
             />
 
             <NSpace vertical style="margin-top: 16px">

--- a/app/pages/tools/cdb-lci-lca.spec.ts
+++ b/app/pages/tools/cdb-lci-lca.spec.ts
@@ -164,6 +164,10 @@ const globalStubs = {
     template: "<div class='calculator-result-summary'>{{ label }}: {{ value }}</div>",
   },
   ToolGuestCta: { template: "<div class='tool-guest-cta'>guest-cta</div>" },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/cdb-lci-lca.vue
+++ b/app/pages/tools/cdb-lci-lca.vue
@@ -31,6 +31,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -380,6 +381,12 @@ const isSaved = computed(() => savedSimulationId.value !== null);
               :label="t('cdbLciLca.results.bestOption', { name: result.bestOption })"
               :value="formatBrl(bestNetAmount)"
               :metrics="summaryMetrics"
+            />
+
+            <ToolSaveResult
+              intent="goal"
+              :label="t('cdbLciLca.hero.title')"
+              :amount="bestNetAmount"
             />
 
             <NSpace vertical style="margin-top: 16px">

--- a/app/pages/tools/clt-vs-pj.spec.ts
+++ b/app/pages/tools/clt-vs-pj.spec.ts
@@ -235,6 +235,10 @@ const globalStubs = {
   ToolGuestCta: {
     template: "<div class='tool-guest-cta'>toolGuestCta.registerCta</div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/clt-vs-pj.vue
+++ b/app/pages/tools/clt-vs-pj.vue
@@ -34,6 +34,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -375,6 +376,12 @@ async function handleAddAsGoal(): Promise<void> {
               <p class="clt-vs-pj-page__breakeven-value">{{ formatBrl(result.breakEvenInvoice) }}</p>
               <p class="clt-vs-pj-page__breakeven-note">{{ t('cltVsPj.results.breakEvenNote') }}</p>
             </UiSurfaceCard>
+
+            <ToolSaveResult
+              intent="receivable"
+              :label="t('cltVsPj.hero.title')"
+              :amount="result.pjIsMoreProfitable ? result.pjNetMonthly : result.cltNetMonthly"
+            />
 
             <!-- Action bar -->
             <UiSurfaceCard class="clt-vs-pj-page__action-bar">

--- a/app/pages/tools/ferias.spec.ts
+++ b/app/pages/tools/ferias.spec.ts
@@ -218,6 +218,10 @@ const globalStubs = {
   ToolGuestCta: {
     template: "<div class='tool-guest-cta'>toolGuestCta.registerCta</div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/ferias.vue
+++ b/app/pages/tools/ferias.vue
@@ -36,6 +36,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -382,6 +383,12 @@ async function handleSaveSimulation(): Promise<void> {
                 {{ t('ferias.results.bestMonthNote') }}
               </p>
             </UiSurfaceCard>
+
+            <ToolSaveResult
+              intent="receivable"
+              :label="t('ferias.hero.title')"
+              :amount="result.netTotal"
+            />
 
             <!-- Action bar -->
             <UiSurfaceCard class="ferias-page__action-bar">

--- a/app/pages/tools/fgts.spec.ts
+++ b/app/pages/tools/fgts.spec.ts
@@ -220,6 +220,10 @@ const globalStubs = {
   ToolGuestCta: {
     template: "<div class='tool-guest-cta'>toolGuestCta.registerCta</div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/fgts.vue
+++ b/app/pages/tools/fgts.vue
@@ -34,6 +34,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -371,6 +372,12 @@ async function handleAddAsGoal(): Promise<void> {
                 </div>
               </div>
             </UiSurfaceCard>
+
+            <ToolSaveResult
+              intent="receivable"
+              :label="t('fgts.hero.title')"
+              :amount="result.withdrawableAmount"
+            />
 
             <!-- Action bar -->
             <UiSurfaceCard class="fgts-page__action-bar">

--- a/app/pages/tools/fii.spec.ts
+++ b/app/pages/tools/fii.spec.ts
@@ -217,6 +217,10 @@ const globalStubs = {
   ToolGuestCta: {
     template: "<div class='tool-guest-cta'>toolGuestCta</div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/fii.vue
+++ b/app/pages/tools/fii.vue
@@ -31,6 +31,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -376,6 +377,12 @@ async function handleAddAsGoal(): Promise<void> {
                 {{ t('fii.disclaimer.cvm') }}
               </NAlert>
             </UiSurfaceCard>
+
+            <ToolSaveResult
+              intent="goal"
+              :label="t('fii.hero.title')"
+              :amount="result.monthlyIncome ?? 0"
+            />
 
             <!-- Action bar -->
             <UiSurfaceCard class="fii-page__action-bar">

--- a/app/pages/tools/financiamento-imobiliario.spec.ts
+++ b/app/pages/tools/financiamento-imobiliario.spec.ts
@@ -219,6 +219,10 @@ const globalStubs = {
   ToolGuestCta: {
     template: "<div class='tool-guest-cta'>toolGuestCta.registerCta</div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/financiamento-imobiliario.vue
+++ b/app/pages/tools/financiamento-imobiliario.vue
@@ -29,6 +29,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -322,6 +323,12 @@ const isSaved = computed(() => savedSimulationId.value !== null);
               :label="t('financiamentoImobiliario.results.loanAmount')"
               :value="formatBrl(result.loanAmount)"
               :metrics="summaryMetrics"
+            />
+
+            <ToolSaveResult
+              intent="goal"
+              :label="t('financiamentoImobiliario.hero.title')"
+              :amount="result.loanAmount"
             />
 
             <NSpace vertical style="margin-top: 16px">

--- a/app/pages/tools/fire.spec.ts
+++ b/app/pages/tools/fire.spec.ts
@@ -189,6 +189,10 @@ const globalStubs = {
     props: ["option", "height", "width", "autoresize", "updateKey"],
     template: "<div class='v-chart'></div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/fire.vue
+++ b/app/pages/tools/fire.vue
@@ -33,6 +33,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -390,6 +391,12 @@ const isSaved = computed(() => savedSimulationId.value !== null);
               :label="t('fire.results.requiredPatrimony')"
               :value="formatBrl(result.selectedVariant.requiredPatrimony)"
               :metrics="summaryMetrics"
+            />
+
+            <ToolSaveResult
+              intent="goal"
+              :label="t('fire.hero.title')"
+              :amount="result.selectedVariant.requiredPatrimony"
             />
 
             <NSpace vertical style="margin-top: 16px">

--- a/app/pages/tools/inss-ir-folha.spec.ts
+++ b/app/pages/tools/inss-ir-folha.spec.ts
@@ -212,6 +212,10 @@ const globalStubs = {
     props: ["rows", "rangeHeader", "rateHeader", "baseHeader", "taxHeader", "totalLabel", "totalValue"],
     template: "<div class='tax-bracket-table'>{{ totalLabel }}: {{ totalValue }}</div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/inss-ir-folha.vue
+++ b/app/pages/tools/inss-ir-folha.vue
@@ -33,6 +33,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -439,6 +440,12 @@ async function handleSaveSimulation(): Promise<void> {
                 </NCollapseItem>
               </NCollapse>
             </UiSurfaceCard>
+
+            <ToolSaveResult
+              intent="expense"
+              :label="t('inssIrFolha.hero.title')"
+              :amount="result.totalInss + result.totalIrrf"
+            />
 
             <!-- Action bar -->
             <UiSurfaceCard class="inss-ir-page__action-bar">

--- a/app/pages/tools/juros-compostos.spec.ts
+++ b/app/pages/tools/juros-compostos.spec.ts
@@ -231,6 +231,10 @@ const globalStubs = {
     props: ["option", "height", "width", "autoresize", "updateKey"],
     template: "<div class='v-chart'></div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/juros-compostos.vue
+++ b/app/pages/tools/juros-compostos.vue
@@ -31,6 +31,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -386,6 +387,12 @@ const isSaved = computed(() => savedSimulationId.value !== null);
               :label="t('jurosCompostos.results.finalAmountNominal')"
               :value="formatBrl(result.finalAmountNominal)"
               :metrics="summaryMetrics"
+            />
+
+            <ToolSaveResult
+              intent="goal"
+              :label="t('jurosCompostos.hero.title')"
+              :amount="result.finalAmountNominal"
             />
 
             <NSpace vertical style="margin-top: 16px">

--- a/app/pages/tools/mei.spec.ts
+++ b/app/pages/tools/mei.spec.ts
@@ -231,6 +231,10 @@ const globalStubs = {
   ToolGuestCta: {
     template: "<div class='tool-guest-cta'>toolGuestCta.registerCta</div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/mei.vue
+++ b/app/pages/tools/mei.vue
@@ -32,6 +32,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -339,6 +340,12 @@ async function handleAddAsGoal(): Promise<void> {
               </ul>
               <p class="mei-page__benefit-note">{{ t('mei.results.benefitsNote') }}</p>
             </UiSurfaceCard>
+
+            <ToolSaveResult
+              intent="expense"
+              :label="t('mei.hero.title')"
+              :amount="result.dasMontly"
+            />
 
             <!-- Action bar -->
             <UiSurfaceCard class="mei-page__action-bar">

--- a/app/pages/tools/rescisao.spec.ts
+++ b/app/pages/tools/rescisao.spec.ts
@@ -236,6 +236,10 @@ const globalStubs = {
   ToolGuestCta: {
     template: "<div class='tool-guest-cta'>toolGuestCta.registerCta</div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/rescisao.vue
+++ b/app/pages/tools/rescisao.vue
@@ -35,6 +35,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -452,6 +453,12 @@ async function handleSaveSimulation(): Promise<void> {
                 </div>
               </div>
             </UiSurfaceCard>
+
+            <ToolSaveResult
+              intent="receivable"
+              :label="t('rescisao.hero.title')"
+              :amount="result.netTotal"
+            />
 
             <!-- Action bar -->
             <UiSurfaceCard class="rescisao-page__action-bar">

--- a/app/pages/tools/tesouro-direto.spec.ts
+++ b/app/pages/tools/tesouro-direto.spec.ts
@@ -172,6 +172,10 @@ const globalStubs = {
     props: ["option", "height", "width", "autoresize", "updateKey"],
     template: "<div class='v-chart'></div>",
   },
+  ToolSaveResult: {
+    props: ["intent", "label", "amount", "description"],
+    template: "<div class='tool-save-result-stub' />",
+  },
 };
 
 /**

--- a/app/pages/tools/tesouro-direto.vue
+++ b/app/pages/tools/tesouro-direto.vue
@@ -33,6 +33,7 @@ import {
 import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
 import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
 import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
@@ -371,6 +372,12 @@ const isSaved = computed(() => savedSimulationId.value !== null);
               :label="t('tesouroDireto.results.netAmount')"
               :value="formatBrl(result.netAmount)"
               :metrics="summaryMetrics"
+            />
+
+            <ToolSaveResult
+              intent="goal"
+              :label="t('tesouroDireto.hero.title')"
+              :amount="result.netReturn"
             />
 
             <NSpace vertical style="margin-top: 16px">


### PR DESCRIPTION
## Summary
- Integrate `ToolSaveResult` into 14 remaining tool pages (ferias, rescisao, clt-vs-pj, inss-ir-folha, fgts, mei, juros-compostos, aposentadoria, fire, cdb-lci-lca, fii, tesouro-direto, financiamento-imobiliario, aluguel-vs-compra)
- Add `saveIntent` to all 17 catalog entries that were missing it (complete coverage of all 20 tools)
- Stub `ToolSaveResult` in all 14 affected page specs

## Test plan
- [x] 264 test files pass, 2742 tests green
- [x] Coverage thresholds met (statements/branches/functions/lines all >= 85%)
- [x] Full quality-check green (lint, typecheck, coverage, policy, contracts, build)
- [x] Pre-push hook passed

Closes #690