### PR TITLE
feat(dashboard): empty-state CTA + UiEmptyState extensions + comparison E2E

### DIFF
--- a/app/components/ui/UiEmptyState/UiEmptyState.types.ts
+++ b/app/components/ui/UiEmptyState/UiEmptyState.types.ts
@@ -8,12 +8,16 @@ export interface UiEmptyStateProps {
   title: string
   /** Descrição secundária */
   description?: string
-  /** Label do botão CTA */
+  /** Label do botão CTA primário */
   actionLabel?: string
+  /** Label do link secundário (renderizado abaixo do CTA) */
+  secondaryLabel?: string
+  /** Se fornecido, renderiza o secundário como `<a href>` em vez de `<button>` */
+  secondaryHref?: string
   /** Variante compacta — menor padding e ícone reduzido, para uso dentro de cards */
   compact?: boolean
 }
 
 export interface UiEmptyStateEmits {
-  (e: "action"): void
+  (e: "action" | "secondary-action"): void
 }

--- a/app/components/ui/UiEmptyState/UiEmptyState.vue
+++ b/app/components/ui/UiEmptyState/UiEmptyState.vue
@@ -8,6 +8,8 @@ const props = withDefaults(defineProps<UiEmptyStateProps>(), {
   icon: undefined,
   description: undefined,
   actionLabel: undefined,
+  secondaryLabel: undefined,
+  secondaryHref: undefined,
   compact: false,
 });
 
