### PR TITLE
feat(tools): add 6 new financial calculators (#622-#627)

### DIFF
--- a/app/features/tools/model/cet.spec.ts
+++ b/app/features/tools/model/cet.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateCet,
+  calculateIof,
+  createDefaultCetFormState,
+  validateCetForm,
+  type CetFormState,
+} from "./cet";
+
+describe("validateCetForm", () => {
+  it("returns errors for all empty required fields", () => {
+    const form = createDefaultCetFormState();
+    const errors = validateCetForm(form);
+    expect(errors).toHaveLength(3);
+  });
+
+  it("returns no errors when required fields are filled", () => {
+    const form: CetFormState = {
+      ...createDefaultCetFormState(),
+      loanAmount: 10000,
+      nominalMonthlyRatePct: 1.5,
+      termMonths: 12,
+    };
+    expect(validateCetForm(form)).toHaveLength(0);
+  });
+});
+
+describe("calculateIof", () => {
+  it("calculates IOF for a 12-month loan", () => {
+    const iof = calculateIof(10000, 12);
+    expect(iof).toBeGreaterThan(0);
+    expect(iof).toBeLessThanOrEqual(300); // max 3% cap
+  });
+
+  it("caps IOF at 3%", () => {
+    const iof = calculateIof(10000, 120);
+    expect(iof).toBe(300);
+  });
+});
+
+describe("calculateCet", () => {
+  it("calculates CET for a basic loan", () => {
+    const form: CetFormState = {
+      ...createDefaultCetFormState(),
+      loanAmount: 10000,
+      nominalMonthlyRatePct: 1.5,
+      termMonths: 12,
+    };
+    const result = calculateCet(form);
+
+    expect(result).not.toBeNull();
+    expect(result!.cetMonthlyPct).toBeGreaterThan(1.5);
+    expect(result!.cetAnnualPct).toBeGreaterThan(result!.nominalAnnualPct);
+    expect(result!.totalPaid).toBeGreaterThan(10000);
+    expect(result!.cashFlows).toHaveLength(12);
+  });
+
+  it("CET is higher when TAC is added", () => {
+    const formBase: CetFormState = {
+      ...createDefaultCetFormState(),
+      loanAmount: 20000,
+      nominalMonthlyRatePct: 2,
+      termMonths: 24,
+    };
+    const formWithTac: CetFormState = { ...formBase, tacAmount: 1000 };
+
+    const resultBase = calculateCet(formBase)!;
+    const resultTac = calculateCet(formWithTac)!;
+
+    expect(resultTac.cetMonthlyPct).toBeGreaterThan(resultBase.cetMonthlyPct);
+  });
+
+  it("CET is higher when insurance is added", () => {
+    const formBase: CetFormState = {
+      ...createDefaultCetFormState(),
+      loanAmount: 20000,
+      nominalMonthlyRatePct: 2,
+      termMonths: 24,
+    };
+    const formWithIns: CetFormState = { ...formBase, insuranceMonthly: 50 };
+
+    const resultBase = calculateCet(formBase)!;
+    const resultIns = calculateCet(formWithIns)!;
+
+    expect(resultIns.cetMonthlyPct).toBeGreaterThan(resultBase.cetMonthlyPct);
+  });
+
+  it("allows IOF override", () => {
+    const form: CetFormState = {
+      ...createDefaultCetFormState(),
+      loanAmount: 10000,
+      nominalMonthlyRatePct: 1.5,
+      termMonths: 12,
+      iofOverride: 500,
+    };
+    const result = calculateCet(form)!;
+    expect(result.iofAmount).toBe(500);
+  });
+
+  it("net amount received accounts for all upfront fees", () => {
+    const form: CetFormState = {
+      ...createDefaultCetFormState(),
+      loanAmount: 10000,
+      nominalMonthlyRatePct: 1.5,
+      termMonths: 12,
+      tacAmount: 200,
+      appraisalFee: 100,
+      iofOverride: 150,
+    };
+    const result = calculateCet(form)!;
+    expect(result.netAmountReceived).toBe(10000 - 200 - 150 - 100);
+  });
+
+  it("monthly payment follows Price table", () => {
+    const form: CetFormState = {
+      ...createDefaultCetFormState(),
+      loanAmount: 10000,
+      nominalMonthlyRatePct: 1,
+      termMonths: 12,
+    };
+    const result = calculateCet(form)!;
+    // PMT for 1% monthly, 12 months, 10000 principal ≈ 888.49
+    expect(result.monthlyPayment).toBeCloseTo(888.49, 0);
+  });
+});

--- a/app/features/tools/model/cet.ts
+++ b/app/features/tools/model/cet.ts
@@ -1,0 +1,192 @@
+/**
+ * Domain model for the CET (Custo Efetivo Total) calculator (#625).
+ *
+ * Computes the total effective cost rate of a loan using Newton-Raphson
+ * to find the internal rate that equates the present value of cash flows
+ * to the net amount received. Includes IOF auto-calculation per Bacen rules.
+ */
+
+import { newtonRaphson, round2 } from "./math-utils";
+
+export const CET_PUBLIC_PATH = "/tools/cet";
+
+// ─── IOF constants (Bacen) ───────────────────────────────────────────────────
+
+const IOF_FIXED_RATE = 0.0038;
+const IOF_DAILY_RATE = 0.000082;
+const IOF_CAP = 0.03;
+
+// ─── Form state ──────────────────────────────────────────────────────────────
+
+export interface CetFormState extends Record<string, unknown> {
+  loanAmount: number | null;
+  nominalMonthlyRatePct: number | null;
+  termMonths: number | null;
+  tacAmount: number;
+  insuranceMonthly: number;
+  appraisalFee: number;
+  iofOverride: number | null;
+}
+
+/**
+ * @returns Default CET form state.
+ */
+export function createDefaultCetFormState(): CetFormState {
+  return {
+    loanAmount: null,
+    nominalMonthlyRatePct: null,
+    termMonths: null,
+    tacAmount: 0,
+    insuranceMonthly: 0,
+    appraisalFee: 0,
+    iofOverride: null,
+  };
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+export interface CetValidationError {
+  field: keyof CetFormState;
+  messageKey: string;
+}
+
+/**
+ * @param form
+ * @returns Validation errors, if any.
+ */
+export function validateCetForm(form: CetFormState): CetValidationError[] {
+  const errors: CetValidationError[] = [];
+
+  if (form.loanAmount === null || form.loanAmount <= 0) {
+    errors.push({ field: "loanAmount", messageKey: "errors.loanAmountRequired" });
+  }
+
+  if (form.nominalMonthlyRatePct === null || form.nominalMonthlyRatePct <= 0) {
+    errors.push({ field: "nominalMonthlyRatePct", messageKey: "errors.rateRequired" });
+  }
+
+  if (form.termMonths === null || form.termMonths < 1) {
+    errors.push({ field: "termMonths", messageKey: "errors.termRequired" });
+  }
+
+  return errors;
+}
+
+// ─── Cash flow ───────────────────────────────────────────────────────────────
+
+export interface CetCashFlow {
+  month: number;
+  payment: number;
+  insurance: number;
+  totalPayment: number;
+}
+
+// ─── Result ──────────────────────────────────────────────────────────────────
+
+export interface CetResult {
+  cetMonthlyPct: number;
+  cetAnnualPct: number;
+  nominalMonthlyPct: number;
+  nominalAnnualPct: number;
+  totalPaid: number;
+  totalCost: number;
+  iofAmount: number;
+  netAmountReceived: number;
+  monthlyPayment: number;
+  cashFlows: CetCashFlow[];
+}
+
+// ─── IOF calculation ─────────────────────────────────────────────────────────
+
+/**
+ * @param loanAmount
+ * @param termMonths
+ * @returns IOF amount (capped at 3%).
+ */
+export function calculateIof(loanAmount: number, termMonths: number): number {
+  const fixedIof = loanAmount * IOF_FIXED_RATE;
+  const avgDays = (termMonths * 30) / 2;
+  const dailyIof = loanAmount * IOF_DAILY_RATE * avgDays;
+  const totalIof = fixedIof + dailyIof;
+  const capped = Math.min(totalIof, loanAmount * IOF_CAP);
+  return round2(capped);
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * @param principal
+ * @param monthlyRate
+ * @param term
+ * @returns PMT via Price table.
+ */
+function calculatePmt(principal: number, monthlyRate: number, term: number): number {
+  return monthlyRate > 0
+    ? round2(principal * monthlyRate / (1 - Math.pow(1 + monthlyRate, -term)))
+    : round2(principal / term);
+}
+
+/**
+ * @param pmt
+ * @param insuranceMonthly
+ * @param term
+ * @returns Cash flows and total paid.
+ */
+function buildCashFlows(
+  pmt: number,
+  insuranceMonthly: number,
+  term: number,
+): { cashFlows: CetCashFlow[]; totalPaid: number } {
+  const cashFlows: CetCashFlow[] = [];
+  let totalPaid = 0;
+  for (let m = 1; m <= term; m++) {
+    const total = round2(pmt + insuranceMonthly);
+    cashFlows.push({ month: m, payment: pmt, insurance: insuranceMonthly, totalPayment: total });
+    totalPaid += total;
+  }
+  return { cashFlows, totalPaid: round2(totalPaid) };
+}
+
+// ─── Calculation ─────────────────────────────────────────────────────────────
+
+/**
+ * @param form
+ * @returns CET result or null if convergence fails.
+ */
+export function calculateCet(form: CetFormState): CetResult | null {
+  const principal = form.loanAmount ?? 0;
+  const monthlyRate = (form.nominalMonthlyRatePct ?? 0) / 100;
+  const term = form.termMonths ?? 0;
+
+  const iofAmount = form.iofOverride !== null
+    ? round2(form.iofOverride)
+    : calculateIof(principal, term);
+
+  const netAmountReceived = round2(principal - form.tacAmount - iofAmount - form.appraisalFee);
+  const pmt = calculatePmt(principal, monthlyRate, term);
+  const { cashFlows, totalPaid } = buildCashFlows(pmt, form.insuranceMonthly, term);
+  const totalCost = round2(totalPaid - netAmountReceived);
+
+  const cetMonthly = newtonRaphson({
+    f: (r) => cashFlows.reduce((pv, cf, i) => pv + cf.totalPayment / Math.pow(1 + r, i + 1), 0) - netAmountReceived,
+    fPrime: (r) => cashFlows.reduce((d, cf, i) => d + -(i + 1) * cf.totalPayment / Math.pow(1 + r, i + 2), 0),
+    x0: monthlyRate > 0 ? monthlyRate : 0.01,
+  });
+  if (cetMonthly === null) { return null; }
+
+  const cetMonthlyPct = round2(cetMonthly * 100 * 100) / 100;
+  const cetAnnualPct = round2((Math.pow(1 + cetMonthly, 12) - 1) * 100 * 100) / 100;
+
+  return {
+    cetMonthlyPct,
+    cetAnnualPct,
+    nominalMonthlyPct: round2((form.nominalMonthlyRatePct ?? 0) * 100) / 100,
+    nominalAnnualPct: round2((Math.pow(1 + monthlyRate, 12) - 1) * 100 * 100) / 100,
+    totalPaid,
+    totalCost,
+    iofAmount,
+    netAmountReceived,
+    monthlyPayment: pmt,
+    cashFlows,
+  };
+}

--- a/app/features/tools/model/custo-estilo-vida.spec.ts
+++ b/app/features/tools/model/custo-estilo-vida.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateCustoEstiloVida,
+  createDefaultCustoEstiloVidaFormState,
+  decodeQueryToForm,
+  encodeFormToQuery,
+  validateCustoEstiloVidaForm,
+  type CustoEstiloVidaFormState,
+} from "./custo-estilo-vida";
+
+describe("validateCustoEstiloVidaForm", () => {
+  it("returns error when no expense has amount", () => {
+    const form = createDefaultCustoEstiloVidaFormState();
+    const errors = validateCustoEstiloVidaForm(form);
+    expect(errors.some((e) => e.messageKey === "errors.atLeastOneExpenseRequired")).toBe(true);
+  });
+
+  it("returns error when horizon < 1", () => {
+    const form: CustoEstiloVidaFormState = {
+      ...createDefaultCustoEstiloVidaFormState(),
+      expenses: [{ name: "Café", monthlyAmount: 200 }],
+      horizonYears: 0,
+    };
+    const errors = validateCustoEstiloVidaForm(form);
+    expect(errors.some((e) => e.messageKey === "errors.horizonRequired")).toBe(true);
+  });
+
+  it("passes with valid form", () => {
+    const form: CustoEstiloVidaFormState = {
+      ...createDefaultCustoEstiloVidaFormState(),
+      expenses: [{ name: "Café", monthlyAmount: 200 }],
+    };
+    expect(validateCustoEstiloVidaForm(form)).toHaveLength(0);
+  });
+});
+
+describe("calculateCustoEstiloVida", () => {
+  it("calculates opportunity cost for single expense", () => {
+    const form: CustoEstiloVidaFormState = {
+      expenses: [{ name: "Streaming", monthlyAmount: 50 }],
+      annualReturnPct: 12,
+      horizonYears: 10,
+    };
+    const result = calculateCustoEstiloVida(form);
+
+    expect(result.totalMonthlyCost).toBe(50);
+    expect(result.totalAnnualCost).toBe(600);
+    expect(result.totalOpportunityCost).toBeGreaterThan(600 * 10);
+    expect(result.expenses).toHaveLength(1);
+    expect(result.expenses[0]!.opportunityCost).toBeGreaterThan(0);
+  });
+
+  it("calculates multiple expenses", () => {
+    const form: CustoEstiloVidaFormState = {
+      expenses: [
+        { name: "Streaming", monthlyAmount: 50 },
+        { name: "Café diário", monthlyAmount: 200 },
+      ],
+      annualReturnPct: 10,
+      horizonYears: 20,
+    };
+    const result = calculateCustoEstiloVida(form);
+
+    expect(result.totalMonthlyCost).toBe(250);
+    expect(result.expenses).toHaveLength(2);
+    expect(result.totalOpportunityCost).toBe(
+      result.expenses[0]!.opportunityCost + result.expenses[1]!.opportunityCost,
+    );
+  });
+
+  it("filters out zero-amount expenses", () => {
+    const form: CustoEstiloVidaFormState = {
+      expenses: [
+        { name: "Streaming", monthlyAmount: 50 },
+        { name: "Vazio", monthlyAmount: 0 },
+      ],
+      annualReturnPct: 12,
+      horizonYears: 5,
+    };
+    const result = calculateCustoEstiloVida(form);
+    expect(result.expenses).toHaveLength(1);
+  });
+
+  it("uses 'Sem nome' for unnamed expenses", () => {
+    const form: CustoEstiloVidaFormState = {
+      expenses: [{ name: "", monthlyAmount: 100 }],
+      annualReturnPct: 12,
+      horizonYears: 5,
+    };
+    const result = calculateCustoEstiloVida(form);
+    expect(result.expenses[0]!.name).toBe("Sem nome");
+  });
+
+  it("handles 0% return rate", () => {
+    const form: CustoEstiloVidaFormState = {
+      expenses: [{ name: "Test", monthlyAmount: 100 }],
+      annualReturnPct: 0,
+      horizonYears: 5,
+    };
+    const result = calculateCustoEstiloVida(form);
+    expect(result.totalOpportunityCost).toBe(6000); // 100 * 60 months, no growth
+  });
+});
+
+describe("URL sharing encode/decode", () => {
+  it("roundtrips form state through encode/decode", () => {
+    const form: CustoEstiloVidaFormState = {
+      expenses: [
+        { name: "Café", monthlyAmount: 200 },
+        { name: "Gym", monthlyAmount: 150 },
+      ],
+      annualReturnPct: 12,
+      horizonYears: 10,
+    };
+    const encoded = encodeFormToQuery(form);
+    const decoded = decodeQueryToForm(encoded);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded!.expenses).toHaveLength(2);
+    expect(decoded!.expenses![0]!.name).toBe("Café");
+    expect(decoded!.expenses![0]!.monthlyAmount).toBe(200);
+    expect(decoded!.annualReturnPct).toBe(12);
+    expect(decoded!.horizonYears).toBe(10);
+  });
+
+  it("returns null for invalid encoded string", () => {
+    expect(decodeQueryToForm("not-valid-base64!!!")).toBeNull();
+  });
+
+  it("returns null when decoded data has no expenses array", () => {
+    const encoded = btoa(JSON.stringify({ r: 12, h: 10 }));
+    expect(decodeQueryToForm(encoded)).toBeNull();
+  });
+
+  it("filters out zero-amount expenses in encoding", () => {
+    const form: CustoEstiloVidaFormState = {
+      expenses: [
+        { name: "Active", monthlyAmount: 100 },
+        { name: "Empty", monthlyAmount: 0 },
+      ],
+      annualReturnPct: 10,
+      horizonYears: 5,
+    };
+    const encoded = encodeFormToQuery(form);
+    const decoded = decodeQueryToForm(encoded);
+    expect(decoded!.expenses).toHaveLength(1);
+  });
+});

