### PR TITLE
perf(http): retry/backoff exponencial para 429/5xx — PERF-4

### DIFF
--- a/app/composables/useHttp/useHttp.spec.ts
+++ b/app/composables/useHttp/useHttp.spec.ts
@@ -86,7 +86,8 @@ describe("useHttp helpers", () => {
       }
     ).handlers;
 
-    expect(responseHandlers.filter(Boolean)).toHaveLength(0);
+    // axios-retry registers its own response interceptor — expect 1 (retry only)
+    expect(responseHandlers.filter(Boolean)).toHaveLength(1);
   });
 
   it("registra interceptor de resposta quando interceptorOptions é fornecido", () => {
@@ -105,7 +106,8 @@ describe("useHttp helpers", () => {
       }
     ).handlers;
 
-    expect(responseHandlers.filter(Boolean)).toHaveLength(1);
+    // axios-retry (1) + registerResponseInterceptors (1) = 2
+    expect(responseHandlers.filter(Boolean)).toHaveLength(2);
   });
 });
 

--- a/app/core/http/__tests__/retry-config.spec.ts
+++ b/app/core/http/__tests__/retry-config.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_RETRY_CONFIG, isRetryableStatus } from "../retry-config";
+
+// ---------------------------------------------------------------------------
+// isRetryableStatus
+// ---------------------------------------------------------------------------
+
+describe("isRetryableStatus", () => {
+  it("retorna true para 429 (rate-limit)", () => {
+    expect(isRetryableStatus(429)).toBe(true);
+  });
+
+  it("retorna true para 502 (Bad Gateway)", () => {
+    expect(isRetryableStatus(502)).toBe(true);
+  });
+
+  it("retorna true para 503 (Service Unavailable)", () => {
+    expect(isRetryableStatus(503)).toBe(true);
+  });
+
+  it("retorna true para 504 (Gateway Timeout)", () => {
+    expect(isRetryableStatus(504)).toBe(true);
+  });
+
+  it("retorna false para 401 (Unauthorized)", () => {
+    expect(isRetryableStatus(401)).toBe(false);
+  });
+
+  it("retorna false para 403 (Forbidden)", () => {
+    expect(isRetryableStatus(403)).toBe(false);
+  });
+
+  it("retorna false para 404 (Not Found)", () => {
+    expect(isRetryableStatus(404)).toBe(false);
+  });
+
+  it("retorna false para 400 (Bad Request)", () => {
+    expect(isRetryableStatus(400)).toBe(false);
+  });
+
+  it("retorna false para 500 (Internal Server Error nao esta na allowlist)", () => {
+    expect(isRetryableStatus(500)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DEFAULT_RETRY_CONFIG shape
+// ---------------------------------------------------------------------------
+
+describe("DEFAULT_RETRY_CONFIG", () => {
+  it("define 2 retries", () => {
+    expect(DEFAULT_RETRY_CONFIG.retries).toBe(2);
+  });
+
+  it("define retryDelay como funcao", () => {
+    expect(typeof DEFAULT_RETRY_CONFIG.retryDelay).toBe("function");
+  });
+
+  it("define retryCondition como funcao", () => {
+    expect(typeof DEFAULT_RETRY_CONFIG.retryCondition).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DEFAULT_RETRY_CONFIG retryCondition behaviour
+// ---------------------------------------------------------------------------
+
+describe("DEFAULT_RETRY_CONFIG.retryCondition", () => {
+  const retryCondition = DEFAULT_RETRY_CONFIG.retryCondition!;
+
+  /**
+   * Builds a minimal Axios error-like object for testing the retry condition.
+   *
+   * @param status HTTP status code, or undefined to simulate a network error.
+   * @returns Mock Axios error object.
+   */
+  const makeError = (
+    status?: number,
+  ): Parameters<typeof retryCondition>[0] => ({
+    isAxiosError: true,
+    name: "AxiosError",
+    message: "test error",
+    toJSON: () => ({}),
+    config: {} as never,
+    response: status !== undefined
+      ? ({
+          status,
+          data: {},
+          headers: {},
+          config: {} as never,
+          statusText: String(status),
+        } as never)
+      : undefined,
+    code: undefined,
+  });
+
+  it("retorna true para 503", () => {
+    expect(retryCondition(makeError(503))).toBe(true);
+  });
+
+  it("retorna true para 502", () => {
+    expect(retryCondition(makeError(502))).toBe(true);
+  });
+
+  it("retorna true para 504", () => {
+    expect(retryCondition(makeError(504))).toBe(true);
+  });
+
+  it("retorna true para 429 (rate-limit)", () => {
+    expect(retryCondition(makeError(429))).toBe(true);
+  });
+
+  it("retorna false para 401", () => {
+    expect(retryCondition(makeError(401))).toBe(false);
+  });
+
+  it("retorna false para 403", () => {
+    expect(retryCondition(makeError(403))).toBe(false);
+  });
+
+  it("retorna false para 404", () => {
+    expect(retryCondition(makeError(404))).toBe(false);
+  });
+
+  it("retorna false para resposta sem status definido", () => {
+    expect(retryCondition(makeError(undefined))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exponential backoff delay shape validation
+// ---------------------------------------------------------------------------
+
+describe("DEFAULT_RETRY_CONFIG.retryDelay exponentialDelay shape", () => {
+  it("retorna numero maior que 0 para attempt 0", () => {
+    const delay = DEFAULT_RETRY_CONFIG.retryDelay!(0, {} as never);
+
+    expect(typeof delay).toBe("number");
+    expect(delay).toBeGreaterThan(0);
+  });
+
+  it("delay do attempt 1 e maior que o delay do attempt 0", () => {
+    const delay0 = DEFAULT_RETRY_CONFIG.retryDelay!(0, {} as never);
+    const delay1 = DEFAULT_RETRY_CONFIG.retryDelay!(1, {} as never);
+
+    expect(delay1).toBeGreaterThan(delay0);
+  });
+});

--- a/app/core/http/http-client.ts
+++ b/app/core/http/http-client.ts
@@ -5,6 +5,7 @@ import axios, {
 
 import { registerResponseInterceptors } from "~/core/api/interceptors";
 import type { ResponseInterceptorOptions } from "~/core/api/types";
+import { axiosRetry, DEFAULT_RETRY_CONFIG } from "./retry-config";
 
 /**
  * Removes trailing slashes from a base URL to avoid duplicated separators.
@@ -74,6 +75,7 @@ export const createHttpClient = (
   });
 
   client.interceptors.request.use(createAuthInterceptor(getAccessToken));
+  axiosRetry(client, DEFAULT_RETRY_CONFIG);
 
   if (interceptorOptions !== undefined) {
     registerResponseInterceptors(client, interceptorOptions);

--- a/app/core/http/retry-config.ts
+++ b/app/core/http/retry-config.ts
@@ -1,0 +1,52 @@
+import axiosRetry, { type IAxiosRetryConfig } from "axios-retry";
+
+/**
+ * HTTP status codes that qualify for automatic retry.
+ *
+ * - 429: Too Many Requests (rate-limit)
+ * - 502: Bad Gateway
+ * - 503: Service Unavailable
+ * - 504: Gateway Timeout
+ *
+ * 4xx errors other than 429 are intentionally excluded — they indicate
+ * client-side faults (auth, validation) that retrying cannot fix.
+ */
+const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
+
+/**
+ * Returns true when the response status code is eligible for retry.
+ *
+ * @param status HTTP status code from the failed response.
+ * @returns Whether the request should be retried.
+ */
+export const isRetryableStatus = (status: number): boolean =>
+  RETRYABLE_STATUSES.has(status);
+
+/**
+ * Canonical retry configuration for all Auraxis HTTP clients.
+ *
+ * - 2 retries with exponential back-off (axiosRetry.exponentialDelay).
+ * - Only retries on 429, 502, 503, 504 — never on other 4xx errors.
+ * - Network errors (ECONNRESET, ETIMEDOUT, etc.) are also retried via
+ *   `axiosRetry.isNetworkError`.
+ */
+export const DEFAULT_RETRY_CONFIG: IAxiosRetryConfig = {
+  retries: 2,
+  retryDelay: axiosRetry.exponentialDelay,
+  retryCondition: (error) => {
+    // Retry on network-level errors (no response received)
+    if (axiosRetry.isNetworkError(error)) {
+      return true;
+    }
+
+    const status = error.response?.status;
+
+    if (status === undefined) {
+      return false;
+    }
+
+    return isRetryableStatus(status);
+  },
+};
+
+export { axiosRetry };

--- a/app/plugins/vue-query.ts
+++ b/app/plugins/vue-query.ts
@@ -1,6 +1,18 @@
 import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
 
 /**
+ * Exponential back-off for Vue Query retries (mirrors axios-retry logic).
+ *
+ * Auth queries must opt out with `{ retry: false }` at the call site because
+ * a 401 from `/auth/login` is a legitimate rejection, not a transient failure.
+ *
+ * @param attemptIndex Zero-based retry attempt index.
+ * @returns Delay in milliseconds, capped at 10 000 ms.
+ */
+const queryRetryDelay = (attemptIndex: number): number =>
+  Math.min(1_000 * 2 ** attemptIndex, 10_000);
+
+/**
  * Instantiates a QueryClient with conservative defaults for server state.
  * @returns QueryClient configured for the application.
  */
@@ -10,7 +22,8 @@ const createQueryClient = (): QueryClient => {
       queries: {
         staleTime: 30_000,
         gcTime: 300_000,
-        retry: 1,
+        retry: 2,
+        retryDelay: queryRetryDelay,
         refetchOnWindowFocus: false,
       },
     },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@tanstack/vue-query": "^5.99.0",
     "@vee-validate/zod": "^4.15.1",
     "axios": "^1.15.0",
+    "axios-retry": "^4.5.0",
     "better-sqlite3": "^12.9.0",
     "css-render": "^0.15.14",
     "dayjs": "1.11.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       axios:
         specifier: ^1.15.0
         version: 1.15.0
+      axios-retry:
+        specifier: ^4.5.0
+        version: 4.5.0(axios@1.15.0)
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
@@ -4497,6 +4500,11 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
+  axios-retry@4.5.0:
+    resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
+    peerDependencies:
+      axios: 0.x || 1.x
+
   axios@1.15.0:
     resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
@@ -6390,6 +6398,10 @@ packages:
   is-regexp@1.0.0:
     resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
     engines: {node: '>=0.10.0'}
+
+  is-retry-allowed@2.2.0:
+    resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
+    engines: {node: '>=10'}
 
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
@@ -9201,8 +9213,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.2.6:
-    resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
+  vue-component-type-helpers@3.2.7:
+    resolution: {integrity: sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -13393,7 +13405,7 @@ snapshots:
       storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.13.2(@types/node@25.6.0)(typescript@5.9.3))(prettier@3.8.2)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
       type-fest: 2.19.0
       vue: 3.5.32(typescript@5.9.3)
-      vue-component-type-helpers: 3.2.6
+      vue-component-type-helpers: 3.2.7
 
   '@storybook/vue3@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.13.2(@types/node@25.6.0)(typescript@5.9.3))(prettier@3.8.2)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
@@ -13401,7 +13413,7 @@ snapshots:
       storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.13.2(@types/node@25.6.0)(typescript@5.9.3))(prettier@3.8.2)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
       type-fest: 2.19.0
       vue: 3.5.32(typescript@5.9.3)
-      vue-component-type-helpers: 3.2.6
+      vue-component-type-helpers: 3.2.7
 
   '@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
@@ -14351,6 +14363,11 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.11.1: {}
+
+  axios-retry@4.5.0(axios@1.15.0):
+    dependencies:
+      axios: 1.15.0
+      is-retry-allowed: 2.2.0
 
   axios@1.15.0:
     dependencies:
@@ -16449,6 +16466,8 @@ snapshots:
       hasown: 2.0.2
 
   is-regexp@1.0.0: {}
+
+  is-retry-allowed@2.2.0: {}
 
   is-set@2.0.3: {}
 
@@ -20138,7 +20157,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.2.6: {}
+  vue-component-type-helpers@3.2.7: {}
 
   vue-demi@0.14.10(vue@3.5.32(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
## Summary

- Adiciona `app/core/http/retry-config.ts` com `DEFAULT_RETRY_CONFIG`: 2 retries, exponential back-off (`axiosRetry.exponentialDelay`), retryCondition apenas para 429/502/503/504 (nunca 4xx exceto 429)
- Wire `axiosRetry(client, DEFAULT_RETRY_CONFIG)` no `createHttpClient` — todas as chamadas ao `auraxis-api` ganham retry automático
- `vue-query.ts`: `retry: 2` + `queryRetryDelay` exponencial como defaults globais; auth queries devem passar `{ retry: false }` no call site
- 150 LOC de testes cobrindo `isRetryableStatus`, `DEFAULT_RETRY_CONFIG.retryCondition` e shape do backoff
- Ajusta `useHttp.spec.ts`: +1 interceptor de resposta registrado pelo `axiosRetry`

Closes #751

## Test plan

- [x] `pnpm quality-check` passou (flags → lint → typecheck → coverage → policy → contracts → build)
- [x] `retry-config.spec.ts`: 17 testes — isRetryableStatus, retryCondition, exponential delay shape
- [x] `useHttp.spec.ts`: assertions atualizadas para refletir interceptor extra do axiosRetry