@@ -16,6 +18,8 @@ const emit = defineEmits<UiEmptyStateEmits>();
 /**
  * Resolves the icon prop to a renderable component.
  * Accepts either a string key from ICON_MAP or a Component reference directly.
+ *
+ * @returns Vue component reference, or undefined when no icon is set.
  */
 const resolvedIcon = computed(() => {
   if (!props.icon) { return undefined; }
@@ -24,6 +28,18 @@ const resolvedIcon = computed(() => {
 });
 
 const iconSize = computed(() => (props.compact ? 24 : 40));
+
+const hasPrimary = computed(() => Boolean(props.actionLabel));
+const hasSecondary = computed(() => Boolean(props.secondaryLabel));
+const hasActions = computed(() => hasPrimary.value || hasSecondary.value);
+
+/**
+ * Handles secondary action click. When `secondaryHref` is set the anchor
+ * navigates naturally; the emit still fires so parents can track analytics.
+ */
+const onSecondary = (): void => {
+  emit("secondary-action");
+};
 </script>
 
 <template>
@@ -32,19 +48,48 @@ const iconSize = computed(() => (props.compact ? 24 : 40));
     :class="{ 'ui-empty-state--compact': compact }"
     role="status"
   >
-    <div v-if="resolvedIcon" class="ui-empty-state__icon-wrap" aria-hidden="true">
-      <component :is="resolvedIcon" :size="iconSize" />
-    </div>
-    <h3 class="ui-empty-state__title">{{ title }}</h3>
-    <p v-if="description" class="ui-empty-state__description">{{ description }}</p>
-    <button
-      v-if="actionLabel"
-      class="ui-empty-state__action"
-      type="button"
-      @click="emit('action')"
-    >
-      {{ actionLabel }}
-    </button>
+    <slot name="icon">
+      <div v-if="resolvedIcon" class="ui-empty-state__icon-wrap" aria-hidden="true">
+        <component :is="resolvedIcon" :size="iconSize" />
+      </div>
+    </slot>
+
+    <slot name="title">
+      <h3 class="ui-empty-state__title">{{ title }}</h3>
+    </slot>
+
+    <slot name="description">
+      <p v-if="description" class="ui-empty-state__description">{{ description }}</p>
+    </slot>
+
+    <slot name="actions">
+      <div v-if="hasActions" class="ui-empty-state__actions">
+        <button
+          v-if="hasPrimary"
+          class="ui-empty-state__action"
+          type="button"
+          @click="emit('action')"
+        >
+          {{ actionLabel }}
+        </button>
+        <a
+          v-if="hasSecondary && secondaryHref"
+          class="ui-empty-state__secondary"
+          :href="secondaryHref"
+          @click="onSecondary"
+        >
+          {{ secondaryLabel }}
+        </a>
+        <button
+          v-else-if="hasSecondary"
+          class="ui-empty-state__secondary"
+          type="button"
+          @click="onSecondary"
+        >
+          {{ secondaryLabel }}
+        </button>
+      </div>
+    </slot>
   </div>
 </template>
 
@@ -103,8 +148,15 @@ const iconSize = computed(() => (props.compact ? 24 : 40));
   font-size: var(--font-size-xs);
 }
 
-.ui-empty-state__action {
+.ui-empty-state__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
   margin-top: var(--space-1);
+}
+
+.ui-empty-state__action {
   padding: 10px var(--space-3);
   background: var(--color-brand-600);
   color: var(--color-bg-base);
@@ -117,5 +169,20 @@ const iconSize = computed(() => (props.compact ? 24 : 40));
 
 .ui-empty-state__action:hover {
   background: var(--color-brand-500);
+}
+
+.ui-empty-state__secondary {
+  background: transparent;
+  border: none;
+  color: var(--color-brand-500);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  text-decoration: none;
+  padding: 0;
+}
+
+.ui-empty-state__secondary:hover {
+  text-decoration: underline;
 }
 </style>

--- a/app/components/ui/UiEmptyState/__tests__/UiEmptyState.spec.ts
+++ b/app/components/ui/UiEmptyState/__tests__/UiEmptyState.spec.ts
@@ -127,12 +127,120 @@ describe("UiEmptyState", () => {
     expect(icon.props("size")).toBe(40);
   });
 
+  it("does not render secondary control when secondaryLabel is not provided", () => {
+    const wrapper = mount(UiEmptyState, {
+      props: { title: "Vazio", actionLabel: "Ação" },
+    });
+    expect(wrapper.find(".ui-empty-state__secondary").exists()).toBe(false);
+  });
+
+  it("renders secondary as button when secondaryLabel is provided without href", () => {
+    const wrapper = mount(UiEmptyState, {
+      props: {
+        title: "Vazio",
+        actionLabel: "Primário",
+        secondaryLabel: "Secundário",
+      },
+    });
+    const secondary = wrapper.find("button.ui-empty-state__secondary");
+    expect(secondary.exists()).toBe(true);
+    expect(secondary.text()).toBe("Secundário");
+  });
+
+  it("renders secondary as anchor when secondaryHref is provided", () => {
+    const wrapper = mount(UiEmptyState, {
+      props: {
+        title: "Vazio",
+        secondaryLabel: "Saiba mais",
+        secondaryHref: "/sobre",
+      },
+    });
+    const link = wrapper.find("a.ui-empty-state__secondary");
+    expect(link.exists()).toBe(true);
+    expect(link.attributes("href")).toBe("/sobre");
+    expect(link.text()).toBe("Saiba mais");
+  });
+
+  it("emits secondary-action when secondary button is clicked", async () => {
+    const wrapper = mount(UiEmptyState, {
+      props: { title: "Vazio", secondaryLabel: "Ajuda" },
+    });
+    await wrapper.find("button.ui-empty-state__secondary").trigger("click");
+    expect(wrapper.emitted("secondary-action")).toBeTruthy();
+    expect(wrapper.emitted("secondary-action")).toHaveLength(1);
+  });
+
+  it("emits secondary-action when secondary anchor is clicked", async () => {
+    const wrapper = mount(UiEmptyState, {
+      props: {
+        title: "Vazio",
+        secondaryLabel: "Saiba mais",
+        secondaryHref: "/sobre",
+      },
+    });
+    await wrapper.find("a.ui-empty-state__secondary").trigger("click");
+    expect(wrapper.emitted("secondary-action")).toBeTruthy();
+  });
+
+  it("renders secondary without primary (secondary alone is valid)", () => {
+    const wrapper = mount(UiEmptyState, {
+      props: { title: "Vazio", secondaryLabel: "Saiba mais" },
+    });
+    expect(wrapper.find(".ui-empty-state__action").exists()).toBe(false);
+    expect(wrapper.find(".ui-empty-state__secondary").exists()).toBe(true);
+  });
+
+  it("does not render actions wrap when no labels are provided", () => {
+    const wrapper = mount(UiEmptyState, {
+      props: { title: "Vazio" },
+    });
+    expect(wrapper.find(".ui-empty-state__actions").exists()).toBe(false);
+  });
+
+  it("slot #icon replaces default icon rendering", () => {
+    const wrapper = mount(UiEmptyState, {
+      props: { title: "Vazio", icon: MockIcon },
+      slots: { icon: "<div class=\"custom-icon\">★</div>" },
+    });
+    expect(wrapper.find(".custom-icon").exists()).toBe(true);
+    expect(wrapper.find(".ui-empty-state__icon-wrap").exists()).toBe(false);
+  });
+
+  it("slot #title replaces default title rendering", () => {
+    const wrapper = mount(UiEmptyState, {
+      props: { title: "Fallback" },
+      slots: { title: "<h2 class=\"custom-title\">Título customizado</h2>" },
+    });
+    expect(wrapper.find(".custom-title").exists()).toBe(true);
+    expect(wrapper.find(".ui-empty-state__title").exists()).toBe(false);
+  });
+
+  it("slot #description replaces default description rendering", () => {
+    const wrapper = mount(UiEmptyState, {
+      props: { title: "Vazio", description: "default" },
+      slots: { description: "<p class=\"custom-desc\">Custom description</p>" },
+    });
+    expect(wrapper.find(".custom-desc").exists()).toBe(true);
+    expect(wrapper.find(".ui-empty-state__description").exists()).toBe(false);
+  });
+
+  it("slot #actions replaces default actions rendering", () => {
+    const wrapper = mount(UiEmptyState, {
+      props: { title: "Vazio", actionLabel: "Default" },
+      slots: { actions: "<div class=\"custom-actions\">Custom CTA</div>" },
+    });
+    expect(wrapper.find(".custom-actions").exists()).toBe(true);
+    expect(wrapper.find(".ui-empty-state__action").exists()).toBe(false);
+  });
+
   it("matches snapshot with all props", () => {
     const wrapper = mount(UiEmptyState, {
       props: {
         title: "Nenhum item",
         description: "Adicione itens para ver aqui.",
         actionLabel: "Adicionar",
+        secondaryLabel: "Saiba mais",
+        secondaryHref: "/docs",
         icon: MockIcon,
       },
     });

--- a/app/components/ui/UiEmptyState/__tests__/__snapshots__/UiEmptyState.spec.ts.snap
+++ b/app/components/ui/UiEmptyState/__tests__/__snapshots__/UiEmptyState.spec.ts.snap
@@ -13,6 +13,7 @@ exports[`UiEmptyState > matches snapshot with all props 1`] = `
 "<div data-v-1eb04e1a="" class="ui-empty-state" role="status">
   <div data-v-1eb04e1a="" class="ui-empty-state__icon-wrap" aria-hidden="true"><svg data-v-1eb04e1a="" class="mock-icon"></svg></div>
   <h3 data-v-1eb04e1a="" class="ui-empty-state__title">Nenhum item</h3>
-  <p data-v-1eb04e1a="" class="ui-empty-state__description">Adicione itens para ver aqui.</p><button data-v-1eb04e1a="" class="ui-empty-state__action" type="button">Adicionar</button>
+  <p data-v-1eb04e1a="" class="ui-empty-state__description">Adicione itens para ver aqui.</p>
+  <div data-v-1eb04e1a="" class="ui-empty-state__actions"><button data-v-1eb04e1a="" class="ui-empty-state__action" type="button">Adicionar</button><a data-v-1eb04e1a="" class="ui-empty-state__secondary" href="/docs">Saiba mais</a></div>
 </div>"
 `;

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -183,6 +183,8 @@
       "noData": "Sem dados para este período",
       "noDataCustom": "Nenhum dado encontrado para o período personalizado.",
       "noDataPeriod": "Ainda não encontramos movimentações para o período selecionado.",
+      "registerFirstTransaction": "Registre sua primeira transação",
+      "learnMore": "Saiba mais sobre o Auraxis",
       "featuredGoals": "Metas em destaque",
       "noGoals": "Sem metas",
       "noGoalsDesc": "Nenhuma meta ativa para o período selecionado.",

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -100,6 +100,18 @@ const isCustomPeriodIncomplete = computed(
   () => selectedPeriod.value === "custom" && (!customStartTs.value || !customEndTs.value),
 );
 
+const isEmptyStateQuickAddOpen = ref<boolean>(false);
+
+/** Opens the first-transaction quick-add modal from the dashboard empty state. */
+const openFirstTransactionForm = (): void => {
+  isEmptyStateQuickAddOpen.value = true;
+};
+
+/** Closes the empty-state quick-add modal (on dismiss or success). */
+const closeFirstTransactionForm = (): void => {
+  isEmptyStateQuickAddOpen.value = false;
+};
+
 const isQuickSelectPeriod = computed((): boolean =>
   ["1m", "3m", "6m", "12m"].includes(selectedPeriod.value),
 );
@@ -196,6 +208,10 @@ const emptyMessage = computed(() =>
           icon="chartLine"
           :title="$t('pages.dashboard.noData')"
           :description="emptyMessage"
+          :action-label="$t('pages.dashboard.registerFirstTransaction')"
+          :secondary-label="$t('pages.dashboard.learnMore')"
+          secondary-href="https://auraxis.com.br/sobre"
+          @action="openFirstTransactionForm"
         />
 
         <template v-else>
@@ -291,6 +307,13 @@ const emptyMessage = computed(() =>
         />
       </UiSurfaceCard>
     </template>
+
+    <QuickTransactionForm
+      :visible="isEmptyStateQuickAddOpen"
+      type="expense"
+      @update:visible="closeFirstTransactionForm"
+      @success="closeFirstTransactionForm"
+    />
   </div>
 </template>
 

--- a/e2e/dashboard/weekly-comparison.spec.ts
+++ b/e2e/dashboard/weekly-comparison.spec.ts
@@ -28,21 +28,39 @@ const MOCK_LOGIN_SUCCESS = {
   },
 };
 
+/**
+ * Must use the "rich contract" shape to trigger the mapper path that reads
+ * `comparison` — the mapper switches on the presence of `period`. Without it,
+ * `mapDashboardOverviewDto` falls through to the simplified path, which always
+ * sets comparison to null regardless of what the mock sends.
+ *
+ * Field names are snake_case to match the actual backend DTO.
+ */
 const MOCK_OVERVIEW_WITH_COMPARISON = {
-  income: 10000,
-  expense: 4000,
-  balance: 6000,
-  netWorth: 50000,
-  goals: [],
-  alerts: [],
-  upcomingDues: [],
-  expensesByCategory: [],
-  comparison: {
-    incomeVsPreviousMonthPercent: 20,
-    expenseVsPreviousMonthPercent: 10,
-    balanceVsPreviousMonthPercent: -5,
+  period: {
+    key: "current_month",
+    start: "2026-04-01",
+    end: "2026-04-30",
+    label: "abril 2026",
   },
-  portfolio: { currentValue: 25000, costBasis: 20000 },
+  summary: {
+    income: 10000,
+    expense: 4000,
+    balance: 6000,
+    upcoming_due_total: 500,
+    net_worth: 50000,
+  },
+  comparison: {
+    income_vs_previous_month_percent: 20,
+    expense_vs_previous_month_percent: 10,
+    balance_vs_previous_month_percent: -5,
+  },
+  timeseries: [],
+  expenses_by_category: [],
+  upcoming_dues: [],
+  goals: [],
+  portfolio: { current_value: 25000, change_percent: null },
+  alerts: [],
 };
 
 /**
@@ -87,6 +105,27 @@ const mockAuthAndDashboard = async (page: Page): Promise<void> => {
         subscription_plan: "free",
       }),
     });
+  });
+
+  await page.route("**/dashboard/survival-index", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        n_months: 3,
+        total_assets: 25000,
+        avg_monthly_expense: 4000,
+        classification: "ok",
+      }),
+    });
+  });
+
+  await page.route("**/wallet/entries**", (route) => {
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([]) });
+  });
+
+  await page.route("**/transactions/due-range**", (route) => {
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ transactions: [], total: 0 }) });
   });
 };
 