--- a/app/features/tools/model/custo-estilo-vida.ts
+++ b/app/features/tools/model/custo-estilo-vida.ts
@@ -1,0 +1,178 @@
+/**
+ * Domain model for the Custo do Estilo de Vida calculator (#627).
+ *
+ * Calculates the opportunity cost of recurring expenses over a
+ * given time horizon if invested instead. Supports URL query param
+ * encoding for viral sharing.
+ */
+
+import { round2 } from "./math-utils";
+
+export const CUSTO_ESTILO_VIDA_PUBLIC_PATH = "/tools/custo-estilo-vida";
+
+// ─── Expense entry ───────────────────────────────────────────────────────────
+
+export interface RecurringExpense {
+  name: string;
+  monthlyAmount: number;
+}
+
+// ─── Form state ──────────────────────────────────────────────────────────────
+
+export interface CustoEstiloVidaFormState extends Record<string, unknown> {
+  expenses: RecurringExpense[];
+  annualReturnPct: number;
+  horizonYears: number;
+}
+
+/**
+ * @returns A blank expense entry.
+ */
+export function createDefaultExpense(): RecurringExpense {
+  return { name: "", monthlyAmount: 0 };
+}
+
+/**
+ * @returns Default form state with two blank expenses.
+ */
+export function createDefaultCustoEstiloVidaFormState(): CustoEstiloVidaFormState {
+  return {
+    expenses: [createDefaultExpense(), createDefaultExpense()],
+    annualReturnPct: 12,
+    horizonYears: 10,
+  };
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+export interface CustoEstiloVidaValidationError {
+  field: string;
+  messageKey: string;
+}
+
+/**
+ * @param form
+ * @returns Validation errors, if any.
+ */
+export function validateCustoEstiloVidaForm(
+  form: CustoEstiloVidaFormState,
+): CustoEstiloVidaValidationError[] {
+  const errors: CustoEstiloVidaValidationError[] = [];
+
+  const hasValidExpense = form.expenses.some((e) => e.monthlyAmount > 0);
+  if (!hasValidExpense) {
+    errors.push({ field: "expenses", messageKey: "errors.atLeastOneExpenseRequired" });
+  }
+
+  if (form.horizonYears < 1) {
+    errors.push({ field: "horizonYears", messageKey: "errors.horizonRequired" });
+  }
+
+  return errors;
+}
+
+// ─── Result ──────────────────────────────────────────────────────────────────
+
+export interface ExpenseOpportunityCost {
+  name: string;
+  monthlyAmount: number;
+  annualCost: number;
+  opportunityCost: number;
+}
+
+export interface CustoEstiloVidaResult {
+  totalMonthlyCost: number;
+  totalAnnualCost: number;
+  totalOpportunityCost: number;
+  expenses: ExpenseOpportunityCost[];
+  horizonYears: number;
+}
+
+// ─── Calculation ─────────────────────────────────────────────────────────────
+
+/**
+ * @param monthlyPayment
+ * @param monthlyRate
+ * @param months
+ * @returns Future value of the annuity.
+ */
+function futureValueOfAnnuity(monthlyPayment: number, monthlyRate: number, months: number): number {
+  if (monthlyRate === 0) { return monthlyPayment * months; }
+  return monthlyPayment * ((Math.pow(1 + monthlyRate, months) - 1) / monthlyRate);
+}
+
+/**
+ * @param form
+ * @returns Opportunity cost result.
+ */
+export function calculateCustoEstiloVida(
+  form: CustoEstiloVidaFormState,
+): CustoEstiloVidaResult {
+  const monthlyRate = Math.pow(1 + form.annualReturnPct / 100, 1 / 12) - 1;
+  const totalMonths = form.horizonYears * 12;
+
+  const validExpenses = form.expenses.filter((e) => e.monthlyAmount > 0);
+
+  const expenses: ExpenseOpportunityCost[] = validExpenses.map((e) => {
+    const annualCost = round2(e.monthlyAmount * 12);
+    const opportunityCost = round2(futureValueOfAnnuity(e.monthlyAmount, monthlyRate, totalMonths));
+    return {
+      name: e.name || "Sem nome",
+      monthlyAmount: round2(e.monthlyAmount),
+      annualCost,
+      opportunityCost,
+    };
+  });
+
+  const totalMonthlyCost = round2(expenses.reduce((s, e) => s + e.monthlyAmount, 0));
+  const totalAnnualCost = round2(totalMonthlyCost * 12);
+  const totalOpportunityCost = round2(expenses.reduce((s, e) => s + e.opportunityCost, 0));
+
+  return {
+    totalMonthlyCost,
+    totalAnnualCost,
+    totalOpportunityCost,
+    expenses,
+    horizonYears: form.horizonYears,
+  };
+}
+
+// ─── URL sharing ─────────────────────────────────────────────────────────────
+
+/**
+ * @param form
+ * @returns Base64-encoded query string.
+ */
+export function encodeFormToQuery(form: CustoEstiloVidaFormState): string {
+  const data = {
+    e: form.expenses.filter((e) => e.monthlyAmount > 0).map((e) => ({
+      n: e.name,
+      v: e.monthlyAmount,
+    })),
+    r: form.annualReturnPct,
+    h: form.horizonYears,
+  };
+  return btoa(JSON.stringify(data));
+}
+
+/**
+ * @param encoded
+ * @returns Decoded form state or null if invalid.
+ */
+export function decodeQueryToForm(encoded: string): Partial<CustoEstiloVidaFormState> | null {
+  try {
+    const data = JSON.parse(atob(encoded)) as {
+      e?: Array<{ n: string; v: number }>;
+      r?: number;
+      h?: number;
+    };
+    if (!data.e || !Array.isArray(data.e)) { return null; }
+    return {
+      expenses: data.e.map((e) => ({ name: e.n, monthlyAmount: e.v })),
+      annualReturnPct: data.r ?? 12,
+      horizonYears: data.h ?? 10,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/app/features/tools/model/math-utils.spec.ts
+++ b/app/features/tools/model/math-utils.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { newtonRaphson, round2 } from "./math-utils";
+
+describe("round2", () => {
+  it("rounds to 2 decimal places", () => {
+    expect(round2(1.005)).toBe(1);
+    expect(round2(1.555)).toBe(1.56);
+    expect(round2(100)).toBe(100);
+    expect(round2(0.001)).toBe(0);
+  });
+});
+
+describe("newtonRaphson", () => {
+  it("finds square root of 2", () => {
+    const root = newtonRaphson({
+      f: (x) => x * x - 2,
+      fPrime: (x) => 2 * x,
+      x0: 1.5,
+    });
+    expect(root).not.toBeNull();
+    expect(Math.abs(root! - Math.SQRT2)).toBeLessThan(1e-9);
+  });
+
+  it("finds root of cubic x^3 - 8 = 0", () => {
+    const root = newtonRaphson({
+      f: (x) => x * x * x - 8,
+      fPrime: (x) => 3 * x * x,
+      x0: 1,
+    });
+    expect(root).not.toBeNull();
+    expect(Math.abs(root! - 2)).toBeLessThan(1e-9);
+  });
+
+  it("returns null when derivative is zero", () => {
+    const root = newtonRaphson({
+      f: (x) => x * x,
+      fPrime: () => 0,
+      x0: 0,
+    });
+    expect(root).toBeNull();
+  });
+
+  it("returns null when max iterations exceeded", () => {
+    const root = newtonRaphson({
+      f: (x) => Math.sin(x),
+      fPrime: (x) => Math.cos(x),
+      x0: Math.PI / 2,
+      tolerance: 1e-10,
+      maxIterations: 1,
+    });
+    expect(root).toBeNull();
+  });
+});

--- a/app/features/tools/model/math-utils.ts
+++ b/app/features/tools/model/math-utils.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared math utilities for financial calculators.
+ */
+
+/**
+ * Rounds a number to 2 decimal places (currency precision).
+ * @param value
+ * @returns The rounded value.
+ */
+export function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export interface NewtonRaphsonOptions {
+  f: (x: number) => number;
+  fPrime: (x: number) => number;
+  x0: number;
+  tolerance?: number;
+  maxIterations?: number;
+}
+
+/**
+ * Finds the root of f(x) = 0 using Newton-Raphson iteration.
+ *
+ * @param options Solver configuration.
+ * @returns The root, or null if convergence fails.
+ */
+export function newtonRaphson(options: NewtonRaphsonOptions): number | null {
+  const { f, fPrime, x0, tolerance = 1e-10, maxIterations = 200 } = options;
+  let x = x0;
+
+  for (let i = 0; i < maxIterations; i++) {
+    const fx = f(x);
+    const fpx = fPrime(x);
+
+    if (Math.abs(fpx) < 1e-15) { return null; }
+
+    const xNext = x - fx / fpx;
+
+    if (Math.abs(xNext - x) < tolerance) { return xNext; }
+
+    x = xNext;
+  }
+
+  return null;
+}

--- a/app/features/tools/model/orcamento-50-30-20.spec.ts
+++ b/app/features/tools/model/orcamento-50-30-20.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateOrcamento,
+  createDefaultOrcamentoFormState,
+  validateOrcamentoForm,
+  type OrcamentoFormState,
+} from "./orcamento-50-30-20";
+
+describe("validateOrcamentoForm", () => {
+  it("returns error when netIncome is null", () => {
+    const form = createDefaultOrcamentoFormState();
+    const errors = validateOrcamentoForm(form);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.field).toBe("netIncome");
+  });
+
+  it("returns no errors when netIncome is provided", () => {
+    const form = { ...createDefaultOrcamentoFormState(), netIncome: 5000 };
+    expect(validateOrcamentoForm(form)).toHaveLength(0);
+  });
+});
+
+describe("calculateOrcamento — simple mode", () => {
+  it("distributes R$10000 into 50/30/20", () => {
+    const form: OrcamentoFormState = {
+      ...createDefaultOrcamentoFormState(),
+      netIncome: 10000,
+      mode: "simple",
+    };
+    const result = calculateOrcamento(form);
+
+    expect(result.slices).toHaveLength(3);
+    const needs = result.slices.find((s) => s.category === "needs")!;
+    const wants = result.slices.find((s) => s.category === "wants")!;
+    const investments = result.slices.find((s) => s.category === "investments")!;
+
+    expect(needs.idealAmount).toBe(5000);
+    expect(wants.idealAmount).toBe(3000);
+    expect(investments.idealAmount).toBe(2000);
+
+    expect(needs.actualAmount).toBeNull();
+    expect(result.totalActual).toBeNull();
+    expect(result.surplus).toBeNull();
+  });
+});
+
+describe("calculateOrcamento — detailed mode", () => {
+  it("compares actual vs ideal and flags deviations > 10%", () => {
+    const form: OrcamentoFormState = {
+      ...createDefaultOrcamentoFormState(),
+      netIncome: 10000,
+      mode: "detailed",
+      actualNeeds: 7000,   // 70% vs ideal 50% → deviation +20%
+      actualWants: 2000,   // 20% vs ideal 30% → deviation -10%
+      actualInvestments: 1000, // 10% vs ideal 20% → deviation -10%
+    };
+    const result = calculateOrcamento(form);
+
+    const needs = result.slices.find((s) => s.category === "needs")!;
+    expect(needs.actualAmount).toBe(7000);
+    expect(needs.actualPct).toBe(70);
+    expect(needs.deviationPct).toBe(20);
+    expect(needs.alert).toBe(true);
+
+    const wants = result.slices.find((s) => s.category === "wants")!;
+    expect(wants.deviationPct).toBe(-10);
+    expect(wants.alert).toBe(false); // exactly 10, not > 10
+
+    expect(result.totalActual).toBe(10000);
+    expect(result.surplus).toBe(0);
+  });
+
+  it("calculates surplus when actual < income", () => {
+    const form: OrcamentoFormState = {
+      ...createDefaultOrcamentoFormState(),
+      netIncome: 10000,
+      mode: "detailed",
+      actualNeeds: 4000,
+      actualWants: 2000,
+      actualInvestments: 1500,
+    };
+    const result = calculateOrcamento(form);
+    expect(result.totalActual).toBe(7500);
+    expect(result.surplus).toBe(2500);
+  });
+
+  it("calculates negative surplus when overspending", () => {
+    const form: OrcamentoFormState = {
+      ...createDefaultOrcamentoFormState(),
+      netIncome: 5000,
+      mode: "detailed",
+      actualNeeds: 3500,
+      actualWants: 2000,
+      actualInvestments: 500,
+    };
+    const result = calculateOrcamento(form);
+    expect(result.surplus).toBe(-1000);
+  });
+});

--- a/app/features/tools/model/orcamento-50-30-20.ts
+++ b/app/features/tools/model/orcamento-50-30-20.ts
@@ -1,0 +1,128 @@
+/**
+ * Domain model for the Orçamento 50/30/20 calculator (#624).
+ *
+ * Distributes net income into Needs (50%), Wants (30%), Investments (20%).
+ * Supports simple mode (just income) and detailed mode (income + actual expenses).
+ */
+
+import { round2 } from "./math-utils";
+
+export const ORCAMENTO_PUBLIC_PATH = "/tools/orcamento-50-30-20";
+
+// ─── Categories ──────────────────────────────────────────────────────────────
+
+export type BudgetCategory = "needs" | "wants" | "investments";
+
+export const BUDGET_RULES: Record<BudgetCategory, number> = {
+  needs: 0.50,
+  wants: 0.30,
+  investments: 0.20,
+};
+
+// ─── Form state ──────────────────────────────────────────────────────────────
+
+export type OrcamentoMode = "simple" | "detailed";
+
+export interface OrcamentoFormState extends Record<string, unknown> {
+  netIncome: number | null;
+  mode: OrcamentoMode;
+  actualNeeds: number;
+  actualWants: number;
+  actualInvestments: number;
+}
+
+/**
+ * @returns Default budget form state.
+ */
+export function createDefaultOrcamentoFormState(): OrcamentoFormState {
+  return {
+    netIncome: null,
+    mode: "simple",
+    actualNeeds: 0,
+    actualWants: 0,
+    actualInvestments: 0,
+  };
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+export interface OrcamentoValidationError {
+  field: keyof OrcamentoFormState;
+  messageKey: string;
+}
+
+/**
+ * @param form
+ * @returns Validation errors, if any.
+ */
+export function validateOrcamentoForm(
+  form: OrcamentoFormState,
+): OrcamentoValidationError[] {
+  const errors: OrcamentoValidationError[] = [];
+
+  if (form.netIncome === null || form.netIncome <= 0) {
+    errors.push({ field: "netIncome", messageKey: "errors.incomeRequired" });
+  }
+
+  return errors;
+}
+
+// ─── Result ──────────────────────────────────────────────────────────────────
+
+export interface BudgetSlice {
+  category: BudgetCategory;
+  idealAmount: number;
+  idealPct: number;
+  actualAmount: number | null;
+  actualPct: number | null;
+  deviationPct: number | null;
+  alert: boolean;
+}
+
+export interface OrcamentoResult {
+  netIncome: number;
+  slices: BudgetSlice[];
+  totalActual: number | null;
+  surplus: number | null;
+}
+
+// ─── Calculation ─────────────────────────────────────────────────────────────
+
+const ALERT_THRESHOLD = 10;
+
+/**
+ * @param form
+ * @returns Budget breakdown result.
+ */
+export function calculateOrcamento(form: OrcamentoFormState): OrcamentoResult {
+  const income = form.netIncome ?? 0;
+  const isDetailed = form.mode === "detailed";
+
+  const categories: BudgetCategory[] = ["needs", "wants", "investments"];
+
+  const actuals: Record<BudgetCategory, number> = {
+    needs: form.actualNeeds,
+    wants: form.actualWants,
+    investments: form.actualInvestments,
+  };
+
+  const slices: BudgetSlice[] = categories.map((cat) => {
+    const idealPct = BUDGET_RULES[cat] * 100;
+    const idealAmount = round2(income * BUDGET_RULES[cat]);
+    const actualAmount = isDetailed ? round2(actuals[cat]) : null;
+    const actualPct = isDetailed && income > 0
+      ? round2((actuals[cat] / income) * 100)
+      : null;
+    const deviationPct = actualPct !== null ? round2(actualPct - idealPct) : null;
+    const alert = deviationPct !== null && Math.abs(deviationPct) > ALERT_THRESHOLD;
+
+    return { category: cat, idealAmount, idealPct, actualAmount, actualPct, deviationPct, alert };
+  });
+
+  const totalActual = isDetailed
+    ? round2(form.actualNeeds + form.actualWants + form.actualInvestments)
+    : null;
+  const surplus = totalActual !== null ? round2(income - totalActual) : null;
+
+  return { netIncome: income, slices, totalActual, surplus };
+}

--- a/app/features/tools/model/quitacao-dividas.spec.ts
+++ b/app/features/tools/model/quitacao-dividas.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateQuitacaoDividas,
+  createDefaultQuitacaoDividasFormState,
+  validateQuitacaoDividasForm,
+  type QuitacaoDividasFormState,
+} from "./quitacao-dividas";
+
+describe("validateQuitacaoDividasForm", () => {
+  it("returns error when fewer than 2 debts", () => {
+    const form: QuitacaoDividasFormState = {
+      debts: [{ name: "A", balance: 1000, monthlyRatePct: 2, minimumPayment: 100 }],
+      extraPayment: 0,
+    };
+    const errors = validateQuitacaoDividasForm(form);
+    expect(errors.some((e) => e.messageKey === "errors.minTwoDebts")).toBe(true);
+  });
+
+  it("returns error when no debt has valid balance", () => {
+    const form = createDefaultQuitacaoDividasFormState();
+    const errors = validateQuitacaoDividasForm(form);
+    expect(errors.some((e) => e.messageKey === "errors.atLeastOneDebtRequired")).toBe(true);
+  });
+
+  it("passes validation with valid debts", () => {
+    const form: QuitacaoDividasFormState = {
+      debts: [
+        { name: "A", balance: 1000, monthlyRatePct: 2, minimumPayment: 100 },
+        { name: "B", balance: 5000, monthlyRatePct: 5, minimumPayment: 200 },
+      ],
+      extraPayment: 300,
+    };
+    expect(validateQuitacaoDividasForm(form)).toHaveLength(0);
+  });
+});
+
+describe("calculateQuitacaoDividas", () => {
+  const baseForm: QuitacaoDividasFormState = {
+    debts: [
+      { name: "Cartão A", balance: 2000, monthlyRatePct: 10, minimumPayment: 200 },
+      { name: "Empréstimo B", balance: 8000, monthlyRatePct: 2, minimumPayment: 400 },
+    ],
+    extraPayment: 500,
+  };
+
+  it("calculates total debt", () => {
+    const result = calculateQuitacaoDividas(baseForm);
+    expect(result.totalDebt).toBe(10000);
+  });
+
+  it("generates both snowball and avalanche strategies", () => {
+    const result = calculateQuitacaoDividas(baseForm);
+    expect(result.snowball.strategy).toBe("snowball");
+    expect(result.avalanche.strategy).toBe("avalanche");
+  });
+
+  it("both strategies eventually pay off all debt", () => {
+    const result = calculateQuitacaoDividas(baseForm);
+    const lastSnowball = result.snowball.timeline[result.snowball.timeline.length - 1];
+    const lastAvalanche = result.avalanche.timeline[result.avalanche.timeline.length - 1];
+    expect(lastSnowball!.totalBalance).toBeLessThan(1);
+    expect(lastAvalanche!.totalBalance).toBeLessThan(1);
+  });
+
+  it("avalanche pays less total interest than snowball (high rate disparity)", () => {
+    const result = calculateQuitacaoDividas(baseForm);
+    expect(result.avalanche.totalInterest).toBeLessThanOrEqual(result.snowball.totalInterest);
+    expect(result.bestStrategy).toBe("avalanche");
+  });
+
+  it("calculates interest saved", () => {
+    const result = calculateQuitacaoDividas(baseForm);
+    expect(result.interestSaved).toBeGreaterThanOrEqual(0);
+    expect(result.interestSaved).toBe(
+      Math.abs(result.snowball.totalInterest - result.avalanche.totalInterest),
+    );
+  });
+
+  it("timeline starts at month 0 with full debt", () => {
+    const result = calculateQuitacaoDividas(baseForm);
+    expect(result.snowball.timeline[0]!.month).toBe(0);
+    expect(result.snowball.timeline[0]!.totalBalance).toBe(10000);
+  });
+
+  it("handles no extra payment", () => {
+    const form: QuitacaoDividasFormState = {
+      ...baseForm,
+      extraPayment: 0,
+    };
+    const result = calculateQuitacaoDividas(form);
+    expect(result.snowball.totalMonths).toBeGreaterThan(0);
+    expect(result.avalanche.totalMonths).toBeGreaterThan(0);
+  });
+
+  it("handles zero-rate debts", () => {
+    const form: QuitacaoDividasFormState = {
+      debts: [
+        { name: "Sem juros", balance: 1000, monthlyRatePct: 0, minimumPayment: 100 },
+        { name: "Com juros", balance: 2000, monthlyRatePct: 3, minimumPayment: 150 },
+      ],
+      extraPayment: 200,
+    };
+    const result = calculateQuitacaoDividas(form);
+    expect(result.totalDebt).toBe(3000);
+    expect(result.snowball.totalMonths).toBeGreaterThan(0);
+  });
+});

--- a/app/features/tools/model/quitacao-dividas.ts
+++ b/app/features/tools/model/quitacao-dividas.ts
@@ -1,0 +1,216 @@
+/**
+ * Domain model for the Quitação de Dívidas calculator (#626).
+ *
+ * Simulates two debt payoff strategies:
+ * - Snowball: pay off smallest balance first.
+ * - Avalanche: pay off highest interest rate first.
+ *
+ * Generates month-by-month amortization for each strategy.
+ */
+
+import { round2 } from "./math-utils";
+
+export const QUITACAO_DIVIDAS_PUBLIC_PATH = "/tools/quitacao-dividas";
+
+// ─── Debt entry ──────────────────────────────────────────────────────────────
+
+export interface DebtEntry {
+  name: string;
+  balance: number;
+  monthlyRatePct: number;
+  minimumPayment: number;
+}
+
+// ─── Form state ──────────────────────────────────────────────────────────────
+
+export interface QuitacaoDividasFormState extends Record<string, unknown> {
+  debts: DebtEntry[];
+  extraPayment: number;
+}
+
+/**
+ * @returns A blank debt entry.
+ */
+export function createDefaultDebtEntry(): DebtEntry {
+  return { name: "", balance: 0, monthlyRatePct: 0, minimumPayment: 0 };
+}
+
+/**
+ * @returns Default form state with two blank debts.
+ */
+export function createDefaultQuitacaoDividasFormState(): QuitacaoDividasFormState {
+  return {
+    debts: [createDefaultDebtEntry(), createDefaultDebtEntry()],
+    extraPayment: 0,
+  };
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+export interface QuitacaoDividasValidationError {
+  field: string;
+  messageKey: string;
+}
+
+/**
+ * @param form
+ * @returns Validation errors, if any.
+ */
+export function validateQuitacaoDividasForm(
+  form: QuitacaoDividasFormState,
+): QuitacaoDividasValidationError[] {
+  const errors: QuitacaoDividasValidationError[] = [];
+
+  if (form.debts.length < 2) {
+    errors.push({ field: "debts", messageKey: "errors.minTwoDebts" });
+  }
+
+  const hasValidDebt = form.debts.some((d) => d.balance > 0 && d.minimumPayment > 0);
+  if (!hasValidDebt) {
+    errors.push({ field: "debts", messageKey: "errors.atLeastOneDebtRequired" });
+  }
+
+  return errors;
+}
+
+// ─── Timeline ────────────────────────────────────────────────────────────────
+
+export interface PayoffTimelinePoint {
+  month: number;
+  totalBalance: number;
+  totalPaid: number;
+}
+
+export type PayoffStrategy = "snowball" | "avalanche";
+
+export interface StrategyResult {
+  strategy: PayoffStrategy;
+  totalMonths: number;
+  totalPaid: number;
+  totalInterest: number;
+  timeline: PayoffTimelinePoint[];
+}
+
+// ─── Result ──────────────────────────────────────────────────────────────────
+
+export interface QuitacaoDividasResult {
+  totalDebt: number;
+  snowball: StrategyResult;
+  avalanche: StrategyResult;
+  interestSaved: number;
+  monthsSaved: number;
+  bestStrategy: PayoffStrategy;
+}
+
+// ─── Simulation ──────────────────────────────────────────────────────────────
+
+interface SimDebt {
+  balance: number;
+  monthlyRate: number;
+  minimumPayment: number;
+}
+
+/**
+ * @param simDebts
+ * @returns Sum of all remaining balances.
+ */
+function getTotalBalance(simDebts: SimDebt[]): number {
+  return simDebts.reduce((sum, d) => sum + d.balance, 0);
+}
+
+/**
+ * @param simDebts Mutated in place — interest accrues on positive balances.
+ */
+function applyInterest(simDebts: SimDebt[]): void {
+  for (const d of simDebts) {
+    if (d.balance > 0) { d.balance = d.balance * (1 + d.monthlyRate); }
+  }
+}
+
+/**
+ * @param simDebts Mutated in place — minimum payments applied.
+ * @returns Total paid this step.
+ */
+function payMinimums(simDebts: SimDebt[]): number {
+  let paid = 0;
+  for (const d of simDebts) {
+    if (d.balance > 0) {
+      const payment = Math.min(d.minimumPayment, d.balance);
+      d.balance -= payment;
+      paid += payment;
+    }
+  }
+  return paid;
+}
+
+/**
+ * @param simDebts Mutated in place — extra payment allocated per strategy.
+ * @param extraPayment
+ * @param strategy
+ * @returns Total extra paid this step.
+ */
+function allocateExtra(simDebts: SimDebt[], extraPayment: number, strategy: PayoffStrategy): number {
+  const active = simDebts.filter((d) => d.balance > 0);
+  if (strategy === "snowball") { active.sort((a, b) => a.balance - b.balance); }
+  else { active.sort((a, b) => b.monthlyRate - a.monthlyRate); }
+
+  let remaining = extraPayment;
+  let paid = 0;
+  for (const d of active) {
+    if (remaining <= 0) { break; }
+    const payment = Math.min(remaining, d.balance);
+    d.balance -= payment;
+    paid += payment;
+    remaining -= payment;
+  }
+  return paid;
+}
+
+/**
+ * @param debts
+ * @param extraPayment
+ * @param strategy
+ * @returns Strategy simulation result.
+ */
+function simulateStrategy(debts: DebtEntry[], extraPayment: number, strategy: PayoffStrategy): StrategyResult {
+  const simDebts: SimDebt[] = debts.filter((d) => d.balance > 0).map((d) => ({
+    balance: d.balance, monthlyRate: d.monthlyRatePct / 100, minimumPayment: d.minimumPayment,
+  }));
+
+  const timeline: PayoffTimelinePoint[] = [{ month: 0, totalBalance: round2(getTotalBalance(simDebts)), totalPaid: 0 }];
+  let month = 0;
+  let totalPaid = 0;
+
+  while (getTotalBalance(simDebts) > 0.01 && month < 600) {
+    month++;
+    applyInterest(simDebts);
+    totalPaid += payMinimums(simDebts);
+    totalPaid += allocateExtra(simDebts, extraPayment, strategy);
+    for (const d of simDebts) { d.balance = round2(Math.max(0, d.balance)); }
+    timeline.push({ month, totalBalance: round2(getTotalBalance(simDebts)), totalPaid: round2(totalPaid) });
+  }
+
+  const originalDebt = debts.filter((d) => d.balance > 0).reduce((s, d) => s + d.balance, 0);
+  return { strategy, totalMonths: month, totalPaid: round2(totalPaid), totalInterest: round2(totalPaid - originalDebt), timeline };
+}
+
+/**
+ * @param form
+ * @returns Debt payoff comparison result.
+ */
+export function calculateQuitacaoDividas(
+  form: QuitacaoDividasFormState,
+): QuitacaoDividasResult {
+  const validDebts = form.debts.filter((d) => d.balance > 0 && d.minimumPayment > 0);
+  const totalDebt = round2(validDebts.reduce((s, d) => s + d.balance, 0));
+
+  const snowball = simulateStrategy(validDebts, form.extraPayment, "snowball");
+  const avalanche = simulateStrategy(validDebts, form.extraPayment, "avalanche");
+
+  const interestSaved = round2(Math.abs(snowball.totalInterest - avalanche.totalInterest));
+  const monthsSaved = Math.abs(snowball.totalMonths - avalanche.totalMonths);
+  const bestStrategy: PayoffStrategy =
+    avalanche.totalInterest <= snowball.totalInterest ? "avalanche" : "snowball";
+
+  return { totalDebt, snowball, avalanche, interestSaved, monthsSaved, bestStrategy };
+}

--- a/app/features/tools/model/reserva-emergencia.spec.ts
+++ b/app/features/tools/model/reserva-emergencia.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateReservaEmergencia,
+  createDefaultReservaEmergenciaFormState,
+  validateReservaEmergenciaForm,
+  type ReservaEmergenciaFormState,
+} from "./reserva-emergencia";
+
+describe("validateReservaEmergenciaForm", () => {
+  it("returns error when monthlyExpenses is null", () => {
+    const form = createDefaultReservaEmergenciaFormState();
+    const errors = validateReservaEmergenciaForm(form);
+    expect(errors.some((e) => e.field === "monthlyExpenses")).toBe(true);
+  });
+
+  it("returns error when monthlyContribution is null", () => {
+    const form = { ...createDefaultReservaEmergenciaFormState(), monthlyExpenses: 3000 };
+    const errors = validateReservaEmergenciaForm(form);
+    expect(errors.some((e) => e.field === "monthlyContribution")).toBe(true);
+  });
+
+  it("returns no errors with valid form", () => {
+    const form: ReservaEmergenciaFormState = {
+      ...createDefaultReservaEmergenciaFormState(),
+      monthlyExpenses: 3000,
+      monthlyContribution: 500,
+    };
+    expect(validateReservaEmergenciaForm(form)).toHaveLength(0);
+  });
+});
+
+describe("calculateReservaEmergencia", () => {
+  it("calculates target as 6x expenses for CLT", () => {
+    const form: ReservaEmergenciaFormState = {
+      ...createDefaultReservaEmergenciaFormState(),
+      monthlyExpenses: 3000,
+      monthlyContribution: 500,
+      profile: "clt",
+    };
+    const result = calculateReservaEmergencia(form);
+    expect(result.targetAmount).toBe(18000);
+    expect(result.profileMonths).toBe(6);
+  });
+
+  it("calculates target as 12x expenses for PJ", () => {
+    const form: ReservaEmergenciaFormState = {
+      ...createDefaultReservaEmergenciaFormState(),
+      monthlyExpenses: 5000,
+      monthlyContribution: 1000,
+      profile: "pj",
+    };
+    const result = calculateReservaEmergencia(form);
+    expect(result.targetAmount).toBe(60000);
+    expect(result.profileMonths).toBe(12);
+  });
+
+  it("calculates target as 18x expenses for empresario", () => {
+    const form: ReservaEmergenciaFormState = {
+      ...createDefaultReservaEmergenciaFormState(),
+      monthlyExpenses: 4000,
+      monthlyContribution: 800,
+      profile: "empresario",
+    };
+    const result = calculateReservaEmergencia(form);
+    expect(result.targetAmount).toBe(72000);
+    expect(result.profileMonths).toBe(18);
+  });
+
+  it("considers currentReserve in gap calculation", () => {
+    const form: ReservaEmergenciaFormState = {
+      ...createDefaultReservaEmergenciaFormState(),
+      monthlyExpenses: 3000,
+      monthlyContribution: 500,
+      currentReserve: 10000,
+      profile: "clt",
+    };
+    const result = calculateReservaEmergencia(form);
+    expect(result.gap).toBe(8000); // 18000 - 10000
+  });
+
+  it("gap is 0 when reserve exceeds target", () => {
+    const form: ReservaEmergenciaFormState = {
+      ...createDefaultReservaEmergenciaFormState(),
+      monthlyExpenses: 2000,
+      monthlyContribution: 500,
+      currentReserve: 20000,
+      profile: "clt",
+    };
+    const result = calculateReservaEmergencia(form);
+    expect(result.gap).toBe(0);
+    expect(result.monthsToTarget).toBe(0);
+  });
+
+  it("generates timeline with month 0 as starting point", () => {
+    const form: ReservaEmergenciaFormState = {
+      ...createDefaultReservaEmergenciaFormState(),
+      monthlyExpenses: 3000,
+      monthlyContribution: 1000,
+      profile: "clt",
+    };
+    const result = calculateReservaEmergencia(form);
+    expect(result.timeline[0]!.month).toBe(0);
+    expect(result.timeline[0]!.balance).toBe(0);
+    expect(result.timeline.length).toBeGreaterThan(1);
+  });
+
+  it("generates investment comparisons for all 4 vehicles", () => {
+    const form: ReservaEmergenciaFormState = {
+      ...createDefaultReservaEmergenciaFormState(),
+      monthlyExpenses: 3000,
+      monthlyContribution: 1000,
+      profile: "clt",
+    };
+    const result = calculateReservaEmergencia(form);
+    expect(result.investments).toHaveLength(4);
+    expect(result.investments[0]!.name).toContain("Selic");
+  });
+
+  it("poupanca takes longer than selic", () => {
+    const form: ReservaEmergenciaFormState = {
+      ...createDefaultReservaEmergenciaFormState(),
+      monthlyExpenses: 3000,
+      monthlyContribution: 500,
+      profile: "clt",
+    };
+    const result = calculateReservaEmergencia(form);
+    const selic = result.investments.find((i) => i.name.includes("Selic"));
+    const poupanca = result.investments.find((i) => i.name.includes("Poupança"));
+    expect(poupanca!.monthsToTarget).toBeGreaterThan(selic!.monthsToTarget);
+  });
+});

--- a/app/features/tools/model/reserva-emergencia.ts
+++ b/app/features/tools/model/reserva-emergencia.ts
@@ -1,0 +1,177 @@
+/**
+ * Domain model for the Reserva de Emergência calculator (#623).
+ *
+ * Calculates the target emergency fund by professional profile,
+ * timeline to reach the goal with compound interest, and
+ * compares investment vehicles (Selic, CDB, Fundo DI, Poupança).
+ */
+
+import { round2 } from "./math-utils";
+
+export const RESERVA_EMERGENCIA_PUBLIC_PATH = "/tools/reserva-emergencia";
+
+// ─── Profile multipliers ─────────────────────────────────────────────────────
+
+export const PROFILE_OPTIONS = [
+  { value: "clt", label: "CLT", months: 6 },
+  { value: "pj", label: "PJ / Prestador", months: 12 },
+  { value: "autonomo", label: "Autônomo", months: 12 },
+  { value: "empresario", label: "Empresário", months: 18 },
+] as const;
+
+export type ProfileType = (typeof PROFILE_OPTIONS)[number]["value"];
+
+// ─── Form state ──────────────────────────────────────────────────────────────
+
+export interface ReservaEmergenciaFormState extends Record<string, unknown> {
+  monthlyExpenses: number | null;
+  profile: ProfileType;
+  currentReserve: number;
+  monthlyContribution: number | null;
+  annualReturnPct: number;
+}
+
+/**
+ * @returns Default form state.
+ */
+export function createDefaultReservaEmergenciaFormState(): ReservaEmergenciaFormState {
+  return {
+    monthlyExpenses: null,
+    profile: "clt",
+    currentReserve: 0,
+    monthlyContribution: null,
+    annualReturnPct: 12.25,
+  };
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+export interface ReservaEmergenciaValidationError {
+  field: keyof ReservaEmergenciaFormState;
+  messageKey: string;
+}
+
+/**
+ * @param form
+ * @returns Validation errors, if any.
+ */
+export function validateReservaEmergenciaForm(
+  form: ReservaEmergenciaFormState,
+): ReservaEmergenciaValidationError[] {
+  const errors: ReservaEmergenciaValidationError[] = [];
+
+  if (form.monthlyExpenses === null || form.monthlyExpenses <= 0) {
+    errors.push({ field: "monthlyExpenses", messageKey: "errors.expensesRequired" });
+  }
+
+  if (form.monthlyContribution === null || form.monthlyContribution <= 0) {
+    errors.push({ field: "monthlyContribution", messageKey: "errors.contributionRequired" });
+  }
+
+  return errors;
+}
+
+// ─── Investment comparison ───────────────────────────────────────────────────
+
+export interface InvestmentComparison {
+  name: string;
+  annualRatePct: number;
+  monthsToTarget: number;
+  finalAmount: number;
+}
+
+// ─── Timeline point ──────────────────────────────────────────────────────────
+
+export interface ReservaTimelinePoint {
+  month: number;
+  balance: number;
+}
+
+// ─── Result ──────────────────────────────────────────────────────────────────
+
+export interface ReservaEmergenciaResult {
+  targetAmount: number;
+  profileMonths: number;
+  gap: number;
+  monthsToTarget: number;
+  timeline: ReservaTimelinePoint[];
+  investments: InvestmentComparison[];
+}
+
+// ─── Reference rates (Selic-based, 2025) ─────────────────────────────────────
+
+const REFERENCE_INVESTMENTS = [
+  { name: "Selic / Tesouro Selic", annualRatePct: 14.25 },
+  { name: "CDB 100% CDI", annualRatePct: 14.15 },
+  { name: "Fundo DI (taxa 0.5%)", annualRatePct: 13.65 },
+  { name: "Poupança", annualRatePct: 7.56 },
+];
+
+// ─── Calculation ─────────────────────────────────────────────────────────────
+
+interface SimulateTargetOptions {
+  current: number;
+  monthlyContribution: number;
+  monthlyRate: number;
+  target: number;
+}
+
+/**
+ * @param options Simulation parameters.
+ * @returns Months to reach target, timeline, and final amount.
+ */
+function simulateMonthsToTarget(
+  options: SimulateTargetOptions,
+): { months: number; timeline: ReservaTimelinePoint[]; finalAmount: number } {
+  const { current, monthlyContribution, monthlyRate, target } = options;
+  const timeline: ReservaTimelinePoint[] = [{ month: 0, balance: round2(current) }];
+  let balance = current;
+  let month = 0;
+  const maxMonths = 600;
+
+  while (balance < target && month < maxMonths) {
+    month++;
+    balance = balance * (1 + monthlyRate) + monthlyContribution;
+    timeline.push({ month, balance: round2(balance) });
+  }
+
+  return { months: month, timeline, finalAmount: round2(balance) };
+}
+
+/**
+ * @param form
+ * @returns Emergency fund calculation result.
+ */
+export function calculateReservaEmergencia(
+  form: ReservaEmergenciaFormState,
+): ReservaEmergenciaResult {
+  const expenses = form.monthlyExpenses ?? 0;
+  const profileEntry = PROFILE_OPTIONS.find((p) => p.value === form.profile) ?? PROFILE_OPTIONS[0];
+  const profileMonths = profileEntry.months;
+  const targetAmount = round2(expenses * profileMonths);
+  const gap = round2(Math.max(0, targetAmount - form.currentReserve));
+  const contribution = form.monthlyContribution ?? 0;
+
+  const userMonthlyRate = Math.pow(1 + form.annualReturnPct / 100, 1 / 12) - 1;
+  const mainSim = simulateMonthsToTarget({ current: form.currentReserve, monthlyContribution: contribution, monthlyRate: userMonthlyRate, target: targetAmount });
+
+  const investments: InvestmentComparison[] = REFERENCE_INVESTMENTS.map((inv) => {
+    const mr = Math.pow(1 + inv.annualRatePct / 100, 1 / 12) - 1;
+    const sim = simulateMonthsToTarget({ current: form.currentReserve, monthlyContribution: contribution, monthlyRate: mr, target: targetAmount });
+    return {
+      name: inv.name,
+      annualRatePct: inv.annualRatePct,
+      monthsToTarget: sim.months,
+      finalAmount: sim.finalAmount,
+    };
+  });
+
+  return {
+    targetAmount,
+    profileMonths,
+    gap,
+    monthsToTarget: mainSim.months,
+    timeline: mainSim.timeline,
+    investments,
+  };
+}

--- a/app/features/tools/model/salario-liquido.spec.ts
+++ b/app/features/tools/model/salario-liquido.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateSalarioLiquido,
+  createDefaultSalarioLiquidoFormState,
+  validateSalarioLiquidoForm,
+  type SalarioLiquidoFormState,
+} from "./salario-liquido";
+
+describe("validateSalarioLiquidoForm", () => {
+  it("returns error when grossSalary is null", () => {
+    const form = createDefaultSalarioLiquidoFormState();
+    const errors = validateSalarioLiquidoForm(form);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.field).toBe("grossSalary");
+  });
+
+  it("returns no errors when grossSalary is provided", () => {
+    const form = { ...createDefaultSalarioLiquidoFormState(), grossSalary: 5000 };
+    expect(validateSalarioLiquidoForm(form)).toHaveLength(0);
+  });
+});
+
+describe("calculateSalarioLiquido", () => {
+  it("calculates net salary for a basic R$5000 gross", () => {
+    const form: SalarioLiquidoFormState = {
+      ...createDefaultSalarioLiquidoFormState(),
+      grossSalary: 5000,
+    };
+    const result = calculateSalarioLiquido(form);
+
+    expect(result.grossSalary).toBe(5000);
+    expect(result.inss).toBeGreaterThan(0);
+    expect(result.irrf).toBeGreaterThanOrEqual(0);
+    expect(result.vtDiscount).toBe(300); // 6% of 5000
+    expect(result.netSalary).toBeLessThan(5000);
+    expect(result.netSalary).toBe(result.grossSalary - result.totalDeductions);
+  });
+
+  it("includes VT discount at 6% by default", () => {
+    const form: SalarioLiquidoFormState = {
+      ...createDefaultSalarioLiquidoFormState(),
+      grossSalary: 3000,
+    };
+    const result = calculateSalarioLiquido(form);
+    expect(result.vtDiscount).toBe(180); // 6% of 3000
+  });
+
+  it("skips VT when opted out", () => {
+    const form: SalarioLiquidoFormState = {
+      ...createDefaultSalarioLiquidoFormState(),
+      grossSalary: 3000,
+      vtOptOut: true,
+    };
+    const result = calculateSalarioLiquido(form);
+    expect(result.vtDiscount).toBe(0);
+  });
+
+  it("applies union contribution as 1 day of salary", () => {
+    const form: SalarioLiquidoFormState = {
+      ...createDefaultSalarioLiquidoFormState(),
+      grossSalary: 3000,
+      unionContribution: true,
+    };
+    const result = calculateSalarioLiquido(form);
+    expect(result.unionDiscount).toBe(100); // 3000/30
+  });
+
+  it("applies alimony percentage", () => {
+    const form: SalarioLiquidoFormState = {
+      ...createDefaultSalarioLiquidoFormState(),
+      grossSalary: 10000,
+      alimonyPct: 30,
+    };
+    const result = calculateSalarioLiquido(form);
+    expect(result.alimonyDiscount).toBe(3000);
+  });
+
+  it("calculates employer total cost", () => {
+    const form: SalarioLiquidoFormState = {
+      ...createDefaultSalarioLiquidoFormState(),
+      grossSalary: 5000,
+    };
+    const result = calculateSalarioLiquido(form);
+    expect(result.employerFgts).toBe(400); // 8%
+    expect(result.employerInss).toBe(1000); // 20%
+    expect(result.employerTotal).toBe(6400); // 5000 + 400 + 1000
+  });
+
+  it("includes health plan and VA/VR deductions", () => {
+    const form: SalarioLiquidoFormState = {
+      ...createDefaultSalarioLiquidoFormState(),
+      grossSalary: 5000,
+      healthPlanDiscount: 200,
+      vaVrDiscount: 100,
+    };
+    const result = calculateSalarioLiquido(form);
+    expect(result.healthPlanDiscount).toBe(200);
+    expect(result.vaVrDiscount).toBe(100);
+    expect(result.deductions.find((d) => d.label === "Plano de Saúde")?.amount).toBe(200);
+    expect(result.deductions.find((d) => d.label === "VA/VR")?.amount).toBe(100);
+  });
+
+  it("deductions sum equals totalDeductions", () => {
+    const form: SalarioLiquidoFormState = {
+      ...createDefaultSalarioLiquidoFormState(),
+      grossSalary: 8000,
+      dependents: 2,
+      healthPlanDiscount: 300,
+      vaVrDiscount: 150,
+      alimonyPct: 10,
+      unionContribution: true,
+    };
+    const result = calculateSalarioLiquido(form);
+    const sumDeductions = result.deductions.reduce((s, d) => s + d.amount, 0);
+    expect(Math.abs(sumDeductions - result.totalDeductions)).toBeLessThan(0.02);
+  });
+
+  it("handles minimum wage correctly", () => {
+    const form: SalarioLiquidoFormState = {
+      ...createDefaultSalarioLiquidoFormState(),
+      grossSalary: 1518,
+    };
+    const result = calculateSalarioLiquido(form);
+    expect(result.inss).toBe(113.85); // 1518 * 7.5%
+    expect(result.irrf).toBe(0); // Below exemption
+    expect(result.netSalary).toBeGreaterThan(0);
+  });
+});

--- a/app/features/tools/model/salario-liquido.ts
+++ b/app/features/tools/model/salario-liquido.ts
@@ -1,0 +1,177 @@
+/**
+ * Domain model for the Salário Líquido CLT calculator (#622).
+ *
+ * Computes net salary from gross, applying INSS, IRRF, VT, VA/VR,
+ * health plan, union contribution, alimony and PGBL deductions.
+ * Also computes the employer cost breakdown.
+ */
+
+import { calcInss, calcIrrfFromGross, IRRF_PER_DEPENDENT_DEDUCTION, BR_TAX_TABLE_YEAR } from "./br-tax-tables";
+import { round2 } from "./math-utils";
+
+export { BR_TAX_TABLE_YEAR };
+
+export const SALARIO_LIQUIDO_PUBLIC_PATH = "/tools/salario-liquido";
+
+// ─── Form state ──────────────────────────────────────────────────────────────
+
+export interface SalarioLiquidoFormState extends Record<string, unknown> {
+  grossSalary: number | null;
+  dependents: number;
+  alimonyPct: number;
+  vtOptOut: boolean;
+  vtPct: number;
+  vaVrDiscount: number;
+  healthPlanDiscount: number;
+  unionContribution: boolean;
+  pgblPct: number;
+}
+
+/**
+ * @returns Default form state for salário líquido.
+ */
+export function createDefaultSalarioLiquidoFormState(): SalarioLiquidoFormState {
+  return {
+    grossSalary: null,
+    dependents: 0,
+    alimonyPct: 0,
+    vtOptOut: false,
+    vtPct: 6,
+    vaVrDiscount: 0,
+    healthPlanDiscount: 0,
+    unionContribution: false,
+    pgblPct: 0,
+  };
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+export interface SalarioLiquidoValidationError {
+  field: keyof SalarioLiquidoFormState;
+  messageKey: string;
+}
+
+/**
+ * @param form
+ * @returns Validation errors, if any.
+ */
+export function validateSalarioLiquidoForm(
+  form: SalarioLiquidoFormState,
+): SalarioLiquidoValidationError[] {
+  const errors: SalarioLiquidoValidationError[] = [];
+
+  if (form.grossSalary === null || form.grossSalary <= 0) {
+    errors.push({ field: "grossSalary", messageKey: "errors.grossSalaryRequired" });
+  }
+
+  return errors;
+}
+
+// ─── Result ──────────────────────────────────────────────────────────────────
+
+export interface SalarioLiquidoDeduction {
+  label: string;
+  amount: number;
+}
+
+export interface SalarioLiquidoResult {
+  grossSalary: number;
+  inss: number;
+  irrf: number;
+  vtDiscount: number;
+  vaVrDiscount: number;
+  healthPlanDiscount: number;
+  unionDiscount: number;
+  alimonyDiscount: number;
+  totalDeductions: number;
+  netSalary: number;
+  deductions: SalarioLiquidoDeduction[];
+  employerFgts: number;
+  employerInss: number;
+  employerTotal: number;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const EMPLOYER_FGTS_RATE = 0.08;
+const EMPLOYER_INSS_RATE = 0.20;
+const MAX_PGBL_PCT = 12;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+interface DiscountBreakdown {
+  inss: number;
+  irrf: number;
+  vtDiscount: number;
+  vaVrDiscount: number;
+  healthPlanDiscount: number;
+  unionDiscount: number;
+  alimonyDiscount: number;
+}
+
+/**
+ * @param gross
+ * @param form
+ * @returns Individual discount amounts.
+ */
+function computeDiscounts(gross: number, form: SalarioLiquidoFormState): DiscountBreakdown {
+  const inss = calcInss(gross);
+  const pgblDeduction = round2(gross * Math.min(form.pgblPct, MAX_PGBL_PCT) / 100);
+  const dependentDeduction = form.dependents * IRRF_PER_DEPENDENT_DEDUCTION;
+  const taxableBase = gross - inss - dependentDeduction - pgblDeduction;
+  const irrf = calcIrrfFromGross(taxableBase + inss + dependentDeduction, inss, form.dependents);
+  return {
+    inss,
+    irrf,
+    vtDiscount: form.vtOptOut ? 0 : round2(gross * form.vtPct / 100),
+    vaVrDiscount: round2(form.vaVrDiscount),
+    healthPlanDiscount: round2(form.healthPlanDiscount),
+    unionDiscount: form.unionContribution ? round2(gross / 30) : 0,
+    alimonyDiscount: round2(gross * form.alimonyPct / 100),
+  };
+}
+
+/**
+ * @param d Discount breakdown.
+ * @returns Labelled deduction list (non-zero items only).
+ */
+function buildDeductionList(d: DiscountBreakdown): SalarioLiquidoDeduction[] {
+  const list: SalarioLiquidoDeduction[] = [
+    { label: "INSS", amount: d.inss },
+    { label: "IRRF", amount: d.irrf },
+  ];
+  if (d.vtDiscount > 0) { list.push({ label: "Vale-Transporte", amount: d.vtDiscount }); }
+  if (d.vaVrDiscount > 0) { list.push({ label: "VA/VR", amount: d.vaVrDiscount }); }
+  if (d.healthPlanDiscount > 0) { list.push({ label: "Plano de Saúde", amount: d.healthPlanDiscount }); }
+  if (d.unionDiscount > 0) { list.push({ label: "Contribuição Sindical", amount: d.unionDiscount }); }
+  if (d.alimonyDiscount > 0) { list.push({ label: "Pensão Alimentícia", amount: d.alimonyDiscount }); }
+  return list;
+}
+
+// ─── Calculation ─────────────────────────────────────────────────────────────
+
+/**
+ * @param form
+ * @returns Salário líquido result with deductions and employer cost.
+ */
+export function calculateSalarioLiquido(form: SalarioLiquidoFormState): SalarioLiquidoResult {
+  const gross = form.grossSalary ?? 0;
+  const d = computeDiscounts(gross, form);
+
+  const totalDeductions = round2(
+    d.inss + d.irrf + d.vtDiscount + d.vaVrDiscount + d.healthPlanDiscount + d.unionDiscount + d.alimonyDiscount,
+  );
+  const employerFgts = round2(gross * EMPLOYER_FGTS_RATE);
+  const employerInss = round2(gross * EMPLOYER_INSS_RATE);
+
+  return {
+    grossSalary: gross,
+    ...d,
+    totalDeductions,
+    netSalary: round2(gross - totalDeductions),
+    deductions: buildDeductionList(d),
+    employerFgts,
+    employerInss,
+    employerTotal: round2(gross + employerFgts + employerInss),
+  };
+}

--- a/app/features/tools/model/tools-catalog.ts
+++ b/app/features/tools/model/tools-catalog.ts
@@ -234,6 +234,72 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     featureFlag: "web.tools.fii",
     saveIntent: "goal",
   },
+  {
+    id: "salario-liquido",
+    name: "Salário Líquido CLT",
+    description:
+      "Calcule o salário líquido com todos os descontos (INSS, IR, VT, VA/VR, plano de saúde) e custo do empregador.",
+    enabled: isFeatureEnabled("web.tools.salario-liquido"),
+    accessLevel: "public",
+    route: "/tools/salario-liquido",
+    featureFlag: "web.tools.salario-liquido",
+    saveIntent: "receivable",
+  },
+  {
+    id: "reserva-emergencia",
+    name: "Reserva de Emergência",
+    description:
+      "Calcule sua meta de reserva de emergência por perfil profissional, com timeline de acumulação e comparação de investimentos.",
+    enabled: isFeatureEnabled("web.tools.reserva-emergencia"),
+    accessLevel: "public",
+    route: "/tools/reserva-emergencia",
+    featureFlag: "web.tools.reserva-emergencia",
+    saveIntent: "goal",
+  },
+  {
+    id: "orcamento-50-30-20",
+    name: "Orçamento 50/30/20",
+    description:
+      "Distribua sua renda em necessidades, desejos e investimentos com comparação real vs ideal.",
+    enabled: isFeatureEnabled("web.tools.orcamento-50-30-20"),
+    accessLevel: "public",
+    route: "/tools/orcamento-50-30-20",
+    featureFlag: "web.tools.orcamento-50-30-20",
+    saveIntent: "goal",
+  },
+  {
+    id: "cet",
+    name: "CET — Custo Efetivo Total",
+    description:
+      "Descubra o custo real de um financiamento calculando o CET com IOF, TAC, seguro e todos os encargos.",
+    enabled: isFeatureEnabled("web.tools.cet"),
+    accessLevel: "public",
+    route: "/tools/cet",
+    featureFlag: "web.tools.cet",
+    saveIntent: "expense",
+  },
+  {
+    id: "quitacao-dividas",
+    name: "Quitação de Dívidas",
+    description:
+      "Compare estratégias Snowball e Avalanche para quitar suas dívidas mais rápido e pagar menos juros.",
+    enabled: isFeatureEnabled("web.tools.quitacao-dividas"),
+    accessLevel: "public",
+    route: "/tools/quitacao-dividas",
+    featureFlag: "web.tools.quitacao-dividas",
+    saveIntent: "goal",
+  },
+  {
+    id: "custo-estilo-vida",
+    name: "Custo do Estilo de Vida",
+    description:
+      "Veja o custo de oportunidade dos seus gastos recorrentes se investidos ao longo do tempo.",
+    enabled: isFeatureEnabled("web.tools.custo-estilo-vida"),
+    accessLevel: "public",
+    route: "/tools/custo-estilo-vida",
+    featureFlag: "web.tools.custo-estilo-vida",
+    saveIntent: "goal",
+  },
 ];
 
 /**

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -3173,5 +3173,304 @@
       "realEstate": "Real Estate",
       "personal": "Personal"
     }
+  },
+  "salarioLiquido": {
+    "seo": {
+      "title": "Net Salary CLT — Auraxis",
+      "description": "Calculate your CLT net salary with all deductions.",
+      "ogTitle": "Net Salary CLT | Auraxis",
+      "ogDescription": "Find out your take-home pay and employer cost."
+    },
+    "hero": {
+      "title": "Net Salary CLT",
+      "subtitle": "Calculate your net salary with all deductions and employer cost."
+    },
+    "form": {
+      "title": "Salary data",
+      "grossSalary": "Gross salary (R$)",
+      "dependents": "Dependents (tax)",
+      "healthPlan": "Health plan (R$)",
+      "vaVr": "Meal/food voucher (R$)",
+      "alimonyPct": "Alimony (%)",
+      "vtOptOut": "No transportation voucher",
+      "unionContribution": "Union contribution (1 day)",
+      "calculate": "Calculate",
+      "reset": "Reset"
+    },
+    "results": {
+      "netSalary": "Net salary",
+      "totalDeductions": "Total deductions",
+      "inss": "INSS",
+      "irrf": "IRRF",
+      "employerFgts": "FGTS (employer)",
+      "employerInss": "Employer INSS",
+      "employerTotal": "Total employer cost"
+    },
+    "actions": {
+      "save": "Save simulation",
+      "saved": "Saved"
+    },
+    "simulation": {
+      "defaultName": "Net Salary CLT"
+    },
+    "errors": {
+      "grossSalaryRequired": "Enter the gross salary."
+    },
+    "disclaimer": {
+      "note": "Based on {year} INSS/IR tables. Consult your accountant for official calculations."
+    }
+  },
+  "reservaEmergencia": {
+    "seo": {
+      "title": "Emergency Fund — Auraxis",
+      "description": "Calculate your emergency fund target by professional profile.",
+      "ogTitle": "Emergency Fund | Auraxis",
+      "ogDescription": "Find your emergency fund target and compare investments."
+    },
+    "hero": {
+      "title": "Emergency Fund",
+      "subtitle": "Calculate your emergency fund target by professional profile."
+    },
+    "form": {
+      "title": "Your data",
+      "monthlyExpenses": "Monthly expenses (R$)",
+      "profile": "Professional profile",
+      "currentReserve": "Current reserve (R$)",
+      "monthlyContribution": "Monthly contribution (R$)",
+      "annualReturnPct": "Annual return (%)",
+      "calculate": "Calculate",
+      "reset": "Reset"
+    },
+    "results": {
+      "targetAmount": "Target amount",
+      "profileMonths": "Months of coverage",
+      "gap": "Gap",
+      "monthsToTarget": "Months to target",
+      "chart": {
+        "xAxis": "Month",
+        "balance": "Balance"
+      }
+    },
+    "actions": {
+      "save": "Save simulation",
+      "saved": "Saved",
+      "addAsGoal": "Create goal",
+      "goalAdded": "Goal created"
+    },
+    "simulation": {
+      "defaultName": "Emergency Fund",
+      "goalName": "Emergency Fund"
+    },
+    "errors": {
+      "expensesRequired": "Enter your monthly expenses.",
+      "contributionRequired": "Enter the monthly contribution."
+    },
+    "disclaimer": {
+      "note": "Reference rates may vary. Consult your investment advisor."
+    }
+  },
+  "orcamento5030": {
+    "seo": {
+      "title": "50/30/20 Budget — Auraxis",
+      "description": "Distribute your income with the 50/30/20 rule.",
+      "ogTitle": "50/30/20 Budget | Auraxis",
+      "ogDescription": "Organize your finances with the 50/30/20 rule."
+    },
+    "hero": {
+      "title": "50/30/20 Budget",
+      "subtitle": "Find out how much to allocate to needs, wants, and investments."
+    },
+    "form": {
+      "title": "Your income",
+      "netIncome": "Monthly net income (R$)",
+      "mode": "Mode",
+      "modeSimple": "Simple",
+      "modeDetailed": "Detailed",
+      "actualNeeds": "Actual spending — Needs (R$)",
+      "actualWants": "Actual spending — Wants (R$)",
+      "actualInvestments": "Actual spending — Investments (R$)",
+      "calculate": "Calculate",
+      "reset": "Reset"
+    },
+    "results": {
+      "distribution": "Ideal distribution",
+      "actual": "Actual",
+      "surplus": "Surplus / Deficit",
+      "investmentGoal": "Monthly investment goal"
+    },
+    "actions": {
+      "save": "Save simulation",
+      "saved": "Saved",
+      "addAsGoal": "Create investment goal",
+      "goalAdded": "Goal created"
+    },
+    "simulation": {
+      "defaultName": "50/30/20 Budget",
+      "goalName": "Monthly investment goal"
+    },
+    "errors": {
+      "incomeRequired": "Enter your net income."
+    },
+    "disclaimer": {
+      "note": "The 50/30/20 rule is a general guideline. Adapt to your needs."
+    }
+  },
+  "cet": {
+    "seo": {
+      "title": "CET — Total Effective Cost — Auraxis",
+      "description": "Discover the real cost of a loan by calculating the CET.",
+      "ogTitle": "CET — Total Effective Cost | Auraxis",
+      "ogDescription": "Compare the nominal rate with the real CET."
+    },
+    "hero": {
+      "title": "CET — Total Effective Cost",
+      "subtitle": "Discover the real cost of a loan including IOF, fees, insurance and hidden charges."
+    },
+    "form": {
+      "title": "Loan data",
+      "loanAmount": "Loan amount (R$)",
+      "nominalMonthlyRate": "Nominal monthly rate (%)",
+      "termMonths": "Term (months)",
+      "tac": "Opening fee (R$)",
+      "insurance": "Monthly insurance (R$)",
+      "appraisal": "Appraisal fee (R$)",
+      "iofOverride": "Manual IOF (R$)",
+      "iofAutoPlaceholder": "Auto-calculated",
+      "calculate": "Calculate",
+      "reset": "Reset"
+    },
+    "results": {
+      "cetAnnual": "CET annual",
+      "cetMonthly": "CET monthly",
+      "nominalMonthly": "Nominal monthly",
+      "nominalAnnual": "Nominal annual",
+      "totalPaid": "Total paid",
+      "totalCost": "Total cost",
+      "netReceived": "Net received",
+      "iof": "IOF",
+      "monthlyPayment": "Monthly payment",
+      "costDescription": "Total loan cost"
+    },
+    "actions": {
+      "save": "Save simulation",
+      "saved": "Saved"
+    },
+    "simulation": {
+      "defaultName": "CET — Total Effective Cost"
+    },
+    "errors": {
+      "loanAmountRequired": "Enter the loan amount.",
+      "rateRequired": "Enter the nominal monthly rate.",
+      "termRequired": "Enter the term in months.",
+      "convergenceFailed": "Could not calculate CET. Check your inputs."
+    },
+    "disclaimer": {
+      "note": "Calculation per Bacen resolution 3,517. Consult your loan contract."
+    }
+  },
+  "quitacaoDividas": {
+    "seo": {
+      "title": "Debt Payoff — Auraxis",
+      "description": "Compare Snowball and Avalanche strategies to pay off debt faster.",
+      "ogTitle": "Debt Payoff | Auraxis",
+      "ogDescription": "Find the best strategy to pay off your debts."
+    },
+    "hero": {
+      "title": "Debt Payoff",
+      "subtitle": "Compare Snowball (smallest balance) and Avalanche (highest rate) strategies."
+    },
+    "form": {
+      "title": "Your debts",
+      "debtName": "Debt name",
+      "debtNamePlaceholder": "e.g. Credit card, Loan",
+      "balance": "Balance (R$)",
+      "monthlyRate": "Monthly rate (%)",
+      "minimumPayment": "Minimum payment (R$)",
+      "extraPayment": "Extra monthly payment (R$)",
+      "addDebt": "Add debt",
+      "removeDebt": "Remove",
+      "calculate": "Simulate",
+      "reset": "Reset"
+    },
+    "results": {
+      "totalDebt": "Total debt",
+      "snowballMonths": "Snowball (months)",
+      "avalancheMonths": "Avalanche (months)",
+      "interestSaved": "Interest saved",
+      "best": {
+        "snowball": "Snowball is better",
+        "avalanche": "Avalanche is better"
+      },
+      "goalDescription": "Goal: pay off all debts",
+      "chart": {
+        "xAxis": "Month"
+      }
+    },
+    "actions": {
+      "save": "Save simulation",
+      "saved": "Saved",
+      "addAsGoal": "Create goal",
+      "goalAdded": "Goal created"
+    },
+    "simulation": {
+      "defaultName": "Debt Payoff",
+      "goalName": "Pay off debts"
+    },
+    "errors": {
+      "minTwoDebts": "Add at least 2 debts.",
+      "atLeastOneDebtRequired": "Fill in at least one debt with balance and minimum payment."
+    },
+    "disclaimer": {
+      "note": "Simplified simulation. Actual compound rates and fees may differ."
+    }
+  },
+  "custoEstiloVida": {
+    "seo": {
+      "title": "Lifestyle Cost — Auraxis",
+      "description": "Discover the opportunity cost of your recurring expenses if invested.",
+      "ogTitle": "Lifestyle Cost | Auraxis",
+      "ogDescription": "See how much your recurring expenses would be worth if invested."
+    },
+    "hero": {
+      "title": "Lifestyle Cost",
+      "subtitle": "Discover the true opportunity cost of your recurring expenses."
+    },
+    "form": {
+      "title": "Your recurring expenses",
+      "expenseName": "Expense name",
+      "expenseNamePlaceholder": "e.g. Streaming, Coffee, Gym",
+      "monthlyAmount": "Monthly amount (R$)",
+      "annualReturnPct": "Annual return (%)",
+      "horizonYears": "Horizon (years)",
+      "addExpense": "Add expense",
+      "removeExpense": "Remove",
+      "calculate": "Calculate",
+      "reset": "Reset"
+    },
+    "results": {
+      "totalOpportunityCost": "Total opportunity cost",
+      "totalMonthly": "Total monthly cost",
+      "totalAnnual": "Total annual cost",
+      "horizon": "Horizon"
+    },
+    "actions": {
+      "save": "Save simulation",
+      "saved": "Saved",
+      "addAsGoal": "Create goal",
+      "goalAdded": "Goal created",
+      "copyShareUrl": "Copy share link",
+      "copied": "Link copied!"
+    },
+    "simulation": {
+      "defaultName": "Lifestyle Cost",
+      "goalName": "Investment opportunity"
+    },
+    "errors": {
+      "atLeastOneExpenseRequired": "Add at least one expense with an amount.",
+      "horizonRequired": "Enter the horizon in years."
+    },
+    "disclaimer": {
+      "note": "Based on constant compound return. Actual results may vary."
+    }
   }
 }

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -3229,5 +3229,304 @@
       "realEstate": "Imóveis",
       "personal": "Pessoal"
     }
+  },
+  "salarioLiquido": {
+    "seo": {
+      "title": "Salário Líquido CLT — Auraxis",
+      "description": "Calcule seu salário líquido CLT com todos os descontos: INSS, IR, VT, VA/VR, plano de saúde e custo do empregador.",
+      "ogTitle": "Salário Líquido CLT | Auraxis",
+      "ogDescription": "Descubra quanto você realmente recebe e quanto o empregador paga."
+    },
+    "hero": {
+      "title": "Salário Líquido CLT",
+      "subtitle": "Calcule seu salário líquido com todos os descontos e veja o custo total para o empregador."
+    },
+    "form": {
+      "title": "Dados do salário",
+      "grossSalary": "Salário bruto (R$)",
+      "dependents": "Dependentes (IR)",
+      "healthPlan": "Desconto plano de saúde (R$)",
+      "vaVr": "Desconto VA/VR (R$)",
+      "alimonyPct": "Pensão alimentícia (%)",
+      "vtOptOut": "Não recebo vale-transporte",
+      "unionContribution": "Contribuição sindical (1 dia)",
+      "calculate": "Calcular",
+      "reset": "Limpar"
+    },
+    "results": {
+      "netSalary": "Salário líquido",
+      "totalDeductions": "Total de descontos",
+      "inss": "INSS",
+      "irrf": "IRRF",
+      "employerFgts": "FGTS (empregador)",
+      "employerInss": "INSS patronal",
+      "employerTotal": "Custo total empregador"
+    },
+    "actions": {
+      "save": "Salvar simulação",
+      "saved": "Simulação salva"
+    },
+    "simulation": {
+      "defaultName": "Salário Líquido CLT"
+    },
+    "errors": {
+      "grossSalaryRequired": "Informe o salário bruto."
+    },
+    "disclaimer": {
+      "note": "Valores baseados nas tabelas INSS/IR de {year}. Consulte seu contador para cálculos oficiais."
+    }
+  },
+  "reservaEmergencia": {
+    "seo": {
+      "title": "Reserva de Emergência — Auraxis",
+      "description": "Calcule sua meta de reserva de emergência por perfil profissional e veja em quanto tempo você atinge o objetivo.",
+      "ogTitle": "Reserva de Emergência | Auraxis",
+      "ogDescription": "Descubra sua meta de reserva de emergência e compare investimentos."
+    },
+    "hero": {
+      "title": "Reserva de Emergência",
+      "subtitle": "Calcule sua meta de reserva por perfil profissional e planeje quanto guardar por mês."
+    },
+    "form": {
+      "title": "Seus dados",
+      "monthlyExpenses": "Despesas fixas mensais (R$)",
+      "profile": "Perfil profissional",
+      "currentReserve": "Reserva atual (R$)",
+      "monthlyContribution": "Aporte mensal (R$)",
+      "annualReturnPct": "Rentabilidade anual (%)",
+      "calculate": "Calcular",
+      "reset": "Limpar"
+    },
+    "results": {
+      "targetAmount": "Meta de reserva",
+      "profileMonths": "Meses de cobertura",
+      "gap": "Falta acumular",
+      "monthsToTarget": "Meses para atingir",
+      "chart": {
+        "xAxis": "Mês",
+        "balance": "Saldo acumulado"
+      }
+    },
+    "actions": {
+      "save": "Salvar simulação",
+      "saved": "Simulação salva",
+      "addAsGoal": "Criar meta",
+      "goalAdded": "Meta criada"
+    },
+    "simulation": {
+      "defaultName": "Reserva de Emergência",
+      "goalName": "Reserva de Emergência"
+    },
+    "errors": {
+      "expensesRequired": "Informe suas despesas mensais.",
+      "contributionRequired": "Informe o aporte mensal."
+    },
+    "disclaimer": {
+      "note": "Taxas de referência podem variar. Consulte seu assessor de investimentos."
+    }
+  },
+  "orcamento5030": {
+    "seo": {
+      "title": "Orçamento 50/30/20 — Auraxis",
+      "description": "Distribua sua renda em necessidades, desejos e investimentos com a regra 50/30/20.",
+      "ogTitle": "Orçamento 50/30/20 | Auraxis",
+      "ogDescription": "Organize suas finanças com a regra 50/30/20."
+    },
+    "hero": {
+      "title": "Orçamento 50/30/20",
+      "subtitle": "Descubra quanto destinar para necessidades, desejos e investimentos."
+    },
+    "form": {
+      "title": "Sua renda",
+      "netIncome": "Renda líquida mensal (R$)",
+      "mode": "Modo",
+      "modeSimple": "Simples",
+      "modeDetailed": "Detalhado",
+      "actualNeeds": "Gastos reais — Necessidades (R$)",
+      "actualWants": "Gastos reais — Desejos (R$)",
+      "actualInvestments": "Gastos reais — Investimentos (R$)",
+      "calculate": "Calcular",
+      "reset": "Limpar"
+    },
+    "results": {
+      "distribution": "Distribuição ideal",
+      "actual": "Real",
+      "surplus": "Sobra / Déficit",
+      "investmentGoal": "Meta mensal de investimento"
+    },
+    "actions": {
+      "save": "Salvar simulação",
+      "saved": "Simulação salva",
+      "addAsGoal": "Criar meta de investimento",
+      "goalAdded": "Meta criada"
+    },
+    "simulation": {
+      "defaultName": "Orçamento 50/30/20",
+      "goalName": "Meta de investimento mensal"
+    },
+    "errors": {
+      "incomeRequired": "Informe sua renda líquida."
+    },
+    "disclaimer": {
+      "note": "A regra 50/30/20 é uma referência geral. Adapte às suas necessidades."
+    }
+  },
+  "cet": {
+    "seo": {
+      "title": "CET — Custo Efetivo Total — Auraxis",
+      "description": "Descubra o custo real de um financiamento calculando o CET com IOF, TAC, seguro e todos os encargos.",
+      "ogTitle": "CET — Custo Efetivo Total | Auraxis",
+      "ogDescription": "Compare a taxa nominal com o CET real e saiba quanto você vai pagar."
+    },
+    "hero": {
+      "title": "CET — Custo Efetivo Total",
+      "subtitle": "Descubra o custo real de um financiamento, incluindo IOF, TAC, seguro e encargos ocultos."
+    },
+    "form": {
+      "title": "Dados do financiamento",
+      "loanAmount": "Valor financiado (R$)",
+      "nominalMonthlyRate": "Taxa nominal mensal (%)",
+      "termMonths": "Prazo (meses)",
+      "tac": "TAC — Taxa de abertura (R$)",
+      "insurance": "Seguro mensal (R$)",
+      "appraisal": "Avaliação do bem (R$)",
+      "iofOverride": "IOF manual (R$)",
+      "iofAutoPlaceholder": "Auto-calculado",
+      "calculate": "Calcular",
+      "reset": "Limpar"
+    },
+    "results": {
+      "cetAnnual": "CET anual",
+      "cetMonthly": "CET mensal",
+      "nominalMonthly": "Taxa nominal mensal",
+      "nominalAnnual": "Taxa nominal anual",
+      "totalPaid": "Total pago",
+      "totalCost": "Custo total dos encargos",
+      "netReceived": "Valor líquido recebido",
+      "iof": "IOF",
+      "monthlyPayment": "Parcela mensal",
+      "costDescription": "Custo total do financiamento"
+    },
+    "actions": {
+      "save": "Salvar simulação",
+      "saved": "Simulação salva"
+    },
+    "simulation": {
+      "defaultName": "CET — Custo Efetivo Total"
+    },
+    "errors": {
+      "loanAmountRequired": "Informe o valor financiado.",
+      "rateRequired": "Informe a taxa nominal mensal.",
+      "termRequired": "Informe o prazo em meses.",
+      "convergenceFailed": "Não foi possível calcular o CET. Verifique os valores informados."
+    },
+    "disclaimer": {
+      "note": "Cálculo conforme resolução Bacen nº 3.517. Consulte o contrato do seu financiamento."
+    }
+  },
+  "quitacaoDividas": {
+    "seo": {
+      "title": "Quitação de Dívidas — Auraxis",
+      "description": "Compare Snowball e Avalanche para quitar suas dívidas mais rápido e pagar menos juros.",
+      "ogTitle": "Quitação de Dívidas | Auraxis",
+      "ogDescription": "Descubra a melhor estratégia para quitar suas dívidas."
+    },
+    "hero": {
+      "title": "Quitação de Dívidas",
+      "subtitle": "Compare estratégias Snowball (menor saldo) e Avalanche (maior taxa) para quitar dívidas."
+    },
+    "form": {
+      "title": "Suas dívidas",
+      "debtName": "Nome da dívida",
+      "debtNamePlaceholder": "Ex: Cartão, Empréstimo",
+      "balance": "Saldo devedor (R$)",
+      "monthlyRate": "Taxa mensal (%)",
+      "minimumPayment": "Pagamento mínimo (R$)",
+      "extraPayment": "Pagamento extra mensal (R$)",
+      "addDebt": "Adicionar dívida",
+      "removeDebt": "Remover",
+      "calculate": "Simular",
+      "reset": "Limpar"
+    },
+    "results": {
+      "totalDebt": "Dívida total",
+      "snowballMonths": "Snowball (meses)",
+      "avalancheMonths": "Avalanche (meses)",
+      "interestSaved": "Economia em juros",
+      "best": {
+        "snowball": "Snowball é melhor",
+        "avalanche": "Avalanche é melhor"
+      },
+      "goalDescription": "Meta: quitar todas as dívidas",
+      "chart": {
+        "xAxis": "Mês"
+      }
+    },
+    "actions": {
+      "save": "Salvar simulação",
+      "saved": "Simulação salva",
+      "addAsGoal": "Criar meta",
+      "goalAdded": "Meta criada"
+    },
+    "simulation": {
+      "defaultName": "Quitação de Dívidas",
+      "goalName": "Quitar dívidas"
+    },
+    "errors": {
+      "minTwoDebts": "Adicione pelo menos 2 dívidas.",
+      "atLeastOneDebtRequired": "Preencha ao menos uma dívida com saldo e pagamento mínimo."
+    },
+    "disclaimer": {
+      "note": "Simulação simplificada. Taxas compostas e encargos reais podem diferir."
+    }
+  },
+  "custoEstiloVida": {
+    "seo": {
+      "title": "Custo do Estilo de Vida — Auraxis",
+      "description": "Descubra o custo de oportunidade dos seus gastos recorrentes se investidos ao longo do tempo.",
+      "ogTitle": "Custo do Estilo de Vida | Auraxis",
+      "ogDescription": "Veja quanto seus gastos recorrentes custariam se fossem investidos."
+    },
+    "hero": {
+      "title": "Custo do Estilo de Vida",
+      "subtitle": "Descubra o verdadeiro custo de oportunidade dos seus gastos recorrentes."
+    },
+    "form": {
+      "title": "Seus gastos recorrentes",
+      "expenseName": "Nome do gasto",
+      "expenseNamePlaceholder": "Ex: Streaming, Café, Academia",
+      "monthlyAmount": "Valor mensal (R$)",
+      "annualReturnPct": "Rentabilidade anual (%)",
+      "horizonYears": "Horizonte (anos)",
+      "addExpense": "Adicionar gasto",
+      "removeExpense": "Remover",
+      "calculate": "Calcular",
+      "reset": "Limpar"
+    },
+    "results": {
+      "totalOpportunityCost": "Custo de oportunidade total",
+      "totalMonthly": "Custo mensal total",
+      "totalAnnual": "Custo anual total",
+      "horizon": "Horizonte"
+    },
+    "actions": {
+      "save": "Salvar simulação",
+      "saved": "Simulação salva",
+      "addAsGoal": "Criar meta",
+      "goalAdded": "Meta criada",
+      "copyShareUrl": "Copiar link para compartilhar",
+      "copied": "Link copiado!"
+    },
+    "simulation": {
+      "defaultName": "Custo do Estilo de Vida",
+      "goalName": "Oportunidade de investimento"
+    },
+    "errors": {
+      "atLeastOneExpenseRequired": "Adicione pelo menos um gasto com valor.",
+      "horizonRequired": "Informe o horizonte em anos."
+    },
+    "disclaimer": {
+      "note": "Simulação baseada em rentabilidade composta constante. Resultados reais podem variar."
+    }
   }
 }

--- a/app/pages/tools/cet.spec.ts
+++ b/app/pages/tools/cet.spec.ts
@@ -1,0 +1,149 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { computed, ref, type App, type ComputedRef } from "vue";
+
+import CetPage from "./cet.vue";
+import type { CetResult } from "~/features/tools/model/cet";
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockSaveMutateAsync = vi.hoisted(() => vi.fn());
+const mockCaptureException = vi.hoisted(() => vi.fn());
+const mockValidate = vi.hoisted(() => vi.fn().mockReturnValue([]));
+const mockCalculate = vi.hoisted(() => vi.fn());
+const mockIsAuthenticated = ref(false);
+const mockHasPremiumAccess = ref(false);
+
+vi.mock("vue-i18n", () => ({ useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({ t: (key: string) => key, n: (v: number) => String(v) }) }));
+vi.mock("#imports", () => ({ definePageMeta: vi.fn(), useHead: vi.fn(), useSeoMeta: vi.fn(), useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({ t: (key: string) => key, n: (v: number) => String(v) }), useRouter: (): { push: typeof mockPush } => ({ push: mockPush }) }));
+vi.mock("#app", () => ({ useRouter: (): { push: typeof mockPush } => ({ push: mockPush }) }));
+vi.mock("echarts/core", () => ({ use: vi.fn() }));
+vi.mock("echarts/charts", () => ({ LineChart: {} }));
+vi.mock("echarts/components", () => ({ GridComponent: {}, TooltipComponent: {}, LegendComponent: {} }));
+vi.mock("echarts/renderers", () => ({ CanvasRenderer: {} }));
+vi.mock("vue-echarts", () => ({ default: { props: ["option", "autoresize"], template: "<div class='v-chart'></div>" } }));
+
+vi.mock("naive-ui", () => ({
+  NAlert: { props: ["type"], template: "<div class='n-alert'><slot /></div>" },
+  NButton: { props: ["type", "size", "loading", "disabled", "quaternary", "block", "attrType"], template: "<button class='n-button' @click='$emit(\"click\")'><slot /></button>", emits: ["click"] },
+  NForm: { emits: ["submit"], template: "<form @submit.prevent='$emit(\"submit\", $event)'><slot /></form>" },
+  NFormItem: { props: ["label"], template: "<div class='n-form-item'><slot /></div>" },
+  NInputNumber: { props: ["value", "min", "max", "precision", "prefix", "placeholder"], emits: ["update:value"], template: "<input class='n-input-number' />" },
+  NSpace: { props: ["vertical", "size"], template: "<div><slot /></div>" },
+  NThing: { props: ["title", "description"], template: "<div class='n-thing'>{{ title }}</div>" },
+  useMessage: vi.fn(() => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() })),
+}));
+
+vi.mock("@tanstack/vue-query", async () => {
+  const actual = await vi.importActual("@tanstack/vue-query");
+  return { ...actual, useQuery: vi.fn(() => ({ data: mockHasPremiumAccess, isLoading: ref(false), isError: ref(false) })), useMutation: vi.fn(() => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false), isError: ref(false) })) };
+});
+
+vi.mock("~/stores/session", () => ({ useSessionStore: (): { isAuthenticated: boolean } => ({ get isAuthenticated(): boolean { return mockIsAuthenticated.value; } }) }));
+vi.mock("~/features/tools/composables/useToolCta", () => ({ useToolCta: (): { showCta: ComputedRef<boolean> } => ({ showCta: computed(() => !mockIsAuthenticated.value) }) }));
+vi.mock("~/composables/useApiError", () => ({ useApiError: (): { getErrorMessage: (err: unknown) => string } => ({ getErrorMessage: vi.fn((err: unknown): string => String(err)) }) }));
+vi.mock("~/core/observability", () => ({ captureException: mockCaptureException }));
+
+vi.mock("~/features/tools/model/cet", () => ({
+  createDefaultCetFormState: (): object => ({ loanAmount: null, nominalMonthlyRatePct: null, termMonths: null, tacAmount: 0, insuranceMonthly: 0, appraisalFee: 0, iofOverride: null }),
+  validateCetForm: mockValidate,
+  calculateCet: mockCalculate,
+}));
+
+vi.mock("~/features/simulations/queries/use-save-simulation-mutation", () => ({ useSaveSimulationMutation: (): { mutateAsync: typeof mockSaveMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false) }) }));
+vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({ useEntitlementQuery: (): { data: typeof mockHasPremiumAccess; isLoading: ReturnType<typeof ref<boolean>> } => ({ data: mockHasPremiumAccess, isLoading: ref(false) }) }));
+
+const mockResult: CetResult = {
+  cetMonthlyPct: 2.15, cetAnnualPct: 28.95, nominalMonthlyPct: 1.5, nominalAnnualPct: 19.56,
+  totalPaid: 13000, totalCost: 3500, iofAmount: 150, netAmountReceived: 9550,
+  monthlyPayment: 1083.33, cashFlows: [{ month: 1, payment: 1083.33, insurance: 0, totalPayment: 1083.33 }],
+};
+
+const globalStubs = {
+  NuxtLayout: { props: ["name"], template: "<div class='nuxt-layout'><slot /></div>" },
+  UiPageHeader: { props: ["title", "subtitle"], template: "<div class='ui-page-header'><h1>{{ title }}</h1></div>" },
+  UiGlassPanel: { props: ["glow"], template: "<div class='ui-glass-panel'><slot /></div>" },
+  UiSurfaceCard: { template: "<div class='ui-surface-card'><slot /></div>" },
+  UiStickySummaryCard: { template: "<div class='ui-sticky-summary-card'><slot /></div>" },
+  CalculatorFormSection: { props: ["title"], template: "<div class='calculator-form-section'><slot /></div>" },
+  CalculatorResultSummary: { props: ["label", "value", "metrics"], template: "<div class='calculator-result-summary'>{{ label }}: {{ value }}</div>" },
+  ToolGuestCta: { template: "<div class='tool-guest-cta'>guest-cta</div>" },
+  ToolSaveResult: { props: ["intent", "label", "amount", "description"], template: "<div class='tool-save-result-stub' />" },
+};
+
+/**
+ *
+ * @param app
+ */
+function nuxtContextPlugin(app: App): void {
+  Reflect.set(app, "$nuxt", {
+    _route: { path: "/tools/cet", meta: {}, params: {}, query: {} },
+    $router: { push: mockPush, replace: vi.fn() }, $config: { public: {} }, payload: { serverRendered: false },
+    ssrContext: { head: { push: vi.fn(() => ({ patch: vi.fn(), dispose: vi.fn() })) } },
+    static: { data: {} }, isHydrating: false, deferHydration: (): void => {},
+    runWithContext: <T>(cb: () => T): T => cb(), hooks: { callHook: vi.fn(), hook: vi.fn() }, _asyncDataPromises: {}, _asyncData: {},
+  });
+}
+
+/**
+ * @returns Mounted component wrapper.
+ */
+function mountPage(): ReturnType<typeof mount> { return mount(CetPage, { global: { plugins: [{ install: nuxtContextPlugin }], stubs: globalStubs } }); }
+
+/**
+ *
+ */
+function resetState(): void {
+  setActivePinia(createPinia()); mockPush.mockClear(); mockSaveMutateAsync.mockReset();
+  mockCaptureException.mockClear(); mockValidate.mockReturnValue([]); mockCalculate.mockReset();
+  mockIsAuthenticated.value = false; mockHasPremiumAccess.value = false;
+}
+
+describe("CetPage — guest layout", () => {
+  beforeEach(resetState);
+  it("renders NuxtLayout", () => { expect(mountPage().find(".nuxt-layout").exists()).toBe(true); });
+  it("shows guest CTA after calculation", async () => {
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".tool-guest-cta").exists()).toBe(true);
+  });
+});
+
+describe("CetPage — form validation", () => {
+  beforeEach(resetState);
+  it("shows validation error", async () => {
+    mockValidate.mockReturnValue([{ field: "loanAmount", messageKey: "errors.loanAmountRequired" }]);
+    const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".n-alert").exists()).toBe(true);
+    expect(mockCalculate).not.toHaveBeenCalled();
+  });
+  it("shows convergence error when calculation returns null", async () => {
+    mockCalculate.mockReturnValue(null); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".n-alert").exists()).toBe(true);
+  });
+});
+
+describe("CetPage — results", () => {
+  beforeEach(resetState);
+  it("shows result summary", async () => {
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".calculator-result-summary").exists()).toBe(true);
+  });
+  it("does not show results before calculation", () => {
+    expect(mountPage().find(".calculator-result-summary").exists()).toBe(false);
+  });
+});
+
+describe("CetPage — save simulation", () => {
+  beforeEach(resetState);
+  it("calls saveSimulationMutation with correct slug", async () => {
+    mockIsAuthenticated.value = true; mockCalculate.mockReturnValue(mockResult);
+    mockSaveMutateAsync.mockResolvedValue({ id: "sim-cet-1" });
+    const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
+    const btn = w.findAll(".n-button").find((b) => b.text().includes("cet.actions.save"));
+    await btn!.trigger("click"); await flushPromises();
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "cet" }));
+  });
+});

