### PR TITLE
chore(dx): update .gitignore — stryker, storybook, claude worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,18 @@ test-results/
 
 bundle-report.json
 stats.html
+
+# Stryker mutation testing
+.stryker-tmp/
+mutation-report/
+
+# Storybook test artifacts
+storybook-static/
+storybook-test-results/
+
+# Claude Code agent worktrees and session data
+.claude/worktrees/
+.claude/
+
+# pnpm patch files
+*.patch


### PR DESCRIPTION
## Summary

- Adiciona `.stryker-tmp/` e `mutation-report/` (Stryker mutation testing — instalado via #738)
- Adiciona `storybook-static/` e `storybook-test-results/` (Storybook test-runner — instalado via #754)
- Adiciona `.claude/worktrees/` e `.claude/` (Claude Code agent isolation worktrees)
- Adiciona `*.patch` (pnpm patch files gerados localmente)

Parte do bloco DX — workspace cleanup.