### PR TITLE
chore(flags): reconcile rescisao and inss-ir-folha with feature flag gate

### DIFF
--- a/app/features/tools/model/tools-catalog.ts
+++ b/app/features/tools/model/tools-catalog.ts
@@ -41,7 +41,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     name: "INSS + IR na Folha",
     description:
       "Veja exatamente quanto INSS e IR descontam do salário, faixa a faixa, com todas as deduções do IR.",
-    enabled: true,
+    enabled: isFeatureEnabled("web.tools.inss-ir-folha"),
     accessLevel: "public",
     route: "/tools/inss-ir-folha",
     featureFlag: "web.tools.inss-ir-folha",
@@ -74,7 +74,7 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     name: "Rescisão Contratual CLT",
     description:
       "Calcule o valor bruto e líquido da rescisão: aviso prévio, 13º, férias, FGTS e descontos de INSS/IR.",
-    enabled: true,
+    enabled: isFeatureEnabled("web.tools.rescisao"),
     accessLevel: "public",
     route: "/tools/rescisao",
     featureFlag: "web.tools.rescisao",

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -56,7 +56,7 @@
       "createdAt": "2026-04-01",
       "removeBy": "2027-12-31",
       "type": "release",
-      "status": "draft",
+      "status": "enabled-prod",
       "description": "Rescisão contratual CLT por tipo de desligamento.",
       "repositories": ["auraxis-web"]
     },
@@ -76,7 +76,7 @@
       "createdAt": "2026-04-01",
       "removeBy": "2027-12-31",
       "type": "release",
-      "status": "draft",
+      "status": "enabled-prod",
       "description": "INSS + IR na folha: desconto real por faixa salarial.",
       "repositories": ["auraxis-web"]
     },


### PR DESCRIPTION
## Resumo

- Promove `web.tools.rescisao` e `web.tools.inss-ir-folha` de `draft` → `enabled-prod` em `config/feature-flags.json`
- Alinha `tools-catalog.ts` para usar `isFeatureEnabled()` nessas duas tools (antes estavam com `enabled: true` hardcoded, ignorando o flag status)

## Contexto

Corresponde à task **TOOLS-GAP-02** (issue #618). Ambas as ferramentas já estão em produção e com páginas deployadas, mas o catálogo estava desalinhado com o registry de flags:
- `feature-flags.json` marcava ambas como `draft`
- `tools-catalog.ts` forçava `enabled: true` sem checar a flag

Após esta mudança, as duas ferramentas passam pelo mesmo gating que as demais tools ativas (`isFeatureEnabled("web.tools.<id>")`) e o registry reflete o estado real.

## Test plan

- [x] `pnpm vitest run app/features/tools/model/tools-catalog` → 12/12 ok
- [x] `pnpm flags:check` → 40 flags válidas
- [x] `pnpm lint` → clean
- [x] Pre-push gate completo passou localmente
- [ ] CI verde no PR

Closes #618