--- a/app/pages/tools/cet.vue
+++ b/app/pages/tools/cet.vue
@@ -1,0 +1,230 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import {
+  NAlert,
+  NButton,
+  NForm,
+  NFormItem,
+  NInputNumber,
+  NSpace,
+  NThing,
+  useMessage,
+} from "naive-ui";
+
+import { captureException } from "~/core/observability";
+import { useApiError } from "~/composables/useApiError";
+import { useCalculatorFormState } from "~/features/tools/composables/use-calculator-form-state";
+import { useSessionStore } from "~/stores/session";
+import { useSaveSimulationMutation } from "~/features/simulations/queries/use-save-simulation-mutation";
+import {
+  calculateCet,
+  createDefaultCetFormState,
+  validateCetForm,
+  type CetFormState,
+  type CetResult,
+} from "~/features/tools/model/cet";
+import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
+import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
+import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
+import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
+import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
+import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
+import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+
+definePageMeta({ layout: false });
+
+const { t, n } = useI18n();
+const toast = useMessage();
+const { getErrorMessage } = useApiError();
+const sessionStore = useSessionStore();
+
+useSeoMeta({
+  title: t("cet.seo.title"),
+  description: t("cet.seo.description"),
+  ogTitle: t("cet.seo.ogTitle"),
+  ogDescription: t("cet.seo.ogDescription"),
+  twitterCard: "summary_large_image",
+});
+
+const isAuthenticated = computed<boolean>(() => sessionStore.isAuthenticated);
+
+const { form, validationError, patch, reset, setValidationError } =
+  useCalculatorFormState<CetFormState>(createDefaultCetFormState);
+
+const result = ref<CetResult | null>(null);
+const savedSimulationId = ref<string | null>(null);
+
+const saveSimulationMutation = useSaveSimulationMutation();
+
+/**
+ * @param value
+ * @returns BRL-formatted string.
+ */
+function formatBrl(value: number): string {
+  return n(value, "currency");
+}
+
+/**
+ * @returns void
+ */
+function handleCalculate(): void {
+  const errors = validateCetForm(form.value);
+  if (errors.length > 0) {
+    const first = errors[0];
+    setValidationError(first ? t(`cet.${first.messageKey}`) : null);
+    return;
+  }
+  setValidationError(null);
+  savedSimulationId.value = null;
+  const calculated = calculateCet(form.value);
+  if (!calculated) {
+    setValidationError(t("cet.errors.convergenceFailed"));
+    return;
+  }
+  result.value = calculated;
+}
+
+/**
+ *
+ */
+function handleReset(): void {
+  reset();
+  result.value = null;
+  savedSimulationId.value = null;
+}
+
+/**
+ *
+ */
+async function handleSaveSimulation(): Promise<void> {
+  if (savedSimulationId.value || !result.value) { return; }
+  try {
+    const sim = await saveSimulationMutation.mutateAsync({
+      name: t("cet.simulation.defaultName"),
+      toolSlug: "cet",
+      inputs: { ...form.value },
+      result: {
+        cetMonthlyPct: result.value.cetMonthlyPct,
+        cetAnnualPct: result.value.cetAnnualPct,
+        totalPaid: result.value.totalPaid,
+        totalCost: result.value.totalCost,
+      },
+    });
+    savedSimulationId.value = sim.id;
+  } catch (err) {
+    captureException(err, { context: "cet/save-simulation" });
+    toast.error(getErrorMessage(err));
+  }
+}
+
+const summaryMetrics = computed(() => {
+  if (!result.value) { return []; }
+  return [
+    { label: t("cet.results.cetMonthly"), value: `${result.value.cetMonthlyPct.toFixed(2)}% a.m.` },
+    { label: t("cet.results.nominalMonthly"), value: `${result.value.nominalMonthlyPct.toFixed(2)}% a.m.` },
+    { label: t("cet.results.nominalAnnual"), value: `${result.value.nominalAnnualPct.toFixed(2)}% a.a.` },
+    { label: t("cet.results.totalPaid"), value: formatBrl(result.value.totalPaid) },
+    { label: t("cet.results.totalCost"), value: formatBrl(result.value.totalCost) },
+  ];
+});
+
+const isSaved = computed(() => savedSimulationId.value !== null);
+const isBridging = computed(() => saveSimulationMutation.isPending.value);
+</script>
+
+<template>
+  <div class="cet-root">
+  <NuxtLayout :name="isAuthenticated ? 'default' : 'tools-public'">
+    <div class="cet-page">
+      <div class="cet-page__layout">
+        <div class="cet-page__form-col">
+          <UiPageHeader
+            :title="t('cet.hero.title')"
+            :subtitle="t('cet.hero.subtitle')"
+          />
+
+          <UiGlassPanel>
+            <NForm @submit.prevent="handleCalculate">
+              <CalculatorFormSection :title="t('cet.form.title')">
+                <NFormItem :label="t('cet.form.loanAmount')">
+                  <NInputNumber :value="form.loanAmount" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => patch({ loanAmount: v })" />
+                </NFormItem>
+
+                <NFormItem :label="t('cet.form.nominalMonthlyRate')">
+                  <NInputNumber :value="form.nominalMonthlyRatePct" :min="0" :precision="2" style="width: 100%" @update:value="(v) => patch({ nominalMonthlyRatePct: v })" />
+                </NFormItem>
+
+                <NFormItem :label="t('cet.form.termMonths')">
+                  <NInputNumber :value="form.termMonths" :min="1" :precision="0" style="width: 100%" @update:value="(v) => patch({ termMonths: v })" />
+                </NFormItem>
+
+                <NFormItem :label="t('cet.form.tac')">
+                  <NInputNumber :value="form.tacAmount" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => patch({ tacAmount: v ?? 0 })" />
+                </NFormItem>
+
+                <NFormItem :label="t('cet.form.insurance')">
+                  <NInputNumber :value="form.insuranceMonthly" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => patch({ insuranceMonthly: v ?? 0 })" />
+                </NFormItem>
+
+                <NFormItem :label="t('cet.form.appraisal')">
+                  <NInputNumber :value="form.appraisalFee" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => patch({ appraisalFee: v ?? 0 })" />
+                </NFormItem>
+
+                <NFormItem :label="t('cet.form.iofOverride')">
+                  <NInputNumber :value="form.iofOverride" :min="0" :precision="2" prefix="R$" :placeholder="t('cet.form.iofAutoPlaceholder')" style="width: 100%" @update:value="(v) => patch({ iofOverride: v })" />
+                </NFormItem>
+              </CalculatorFormSection>
+
+              <NAlert v-if="validationError" type="error" style="margin-bottom: 16px">
+                {{ validationError }}
+              </NAlert>
+
+              <NSpace style="margin-top: 16px">
+                <NButton type="primary" attr-type="submit" :loading="isBridging">
+                  {{ t('cet.form.calculate') }}
+                </NButton>
+                <NButton quaternary @click="handleReset">
+                  {{ t('cet.form.reset') }}
+                </NButton>
+              </NSpace>
+            </NForm>
+          </UiGlassPanel>
+        </div>
+
+        <div v-if="result" class="cet-page__result-col">
+          <UiStickySummaryCard>
+            <CalculatorResultSummary
+              :label="t('cet.results.cetAnnual')"
+              :value="`${result.cetAnnualPct.toFixed(2)}% a.a.`"
+              :metrics="summaryMetrics"
+            />
+
+            <ToolSaveResult
+              intent="expense"
+              :label="t('cet.hero.title')"
+              :amount="result.totalCost"
+              :description="t('cet.results.costDescription')"
+            />
+
+            <NSpace vertical style="margin-top: 16px">
+              <NButton v-if="isAuthenticated" :loading="saveSimulationMutation.isPending.value" :disabled="isSaved" block @click="handleSaveSimulation">
+                {{ isSaved ? t('cet.actions.saved') : t('cet.actions.save') }}
+              </NButton>
+            </NSpace>
+          </UiStickySummaryCard>
+
+          <UiSurfaceCard>
+            <NThing :title="t('cet.results.netReceived')" :description="formatBrl(result.netAmountReceived)" />
+            <NThing :title="t('cet.results.iof')" :description="formatBrl(result.iofAmount)" />
+            <NThing :title="t('cet.results.monthlyPayment')" :description="formatBrl(result.monthlyPayment)" />
+          </UiSurfaceCard>
+
+          <p class="cet-page__disclaimer">{{ t('cet.disclaimer.note') }}</p>
+        </div>
+      </div>
+    </div>
+    <ToolGuestCta v-if="!isAuthenticated" />
+  </NuxtLayout>
+  </div>
+</template>

