### PR TITLE
feat(ds): wave-4 — migrar aliases bridge para tokens v3 canônicos (closes #733)

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -51,6 +51,9 @@
   --color-brand-700: #1598be;
   --color-brand-800: #1598be;
 
+  /* Accent — secondary (violet) */
+  --color-accent: #8b7dff;
+
   /* Brand glows (cyan-based) */
   --color-brand-glow-lg:  rgba(68, 212, 255, 0.4);
   --color-brand-glow-md:  rgba(68, 212, 255, 0.3);

--- a/app/components/auth/AuthBrandPanel/AuthBrandPanel.vue
+++ b/app/components/auth/AuthBrandPanel/AuthBrandPanel.vue
@@ -60,7 +60,7 @@ import { PieChart } from "lucide-vue-next";
   border-radius: var(--radius-sm);
   display: grid;
   place-items: center;
-  background: linear-gradient(145deg, var(--accent-cyan, #44d4ff), var(--accent-violet, #8b7dff));
+  background: linear-gradient(145deg, var(--color-brand-500), var(--color-accent));
   color: #0b1626;
   font-weight: var(--font-weight-extrabold);
 }
@@ -76,13 +76,13 @@ import { PieChart } from "lucide-vue-next";
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  border: 1px solid var(--border-strong, rgba(68, 212, 255, 0.4));
+  border: 1px solid var(--color-brand-glow-lg);
   border-radius: var(--radius-full);
   padding: 7px 12px;
   font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--accent-cyan, #44d4ff);
+  color: var(--color-brand-500);
   background: rgba(68, 212, 255, 0.1);
 }
 

--- a/app/components/auth/LoginForm/LoginForm.vue
+++ b/app/components/auth/LoginForm/LoginForm.vue
@@ -141,7 +141,7 @@ const isPending = computed(() => props.loading || isSubmitting.value);
 
 .auth-card__input:focus {
   outline: none;
-  border-color: var(--accent-cyan, #44d4ff);
+  border-color: var(--color-brand-500);
   box-shadow: 0 0 0 3px rgba(68, 212, 255, 0.18);
 }
 
@@ -162,7 +162,7 @@ const isPending = computed(() => props.loading || isSubmitting.value);
 }
 
 .auth-card__link {
-  color: var(--accent-cyan, #44d4ff);
+  color: var(--color-brand-500);
   font-weight: var(--font-weight-bold);
   font-size: var(--font-size-sm);
   text-decoration: none;
@@ -170,7 +170,7 @@ const isPending = computed(() => props.loading || isSubmitting.value);
 }
 
 .auth-card__link:hover {
-  color: var(--accent-lime, #42e8a9);
+  color: var(--color-positive);
 }
 
 .auth-card__submit {

--- a/app/components/ui/UiAppShell/UiAppShell.vue
+++ b/app/components/ui/UiAppShell/UiAppShell.vue
@@ -140,7 +140,7 @@ const currentRoute = computed(() => route.path);
 .ui-app-shell__logo-mark {
   width: 32px;
   height: 32px;
-  background: linear-gradient(145deg, var(--accent-cyan, #44d4ff), var(--accent-violet, #8b7dff));
+  background: linear-gradient(145deg, var(--color-brand-500), var(--color-accent));
   border-radius: var(--radius-sm);
   display: flex;
   align-items: center;

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -82,7 +82,7 @@ function tItemPrice(prefix: string): { title: string; price: string; description
           <p class="landing-kpi landing-kpi--info">{{ t('pages.home.hero.previewValue') }}</p>
           <p class="landing-hero__card-desc">{{ t('pages.home.hero.previewDesc') }}</p>
           <svg class="landing-sparkline" viewBox="0 0 600 180" role="img" aria-hidden="true">
-            <polyline fill="none" stroke="var(--accent-cyan, #44d4ff)" stroke-width="4" points="10,128 90,112 170,96 250,88 330,71 410,66 490,58 590,38" />
+            <polyline fill="none" stroke="var(--color-brand-500)" stroke-width="4" points="10,128 90,112 170,96 250,88 330,71 410,66 490,58 590,38" />
             <polyline fill="none" stroke="var(--color-negative, #ff6f79)" stroke-width="4" points="10,145 90,133 170,125 250,114 330,106 410,111 490,103 590,99" opacity="0.9" />
           </svg>
         </article>
@@ -180,7 +180,7 @@ function tItemPrice(prefix: string): { title: string; price: string; description
   font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--accent-cyan, #44d4ff);
+  color: var(--color-brand-500);
   background: rgba(68, 212, 255, 0.1);
   font-weight: var(--font-weight-semibold);
 }
@@ -218,7 +218,7 @@ function tItemPrice(prefix: string): { title: string; price: string; description
 }
 
 .landing-btn--secondary:hover {
-  border-color: var(--accent-cyan, #44d4ff);
+  border-color: var(--color-brand-500);
   color: var(--color-text-primary);
 }
 
@@ -320,7 +320,7 @@ function tItemPrice(prefix: string): { title: string; price: string; description
 }
 
 .landing-kpi--info {
-  color: var(--accent-cyan, #44d4ff);
+  color: var(--color-brand-500);
 }
 
 .landing-kpi--profit {


### PR DESCRIPTION
## Summary

- Adiciona `--color-accent: #8b7dff` ao `main.css` — token v3 canônico para o violet/secondary (faltava na paleta)
- Substitui todas as referências aos aliases do bridge CSS (`--accent-cyan`, `--accent-violet`, `--accent-lime`, `--border-strong`) pelos tokens v3 diretos em 4 componentes
- Adiciona `.stryker-tmp/**` e `mutation-report/**` ao ignore do ESLint (gerados pelo Stryker, não são código de produto)

### Mapeamento de tokens

| Legacy alias | Token v3 |
|---|---|
| `--accent-cyan` | `--color-brand-500` |
| `--accent-violet` | `--color-accent` (novo) |
| `--accent-lime` | `--color-positive` |
| `--border-strong` | `--color-brand-glow-lg` |

### Arquivos modificados

- `app/assets/css/main.css` — novo token `--color-accent`
- `app/pages/index.vue`
- `app/components/ui/UiAppShell/UiAppShell.vue`
- `app/components/auth/LoginForm/LoginForm.vue`
- `app/components/auth/AuthBrandPanel/AuthBrandPanel.vue`
- `eslint.config.mjs` — ignore Stryker sandboxes

## Test plan

- [x] `pnpm quality-check` passa (flags → lint → typecheck → coverage → policy → contracts → build)
- [x] Zero aliases bridge em `app/` (grep limpo)
- [ ] Visual review: landing page, login, app shell

## Dependências

- PRs #757/#758 (Wave-3) ainda abertos — `WalletEntryFormFields.vue` (`--warning-color`) será tratado naqueles PRs
- Wave-5 (#734): remoção do `ds-bridge.css` e do import em `nuxt.config.ts` após merge de #757/#758