--- a/e2e/dashboard/weekly-comparison.spec.ts
+++ b/e2e/dashboard/weekly-comparison.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect, type Page } from "@playwright/test";
+import { waitForHydration } from "../helpers/auth";
+
+/**
+ * E2E suite: Dashboard period comparison — MSW-backed.
+ *
+ * Context: issue #636 refers to "weekly comparison" but the current
+ * `DashboardComparison` schema exposes only month-over-previous-month deltas
+ * (`incomeVsPreviousMonthPercent`, `expenseVsPreviousMonthPercent`,
+ * `balanceVsPreviousMonthPercent`). This suite audits that when the overview
+ * API returns a populated `comparison`, the dashboard summary grid renders a
+ * `UiTrendBadge` for each metric that carries a delta, with the correct
+ * direction modifier class.
+ */
+
+const MOCK_LOGIN_SUCCESS = {
+  success: true,
+  message: "Authenticated",
+  data: {
+    token: "mock-access-token",
+    refresh_token: "mock-refresh-token",
+    user: {
+      id: "user-1",
+      name: "Test User",
+      email: "test@auraxis.com",
+      email_confirmed: true,
+    },
+  },
+};
+
+const MOCK_OVERVIEW_WITH_COMPARISON = {
+  income: 10000,
+  expense: 4000,
+  balance: 6000,
+  netWorth: 50000,
+  goals: [],
+  alerts: [],
+  upcomingDues: [],
+  expensesByCategory: [],
+  comparison: {
+    incomeVsPreviousMonthPercent: 20,
+    expenseVsPreviousMonthPercent: 10,
+    balanceVsPreviousMonthPercent: -5,
+  },
+  portfolio: { currentValue: 25000, costBasis: 20000 },
+};
+
+/**
+ * Registers mock routes for an authenticated dashboard session with a
+ * populated month-over-month comparison object.
+ *
+ * @param page - Playwright page instance.
+ */
+const mockAuthAndDashboard = async (page: Page): Promise<void> => {
+  await page.route("**/auth/login", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_LOGIN_SUCCESS),
+    });
+  });
+
+  await page.route("**/dashboard/overview", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_OVERVIEW_WITH_COMPARISON),
+    });
+  });
+
+  await page.route("**/dashboard/trends", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ series: [] }),
+    });
+  });
+
+  await page.route("**/user/me", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "user-1",
+        email: "test@auraxis.com",
+        name: "Test User",
+        subscription_plan: "free",
+      }),
+    });
+  });
+};
+
+/**
+ * Performs the mocked login → dashboard navigation flow.
+ *
+ * @param page - Playwright page instance.
+ */
+const loginAndLandOnDashboard = async (page: Page): Promise<void> => {
+  await page.goto("/login");
+  await waitForHydration(page);
+  await page.locator("#login-email").fill("test@auraxis.com");
+  await page.locator("#login-password").fill("ValidPassword1!");
+  await page.getByRole("button", { name: /entrar/i }).click();
+  await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 });
+};
+
+test.describe("Dashboard — period comparison (month-over-month)", () => {
+  test("renders a trend badge inside summary-grid when comparison is present", async ({ page }) => {
+    await mockAuthAndDashboard(page);
+    await loginAndLandOnDashboard(page);
+
+    const summaryGrid = page.locator(".summary-grid");
+    await expect(summaryGrid).toBeVisible({ timeout: 10_000 });
+
+    const trendBadges = summaryGrid.locator(".ui-trend-badge");
+    await expect(trendBadges.first()).toBeVisible({ timeout: 10_000 });
+    expect(await trendBadges.count()).toBeGreaterThanOrEqual(1);
+  });
+
+  test("uses --positive modifier class for positive income delta", async ({ page }) => {
+    await mockAuthAndDashboard(page);
+    await loginAndLandOnDashboard(page);
+
+    const summaryGrid = page.locator(".summary-grid");
+    await expect(summaryGrid).toBeVisible({ timeout: 10_000 });
+
+    const positive = summaryGrid.locator(".ui-trend-badge--positive");
+    await expect(positive.first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("uses --negative modifier class for negative balance delta", async ({ page }) => {
+    await mockAuthAndDashboard(page);
+    await loginAndLandOnDashboard(page);
+
+    const summaryGrid = page.locator(".summary-grid");
+    await expect(summaryGrid).toBeVisible({ timeout: 10_000 });
+
+    const negative = summaryGrid.locator(".ui-trend-badge--negative");
+    await expect(negative.first()).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/dashboard/weekly-comparison.spec.ts
+++ b/e2e/dashboard/weekly-comparison.spec.ts
@@ -78,7 +78,10 @@ const mockAuthAndDashboard = async (page: Page): Promise<void> => {
     });
   });
 
-  await page.route("**/dashboard/overview", (route) => {
+  // Trailing ** is required — Playwright globs anchor with ^ and $, so a
+  // pattern without ** at the end will NOT match URLs with query strings
+  // (e.g. /dashboard/overview?month=2026-04).
+  await page.route("**/dashboard/overview**", (route) => {
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -86,7 +89,7 @@ const mockAuthAndDashboard = async (page: Page): Promise<void> => {
     });
   });
 
-  await page.route("**/dashboard/trends", (route) => {
+  await page.route("**/dashboard/trends**", (route) => {
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/e2e/specs/dashboard.spec.ts
+++ b/e2e/specs/dashboard.spec.ts
@@ -57,7 +57,9 @@ const mockAuthAndDashboard = async (page: Page): Promise<void> => {
 		});
 	});
 
-	await page.route("**/dashboard/overview", (route) => {
+	// Trailing ** required — Playwright globs are anchored; without it the
+	// pattern does not match URLs with query strings (?month=2026-04).
+	await page.route("**/dashboard/overview**", (route) => {
 		route.fulfill({
 			status: 200,
 			contentType: "application/json",
@@ -65,7 +67,7 @@ const mockAuthAndDashboard = async (page: Page): Promise<void> => {
 		});
 	});
 
-	await page.route("**/dashboard/trends", (route) => {
+	await page.route("**/dashboard/trends**", (route) => {
 		route.fulfill({
 			status: 200,
 			contentType: "application/json",


### PR DESCRIPTION
## Summary

- **#547** — `UiEmptyState` ganha CTA secundária (link/button via `secondaryLabel` + `secondaryHref`), slots `#icon` / `#title` / `#description` / `#actions` para customização, e novos testes (28 its, 100% cobertura).
- **#548** — Dashboard (`/dashboard`) passa a expor "Registre sua primeira transação" + link secundário "Saiba mais sobre o Auraxis" no empty-state quando não há `summary`. O clique no CTA reaproveita `QuickTransactionForm` para reduzir fricção do first-time user.
- **#636** — Novo E2E `e2e/dashboard/weekly-comparison.spec.ts` (MSW-backed) audita renderização de `UiTrendBadge` dentro de `.summary-grid` quando o overview traz `comparison`.

> **Nota sobre #636 — "comparação semanal":** o schema atual (`DashboardComparison`) expõe apenas deltas month-over-previous-month (`incomeVsPreviousMonthPercent`, `expenseVsPreviousMonthPercent`, `balanceVsPreviousMonthPercent`). O E2E valida a renderização desse contrato existente. Se a intenção original era comparação semanal, abrir issue de follow-up no backend para estender o DTO — o componente já está preparado para receber deltas de qualquer periodicidade.

## Test plan

- [x] \`pnpm quality-check\` (lint + typecheck + test:coverage + policy + contracts + build) passou localmente
- [x] 28 its em \`UiEmptyState.spec.ts\` (100% cobertura do componente)
- [ ] CI verde
- [ ] E2E \`dashboard/weekly-comparison.spec.ts\` roda no pipeline (ou manual via \`pnpm test:e2e:chromium\`)
- [ ] QA visual: \`/dashboard\` sem dados mostra CTA + link secundário
- [ ] QA visual: \`/dashboard\` com comparação populada mostra badges de tendência

Closes #547
Closes #548
Closes #636