--- a/app/pages/tools/custo-estilo-vida.spec.ts
+++ b/app/pages/tools/custo-estilo-vida.spec.ts
@@ -1,0 +1,165 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { computed, ref, type App, type ComputedRef } from "vue";
+
+import CustoEstiloVidaPage from "./custo-estilo-vida.vue";
+import type { CustoEstiloVidaResult } from "~/features/tools/model/custo-estilo-vida";
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockSaveMutateAsync = vi.hoisted(() => vi.fn());
+const mockCreateGoalMutateAsync = vi.hoisted(() => vi.fn());
+const mockCaptureException = vi.hoisted(() => vi.fn());
+const mockValidate = vi.hoisted(() => vi.fn().mockReturnValue([]));
+const mockCalculate = vi.hoisted(() => vi.fn());
+const mockIsAuthenticated = ref(false);
+const mockHasPremiumAccess = ref(false);
+
+vi.mock("vue-i18n", () => ({ useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({ t: (key: string) => key, n: (v: number) => String(v) }) }));
+vi.mock("#imports", () => ({ definePageMeta: vi.fn(), useHead: vi.fn(), useSeoMeta: vi.fn(), useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({ t: (key: string) => key, n: (v: number) => String(v) }), useRouter: (): { push: typeof mockPush } => ({ push: mockPush }) }));
+vi.mock("#app", () => ({ useRouter: (): { push: typeof mockPush } => ({ push: mockPush }) }));
+vi.mock("echarts/core", () => ({ use: vi.fn() }));
+vi.mock("echarts/charts", () => ({ LineChart: {} }));
+vi.mock("echarts/components", () => ({ GridComponent: {}, TooltipComponent: {}, LegendComponent: {} }));
+vi.mock("echarts/renderers", () => ({ CanvasRenderer: {} }));
+vi.mock("vue-echarts", () => ({ default: { props: ["option", "autoresize"], template: "<div class='v-chart'></div>" } }));
+
+vi.mock("naive-ui", () => ({
+  NAlert: { props: ["type"], template: "<div class='n-alert'><slot /></div>" },
+  NButton: { props: ["type", "size", "loading", "disabled", "quaternary", "block", "attrType"], template: "<button class='n-button' @click='$emit(\"click\")'><slot /></button>", emits: ["click"] },
+  NForm: { emits: ["submit"], template: "<form @submit.prevent='$emit(\"submit\", $event)'><slot /></form>" },
+  NFormItem: { props: ["label"], template: "<div class='n-form-item'><slot /></div>" },
+  NInput: { props: ["value", "placeholder"], emits: ["update:value"], template: "<input class='n-input' />" },
+  NInputNumber: { props: ["value", "min", "max", "precision", "prefix"], emits: ["update:value"], template: "<input class='n-input-number' />" },
+  NSpace: { props: ["vertical", "size"], template: "<div><slot /></div>" },
+  NThing: { props: ["title", "description"], template: "<div class='n-thing'>{{ title }}</div>" },
+  useMessage: vi.fn(() => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() })),
+}));
+
+vi.mock("@tanstack/vue-query", async () => {
+  const actual = await vi.importActual("@tanstack/vue-query");
+  return { ...actual, useQuery: vi.fn(() => ({ data: mockHasPremiumAccess, isLoading: ref(false), isError: ref(false) })), useMutation: vi.fn(() => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false), isError: ref(false) })) };
+});
+
+vi.mock("~/stores/session", () => ({ useSessionStore: (): { isAuthenticated: boolean } => ({ get isAuthenticated(): boolean { return mockIsAuthenticated.value; } }) }));
+vi.mock("~/features/tools/composables/useToolCta", () => ({ useToolCta: (): { showCta: ComputedRef<boolean> } => ({ showCta: computed(() => !mockIsAuthenticated.value) }) }));
+vi.mock("~/composables/useApiError", () => ({ useApiError: (): { getErrorMessage: (err: unknown) => string } => ({ getErrorMessage: vi.fn((err: unknown): string => String(err)) }) }));
+vi.mock("~/core/observability", () => ({ captureException: mockCaptureException }));
+
+vi.mock("~/features/tools/model/custo-estilo-vida", () => ({
+  createDefaultExpense: (): object => ({ name: "", monthlyAmount: 0 }),
+  createDefaultCustoEstiloVidaFormState: (): object => ({ expenses: [{ name: "", monthlyAmount: 0 }, { name: "", monthlyAmount: 0 }], annualReturnPct: 12, horizonYears: 10 }),
+  decodeQueryToForm: vi.fn().mockReturnValue(null),
+  encodeFormToQuery: vi.fn().mockReturnValue("encoded"),
+  validateCustoEstiloVidaForm: mockValidate,
+  calculateCustoEstiloVida: mockCalculate,
+}));
+
+vi.mock("~/features/simulations/queries/use-save-simulation-mutation", () => ({ useSaveSimulationMutation: (): { mutateAsync: typeof mockSaveMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false) }) }));
+vi.mock("~/features/goals/queries/use-create-goal-mutation", () => ({ useCreateGoalMutation: (): { mutateAsync: typeof mockCreateGoalMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockCreateGoalMutateAsync, isPending: ref(false) }) }));
+vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({ useEntitlementQuery: (): { data: typeof mockHasPremiumAccess; isLoading: ReturnType<typeof ref<boolean>> } => ({ data: mockHasPremiumAccess, isLoading: ref(false) }) }));
+
+const mockResult: CustoEstiloVidaResult = {
+  totalMonthlyCost: 250, totalAnnualCost: 3000, totalOpportunityCost: 55000,
+  expenses: [
+    { name: "Streaming", monthlyAmount: 50, annualCost: 600, opportunityCost: 11000 },
+    { name: "Café", monthlyAmount: 200, annualCost: 2400, opportunityCost: 44000 },
+  ],
+  horizonYears: 10,
+};
+
+const globalStubs = {
+  NuxtLayout: { props: ["name"], template: "<div class='nuxt-layout'><slot /></div>" },
+  UiPageHeader: { props: ["title", "subtitle"], template: "<div class='ui-page-header'><h1>{{ title }}</h1></div>" },
+  UiGlassPanel: { props: ["glow"], template: "<div class='ui-glass-panel'><slot /></div>" },
+  UiSurfaceCard: { template: "<div class='ui-surface-card'><slot /></div>" },
+  UiStickySummaryCard: { template: "<div class='ui-sticky-summary-card'><slot /></div>" },
+  CalculatorFormSection: { props: ["title"], template: "<div class='calculator-form-section'><slot /></div>" },
+  CalculatorResultSummary: { props: ["label", "value", "metrics"], template: "<div class='calculator-result-summary'>{{ label }}: {{ value }}</div>" },
+  ToolGuestCta: { template: "<div class='tool-guest-cta'>guest-cta</div>" },
+  ToolSaveResult: { props: ["intent", "label", "amount", "description"], template: "<div class='tool-save-result-stub' />" },
+};
+
+/**
+ *
+ * @param app
+ */
+function nuxtContextPlugin(app: App): void {
+  Reflect.set(app, "$nuxt", {
+    _route: { path: "/tools/custo-estilo-vida", meta: {}, params: {}, query: {} },
+    $router: { push: mockPush, replace: vi.fn() }, $config: { public: {} }, payload: { serverRendered: false },
+    ssrContext: { head: { push: vi.fn(() => ({ patch: vi.fn(), dispose: vi.fn() })) } },
+    static: { data: {} }, isHydrating: false, deferHydration: (): void => {},
+    runWithContext: <T>(cb: () => T): T => cb(), hooks: { callHook: vi.fn(), hook: vi.fn() }, _asyncDataPromises: {}, _asyncData: {},
+  });
+}
+
+/**
+ * @returns Mounted component wrapper.
+ */
+function mountPage(): ReturnType<typeof mount> { return mount(CustoEstiloVidaPage, { global: { plugins: [{ install: nuxtContextPlugin }], stubs: globalStubs } }); }
+
+/**
+ *
+ */
+function resetState(): void {
+  setActivePinia(createPinia()); mockPush.mockClear(); mockSaveMutateAsync.mockReset();
+  mockCreateGoalMutateAsync.mockReset(); mockCaptureException.mockClear();
+  mockValidate.mockReturnValue([]); mockCalculate.mockReset();
+  mockIsAuthenticated.value = false; mockHasPremiumAccess.value = false;
+}
+
+describe("CustoEstiloVidaPage — guest layout", () => {
+  beforeEach(resetState);
+  it("renders NuxtLayout", () => { expect(mountPage().find(".nuxt-layout").exists()).toBe(true); });
+  it("shows guest CTA after calculation", async () => {
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".tool-guest-cta").exists()).toBe(true);
+  });
+});
+
+describe("CustoEstiloVidaPage — form validation", () => {
+  beforeEach(resetState);
+  it("shows validation error", async () => {
+    mockValidate.mockReturnValue([{ field: "expenses", messageKey: "errors.atLeastOneExpenseRequired" }]);
+    const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".n-alert").exists()).toBe(true);
+    expect(mockCalculate).not.toHaveBeenCalled();
+  });
+});
+
+describe("CustoEstiloVidaPage — results", () => {
+  beforeEach(resetState);
+  it("shows result summary", async () => {
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".calculator-result-summary").exists()).toBe(true);
+  });
+  it("does not show results before calculation", () => {
+    expect(mountPage().find(".calculator-result-summary").exists()).toBe(false);
+  });
+});
+
+describe("CustoEstiloVidaPage — save simulation", () => {
+  beforeEach(resetState);
+  it("calls saveSimulationMutation", async () => {
+    mockIsAuthenticated.value = true; mockCalculate.mockReturnValue(mockResult);
+    mockSaveMutateAsync.mockResolvedValue({ id: "sim-cev-1" });
+    const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
+    const btn = w.findAll(".n-button").find((b) => b.text().includes("custoEstiloVida.actions.save"));
+    await btn!.trigger("click"); await flushPromises();
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "custo_estilo_vida" }));
+  });
+});
+
+describe("CustoEstiloVidaPage — add as goal", () => {
+  beforeEach(resetState);
+  it("shows goal button for premium users", async () => {
+    mockIsAuthenticated.value = true; mockHasPremiumAccess.value = true;
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    const btn = w.findAll(".n-button").find((b) => b.text().includes("custoEstiloVida.actions.addAsGoal"));
+    expect(btn).toBeDefined();
+  });
+});

--- a/app/pages/tools/custo-estilo-vida.vue
+++ b/app/pages/tools/custo-estilo-vida.vue
@@ -1,0 +1,319 @@
+<script setup lang="ts">
+import { computed, ref, onMounted } from "vue";
+import {
+  NAlert,
+  NButton,
+  NForm,
+  NFormItem,
+  NInput,
+  NInputNumber,
+  NSpace,
+  NThing,
+  useMessage,
+} from "naive-ui";
+
+import { captureException } from "~/core/observability";
+import { useApiError } from "~/composables/useApiError";
+import { useCalculatorFormState } from "~/features/tools/composables/use-calculator-form-state";
+import { useSessionStore } from "~/stores/session";
+import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
+import { useSaveSimulationMutation } from "~/features/simulations/queries/use-save-simulation-mutation";
+import { useCreateGoalMutation } from "~/features/goals/queries/use-create-goal-mutation";
+import {
+  calculateCustoEstiloVida,
+  createDefaultExpense,
+  createDefaultCustoEstiloVidaFormState,
+  decodeQueryToForm,
+  encodeFormToQuery,
+  validateCustoEstiloVidaForm,
+  type CustoEstiloVidaFormState,
+  type CustoEstiloVidaResult,
+} from "~/features/tools/model/custo-estilo-vida";
+import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
+import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
+import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
+import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
+import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
+import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
+import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+
+definePageMeta({ layout: false });
+
+const { t, n } = useI18n();
+const toast = useMessage();
+const { getErrorMessage } = useApiError();
+const sessionStore = useSessionStore();
+
+useSeoMeta({
+  title: t("custoEstiloVida.seo.title"),
+  description: t("custoEstiloVida.seo.description"),
+  ogTitle: t("custoEstiloVida.seo.ogTitle"),
+  ogDescription: t("custoEstiloVida.seo.ogDescription"),
+  twitterCard: "summary_large_image",
+});
+
+const isAuthenticated = computed<boolean>(() => sessionStore.isAuthenticated);
+const premiumAccessQuery = useEntitlementQuery("advanced_simulations");
+const hasPremiumAccess = computed<boolean>(() => premiumAccessQuery.data.value === true);
+
+const { form, validationError, patch, reset, setValidationError } =
+  useCalculatorFormState<CustoEstiloVidaFormState>(createDefaultCustoEstiloVidaFormState);
+
+const result = ref<CustoEstiloVidaResult | null>(null);
+const savedSimulationId = ref<string | null>(null);
+const goalAdded = ref(false);
+const shareUrl = ref<string | null>(null);
+
+const saveSimulationMutation = useSaveSimulationMutation();
+const createGoalMutation = useCreateGoalMutation();
+
+/**
+ * @param value
+ * @returns BRL-formatted string.
+ */
+function formatBrl(value: number): string {
+  return n(value, "currency");
+}
+
+/**
+ * @returns void
+ */
+function addExpense(): void {
+  patch({ expenses: [...form.value.expenses, createDefaultExpense()] });
+}
+
+/**
+ *
+ * @param index
+ */
+function removeExpense(index: number): void {
+  if (form.value.expenses.length <= 1) { return; }
+  const expenses = [...form.value.expenses];
+  expenses.splice(index, 1);
+  patch({ expenses });
+}
+
+/**
+ *
+ * @param index
+ * @param field
+ * @param value
+ */
+function updateExpense(index: number, field: string, value: unknown): void {
+  const expenses = [...form.value.expenses];
+  const current = expenses[index];
+  if (!current) { return; }
+  expenses[index] = { ...current, [field]: value };
+  patch({ expenses });
+}
+
+onMounted(() => {
+  if (typeof window === "undefined") { return; }
+  const data = new URLSearchParams(window.location.search).get("d");
+  if (!data) { return; }
+  const decoded = decodeQueryToForm(data);
+  if (!decoded) { return; }
+  if (decoded.expenses) { patch({ expenses: decoded.expenses }); }
+  if (decoded.annualReturnPct !== undefined) { patch({ annualReturnPct: decoded.annualReturnPct }); }
+  if (decoded.horizonYears !== undefined) { patch({ horizonYears: decoded.horizonYears }); }
+});
+
+/**
+ *
+ */
+function handleCalculate(): void {
+  const errors = validateCustoEstiloVidaForm(form.value);
+  if (errors.length > 0) {
+    const first = errors[0];
+    setValidationError(first ? t(`custoEstiloVida.${first.messageKey}`) : null);
+    return;
+  }
+  setValidationError(null);
+  savedSimulationId.value = null;
+  goalAdded.value = false;
+  result.value = calculateCustoEstiloVida(form.value);
+  shareUrl.value = `${window.location.origin}${window.location.pathname}?d=${encodeFormToQuery(form.value)}`;
+}
+
+/**
+ *
+ */
+function handleReset(): void {
+  reset();
+  result.value = null;
+  savedSimulationId.value = null;
+  goalAdded.value = false;
+  shareUrl.value = null;
+}
+
+/**
+ *
+ */
+function handleCopyShareUrl(): void {
+  if (shareUrl.value) {
+    navigator.clipboard.writeText(shareUrl.value);
+    toast.success(t("custoEstiloVida.actions.copied"));
+  }
+}
+
+/**
+ * @returns Saved simulation ID or null.
+ */
+async function ensureSimulationSaved(): Promise<string | null> {
+  if (savedSimulationId.value) { return savedSimulationId.value; }
+  if (!result.value) { return null; }
+  try {
+    const sim = await saveSimulationMutation.mutateAsync({
+      name: t("custoEstiloVida.simulation.defaultName"),
+      toolSlug: "custo_estilo_vida",
+      inputs: { ...form.value },
+      result: {
+        totalOpportunityCost: result.value.totalOpportunityCost,
+        totalMonthlyCost: result.value.totalMonthlyCost,
+      },
+    });
+    savedSimulationId.value = sim.id;
+    return sim.id;
+  } catch (err) {
+    captureException(err, { context: "custo-estilo-vida/save-simulation" });
+    toast.error(getErrorMessage(err));
+    return null;
+  }
+}
+
+/**
+ *
+ */
+async function handleSaveSimulation(): Promise<void> { await ensureSimulationSaved(); }
+
+/**
+ *
+ */
+async function handleAddAsGoal(): Promise<void> {
+  if (!result.value) { return; }
+  await ensureSimulationSaved();
+  try {
+    await createGoalMutation.mutateAsync({
+      name: t("custoEstiloVida.simulation.goalName"),
+      target_amount: result.value.totalOpportunityCost,
+    });
+    goalAdded.value = true;
+  } catch (err) {
+    captureException(err, { context: "custo-estilo-vida/add-as-goal" });
+    toast.error(getErrorMessage(err));
+  }
+}
+
+const summaryMetrics = computed(() => {
+  if (!result.value) { return []; }
+  return [
+    { label: t("custoEstiloVida.results.totalMonthly"), value: formatBrl(result.value.totalMonthlyCost) },
+    { label: t("custoEstiloVida.results.totalAnnual"), value: formatBrl(result.value.totalAnnualCost) },
+    { label: t("custoEstiloVida.results.horizon"), value: `${result.value.horizonYears} anos` },
+  ];
+});
+
+const isSaved = computed(() => savedSimulationId.value !== null);
+const isBridging = computed(() => saveSimulationMutation.isPending.value || createGoalMutation.isPending.value);
+</script>
+
+<template>
+  <div class="custo-estilo-vida-root">
+  <NuxtLayout :name="isAuthenticated ? 'default' : 'tools-public'">
+    <div class="custo-estilo-vida-page">
+      <div class="custo-estilo-vida-page__layout">
+        <div class="custo-estilo-vida-page__form-col">
+          <UiPageHeader
+            :title="t('custoEstiloVida.hero.title')"
+            :subtitle="t('custoEstiloVida.hero.subtitle')"
+          />
+
+          <UiGlassPanel>
+            <NForm @submit.prevent="handleCalculate">
+              <CalculatorFormSection :title="t('custoEstiloVida.form.title')">
+                <div v-for="(exp, i) in form.expenses" :key="i" class="custo-estilo-vida-page__expense-row">
+                  <NFormItem :label="t('custoEstiloVida.form.expenseName')">
+                    <NInput :value="exp.name" :placeholder="t('custoEstiloVida.form.expenseNamePlaceholder')" @update:value="(v) => updateExpense(i, 'name', v)" />
+                  </NFormItem>
+                  <NFormItem :label="t('custoEstiloVida.form.monthlyAmount')">
+                    <NInputNumber :value="exp.monthlyAmount" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => updateExpense(i, 'monthlyAmount', v ?? 0)" />
+                  </NFormItem>
+                  <NButton v-if="form.expenses.length > 1" quaternary size="small" @click="removeExpense(i)">
+                    {{ t('custoEstiloVida.form.removeExpense') }}
+                  </NButton>
+                </div>
+
+                <NButton size="small" style="margin-bottom: 16px" @click="addExpense">
+                  {{ t('custoEstiloVida.form.addExpense') }}
+                </NButton>
+
+                <NFormItem :label="t('custoEstiloVida.form.annualReturnPct')">
+                  <NInputNumber :value="form.annualReturnPct" :min="0" :precision="2" style="width: 100%" @update:value="(v) => patch({ annualReturnPct: v ?? 12 })" />
+                </NFormItem>
+
+                <NFormItem :label="t('custoEstiloVida.form.horizonYears')">
+                  <NInputNumber :value="form.horizonYears" :min="1" :precision="0" style="width: 100%" @update:value="(v) => patch({ horizonYears: v ?? 10 })" />
+                </NFormItem>
+              </CalculatorFormSection>
+
+              <NAlert v-if="validationError" type="error" style="margin-bottom: 16px">
+                {{ validationError }}
+              </NAlert>
+
+              <NSpace style="margin-top: 16px">
+                <NButton type="primary" attr-type="submit" :loading="isBridging">
+                  {{ t('custoEstiloVida.form.calculate') }}
+                </NButton>
+                <NButton quaternary @click="handleReset">
+                  {{ t('custoEstiloVida.form.reset') }}
+                </NButton>
+              </NSpace>
+            </NForm>
+          </UiGlassPanel>
+        </div>
+
+        <div v-if="result" class="custo-estilo-vida-page__result-col">
+          <UiStickySummaryCard>
+            <CalculatorResultSummary
+              :label="t('custoEstiloVida.results.totalOpportunityCost')"
+              :value="formatBrl(result.totalOpportunityCost)"
+              :metrics="summaryMetrics"
+            />
+
+            <ToolSaveResult
+              intent="goal"
+              :label="t('custoEstiloVida.hero.title')"
+              :amount="result.totalOpportunityCost"
+            />
+
+            <NSpace vertical style="margin-top: 16px">
+              <NButton v-if="isAuthenticated" :loading="saveSimulationMutation.isPending.value" :disabled="isSaved" block @click="handleSaveSimulation">
+                {{ isSaved ? t('custoEstiloVida.actions.saved') : t('custoEstiloVida.actions.save') }}
+              </NButton>
+              <NButton v-if="hasPremiumAccess" type="primary" :loading="createGoalMutation.isPending.value" :disabled="goalAdded" block @click="handleAddAsGoal">
+                {{ goalAdded ? t('custoEstiloVida.actions.goalAdded') : t('custoEstiloVida.actions.addAsGoal') }}
+              </NButton>
+              <NButton v-if="shareUrl" block quaternary @click="handleCopyShareUrl">
+                {{ t('custoEstiloVida.actions.copyShareUrl') }}
+              </NButton>
+            </NSpace>
+          </UiStickySummaryCard>
+
+          <UiSurfaceCard>
+            <NThing
+              v-for="exp in result.expenses"
+              :key="exp.name"
+              :title="exp.name"
+              :description="`${formatBrl(exp.monthlyAmount)}/mês → ${formatBrl(exp.opportunityCost)} em ${result.horizonYears} anos`"
+            />
+          </UiSurfaceCard>
+
+          <p class="custo-estilo-vida-page__disclaimer">{{ t('custoEstiloVida.disclaimer.note') }}</p>
+        </div>
+      </div>
+    </div>
+    <ToolGuestCta v-if="!isAuthenticated" />
+  </NuxtLayout>
+  </div>
+</template>

--- a/app/pages/tools/orcamento-50-30-20.spec.ts
+++ b/app/pages/tools/orcamento-50-30-20.spec.ts
@@ -1,0 +1,164 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { computed, ref, type App, type ComputedRef } from "vue";
+
+import OrcamentoPage from "./orcamento-50-30-20.vue";
+import type { OrcamentoResult } from "~/features/tools/model/orcamento-50-30-20";
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockSaveMutateAsync = vi.hoisted(() => vi.fn());
+const mockCreateGoalMutateAsync = vi.hoisted(() => vi.fn());
+const mockCaptureException = vi.hoisted(() => vi.fn());
+const mockValidate = vi.hoisted(() => vi.fn().mockReturnValue([]));
+const mockCalculate = vi.hoisted(() => vi.fn());
+const mockIsAuthenticated = ref(false);
+const mockHasPremiumAccess = ref(false);
+
+vi.mock("vue-i18n", () => ({ useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({ t: (key: string) => key, n: (v: number) => String(v) }) }));
+vi.mock("#imports", () => ({ definePageMeta: vi.fn(), useHead: vi.fn(), useSeoMeta: vi.fn(), useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({ t: (key: string) => key, n: (v: number) => String(v) }), useRouter: (): { push: typeof mockPush } => ({ push: mockPush }) }));
+vi.mock("#app", () => ({ useRouter: (): { push: typeof mockPush } => ({ push: mockPush }) }));
+vi.mock("echarts/core", () => ({ use: vi.fn() }));
+vi.mock("echarts/charts", () => ({ LineChart: {} }));
+vi.mock("echarts/components", () => ({ GridComponent: {}, TooltipComponent: {}, LegendComponent: {} }));
+vi.mock("echarts/renderers", () => ({ CanvasRenderer: {} }));
+vi.mock("vue-echarts", () => ({ default: { props: ["option", "autoresize"], template: "<div class='v-chart'></div>" } }));
+
+vi.mock("naive-ui", () => ({
+  NAlert: { props: ["type"], template: "<div class='n-alert'><slot /></div>" },
+  NButton: { props: ["type", "size", "loading", "disabled", "quaternary", "block", "attrType"], template: "<button class='n-button' @click='$emit(\"click\")'><slot /></button>", emits: ["click"] },
+  NForm: { emits: ["submit"], template: "<form @submit.prevent='$emit(\"submit\", $event)'><slot /></form>" },
+  NFormItem: { props: ["label"], template: "<div class='n-form-item'><slot /></div>" },
+  NInputNumber: { props: ["value", "min", "max", "precision", "prefix"], emits: ["update:value"], template: "<input class='n-input-number' />" },
+  NSelect: { props: ["value", "options"], emits: ["update:value"], template: "<select class='n-select'></select>" },
+  NSpace: { props: ["vertical", "size"], template: "<div><slot /></div>" },
+  NTag: { props: ["round", "type"], template: "<span class='n-tag'><slot /></span>" },
+  NThing: { props: ["title", "description"], template: "<div class='n-thing'>{{ title }}<slot name='footer' /></div>" },
+  useMessage: vi.fn(() => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() })),
+}));
+
+vi.mock("@tanstack/vue-query", async () => {
+  const actual = await vi.importActual("@tanstack/vue-query");
+  return { ...actual, useQuery: vi.fn(() => ({ data: mockHasPremiumAccess, isLoading: ref(false), isError: ref(false) })), useMutation: vi.fn(() => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false), isError: ref(false) })) };
+});
+
+vi.mock("~/stores/session", () => ({ useSessionStore: (): { isAuthenticated: boolean } => ({ get isAuthenticated(): boolean { return mockIsAuthenticated.value; } }) }));
+vi.mock("~/features/tools/composables/useToolCta", () => ({ useToolCta: (): { showCta: ComputedRef<boolean> } => ({ showCta: computed(() => !mockIsAuthenticated.value) }) }));
+vi.mock("~/composables/useApiError", () => ({ useApiError: (): { getErrorMessage: (err: unknown) => string } => ({ getErrorMessage: vi.fn((err: unknown): string => String(err)) }) }));
+vi.mock("~/core/observability", () => ({ captureException: mockCaptureException }));
+
+vi.mock("~/features/tools/model/orcamento-50-30-20", () => ({
+  createDefaultOrcamentoFormState: (): object => ({ netIncome: null, mode: "simple", actualNeeds: 0, actualWants: 0, actualInvestments: 0 }),
+  validateOrcamentoForm: mockValidate,
+  calculateOrcamento: mockCalculate,
+}));
+
+vi.mock("~/features/simulations/queries/use-save-simulation-mutation", () => ({ useSaveSimulationMutation: (): { mutateAsync: typeof mockSaveMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false) }) }));
+vi.mock("~/features/goals/queries/use-create-goal-mutation", () => ({ useCreateGoalMutation: (): { mutateAsync: typeof mockCreateGoalMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockCreateGoalMutateAsync, isPending: ref(false) }) }));
+vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({ useEntitlementQuery: (): { data: typeof mockHasPremiumAccess; isLoading: ReturnType<typeof ref<boolean>> } => ({ data: mockHasPremiumAccess, isLoading: ref(false) }) }));
+
+const mockResult: OrcamentoResult = {
+  netIncome: 10000,
+  slices: [
+    { category: "needs", idealAmount: 5000, idealPct: 50, actualAmount: null, actualPct: null, deviationPct: null, alert: false },
+    { category: "wants", idealAmount: 3000, idealPct: 30, actualAmount: null, actualPct: null, deviationPct: null, alert: false },
+    { category: "investments", idealAmount: 2000, idealPct: 20, actualAmount: null, actualPct: null, deviationPct: null, alert: false },
+  ],
+  totalActual: null, surplus: null,
+};
+
+const globalStubs = {
+  NuxtLayout: { props: ["name"], template: "<div class='nuxt-layout'><slot /></div>" },
+  UiPageHeader: { props: ["title", "subtitle"], template: "<div class='ui-page-header'><h1>{{ title }}</h1></div>" },
+  UiGlassPanel: { props: ["glow"], template: "<div class='ui-glass-panel'><slot /></div>" },
+  UiSurfaceCard: { template: "<div class='ui-surface-card'><slot /></div>" },
+  UiStickySummaryCard: { template: "<div class='ui-sticky-summary-card'><slot /></div>" },
+  CalculatorFormSection: { props: ["title"], template: "<div class='calculator-form-section'><slot /></div>" },
+  CalculatorResultSummary: { props: ["label", "value", "metrics"], template: "<div class='calculator-result-summary'>{{ label }}: {{ value }}</div>" },
+  ToolGuestCta: { template: "<div class='tool-guest-cta'>guest-cta</div>" },
+  ToolSaveResult: { props: ["intent", "label", "amount", "description"], template: "<div class='tool-save-result-stub' />" },
+};
+
+/**
+ *
+ * @param app
+ */
+function nuxtContextPlugin(app: App): void {
+  Reflect.set(app, "$nuxt", {
+    _route: { path: "/tools/orcamento-50-30-20", meta: {}, params: {}, query: {} },
+    $router: { push: mockPush, replace: vi.fn() }, $config: { public: {} }, payload: { serverRendered: false },
+    ssrContext: { head: { push: vi.fn(() => ({ patch: vi.fn(), dispose: vi.fn() })) } },
+    static: { data: {} }, isHydrating: false, deferHydration: (): void => {},
+    runWithContext: <T>(cb: () => T): T => cb(), hooks: { callHook: vi.fn(), hook: vi.fn() }, _asyncDataPromises: {}, _asyncData: {},
+  });
+}
+
+/**
+ * @returns Mounted component wrapper.
+ */
+function mountPage(): ReturnType<typeof mount> { return mount(OrcamentoPage, { global: { plugins: [{ install: nuxtContextPlugin }], stubs: globalStubs } }); }
+
+/**
+ *
+ */
+function resetState(): void {
+  setActivePinia(createPinia()); mockPush.mockClear(); mockSaveMutateAsync.mockReset();
+  mockCreateGoalMutateAsync.mockReset(); mockCaptureException.mockClear();
+  mockValidate.mockReturnValue([]); mockCalculate.mockReset();
+  mockIsAuthenticated.value = false; mockHasPremiumAccess.value = false;
+}
+
+describe("OrcamentoPage — guest layout", () => {
+  beforeEach(resetState);
+  it("renders NuxtLayout", () => { expect(mountPage().find(".nuxt-layout").exists()).toBe(true); });
+  it("shows guest CTA after calculation", async () => {
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".tool-guest-cta").exists()).toBe(true);
+  });
+});
+
+describe("OrcamentoPage — form validation", () => {
+  beforeEach(resetState);
+  it("shows validation error", async () => {
+    mockValidate.mockReturnValue([{ field: "netIncome", messageKey: "errors.incomeRequired" }]);
+    const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".n-alert").exists()).toBe(true);
+    expect(mockCalculate).not.toHaveBeenCalled();
+  });
+});
+
+describe("OrcamentoPage — results", () => {
+  beforeEach(resetState);
+  it("shows result summary", async () => {
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".calculator-result-summary").exists()).toBe(true);
+  });
+  it("does not show results before calculation", () => {
+    expect(mountPage().find(".calculator-result-summary").exists()).toBe(false);
+  });
+});
+
+describe("OrcamentoPage — save simulation", () => {
+  beforeEach(resetState);
+  it("calls saveSimulationMutation with correct slug", async () => {
+    mockIsAuthenticated.value = true; mockCalculate.mockReturnValue(mockResult);
+    mockSaveMutateAsync.mockResolvedValue({ id: "sim-orc-1" });
+    const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
+    const btn = w.findAll(".n-button").find((b) => b.text().includes("orcamento5030.actions.save"));
+    await btn!.trigger("click"); await flushPromises();
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "orcamento_50_30_20" }));
+  });
+});
+
+describe("OrcamentoPage — add as goal", () => {
+  beforeEach(resetState);
+  it("shows goal button for premium users", async () => {
+    mockIsAuthenticated.value = true; mockHasPremiumAccess.value = true;
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    const btn = w.findAll(".n-button").find((b) => b.text().includes("orcamento5030.actions.addAsGoal"));
+    expect(btn).toBeDefined();
+  });
+});

--- a/app/pages/tools/orcamento-50-30-20.vue
+++ b/app/pages/tools/orcamento-50-30-20.vue
@@ -1,0 +1,267 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import {
+  NAlert,
+  NButton,
+  NForm,
+  NFormItem,
+  NInputNumber,
+  NSelect,
+  NSpace,
+  NTag,
+  NThing,
+  useMessage,
+} from "naive-ui";
+
+import { captureException } from "~/core/observability";
+import { useApiError } from "~/composables/useApiError";
+import { useCalculatorFormState } from "~/features/tools/composables/use-calculator-form-state";
+import { useSessionStore } from "~/stores/session";
+import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
+import { useSaveSimulationMutation } from "~/features/simulations/queries/use-save-simulation-mutation";
+import { useCreateGoalMutation } from "~/features/goals/queries/use-create-goal-mutation";
+import {
+  calculateOrcamento,
+  createDefaultOrcamentoFormState,
+  validateOrcamentoForm,
+  type OrcamentoFormState,
+  type OrcamentoResult,
+} from "~/features/tools/model/orcamento-50-30-20";
+import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
+import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
+import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
+import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
+import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
+import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
+import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+
+definePageMeta({ layout: false });
+
+const { t, n } = useI18n();
+const toast = useMessage();
+const { getErrorMessage } = useApiError();
+const sessionStore = useSessionStore();
+
+useSeoMeta({
+  title: t("orcamento5030.seo.title"),
+  description: t("orcamento5030.seo.description"),
+  ogTitle: t("orcamento5030.seo.ogTitle"),
+  ogDescription: t("orcamento5030.seo.ogDescription"),
+  twitterCard: "summary_large_image",
+});
+
+const isAuthenticated = computed<boolean>(() => sessionStore.isAuthenticated);
+const premiumAccessQuery = useEntitlementQuery("advanced_simulations");
+const hasPremiumAccess = computed<boolean>(() => premiumAccessQuery.data.value === true);
+
+const { form, validationError, patch, reset, setValidationError } =
+  useCalculatorFormState<OrcamentoFormState>(createDefaultOrcamentoFormState);
+
+const result = ref<OrcamentoResult | null>(null);
+const savedSimulationId = ref<string | null>(null);
+const goalAdded = ref(false);
+
+const modeOptions = computed(() => [
+  { label: t("orcamento5030.form.modeSimple"), value: "simple" },
+  { label: t("orcamento5030.form.modeDetailed"), value: "detailed" },
+]);
+
+const categoryLabels: Record<string, string> = {
+  needs: "Necessidades (50%)",
+  wants: "Desejos (30%)",
+  investments: "Investimentos (20%)",
+};
+
+const saveSimulationMutation = useSaveSimulationMutation();
+const createGoalMutation = useCreateGoalMutation();
+
+/**
+ * @param value
+ * @returns BRL-formatted string.
+ */
+function formatBrl(value: number): string {
+  return n(value, "currency");
+}
+
+/**
+ * @returns void
+ */
+function handleCalculate(): void {
+  const errors = validateOrcamentoForm(form.value);
+  if (errors.length > 0) {
+    const first = errors[0];
+    setValidationError(first ? t(`orcamento5030.${first.messageKey}`) : null);
+    return;
+  }
+  setValidationError(null);
+  savedSimulationId.value = null;
+  goalAdded.value = false;
+  result.value = calculateOrcamento(form.value);
+}
+
+/**
+ *
+ */
+function handleReset(): void {
+  reset();
+  result.value = null;
+  savedSimulationId.value = null;
+  goalAdded.value = false;
+}
+
+/**
+ * @returns Saved simulation ID or null.
+ */
+async function ensureSimulationSaved(): Promise<string | null> {
+  if (savedSimulationId.value) { return savedSimulationId.value; }
+  if (!result.value) { return null; }
+  try {
+    const sim = await saveSimulationMutation.mutateAsync({
+      name: t("orcamento5030.simulation.defaultName"),
+      toolSlug: "orcamento_50_30_20",
+      inputs: { ...form.value },
+      result: { netIncome: result.value.netIncome, slices: result.value.slices },
+    });
+    savedSimulationId.value = sim.id;
+    return sim.id;
+  } catch (err) {
+    captureException(err, { context: "orcamento-50-30-20/save-simulation" });
+    toast.error(getErrorMessage(err));
+    return null;
+  }
+}
+
+/**
+ *
+ */
+async function handleSaveSimulation(): Promise<void> { await ensureSimulationSaved(); }
+
+/**
+ *
+ */
+async function handleAddAsGoal(): Promise<void> {
+  if (!result.value) { return; }
+  await ensureSimulationSaved();
+  const investmentSlice = result.value.slices.find((s) => s.category === "investments");
+  try {
+    await createGoalMutation.mutateAsync({
+      name: t("orcamento5030.simulation.goalName"),
+      target_amount: investmentSlice?.idealAmount ?? 0,
+    });
+    goalAdded.value = true;
+  } catch (err) {
+    captureException(err, { context: "orcamento-50-30-20/add-as-goal" });
+    toast.error(getErrorMessage(err));
+  }
+}
+
+const summaryMetrics = computed(() => {
+  if (!result.value) { return []; }
+  return result.value.slices.map((s) => ({
+    label: categoryLabels[s.category] ?? s.category,
+    value: formatBrl(s.idealAmount),
+  }));
+});
+
+const isSaved = computed(() => savedSimulationId.value !== null);
+const isBridging = computed(() => saveSimulationMutation.isPending.value || createGoalMutation.isPending.value);
+</script>
+
+<template>
+  <div class="orcamento-5030-root">
+  <NuxtLayout :name="isAuthenticated ? 'default' : 'tools-public'">
+    <div class="orcamento-5030-page">
+      <div class="orcamento-5030-page__layout">
+        <div class="orcamento-5030-page__form-col">
+          <UiPageHeader
+            :title="t('orcamento5030.hero.title')"
+            :subtitle="t('orcamento5030.hero.subtitle')"
+          />
+
+          <UiGlassPanel>
+            <NForm @submit.prevent="handleCalculate">
+              <CalculatorFormSection :title="t('orcamento5030.form.title')">
+                <NFormItem :label="t('orcamento5030.form.netIncome')">
+                  <NInputNumber :value="form.netIncome" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => patch({ netIncome: v })" />
+                </NFormItem>
+
+                <NFormItem :label="t('orcamento5030.form.mode')">
+                  <NSelect :value="form.mode" :options="modeOptions" style="width: 100%" @update:value="(v) => patch({ mode: v })" />
+                </NFormItem>
+
+                <template v-if="form.mode === 'detailed'">
+                  <NFormItem :label="t('orcamento5030.form.actualNeeds')">
+                    <NInputNumber :value="form.actualNeeds" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => patch({ actualNeeds: v ?? 0 })" />
+                  </NFormItem>
+                  <NFormItem :label="t('orcamento5030.form.actualWants')">
+                    <NInputNumber :value="form.actualWants" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => patch({ actualWants: v ?? 0 })" />
+                  </NFormItem>
+                  <NFormItem :label="t('orcamento5030.form.actualInvestments')">
+                    <NInputNumber :value="form.actualInvestments" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => patch({ actualInvestments: v ?? 0 })" />
+                  </NFormItem>
+                </template>
+              </CalculatorFormSection>
+
+              <NAlert v-if="validationError" type="error" style="margin-bottom: 16px">
+                {{ validationError }}
+              </NAlert>
+
+              <NSpace style="margin-top: 16px">
+                <NButton type="primary" attr-type="submit" :loading="isBridging">
+                  {{ t('orcamento5030.form.calculate') }}
+                </NButton>
+                <NButton quaternary @click="handleReset">
+                  {{ t('orcamento5030.form.reset') }}
+                </NButton>
+              </NSpace>
+            </NForm>
+          </UiGlassPanel>
+        </div>
+
+        <div v-if="result" class="orcamento-5030-page__result-col">
+          <UiStickySummaryCard>
+            <CalculatorResultSummary
+              :label="t('orcamento5030.results.distribution')"
+              :value="formatBrl(result.netIncome)"
+              :metrics="summaryMetrics"
+            />
+
+            <ToolSaveResult
+              intent="goal"
+              :label="t('orcamento5030.hero.title')"
+              :amount="result.slices.find((s) => s.category === 'investments')?.idealAmount ?? 0"
+              :description="t('orcamento5030.results.investmentGoal')"
+            />
+
+            <NSpace vertical style="margin-top: 16px">
+              <NButton v-if="isAuthenticated" :loading="saveSimulationMutation.isPending.value" :disabled="isSaved" block @click="handleSaveSimulation">
+                {{ isSaved ? t('orcamento5030.actions.saved') : t('orcamento5030.actions.save') }}
+              </NButton>
+              <NButton v-if="hasPremiumAccess" type="primary" :loading="createGoalMutation.isPending.value" :disabled="goalAdded" block @click="handleAddAsGoal">
+                {{ goalAdded ? t('orcamento5030.actions.goalAdded') : t('orcamento5030.actions.addAsGoal') }}
+              </NButton>
+            </NSpace>
+          </UiStickySummaryCard>
+
+          <UiSurfaceCard>
+            <NThing v-for="s in result.slices" :key="s.category" :title="categoryLabels[s.category]" :description="formatBrl(s.idealAmount)">
+              <template v-if="s.actualAmount !== null" #footer>
+                <NSpace>
+                  <span>{{ t('orcamento5030.results.actual') }}: {{ formatBrl(s.actualAmount) }} ({{ s.actualPct }}%)</span>
+                  <NTag v-if="s.alert" type="error" round>{{ s.deviationPct! > 0 ? '+' : '' }}{{ s.deviationPct }}%</NTag>
+                </NSpace>
+              </template>
+            </NThing>
+          </UiSurfaceCard>
+
+          <UiSurfaceCard v-if="result.surplus !== null">
+            <NThing :title="t('orcamento5030.results.surplus')" :description="formatBrl(result.surplus)" />
+          </UiSurfaceCard>
+        </div>
+      </div>
+    </div>
+    <ToolGuestCta v-if="!isAuthenticated" />
+  </NuxtLayout>
+  </div>
+</template>

--- a/app/pages/tools/quitacao-dividas.spec.ts
+++ b/app/pages/tools/quitacao-dividas.spec.ts
@@ -1,0 +1,154 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { computed, ref, type App, type ComputedRef } from "vue";
+
+import QuitacaoDividasPage from "./quitacao-dividas.vue";
+import type { QuitacaoDividasResult } from "~/features/tools/model/quitacao-dividas";
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockSaveMutateAsync = vi.hoisted(() => vi.fn());
+const mockCreateGoalMutateAsync = vi.hoisted(() => vi.fn());
+const mockCaptureException = vi.hoisted(() => vi.fn());
+const mockValidate = vi.hoisted(() => vi.fn().mockReturnValue([]));
+const mockCalculate = vi.hoisted(() => vi.fn());
+const mockIsAuthenticated = ref(false);
+const mockHasPremiumAccess = ref(false);
+
+vi.mock("vue-i18n", () => ({ useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({ t: (key: string) => key, n: (v: number) => String(v) }) }));
+vi.mock("#imports", () => ({ definePageMeta: vi.fn(), useHead: vi.fn(), useSeoMeta: vi.fn(), useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({ t: (key: string) => key, n: (v: number) => String(v) }), useRouter: (): { push: typeof mockPush } => ({ push: mockPush }) }));
+vi.mock("#app", () => ({ useRouter: (): { push: typeof mockPush } => ({ push: mockPush }) }));
+vi.mock("echarts/core", () => ({ use: vi.fn() }));
+vi.mock("echarts/charts", () => ({ LineChart: {} }));
+vi.mock("echarts/components", () => ({ GridComponent: {}, TooltipComponent: {}, LegendComponent: {} }));
+vi.mock("echarts/renderers", () => ({ CanvasRenderer: {} }));
+vi.mock("vue-echarts", () => ({ default: { props: ["option", "autoresize"], template: "<div class='v-chart'></div>" } }));
+
+vi.mock("naive-ui", () => ({
+  NAlert: { props: ["type"], template: "<div class='n-alert'><slot /></div>" },
+  NButton: { props: ["type", "size", "loading", "disabled", "quaternary", "block", "attrType"], template: "<button class='n-button' @click='$emit(\"click\")'><slot /></button>", emits: ["click"] },
+  NForm: { emits: ["submit"], template: "<form @submit.prevent='$emit(\"submit\", $event)'><slot /></form>" },
+  NFormItem: { props: ["label"], template: "<div class='n-form-item'><slot /></div>" },
+  NInput: { props: ["value", "placeholder"], emits: ["update:value"], template: "<input class='n-input' />" },
+  NInputNumber: { props: ["value", "min", "max", "precision", "prefix"], emits: ["update:value"], template: "<input class='n-input-number' />" },
+  NSpace: { props: ["vertical", "size"], template: "<div><slot /></div>" },
+  NTag: { props: ["round", "type"], template: "<span class='n-tag'><slot /></span>" },
+  NThing: { props: ["title", "description"], template: "<div class='n-thing'>{{ title }}</div>" },
+  useMessage: vi.fn(() => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() })),
+}));
+
+vi.mock("@tanstack/vue-query", async () => {
+  const actual = await vi.importActual("@tanstack/vue-query");
+  return { ...actual, useQuery: vi.fn(() => ({ data: mockHasPremiumAccess, isLoading: ref(false), isError: ref(false) })), useMutation: vi.fn(() => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false), isError: ref(false) })) };
+});
+
+vi.mock("~/stores/session", () => ({ useSessionStore: (): { isAuthenticated: boolean } => ({ get isAuthenticated(): boolean { return mockIsAuthenticated.value; } }) }));
+vi.mock("~/features/tools/composables/useToolCta", () => ({ useToolCta: (): { showCta: ComputedRef<boolean> } => ({ showCta: computed(() => !mockIsAuthenticated.value) }) }));
+vi.mock("~/composables/useApiError", () => ({ useApiError: (): { getErrorMessage: (err: unknown) => string } => ({ getErrorMessage: vi.fn((err: unknown): string => String(err)) }) }));
+vi.mock("~/core/observability", () => ({ captureException: mockCaptureException }));
+
+vi.mock("~/features/tools/model/quitacao-dividas", () => ({
+  createDefaultDebtEntry: (): object => ({ name: "", balance: 0, monthlyRatePct: 0, minimumPayment: 0 }),
+  createDefaultQuitacaoDividasFormState: (): object => ({ debts: [{ name: "", balance: 0, monthlyRatePct: 0, minimumPayment: 0 }, { name: "", balance: 0, monthlyRatePct: 0, minimumPayment: 0 }], extraPayment: 0 }),
+  validateQuitacaoDividasForm: mockValidate,
+  calculateQuitacaoDividas: mockCalculate,
+}));
+
+vi.mock("~/features/simulations/queries/use-save-simulation-mutation", () => ({ useSaveSimulationMutation: (): { mutateAsync: typeof mockSaveMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false) }) }));
+vi.mock("~/features/goals/queries/use-create-goal-mutation", () => ({ useCreateGoalMutation: (): { mutateAsync: typeof mockCreateGoalMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockCreateGoalMutateAsync, isPending: ref(false) }) }));
+vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({ useEntitlementQuery: (): { data: typeof mockHasPremiumAccess; isLoading: ReturnType<typeof ref<boolean>> } => ({ data: mockHasPremiumAccess, isLoading: ref(false) }) }));
+
+const mockResult: QuitacaoDividasResult = {
+  totalDebt: 10000,
+  snowball: { strategy: "snowball", totalMonths: 15, totalPaid: 13000, totalInterest: 3000, timeline: [{ month: 0, totalBalance: 10000, totalPaid: 0 }] },
+  avalanche: { strategy: "avalanche", totalMonths: 14, totalPaid: 12500, totalInterest: 2500, timeline: [{ month: 0, totalBalance: 10000, totalPaid: 0 }] },
+  interestSaved: 500, monthsSaved: 1, bestStrategy: "avalanche",
+};
+
+const globalStubs = {
+  NuxtLayout: { props: ["name"], template: "<div class='nuxt-layout'><slot /></div>" },
+  UiPageHeader: { props: ["title", "subtitle"], template: "<div class='ui-page-header'><h1>{{ title }}</h1></div>" },
+  UiGlassPanel: { props: ["glow"], template: "<div class='ui-glass-panel'><slot /></div>" },
+  UiSurfaceCard: { template: "<div class='ui-surface-card'><slot /></div>" },
+  UiStickySummaryCard: { template: "<div class='ui-sticky-summary-card'><slot /></div>" },
+  CalculatorFormSection: { props: ["title"], template: "<div class='calculator-form-section'><slot /></div>" },
+  CalculatorResultSummary: { props: ["label", "value", "metrics"], template: "<div class='calculator-result-summary'>{{ label }}: {{ value }}</div>" },
+  ToolGuestCta: { template: "<div class='tool-guest-cta'>guest-cta</div>" },
+  UiChart: { props: ["option", "height"], template: "<div class='v-chart'></div>" },
+  ToolSaveResult: { props: ["intent", "label", "amount", "description"], template: "<div class='tool-save-result-stub' />" },
+};
+
+/**
+ *
+ * @param app
+ */
+function nuxtContextPlugin(app: App): void {
+  Reflect.set(app, "$nuxt", {
+    _route: { path: "/tools/quitacao-dividas", meta: {}, params: {}, query: {} },
+    $router: { push: mockPush, replace: vi.fn() }, $config: { public: {} }, payload: { serverRendered: false },
+    ssrContext: { head: { push: vi.fn(() => ({ patch: vi.fn(), dispose: vi.fn() })) } },
+    static: { data: {} }, isHydrating: false, deferHydration: (): void => {},
+    runWithContext: <T>(cb: () => T): T => cb(), hooks: { callHook: vi.fn(), hook: vi.fn() }, _asyncDataPromises: {}, _asyncData: {},
+  });
+}
+
+/**
+ * @returns Mounted component wrapper.
+ */
+function mountPage(): ReturnType<typeof mount> { return mount(QuitacaoDividasPage, { global: { plugins: [{ install: nuxtContextPlugin }], stubs: globalStubs } }); }
+
+/**
+ *
+ */
+function resetState(): void {
+  setActivePinia(createPinia()); mockPush.mockClear(); mockSaveMutateAsync.mockReset();
+  mockCreateGoalMutateAsync.mockReset(); mockCaptureException.mockClear();
+  mockValidate.mockReturnValue([]); mockCalculate.mockReset();
+  mockIsAuthenticated.value = false; mockHasPremiumAccess.value = false;
+}
+
+describe("QuitacaoDividasPage — guest layout", () => {
+  beforeEach(resetState);
+  it("renders NuxtLayout", () => { expect(mountPage().find(".nuxt-layout").exists()).toBe(true); });
+  it("shows guest CTA after calculation", async () => {
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".tool-guest-cta").exists()).toBe(true);
+  });
+});
+
+describe("QuitacaoDividasPage — form validation", () => {
+  beforeEach(resetState);
+  it("shows validation error", async () => {
+    mockValidate.mockReturnValue([{ field: "debts", messageKey: "errors.atLeastOneDebtRequired" }]);
+    const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".n-alert").exists()).toBe(true);
+    expect(mockCalculate).not.toHaveBeenCalled();
+  });
+});
+
+describe("QuitacaoDividasPage — results", () => {
+  beforeEach(resetState);
+  it("shows result summary", async () => {
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".calculator-result-summary").exists()).toBe(true);
+  });
+  it("shows best strategy tag", async () => {
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".n-tag").exists()).toBe(true);
+  });
+});
+
+describe("QuitacaoDividasPage — save simulation", () => {
+  beforeEach(resetState);
+  it("calls saveSimulationMutation", async () => {
+    mockIsAuthenticated.value = true; mockCalculate.mockReturnValue(mockResult);
+    mockSaveMutateAsync.mockResolvedValue({ id: "sim-qd-1" });
+    const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
+    const btn = w.findAll(".n-button").find((b) => b.text().includes("quitacaoDividas.actions.save"));
+    await btn!.trigger("click"); await flushPromises();
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "quitacao_dividas" }));
+  });
+});

--- a/app/pages/tools/quitacao-dividas.vue
+++ b/app/pages/tools/quitacao-dividas.vue
@@ -1,0 +1,316 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import type { EChartsOption } from "echarts";
+import {
+  NAlert,
+  NButton,
+  NForm,
+  NFormItem,
+  NInput,
+  NInputNumber,
+  NSpace,
+  NTag,
+  NThing,
+  useMessage,
+} from "naive-ui";
+
+import { captureException } from "~/core/observability";
+import { useApiError } from "~/composables/useApiError";
+import { useCalculatorFormState } from "~/features/tools/composables/use-calculator-form-state";
+import { useSessionStore } from "~/stores/session";
+import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
+import { useSaveSimulationMutation } from "~/features/simulations/queries/use-save-simulation-mutation";
+import { useCreateGoalMutation } from "~/features/goals/queries/use-create-goal-mutation";
+import {
+  calculateQuitacaoDividas,
+  createDefaultDebtEntry,
+  createDefaultQuitacaoDividasFormState,
+  validateQuitacaoDividasForm,
+  type QuitacaoDividasFormState,
+  type QuitacaoDividasResult,
+} from "~/features/tools/model/quitacao-dividas";
+import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
+import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
+import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
+import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
+import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
+import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
+import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import UiChart from "~/components/ui/UiChart.vue";
+
+definePageMeta({ layout: false });
+
+const { t, n } = useI18n();
+const toast = useMessage();
+const { getErrorMessage } = useApiError();
+const sessionStore = useSessionStore();
+
+useSeoMeta({
+  title: t("quitacaoDividas.seo.title"),
+  description: t("quitacaoDividas.seo.description"),
+  ogTitle: t("quitacaoDividas.seo.ogTitle"),
+  ogDescription: t("quitacaoDividas.seo.ogDescription"),
+  twitterCard: "summary_large_image",
+});
+
+const isAuthenticated = computed<boolean>(() => sessionStore.isAuthenticated);
+const premiumAccessQuery = useEntitlementQuery("advanced_simulations");
+const hasPremiumAccess = computed<boolean>(() => premiumAccessQuery.data.value === true);
+
+const { form, validationError, patch, reset, setValidationError } =
+  useCalculatorFormState<QuitacaoDividasFormState>(createDefaultQuitacaoDividasFormState);
+
+const result = ref<QuitacaoDividasResult | null>(null);
+const savedSimulationId = ref<string | null>(null);
+const goalAdded = ref(false);
+
+const saveSimulationMutation = useSaveSimulationMutation();
+const createGoalMutation = useCreateGoalMutation();
+
+/**
+ * @param value
+ * @returns BRL-formatted string.
+ */
+function formatBrl(value: number): string {
+  return n(value, "currency");
+}
+
+/**
+ * @returns void
+ */
+function addDebt(): void {
+  patch({ debts: [...form.value.debts, createDefaultDebtEntry()] });
+}
+
+/**
+ *
+ * @param index
+ */
+function removeDebt(index: number): void {
+  if (form.value.debts.length <= 2) { return; }
+  const debts = [...form.value.debts];
+  debts.splice(index, 1);
+  patch({ debts });
+}
+
+/**
+ *
+ * @param index
+ * @param field
+ * @param value
+ */
+function updateDebt(index: number, field: string, value: unknown): void {
+  const debts = [...form.value.debts];
+  const current = debts[index];
+  if (!current) { return; }
+  debts[index] = { ...current, [field]: value };
+  patch({ debts });
+}
+
+/**
+ *
+ */
+function handleCalculate(): void {
+  const errors = validateQuitacaoDividasForm(form.value);
+  if (errors.length > 0) {
+    const first = errors[0];
+    setValidationError(first ? t(`quitacaoDividas.${first.messageKey}`) : null);
+    return;
+  }
+  setValidationError(null);
+  savedSimulationId.value = null;
+  goalAdded.value = false;
+  result.value = calculateQuitacaoDividas(form.value);
+}
+
+/**
+ *
+ */
+function handleReset(): void {
+  reset();
+  result.value = null;
+  savedSimulationId.value = null;
+  goalAdded.value = false;
+}
+
+const chartOption = computed<EChartsOption>(() => {
+  if (!result.value) { return {} as EChartsOption; }
+  const months = result.value.snowball.timeline.map((p) => String(p.month));
+  return {
+    tooltip: { trigger: "axis" },
+    legend: { data: ["Snowball", "Avalanche"] },
+    xAxis: { type: "category", data: months, name: t("quitacaoDividas.results.chart.xAxis") },
+    yAxis: { type: "value", axisLabel: { formatter: (val: number): string => formatBrl(val) } },
+    series: [
+      { name: "Snowball", type: "line", data: result.value.snowball.timeline.map((p) => p.totalBalance), smooth: true },
+      { name: "Avalanche", type: "line", data: result.value.avalanche.timeline.map((p) => p.totalBalance), smooth: true },
+    ],
+  } as unknown as EChartsOption;
+});
+
+/**
+ * @returns Saved simulation ID or null.
+ */
+async function ensureSimulationSaved(): Promise<string | null> {
+  if (savedSimulationId.value) { return savedSimulationId.value; }
+  if (!result.value) { return null; }
+  try {
+    const sim = await saveSimulationMutation.mutateAsync({
+      name: t("quitacaoDividas.simulation.defaultName"),
+      toolSlug: "quitacao_dividas",
+      inputs: { ...form.value },
+      result: {
+        totalDebt: result.value.totalDebt,
+        bestStrategy: result.value.bestStrategy,
+        interestSaved: result.value.interestSaved,
+      },
+    });
+    savedSimulationId.value = sim.id;
+    return sim.id;
+  } catch (err) {
+    captureException(err, { context: "quitacao-dividas/save-simulation" });
+    toast.error(getErrorMessage(err));
+    return null;
+  }
+}
+
+/**
+ *
+ */
+async function handleSaveSimulation(): Promise<void> { await ensureSimulationSaved(); }
+
+/**
+ *
+ */
+async function handleAddAsGoal(): Promise<void> {
+  if (!result.value) { return; }
+  await ensureSimulationSaved();
+  try {
+    await createGoalMutation.mutateAsync({
+      name: t("quitacaoDividas.simulation.goalName"),
+      target_amount: result.value.totalDebt,
+    });
+    goalAdded.value = true;
+  } catch (err) {
+    captureException(err, { context: "quitacao-dividas/add-as-goal" });
+    toast.error(getErrorMessage(err));
+  }
+}
+
+const summaryMetrics = computed(() => {
+  if (!result.value) { return []; }
+  return [
+    { label: t("quitacaoDividas.results.snowballMonths"), value: `${result.value.snowball.totalMonths} meses` },
+    { label: t("quitacaoDividas.results.avalancheMonths"), value: `${result.value.avalanche.totalMonths} meses` },
+    { label: t("quitacaoDividas.results.interestSaved"), value: formatBrl(result.value.interestSaved) },
+  ];
+});
+
+const isSaved = computed(() => savedSimulationId.value !== null);
+const isBridging = computed(() => saveSimulationMutation.isPending.value || createGoalMutation.isPending.value);
+</script>
+
+<template>
+  <div class="quitacao-dividas-root">
+  <NuxtLayout :name="isAuthenticated ? 'default' : 'tools-public'">
+    <div class="quitacao-dividas-page">
+      <div class="quitacao-dividas-page__layout">
+        <div class="quitacao-dividas-page__form-col">
+          <UiPageHeader
+            :title="t('quitacaoDividas.hero.title')"
+            :subtitle="t('quitacaoDividas.hero.subtitle')"
+          />
+
+          <UiGlassPanel>
+            <NForm @submit.prevent="handleCalculate">
+              <CalculatorFormSection :title="t('quitacaoDividas.form.title')">
+                <div v-for="(debt, i) in form.debts" :key="i" class="quitacao-dividas-page__debt-row">
+                  <NFormItem :label="t('quitacaoDividas.form.debtName')">
+                    <NInput :value="debt.name" :placeholder="t('quitacaoDividas.form.debtNamePlaceholder')" @update:value="(v) => updateDebt(i, 'name', v)" />
+                  </NFormItem>
+                  <NFormItem :label="t('quitacaoDividas.form.balance')">
+                    <NInputNumber :value="debt.balance" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => updateDebt(i, 'balance', v ?? 0)" />
+                  </NFormItem>
+                  <NFormItem :label="t('quitacaoDividas.form.monthlyRate')">
+                    <NInputNumber :value="debt.monthlyRatePct" :min="0" :precision="2" style="width: 100%" @update:value="(v) => updateDebt(i, 'monthlyRatePct', v ?? 0)" />
+                  </NFormItem>
+                  <NFormItem :label="t('quitacaoDividas.form.minimumPayment')">
+                    <NInputNumber :value="debt.minimumPayment" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => updateDebt(i, 'minimumPayment', v ?? 0)" />
+                  </NFormItem>
+                  <NButton v-if="form.debts.length > 2" quaternary size="small" @click="removeDebt(i)">
+                    {{ t('quitacaoDividas.form.removeDebt') }}
+                  </NButton>
+                </div>
+
+                <NButton size="small" style="margin-bottom: 16px" @click="addDebt">
+                  {{ t('quitacaoDividas.form.addDebt') }}
+                </NButton>
+
+                <NFormItem :label="t('quitacaoDividas.form.extraPayment')">
+                  <NInputNumber :value="form.extraPayment" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => patch({ extraPayment: v ?? 0 })" />
+                </NFormItem>
+              </CalculatorFormSection>
+
+              <NAlert v-if="validationError" type="error" style="margin-bottom: 16px">
+                {{ validationError }}
+              </NAlert>
+
+              <NSpace style="margin-top: 16px">
+                <NButton type="primary" attr-type="submit" :loading="isBridging">
+                  {{ t('quitacaoDividas.form.calculate') }}
+                </NButton>
+                <NButton quaternary @click="handleReset">
+                  {{ t('quitacaoDividas.form.reset') }}
+                </NButton>
+              </NSpace>
+            </NForm>
+          </UiGlassPanel>
+        </div>
+
+        <div v-if="result" class="quitacao-dividas-page__result-col">
+          <UiStickySummaryCard>
+            <CalculatorResultSummary
+              :label="t('quitacaoDividas.results.totalDebt')"
+              :value="formatBrl(result.totalDebt)"
+              :metrics="summaryMetrics"
+            />
+
+            <NTag :type="result.bestStrategy === 'avalanche' ? 'success' : 'info'" round>
+              {{ t(`quitacaoDividas.results.best.${result.bestStrategy}`) }}
+            </NTag>
+
+            <ToolSaveResult
+              intent="goal"
+              :label="t('quitacaoDividas.hero.title')"
+              :amount="result.totalDebt"
+              :description="t('quitacaoDividas.results.goalDescription')"
+            />
+
+            <NSpace vertical style="margin-top: 16px">
+              <NButton v-if="isAuthenticated" :loading="saveSimulationMutation.isPending.value" :disabled="isSaved" block @click="handleSaveSimulation">
+                {{ isSaved ? t('quitacaoDividas.actions.saved') : t('quitacaoDividas.actions.save') }}
+              </NButton>
+              <NButton v-if="hasPremiumAccess" type="primary" :loading="createGoalMutation.isPending.value" :disabled="goalAdded" block @click="handleAddAsGoal">
+                {{ goalAdded ? t('quitacaoDividas.actions.goalAdded') : t('quitacaoDividas.actions.addAsGoal') }}
+              </NButton>
+            </NSpace>
+          </UiStickySummaryCard>
+
+          <UiSurfaceCard>
+            <NThing :title="'Snowball'" :description="`${result.snowball.totalMonths} meses — ${formatBrl(result.snowball.totalInterest)} em juros`" />
+            <NThing :title="'Avalanche'" :description="`${result.avalanche.totalMonths} meses — ${formatBrl(result.avalanche.totalInterest)} em juros`" />
+          </UiSurfaceCard>
+
+          <UiSurfaceCard>
+            <UiChart :option="chartOption" height="280px" />
+          </UiSurfaceCard>
+
+          <p class="quitacao-dividas-page__disclaimer">{{ t('quitacaoDividas.disclaimer.note') }}</p>
+        </div>
+      </div>
+    </div>
+    <ToolGuestCta v-if="!isAuthenticated" />
+  </NuxtLayout>
+  </div>
+</template>

--- a/app/pages/tools/reserva-emergencia.spec.ts
+++ b/app/pages/tools/reserva-emergencia.spec.ts
@@ -1,0 +1,169 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { computed, ref, type App, type ComputedRef } from "vue";
+
+import ReservaEmergenciaPage from "./reserva-emergencia.vue";
+import type { ReservaEmergenciaResult } from "~/features/tools/model/reserva-emergencia";
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockSaveMutateAsync = vi.hoisted(() => vi.fn());
+const mockCreateGoalMutateAsync = vi.hoisted(() => vi.fn());
+const mockCaptureException = vi.hoisted(() => vi.fn());
+const mockValidate = vi.hoisted(() => vi.fn().mockReturnValue([]));
+const mockCalculate = vi.hoisted(() => vi.fn());
+const mockIsAuthenticated = ref(false);
+const mockHasPremiumAccess = ref(false);
+
+vi.mock("vue-i18n", () => ({
+  useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({ t: (key: string) => key, n: (v: number) => String(v) }),
+}));
+
+vi.mock("#imports", () => ({
+  definePageMeta: vi.fn(), useHead: vi.fn(), useSeoMeta: vi.fn(),
+  useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({ t: (key: string) => key, n: (v: number) => String(v) }),
+  useRouter: (): { push: typeof mockPush } => ({ push: mockPush }),
+}));
+
+vi.mock("#app", () => ({ useRouter: (): { push: typeof mockPush } => ({ push: mockPush }) }));
+vi.mock("echarts/core", () => ({ use: vi.fn() }));
+vi.mock("echarts/charts", () => ({ LineChart: {} }));
+vi.mock("echarts/components", () => ({ GridComponent: {}, TooltipComponent: {}, LegendComponent: {} }));
+vi.mock("echarts/renderers", () => ({ CanvasRenderer: {} }));
+vi.mock("vue-echarts", () => ({ default: { props: ["option", "autoresize"], template: "<div class='v-chart'></div>" } }));
+
+vi.mock("naive-ui", () => ({
+  NAlert: { props: ["type"], template: "<div class='n-alert'><slot /></div>" },
+  NButton: { props: ["type", "size", "loading", "disabled", "quaternary", "block", "attrType"], template: "<button class='n-button' @click='$emit(\"click\")'><slot /></button>", emits: ["click"] },
+  NForm: { emits: ["submit"], template: "<form @submit.prevent='$emit(\"submit\", $event)'><slot /></form>" },
+  NFormItem: { props: ["label"], template: "<div class='n-form-item'><slot /></div>" },
+  NInputNumber: { props: ["value", "min", "max", "precision", "prefix"], emits: ["update:value"], template: "<input class='n-input-number' />" },
+  NSelect: { props: ["value", "options"], emits: ["update:value"], template: "<select class='n-select'></select>" },
+  NSpace: { props: ["vertical", "size"], template: "<div><slot /></div>" },
+  NThing: { props: ["title", "description"], template: "<div class='n-thing'>{{ title }}</div>" },
+  useMessage: vi.fn(() => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() })),
+}));
+
+vi.mock("@tanstack/vue-query", async () => {
+  const actual = await vi.importActual("@tanstack/vue-query");
+  return { ...actual, useQuery: vi.fn(() => ({ data: mockHasPremiumAccess, isLoading: ref(false), isError: ref(false) })), useMutation: vi.fn(() => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false), isError: ref(false) })) };
+});
+
+vi.mock("~/stores/session", () => ({ useSessionStore: (): { isAuthenticated: boolean } => ({ get isAuthenticated(): boolean { return mockIsAuthenticated.value; } }) }));
+vi.mock("~/features/tools/composables/useToolCta", () => ({ useToolCta: (): { showCta: ComputedRef<boolean> } => ({ showCta: computed(() => !mockIsAuthenticated.value) }) }));
+vi.mock("~/composables/useApiError", () => ({ useApiError: (): { getErrorMessage: (err: unknown) => string } => ({ getErrorMessage: vi.fn((err: unknown): string => String(err)) }) }));
+vi.mock("~/core/observability", () => ({ captureException: mockCaptureException }));
+
+vi.mock("~/features/tools/model/reserva-emergencia", () => ({
+  PROFILE_OPTIONS: [{ value: "clt", label: "CLT", months: 6 }],
+  createDefaultReservaEmergenciaFormState: (): object => ({ monthlyExpenses: null, profile: "clt", currentReserve: 0, monthlyContribution: null, annualReturnPct: 12.25 }),
+  validateReservaEmergenciaForm: mockValidate,
+  calculateReservaEmergencia: mockCalculate,
+}));
+
+vi.mock("~/features/simulations/queries/use-save-simulation-mutation", () => ({ useSaveSimulationMutation: (): { mutateAsync: typeof mockSaveMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false) }) }));
+vi.mock("~/features/goals/queries/use-create-goal-mutation", () => ({ useCreateGoalMutation: (): { mutateAsync: typeof mockCreateGoalMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockCreateGoalMutateAsync, isPending: ref(false) }) }));
+vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({ useEntitlementQuery: (): { data: typeof mockHasPremiumAccess; isLoading: ReturnType<typeof ref<boolean>> } => ({ data: mockHasPremiumAccess, isLoading: ref(false) }) }));
+
+const mockResult: ReservaEmergenciaResult = {
+  targetAmount: 18000, profileMonths: 6, gap: 18000, monthsToTarget: 16,
+  timeline: [{ month: 0, balance: 0 }, { month: 16, balance: 18000 }],
+  investments: [{ name: "Selic", annualRatePct: 14.25, monthsToTarget: 15, finalAmount: 18100 }],
+};
+
+const globalStubs = {
+  NuxtLayout: { props: ["name"], template: "<div class='nuxt-layout'><slot /></div>" },
+  UiPageHeader: { props: ["title", "subtitle"], template: "<div class='ui-page-header'><h1>{{ title }}</h1></div>" },
+  UiGlassPanel: { props: ["glow"], template: "<div class='ui-glass-panel'><slot /></div>" },
+  UiSurfaceCard: { template: "<div class='ui-surface-card'><slot /></div>" },
+  UiStickySummaryCard: { template: "<div class='ui-sticky-summary-card'><slot /></div>" },
+  CalculatorFormSection: { props: ["title"], template: "<div class='calculator-form-section'><slot /></div>" },
+  CalculatorResultSummary: { props: ["label", "value", "metrics"], template: "<div class='calculator-result-summary'>{{ label }}: {{ value }}</div>" },
+  ToolGuestCta: { template: "<div class='tool-guest-cta'>guest-cta</div>" },
+  UiChart: { props: ["option", "height"], template: "<div class='v-chart'></div>" },
+  ToolSaveResult: { props: ["intent", "label", "amount", "description"], template: "<div class='tool-save-result-stub' />" },
+};
+
+/**
+ *
+ * @param app
+ */
+function nuxtContextPlugin(app: App): void {
+  Reflect.set(app, "$nuxt", {
+    _route: { path: "/tools/reserva-emergencia", meta: {}, params: {}, query: {} },
+    $router: { push: mockPush, replace: vi.fn() }, $config: { public: {} }, payload: { serverRendered: false },
+    ssrContext: { head: { push: vi.fn(() => ({ patch: vi.fn(), dispose: vi.fn() })) } },
+    static: { data: {} }, isHydrating: false, deferHydration: (): void => {},
+    runWithContext: <T>(cb: () => T): T => cb(), hooks: { callHook: vi.fn(), hook: vi.fn() }, _asyncDataPromises: {}, _asyncData: {},
+  });
+}
+
+/**
+ * @returns Mounted component wrapper.
+ */
+function mountPage(): ReturnType<typeof mount> { return mount(ReservaEmergenciaPage, { global: { plugins: [{ install: nuxtContextPlugin }], stubs: globalStubs } }); }
+
+/**
+ *
+ */
+function resetState(): void {
+  setActivePinia(createPinia()); mockPush.mockClear(); mockSaveMutateAsync.mockReset();
+  mockCreateGoalMutateAsync.mockReset(); mockCaptureException.mockClear();
+  mockValidate.mockReturnValue([]); mockCalculate.mockReset();
+  mockIsAuthenticated.value = false; mockHasPremiumAccess.value = false;
+}
+
+describe("ReservaEmergenciaPage — guest layout", () => {
+  beforeEach(resetState);
+  it("renders NuxtLayout", () => { expect(mountPage().find(".nuxt-layout").exists()).toBe(true); });
+  it("shows guest CTA after calculation", async () => {
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".tool-guest-cta").exists()).toBe(true);
+  });
+});
+
+describe("ReservaEmergenciaPage — form validation", () => {
+  beforeEach(resetState);
+  it("shows validation error", async () => {
+    mockValidate.mockReturnValue([{ field: "monthlyExpenses", messageKey: "errors.expensesRequired" }]);
+    const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".n-alert").exists()).toBe(true);
+    expect(mockCalculate).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReservaEmergenciaPage — results", () => {
+  beforeEach(resetState);
+  it("shows result summary", async () => {
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.find(".calculator-result-summary").exists()).toBe(true);
+  });
+  it("does not show results before calculation", () => {
+    expect(mountPage().find(".calculator-result-summary").exists()).toBe(false);
+  });
+});
+
+describe("ReservaEmergenciaPage — save simulation", () => {
+  beforeEach(resetState);
+  it("calls saveSimulationMutation", async () => {
+    mockIsAuthenticated.value = true; mockCalculate.mockReturnValue(mockResult);
+    mockSaveMutateAsync.mockResolvedValue({ id: "sim-re-1" });
+    const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
+    const btn = w.findAll(".n-button").find((b) => b.text().includes("reservaEmergencia.actions.save"));
+    await btn!.trigger("click"); await flushPromises();
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "reserva_emergencia" }));
+  });
+});
+
+describe("ReservaEmergenciaPage — add as goal", () => {
+  beforeEach(resetState);
+  it("shows goal button for premium users", async () => {
+    mockIsAuthenticated.value = true; mockHasPremiumAccess.value = true;
+    mockCalculate.mockReturnValue(mockResult); const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    const btn = w.findAll(".n-button").find((b) => b.text().includes("reservaEmergencia.actions.addAsGoal"));
+    expect(btn).toBeDefined();
+  });
+});

--- a/app/pages/tools/reserva-emergencia.vue
+++ b/app/pages/tools/reserva-emergencia.vue
@@ -1,0 +1,270 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import type { EChartsOption } from "echarts";
+import {
+  NAlert,
+  NButton,
+  NForm,
+  NFormItem,
+  NInputNumber,
+  NSelect,
+  NSpace,
+  NThing,
+  useMessage,
+} from "naive-ui";
+
+import { captureException } from "~/core/observability";
+import { useApiError } from "~/composables/useApiError";
+import { useCalculatorFormState } from "~/features/tools/composables/use-calculator-form-state";
+import { useSessionStore } from "~/stores/session";
+import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
+import { useSaveSimulationMutation } from "~/features/simulations/queries/use-save-simulation-mutation";
+import { useCreateGoalMutation } from "~/features/goals/queries/use-create-goal-mutation";
+import {
+  PROFILE_OPTIONS,
+  calculateReservaEmergencia,
+  createDefaultReservaEmergenciaFormState,
+  validateReservaEmergenciaForm,
+  type ReservaEmergenciaFormState,
+  type ReservaEmergenciaResult,
+} from "~/features/tools/model/reserva-emergencia";
+import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
+import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
+import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
+import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
+import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
+import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
+import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import UiChart from "~/components/ui/UiChart.vue";
+
+definePageMeta({ layout: false });
+
+const { t, n } = useI18n();
+const toast = useMessage();
+const { getErrorMessage } = useApiError();
+const sessionStore = useSessionStore();
+
+useSeoMeta({
+  title: t("reservaEmergencia.seo.title"),
+  description: t("reservaEmergencia.seo.description"),
+  ogTitle: t("reservaEmergencia.seo.ogTitle"),
+  ogDescription: t("reservaEmergencia.seo.ogDescription"),
+  twitterCard: "summary_large_image",
+});
+
+const isAuthenticated = computed<boolean>(() => sessionStore.isAuthenticated);
+const premiumAccessQuery = useEntitlementQuery("advanced_simulations");
+const hasPremiumAccess = computed<boolean>(() => premiumAccessQuery.data.value === true);
+
+const { form, validationError, patch, reset, setValidationError } =
+  useCalculatorFormState<ReservaEmergenciaFormState>(createDefaultReservaEmergenciaFormState);
+
+const result = ref<ReservaEmergenciaResult | null>(null);
+const savedSimulationId = ref<string | null>(null);
+const goalAdded = ref(false);
+
+const profileOptions = computed(() =>
+  PROFILE_OPTIONS.map((p) => ({ label: p.label, value: p.value })),
+);
+
+const saveSimulationMutation = useSaveSimulationMutation();
+const createGoalMutation = useCreateGoalMutation();
+
+/**
+ * @param value
+ * @returns BRL-formatted string.
+ */
+function formatBrl(value: number): string {
+  return n(value, "currency");
+}
+
+/**
+ * @returns void
+ */
+function handleCalculate(): void {
+  const errors = validateReservaEmergenciaForm(form.value);
+  if (errors.length > 0) {
+    const first = errors[0];
+    setValidationError(first ? t(`reservaEmergencia.${first.messageKey}`) : null);
+    return;
+  }
+  setValidationError(null);
+  savedSimulationId.value = null;
+  goalAdded.value = false;
+  result.value = calculateReservaEmergencia(form.value);
+}
+
+/**
+ *
+ */
+function handleReset(): void {
+  reset();
+  result.value = null;
+  savedSimulationId.value = null;
+  goalAdded.value = false;
+}
+
+const chartOption = computed<EChartsOption>(() => {
+  if (!result.value) { return {} as EChartsOption; }
+  const months = result.value.timeline.map((p) => String(p.month));
+  const balanceData = result.value.timeline.map((p) => p.balance);
+  return {
+    tooltip: { trigger: "axis" },
+    xAxis: { type: "category", data: months, name: t("reservaEmergencia.results.chart.xAxis") },
+    yAxis: { type: "value", axisLabel: { formatter: (val: number): string => formatBrl(val) } },
+    series: [
+      { name: t("reservaEmergencia.results.chart.balance"), type: "area", data: balanceData, smooth: true, areaStyle: {} },
+    ],
+  } as unknown as EChartsOption;
+});
+
+/**
+ * @returns Saved simulation ID or null.
+ */
+async function ensureSimulationSaved(): Promise<string | null> {
+  if (savedSimulationId.value) { return savedSimulationId.value; }
+  if (!result.value) { return null; }
+  try {
+    const sim = await saveSimulationMutation.mutateAsync({
+      name: t("reservaEmergencia.simulation.defaultName"),
+      toolSlug: "reserva_emergencia",
+      inputs: { ...form.value },
+      result: { targetAmount: result.value.targetAmount, monthsToTarget: result.value.monthsToTarget, gap: result.value.gap },
+    });
+    savedSimulationId.value = sim.id;
+    return sim.id;
+  } catch (err) {
+    captureException(err, { context: "reserva-emergencia/save-simulation" });
+    toast.error(getErrorMessage(err));
+    return null;
+  }
+}
+
+/**
+ *
+ */
+async function handleSaveSimulation(): Promise<void> { await ensureSimulationSaved(); }
+
+/**
+ *
+ */
+async function handleAddAsGoal(): Promise<void> {
+  if (!result.value) { return; }
+  await ensureSimulationSaved();
+  try {
+    await createGoalMutation.mutateAsync({
+      name: t("reservaEmergencia.simulation.goalName"),
+      target_amount: result.value.targetAmount,
+    });
+    goalAdded.value = true;
+  } catch (err) {
+    captureException(err, { context: "reserva-emergencia/add-as-goal" });
+    toast.error(getErrorMessage(err));
+  }
+}
+
+const summaryMetrics = computed(() => {
+  if (!result.value) { return []; }
+  return [
+    { label: t("reservaEmergencia.results.profileMonths"), value: `${result.value.profileMonths} meses` },
+    { label: t("reservaEmergencia.results.gap"), value: formatBrl(result.value.gap) },
+    { label: t("reservaEmergencia.results.monthsToTarget"), value: `${result.value.monthsToTarget} meses` },
+  ];
+});
+
+const isSaved = computed(() => savedSimulationId.value !== null);
+const isBridging = computed(() => saveSimulationMutation.isPending.value || createGoalMutation.isPending.value);
+</script>
+
+<template>
+  <div class="reserva-emergencia-root">
+  <NuxtLayout :name="isAuthenticated ? 'default' : 'tools-public'">
+    <div class="reserva-emergencia-page">
+      <div class="reserva-emergencia-page__layout">
+        <div class="reserva-emergencia-page__form-col">
+          <UiPageHeader
+            :title="t('reservaEmergencia.hero.title')"
+            :subtitle="t('reservaEmergencia.hero.subtitle')"
+          />
+
+          <UiGlassPanel>
+            <NForm @submit.prevent="handleCalculate">
+              <CalculatorFormSection :title="t('reservaEmergencia.form.title')">
+                <NFormItem :label="t('reservaEmergencia.form.monthlyExpenses')">
+                  <NInputNumber :value="form.monthlyExpenses" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => patch({ monthlyExpenses: v })" />
+                </NFormItem>
+
+                <NFormItem :label="t('reservaEmergencia.form.profile')">
+                  <NSelect :value="form.profile" :options="profileOptions" style="width: 100%" @update:value="(v) => patch({ profile: v })" />
+                </NFormItem>
+
+                <NFormItem :label="t('reservaEmergencia.form.currentReserve')">
+                  <NInputNumber :value="form.currentReserve" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => patch({ currentReserve: v ?? 0 })" />
+                </NFormItem>
+
+                <NFormItem :label="t('reservaEmergencia.form.monthlyContribution')">
+                  <NInputNumber :value="form.monthlyContribution" :min="0" :precision="2" prefix="R$" style="width: 100%" @update:value="(v) => patch({ monthlyContribution: v })" />
+                </NFormItem>
+
+                <NFormItem :label="t('reservaEmergencia.form.annualReturnPct')">
+                  <NInputNumber :value="form.annualReturnPct" :min="0" :precision="2" style="width: 100%" @update:value="(v) => patch({ annualReturnPct: v ?? 12.25 })" />
+                </NFormItem>
+              </CalculatorFormSection>
+
+              <NAlert v-if="validationError" type="error" style="margin-bottom: 16px">
+                {{ validationError }}
+              </NAlert>
+
+              <NSpace style="margin-top: 16px">
+                <NButton type="primary" attr-type="submit" :loading="isBridging">
+                  {{ t('reservaEmergencia.form.calculate') }}
+                </NButton>
+                <NButton quaternary @click="handleReset">
+                  {{ t('reservaEmergencia.form.reset') }}
+                </NButton>
+              </NSpace>
+            </NForm>
+          </UiGlassPanel>
+        </div>
+
+        <div v-if="result" class="reserva-emergencia-page__result-col">
+          <UiStickySummaryCard>
+            <CalculatorResultSummary
+              :label="t('reservaEmergencia.results.targetAmount')"
+              :value="formatBrl(result.targetAmount)"
+              :metrics="summaryMetrics"
+            />
+
+            <ToolSaveResult
+              intent="goal"
+              :label="t('reservaEmergencia.hero.title')"
+              :amount="result.targetAmount"
+            />
+
+            <NSpace vertical style="margin-top: 16px">
+              <NButton v-if="isAuthenticated" :loading="saveSimulationMutation.isPending.value" :disabled="isSaved" block @click="handleSaveSimulation">
+                {{ isSaved ? t('reservaEmergencia.actions.saved') : t('reservaEmergencia.actions.save') }}
+              </NButton>
+              <NButton v-if="hasPremiumAccess" type="primary" :loading="createGoalMutation.isPending.value" :disabled="goalAdded" block @click="handleAddAsGoal">
+                {{ goalAdded ? t('reservaEmergencia.actions.goalAdded') : t('reservaEmergencia.actions.addAsGoal') }}
+              </NButton>
+            </NSpace>
+          </UiStickySummaryCard>
+
+          <UiSurfaceCard>
+            <NThing v-for="inv in result.investments" :key="inv.name" :title="inv.name" :description="`${inv.monthsToTarget} meses (${inv.annualRatePct}% a.a.)`" />
+          </UiSurfaceCard>
+
+          <UiSurfaceCard>
+            <UiChart :option="chartOption" height="280px" />
+          </UiSurfaceCard>
+
+          <p class="reserva-emergencia-page__disclaimer">{{ t('reservaEmergencia.disclaimer.note') }}</p>
+        </div>
+      </div>
+    </div>
+    <ToolGuestCta v-if="!isAuthenticated" />
+  </NuxtLayout>
+  </div>
+</template>

--- a/app/pages/tools/salario-liquido.spec.ts
+++ b/app/pages/tools/salario-liquido.spec.ts
@@ -1,0 +1,255 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { computed, ref, type App, type ComputedRef } from "vue";
+
+import SalarioLiquidoPage from "./salario-liquido.vue";
+import type { SalarioLiquidoResult } from "~/features/tools/model/salario-liquido";
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockSaveMutateAsync = vi.hoisted(() => vi.fn());
+const mockCreateReceivableMutateAsync = vi.hoisted(() => vi.fn());
+const mockCaptureException = vi.hoisted(() => vi.fn());
+const mockValidate = vi.hoisted(() => vi.fn().mockReturnValue([]));
+const mockCalculate = vi.hoisted(() => vi.fn());
+const mockIsAuthenticated = ref(false);
+const mockHasPremiumAccess = ref(false);
+
+vi.mock("vue-i18n", () => ({
+  useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({
+    t: (key: string) => key,
+    n: (v: number) => String(v),
+  }),
+}));
+
+vi.mock("#imports", () => ({
+  definePageMeta: vi.fn(),
+  useHead: vi.fn(),
+  useSeoMeta: vi.fn(),
+  useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({
+    t: (key: string) => key,
+    n: (v: number) => String(v),
+  }),
+  useRouter: (): { push: typeof mockPush } => ({ push: mockPush }),
+}));
+
+vi.mock("#app", () => ({
+  useRouter: (): { push: typeof mockPush } => ({ push: mockPush }),
+}));
+
+vi.mock("echarts/core", () => ({ use: vi.fn() }));
+vi.mock("echarts/charts", () => ({ LineChart: {} }));
+vi.mock("echarts/components", () => ({ GridComponent: {}, TooltipComponent: {}, LegendComponent: {} }));
+vi.mock("echarts/renderers", () => ({ CanvasRenderer: {} }));
+vi.mock("vue-echarts", () => ({ default: { props: ["option", "autoresize"], template: "<div class='v-chart'></div>" } }));
+
+vi.mock("naive-ui", () => ({
+  NAlert: { props: ["type"], template: "<div class='n-alert'><slot /></div>" },
+  NButton: {
+    props: ["type", "size", "loading", "disabled", "quaternary", "block", "attrType"],
+    template: "<button class='n-button' @click='$emit(\"click\")'><slot /></button>",
+    emits: ["click"],
+  },
+  NCheckbox: {
+    props: ["checked"],
+    emits: ["update:checked"],
+    template: "<label class='n-checkbox'><input type='checkbox' :checked='checked' @change='$emit(\"update:checked\", $event.target.checked)' /><slot /></label>",
+  },
+  NForm: { emits: ["submit"], template: "<form @submit.prevent='$emit(\"submit\", $event)'><slot /></form>" },
+  NFormItem: { props: ["label"], template: "<div class='n-form-item'><slot /></div>" },
+  NInputNumber: {
+    props: ["value", "min", "max", "precision", "prefix", "placeholder"],
+    emits: ["update:value"],
+    template: "<input class='n-input-number' :value='value' @change='$emit(\"update:value\", $event.target.value ? parseFloat($event.target.value) : null)' />",
+  },
+  NSpace: { props: ["vertical", "size"], template: "<div><slot /></div>" },
+  NThing: { props: ["title", "description"], template: "<div class='n-thing'><strong>{{ title }}</strong></div>" },
+  useMessage: vi.fn(() => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() })),
+}));
+
+vi.mock("@tanstack/vue-query", async () => {
+  const actual = await vi.importActual("@tanstack/vue-query");
+  return {
+    ...actual,
+    useQuery: vi.fn(() => ({ data: mockHasPremiumAccess, isLoading: ref(false), isError: ref(false) })),
+    useMutation: vi.fn(() => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false), isError: ref(false) })),
+  };
+});
+
+vi.mock("~/stores/session", () => ({
+  useSessionStore: (): { isAuthenticated: boolean } => ({
+    get isAuthenticated(): boolean { return mockIsAuthenticated.value; },
+  }),
+}));
+
+vi.mock("~/features/tools/composables/useToolCta", () => ({
+  useToolCta: (): { showCta: ComputedRef<boolean> } => ({
+    showCta: computed(() => !mockIsAuthenticated.value),
+  }),
+}));
+
+vi.mock("~/composables/useApiError", () => ({
+  useApiError: (): { getErrorMessage: (err: unknown) => string } => ({ getErrorMessage: vi.fn((err: unknown): string => String(err)) }),
+}));
+vi.mock("~/core/observability", () => ({ captureException: mockCaptureException }));
+
+vi.mock("~/features/tools/model/salario-liquido", () => ({
+  BR_TAX_TABLE_YEAR: 2025,
+  createDefaultSalarioLiquidoFormState: (): object => ({
+    grossSalary: null, dependents: 0, alimonyPct: 0, vtOptOut: false, vtPct: 6,
+    vaVrDiscount: 0, healthPlanDiscount: 0, unionContribution: false, pgblPct: 0,
+  }),
+  validateSalarioLiquidoForm: mockValidate,
+  calculateSalarioLiquido: mockCalculate,
+}));
+
+vi.mock("~/features/simulations/queries/use-save-simulation-mutation", () => ({
+  useSaveSimulationMutation: (): { mutateAsync: typeof mockSaveMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({
+    mutateAsync: mockSaveMutateAsync, isPending: ref(false),
+  }),
+}));
+
+vi.mock("~/features/receivables/queries/use-create-receivable-mutation", () => ({
+  useCreateReceivableMutation: (): { mutateAsync: typeof mockCreateReceivableMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({
+    mutateAsync: mockCreateReceivableMutateAsync, isPending: ref(false),
+  }),
+}));
+
+vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
+  useEntitlementQuery: (): { data: typeof mockHasPremiumAccess; isLoading: ReturnType<typeof ref<boolean>> } => ({
+    data: mockHasPremiumAccess, isLoading: ref(false),
+  }),
+}));
+
+const mockResult: SalarioLiquidoResult = {
+  grossSalary: 5000, inss: 424.82, irrf: 47.15, vtDiscount: 300, vaVrDiscount: 0,
+  healthPlanDiscount: 0, unionDiscount: 0, alimonyDiscount: 0, totalDeductions: 771.97,
+  netSalary: 4228.03, deductions: [{ label: "INSS", amount: 424.82 }, { label: "IRRF", amount: 47.15 }, { label: "Vale-Transporte", amount: 300 }],
+  employerFgts: 400, employerInss: 1000, employerTotal: 6400,
+};
+
+const globalStubs = {
+  NuxtLayout: { props: ["name"], template: "<div class='nuxt-layout'><slot /></div>" },
+  UiPageHeader: { props: ["title", "subtitle"], template: "<div class='ui-page-header'><h1>{{ title }}</h1></div>" },
+  UiGlassPanel: { props: ["glow"], template: "<div class='ui-glass-panel'><slot /></div>" },
+  UiSurfaceCard: { template: "<div class='ui-surface-card'><slot /></div>" },
+  UiStickySummaryCard: { template: "<div class='ui-sticky-summary-card'><slot /></div>" },
+  CalculatorFormSection: { props: ["title"], template: "<div class='calculator-form-section'><slot /></div>" },
+  CalculatorResultSummary: { props: ["label", "value", "metrics"], template: "<div class='calculator-result-summary'>{{ label }}: {{ value }}</div>" },
+  ToolGuestCta: { template: "<div class='tool-guest-cta'>guest-cta</div>" },
+  ToolSaveResult: { props: ["intent", "label", "amount", "description"], template: "<div class='tool-save-result-stub' />" },
+};
+
+/**
+ *
+ * @param app
+ */
+function nuxtContextPlugin(app: App): void {
+  Reflect.set(app, "$nuxt", {
+    _route: { path: "/tools/salario-liquido", meta: {}, params: {}, query: {} },
+    $router: { push: mockPush, replace: vi.fn() },
+    $config: { public: {} }, payload: { serverRendered: false },
+    ssrContext: { head: { push: vi.fn(() => ({ patch: vi.fn(), dispose: vi.fn() })) } },
+    static: { data: {} }, isHydrating: false, deferHydration: (): void => {},
+    runWithContext: <T>(cb: () => T): T => cb(),
+    hooks: { callHook: vi.fn(), hook: vi.fn() }, _asyncDataPromises: {}, _asyncData: {},
+  });
+}
+
+/**
+ * @returns Mounted component wrapper.
+ */
+function mountPage(): ReturnType<typeof mount> {
+  return mount(SalarioLiquidoPage, { global: { plugins: [{ install: nuxtContextPlugin }], stubs: globalStubs } });
+}
+
+/**
+ *
+ */
+function resetState(): void {
+  setActivePinia(createPinia());
+  mockPush.mockClear(); mockSaveMutateAsync.mockReset(); mockCreateReceivableMutateAsync.mockReset();
+  mockCaptureException.mockClear(); mockValidate.mockReturnValue([]); mockCalculate.mockReset();
+  mockIsAuthenticated.value = false; mockHasPremiumAccess.value = false;
+}
+
+describe("SalarioLiquidoPage — guest layout", () => {
+  beforeEach(resetState);
+
+  it("renders NuxtLayout", () => {
+    expect(mountPage().find(".nuxt-layout").exists()).toBe(true);
+  });
+
+  it("shows guest CTA after valid calculation", async () => {
+    mockCalculate.mockReturnValue(mockResult);
+    const w = mountPage();
+    await w.find("form").trigger("submit");
+    await flushPromises();
+    expect(w.find(".tool-guest-cta").exists()).toBe(true);
+  });
+});
+
+describe("SalarioLiquidoPage — form validation", () => {
+  beforeEach(resetState);
+
+  it("shows validation error when grossSalary is missing", async () => {
+    mockValidate.mockReturnValue([{ field: "grossSalary", messageKey: "errors.grossSalaryRequired" }]);
+    const w = mountPage();
+    await w.find("form").trigger("submit");
+    await flushPromises();
+    expect(w.find(".n-alert").exists()).toBe(true);
+    expect(mockCalculate).not.toHaveBeenCalled();
+  });
+
+  it("clears validation error on valid submit", async () => {
+    mockValidate.mockReturnValueOnce([{ field: "grossSalary", messageKey: "errors.grossSalaryRequired" }]).mockReturnValue([]);
+    mockCalculate.mockReturnValue(mockResult);
+    const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    await w.find("form").trigger("submit"); await flushPromises();
+    expect(w.text()).not.toContain("errors.grossSalaryRequired");
+  });
+});
+
+describe("SalarioLiquidoPage — results", () => {
+  beforeEach(resetState);
+
+  it("shows result summary after valid calculation", async () => {
+    mockCalculate.mockReturnValue(mockResult);
+    const w = mountPage();
+    await w.find("form").trigger("submit");
+    await flushPromises();
+    expect(w.find(".calculator-result-summary").exists()).toBe(true);
+  });
+
+  it("does not show results before calculation", () => {
+    expect(mountPage().find(".calculator-result-summary").exists()).toBe(false);
+  });
+});
+
+describe("SalarioLiquidoPage — save simulation", () => {
+  beforeEach(resetState);
+
+  it("calls saveSimulationMutation with correct slug", async () => {
+    mockIsAuthenticated.value = true;
+    mockCalculate.mockReturnValue(mockResult);
+    mockSaveMutateAsync.mockResolvedValue({ id: "sim-sl-1" });
+    const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    const btn = w.findAll(".n-button").find((b) => b.text().includes("salarioLiquido.actions.save"));
+    expect(btn).toBeDefined();
+    await btn!.trigger("click"); await flushPromises();
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "salario_liquido" }));
+  });
+
+  it("captures exception on save failure", async () => {
+    mockIsAuthenticated.value = true;
+    mockCalculate.mockReturnValue(mockResult);
+    mockSaveMutateAsync.mockRejectedValue(new Error("fail"));
+    const w = mountPage();
+    await w.find("form").trigger("submit"); await flushPromises();
+    const btn = w.findAll(".n-button").find((b) => b.text().includes("salarioLiquido.actions.save"));
+    await btn!.trigger("click"); await flushPromises();
+    expect(mockCaptureException).toHaveBeenCalledOnce();
+  });
+});

--- a/app/pages/tools/salario-liquido.vue
+++ b/app/pages/tools/salario-liquido.vue
@@ -1,0 +1,282 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import {
+  NAlert,
+  NButton,
+  NCheckbox,
+  NForm,
+  NFormItem,
+  NInputNumber,
+  NSpace,
+  NThing,
+  useMessage,
+} from "naive-ui";
+
+import { captureException } from "~/core/observability";
+import { useApiError } from "~/composables/useApiError";
+import { useCalculatorFormState } from "~/features/tools/composables/use-calculator-form-state";
+import { useSessionStore } from "~/stores/session";
+import { useSaveSimulationMutation } from "~/features/simulations/queries/use-save-simulation-mutation";
+import { useCreateReceivableMutation } from "~/features/receivables/queries/use-create-receivable-mutation";
+import {
+  BR_TAX_TABLE_YEAR,
+  calculateSalarioLiquido,
+  createDefaultSalarioLiquidoFormState,
+  validateSalarioLiquidoForm,
+  type SalarioLiquidoFormState,
+  type SalarioLiquidoResult,
+} from "~/features/tools/model/salario-liquido";
+import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
+import CalculatorResultSummary from "~/components/tool/CalculatorResultSummary/CalculatorResultSummary.vue";
+import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import ToolSaveResult from "~/components/tool/ToolSaveResult/ToolSaveResult.vue";
+import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
+import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
+import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
+import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+
+definePageMeta({ layout: false });
+
+const { t, n } = useI18n();
+const toast = useMessage();
+const { getErrorMessage } = useApiError();
+const sessionStore = useSessionStore();
+
+useSeoMeta({
+  title: t("salarioLiquido.seo.title"),
+  description: t("salarioLiquido.seo.description"),
+  ogTitle: t("salarioLiquido.seo.ogTitle"),
+  ogDescription: t("salarioLiquido.seo.ogDescription"),
+  twitterCard: "summary_large_image",
+});
+
+const isAuthenticated = computed<boolean>(() => sessionStore.isAuthenticated);
+
+const { form, validationError, patch, reset, setValidationError } =
+  useCalculatorFormState<SalarioLiquidoFormState>(createDefaultSalarioLiquidoFormState);
+
+const result = ref<SalarioLiquidoResult | null>(null);
+const savedSimulationId = ref<string | null>(null);
+
+const saveSimulationMutation = useSaveSimulationMutation();
+const createReceivableMutation = useCreateReceivableMutation();
+
+/**
+ * @param value
+ * @returns BRL-formatted string.
+ */
+function formatBrl(value: number): string {
+  return n(value, "currency");
+}
+
+/**
+ * @returns void
+ */
+function handleCalculate(): void {
+  const errors = validateSalarioLiquidoForm(form.value);
+  if (errors.length > 0) {
+    const first = errors[0];
+    setValidationError(first ? t(`salarioLiquido.${first.messageKey}`) : null);
+    return;
+  }
+  setValidationError(null);
+  savedSimulationId.value = null;
+  result.value = calculateSalarioLiquido(form.value);
+}
+
+/**
+ *
+ */
+function handleReset(): void {
+  reset();
+  result.value = null;
+  savedSimulationId.value = null;
+}
+
+/**
+ *
+ */
+async function handleSaveSimulation(): Promise<void> {
+  if (savedSimulationId.value || !result.value) { return; }
+  try {
+    const sim = await saveSimulationMutation.mutateAsync({
+      name: t("salarioLiquido.simulation.defaultName"),
+      toolSlug: "salario_liquido",
+      inputs: { ...form.value },
+      result: {
+        netSalary: result.value.netSalary,
+        totalDeductions: result.value.totalDeductions,
+        employerTotal: result.value.employerTotal,
+      },
+    });
+    savedSimulationId.value = sim.id;
+  } catch (err) {
+    captureException(err, { context: "salario-liquido/save-simulation" });
+    toast.error(getErrorMessage(err));
+  }
+}
+
+const summaryMetrics = computed(() => {
+  if (!result.value) { return []; }
+  return [
+    { label: t("salarioLiquido.results.totalDeductions"), value: formatBrl(result.value.totalDeductions) },
+    { label: t("salarioLiquido.results.inss"), value: formatBrl(result.value.inss) },
+    { label: t("salarioLiquido.results.irrf"), value: formatBrl(result.value.irrf) },
+    { label: t("salarioLiquido.results.employerTotal"), value: formatBrl(result.value.employerTotal) },
+  ];
+});
+
+const isSaved = computed(() => savedSimulationId.value !== null);
+const isBridging = computed(() => saveSimulationMutation.isPending.value || createReceivableMutation.isPending.value);
+</script>
+
+<template>
+  <div class="salario-liquido-root">
+  <NuxtLayout :name="isAuthenticated ? 'default' : 'tools-public'">
+    <div class="salario-liquido-page">
+      <div class="salario-liquido-page__layout">
+        <div class="salario-liquido-page__form-col">
+          <UiPageHeader
+            :title="t('salarioLiquido.hero.title')"
+            :subtitle="t('salarioLiquido.hero.subtitle')"
+          />
+
+          <UiGlassPanel>
+            <NForm @submit.prevent="handleCalculate">
+              <CalculatorFormSection :title="t('salarioLiquido.form.title')">
+                <NFormItem :label="t('salarioLiquido.form.grossSalary')">
+                  <NInputNumber
+                    :value="form.grossSalary"
+                    :min="0"
+                    :precision="2"
+                    prefix="R$"
+                    style="width: 100%"
+                    @update:value="(v) => patch({ grossSalary: v })"
+                  />
+                </NFormItem>
+
+                <NFormItem :label="t('salarioLiquido.form.dependents')">
+                  <NInputNumber
+                    :value="form.dependents"
+                    :min="0"
+                    :precision="0"
+                    style="width: 100%"
+                    @update:value="(v) => patch({ dependents: v ?? 0 })"
+                  />
+                </NFormItem>
+
+                <NFormItem :label="t('salarioLiquido.form.healthPlan')">
+                  <NInputNumber
+                    :value="form.healthPlanDiscount"
+                    :min="0"
+                    :precision="2"
+                    prefix="R$"
+                    style="width: 100%"
+                    @update:value="(v) => patch({ healthPlanDiscount: v ?? 0 })"
+                  />
+                </NFormItem>
+
+                <NFormItem :label="t('salarioLiquido.form.vaVr')">
+                  <NInputNumber
+                    :value="form.vaVrDiscount"
+                    :min="0"
+                    :precision="2"
+                    prefix="R$"
+                    style="width: 100%"
+                    @update:value="(v) => patch({ vaVrDiscount: v ?? 0 })"
+                  />
+                </NFormItem>
+
+                <NFormItem :label="t('salarioLiquido.form.alimonyPct')">
+                  <NInputNumber
+                    :value="form.alimonyPct"
+                    :min="0"
+                    :max="100"
+                    :precision="1"
+                    style="width: 100%"
+                    @update:value="(v) => patch({ alimonyPct: v ?? 0 })"
+                  />
+                </NFormItem>
+
+                <NCheckbox
+                  :checked="form.vtOptOut"
+                  @update:checked="(v) => patch({ vtOptOut: v })"
+                >
+                  {{ t('salarioLiquido.form.vtOptOut') }}
+                </NCheckbox>
+
+                <NCheckbox
+                  :checked="form.unionContribution"
+                  @update:checked="(v) => patch({ unionContribution: v })"
+                >
+                  {{ t('salarioLiquido.form.unionContribution') }}
+                </NCheckbox>
+              </CalculatorFormSection>
+
+              <NAlert v-if="validationError" type="error" style="margin-bottom: 16px">
+                {{ validationError }}
+              </NAlert>
+
+              <NSpace style="margin-top: 16px">
+                <NButton type="primary" attr-type="submit" :loading="isBridging">
+                  {{ t('salarioLiquido.form.calculate') }}
+                </NButton>
+                <NButton quaternary @click="handleReset">
+                  {{ t('salarioLiquido.form.reset') }}
+                </NButton>
+              </NSpace>
+            </NForm>
+          </UiGlassPanel>
+          <p class="salario-liquido-page__disclaimer">
+            {{ t('salarioLiquido.disclaimer.note', { year: BR_TAX_TABLE_YEAR }) }}
+          </p>
+        </div>
+
+        <div v-if="result" class="salario-liquido-page__result-col">
+          <UiStickySummaryCard>
+            <CalculatorResultSummary
+              :label="t('salarioLiquido.results.netSalary')"
+              :value="formatBrl(result.netSalary)"
+              :metrics="summaryMetrics"
+            />
+
+            <ToolSaveResult
+              intent="receivable"
+              :label="t('salarioLiquido.hero.title')"
+              :amount="result.netSalary"
+            />
+
+            <NSpace vertical style="margin-top: 16px">
+              <NButton
+                v-if="isAuthenticated"
+                :loading="saveSimulationMutation.isPending.value"
+                :disabled="isSaved"
+                block
+                @click="handleSaveSimulation"
+              >
+                {{ isSaved ? t('salarioLiquido.actions.saved') : t('salarioLiquido.actions.save') }}
+              </NButton>
+            </NSpace>
+          </UiStickySummaryCard>
+
+          <UiSurfaceCard>
+            <NThing
+              v-for="d in result.deductions"
+              :key="d.label"
+              :title="d.label"
+              :description="formatBrl(d.amount)"
+            />
+          </UiSurfaceCard>
+
+          <UiSurfaceCard>
+            <NThing :title="t('salarioLiquido.results.employerFgts')" :description="formatBrl(result.employerFgts)" />
+            <NThing :title="t('salarioLiquido.results.employerInss')" :description="formatBrl(result.employerInss)" />
+            <NThing :title="t('salarioLiquido.results.employerTotal')" :description="formatBrl(result.employerTotal)" />
+          </UiSurfaceCard>
+        </div>
+      </div>
+    </div>
+    <ToolGuestCta v-if="!isAuthenticated" />
+  </NuxtLayout>
+  </div>
+</template>

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -349,6 +349,66 @@
       "status": "enabled-prod",
       "description": "Página de orçamentos com acompanhamento de gastos por categoria e período.",
       "repositories": ["auraxis-web"]
+    },
+    {
+      "key": "web.tools.salario-liquido",
+      "owner": "platform",
+      "createdAt": "2026-04-17",
+      "removeBy": "2027-12-31",
+      "type": "release",
+      "status": "draft",
+      "description": "Calculadora de salário líquido CLT com todos os descontos e custo do empregador.",
+      "repositories": ["auraxis-web"]
+    },
+    {
+      "key": "web.tools.reserva-emergencia",
+      "owner": "platform",
+      "createdAt": "2026-04-17",
+      "removeBy": "2027-12-31",
+      "type": "release",
+      "status": "draft",
+      "description": "Calculadora de reserva de emergência por perfil profissional.",
+      "repositories": ["auraxis-web"]
+    },
+    {
+      "key": "web.tools.orcamento-50-30-20",
+      "owner": "platform",
+      "createdAt": "2026-04-17",
+      "removeBy": "2027-12-31",
+      "type": "release",
+      "status": "draft",
+      "description": "Orçamento 50/30/20: distribuição ideal vs real de renda.",
+      "repositories": ["auraxis-web"]
+    },
+    {
+      "key": "web.tools.cet",
+      "owner": "platform",
+      "createdAt": "2026-04-17",
+      "removeBy": "2027-12-31",
+      "type": "release",
+      "status": "draft",
+      "description": "CET — Custo Efetivo Total de financiamentos com Newton-Raphson.",
+      "repositories": ["auraxis-web"]
+    },
+    {
+      "key": "web.tools.quitacao-dividas",
+      "owner": "platform",
+      "createdAt": "2026-04-17",
+      "removeBy": "2027-12-31",
+      "type": "release",
+      "status": "draft",
+      "description": "Quitação de dívidas: Snowball vs Avalanche.",
+      "repositories": ["auraxis-web"]
+    },
+    {
+      "key": "web.tools.custo-estilo-vida",
+      "owner": "platform",
+      "createdAt": "2026-04-17",
+      "removeBy": "2027-12-31",
+      "type": "release",
+      "status": "draft",
+      "description": "Custo do estilo de vida: custo de oportunidade de gastos recorrentes.",
+      "repositories": ["auraxis-web"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Implements 6 new financial calculators: Salário Líquido CLT (#622), Reserva de Emergência (#623), Orçamento 50/30/20 (#624), CET (#625), Quitação de Dívidas (#626), Custo do Estilo de Vida (#627)
- Each tool: domain model + validation, Vue page with dual layout (guest/auth), ToolSaveResult integration (receivable/expense/goal per tool), save simulation, i18n (pt/en), feature flags (draft), and unit tests
- Subscriber integration: authenticated users can save simulations; premium users can create goals/receivables from results

## What's in each tool

| Tool | SaveIntent | Subscriber bridge |
|------|-----------|-------------------|
| Salário Líquido | receivable | Creates receivable from net salary |
| Reserva de Emergência | goal | Creates savings goal from target amount |
| Orçamento 50/30/20 | goal | Creates goal from ideal budget |
| CET | expense | Creates expense from total cost |
| Quitação de Dívidas | goal | Creates goal from total debt |
| Custo do Estilo de Vida | goal | Creates goal from opportunity cost |

## Technical highlights
- Shared `math-utils.ts` with `round2()` and Newton-Raphson solver (options object pattern)
- Progressive INSS/IRRF tax tables from `br-tax-tables.ts` for salário líquido
- Snowball vs Avalanche debt payoff algorithms with timeline charts
- IOF auto-calculation per Bacen rules for CET
- URL query param encoding (base64 JSON) for viral sharing in Custo do Estilo de Vida
- All model functions refactored to pass lint gates (max-statements, max-params, cognitive-complexity)

## Test plan
- [x] 14 model spec files (math-utils, 6 calculators) — all passing
- [x] 6 page spec files (guest layout, validation, results, save simulation, premium goals)
- [x] `pnpm quality-check` passes: flags:check, lint (0 errors), typecheck (0 errors), test:coverage (92%+ all metrics), policy:check, contracts:check, build
- [x] Pre-push hooks pass with coverage above 85% threshold