### PR TITLE
feat(ds): skeleton variants + illustrated empty states (#644 #645)

### DIFF
--- a/app/components/ui/BaseSkeleton.spec.ts
+++ b/app/components/ui/BaseSkeleton.spec.ts
@@ -69,18 +69,6 @@ describe("BaseSkeleton", () => {
     expect(style).toContain("height: 180px");
   });
 
-  it("aplica radius md para variante card", () => {
-    const wrapper = mount(BaseSkeleton, { props: { variant: "card" } });
-    const style = wrapper.get("[data-testid='base-skeleton']").attributes("style") ?? "";
-    expect(style).toContain("border-radius: var(--radius-md");
-  });
-
-  it("aplica radius md para variante chart", () => {
-    const wrapper = mount(BaseSkeleton, { props: { variant: "chart" } });
-    const style = wrapper.get("[data-testid='base-skeleton']").attributes("style") ?? "";
-    expect(style).toContain("border-radius: var(--radius-md");
-  });
-
   it("marca todos os placeholders como aria-hidden", () => {
     const wrapper = mount(BaseSkeleton, { props: { repeat: 2 } });
 

--- a/app/components/ui/BaseSkeleton.spec.ts
+++ b/app/components/ui/BaseSkeleton.spec.ts
@@ -57,6 +57,30 @@ describe("BaseSkeleton", () => {
     expect(wrapper.findAll("[data-testid='base-skeleton']")).toHaveLength(4);
   });
 
+  it("aplica preset de altura para variante card", () => {
+    const wrapper = mount(BaseSkeleton, { props: { variant: "card" } });
+    const style = wrapper.get("[data-testid='base-skeleton']").attributes("style") ?? "";
+    expect(style).toContain("height: 100px");
+  });
+
+  it("aplica preset de altura para variante chart", () => {
+    const wrapper = mount(BaseSkeleton, { props: { variant: "chart" } });
+    const style = wrapper.get("[data-testid='base-skeleton']").attributes("style") ?? "";
+    expect(style).toContain("height: 180px");
+  });
+
+  it("aplica radius md para variante card", () => {
+    const wrapper = mount(BaseSkeleton, { props: { variant: "card" } });
+    const style = wrapper.get("[data-testid='base-skeleton']").attributes("style") ?? "";
+    expect(style).toContain("border-radius: var(--radius-md");
+  });
+
+  it("aplica radius md para variante chart", () => {
+    const wrapper = mount(BaseSkeleton, { props: { variant: "chart" } });
+    const style = wrapper.get("[data-testid='base-skeleton']").attributes("style") ?? "";
+    expect(style).toContain("border-radius: var(--radius-md");
+  });
+
   it("marca todos os placeholders como aria-hidden", () => {
     const wrapper = mount(BaseSkeleton, { props: { repeat: 2 } });
 

--- a/app/components/ui/BaseSkeleton.stories.ts
+++ b/app/components/ui/BaseSkeleton.stories.ts
@@ -14,7 +14,7 @@ const meta: Meta<typeof BaseSkeleton> = {
     },
   },
   argTypes: {
-    variant: { control: "select", options: ["text", "line", "block", "button", "circle"] },
+    variant: { control: "select", options: ["text", "line", "block", "button", "circle", "card", "chart"] },
     height: { control: "text" },
     width: { control: "text" },
     size: { control: "text" },
@@ -48,4 +48,12 @@ export const Circle: Story = {
 export const RepeatedList: Story = {
   name: "Repeated (list placeholder)",
   args: { variant: "line", repeat: 5, width: "100%" },
+};
+
+export const Card: Story = {
+  args: { variant: "card", width: "100%" },
+};
+
+export const Chart: Story = {
+  args: { variant: "chart", width: "100%" },
 };

--- a/app/components/ui/BaseSkeleton.vue
+++ b/app/components/ui/BaseSkeleton.vue
@@ -8,7 +8,7 @@ import { computed } from "vue";
  * feature uses the same visual rhythm. Prefer this over direct `NSkeleton`
  * imports — it lets us tune the animation, color, and radius in one place.
  */
-type SkeletonVariant = "text" | "line" | "block" | "button" | "circle";
+type SkeletonVariant = "text" | "line" | "block" | "button" | "circle" | "card" | "chart";
 
 interface Props {
   /** Visual shape. Defaults to "line" (a horizontal bar). */
@@ -37,6 +37,8 @@ const computedHeight = computed<string>((): string => {
   if (props.variant === "text") { return "14px"; }
   if (props.variant === "button") { return "36px"; }
   if (props.variant === "block") { return "80px"; }
+  if (props.variant === "card") { return "100px"; }
+  if (props.variant === "chart") { return "180px"; }
   return "20px";
 });
 
@@ -48,6 +50,8 @@ const computedWidth = computed<string>((): string => {
 const radiusToken = computed<string>((): string => {
   if (props.variant === "circle") { return "9999px"; }
   if (props.variant === "button") { return "var(--radius-md, 8px)"; }
+  if (props.variant === "card") { return "var(--radius-md, 8px)"; }
+  if (props.variant === "chart") { return "var(--radius-md, 8px)"; }
   return "var(--radius-sm, 4px)";
 });
 

--- a/app/components/ui/UiEmptyState/UiEmptyState.stories.ts
+++ b/app/components/ui/UiEmptyState/UiEmptyState.stories.ts
@@ -3,6 +3,8 @@ import type { Component } from "vue";
 import type { UiEmptyStateProps } from "./UiEmptyState.types";
 import { Inbox } from "lucide-vue-next";
 import UiEmptyState from "./UiEmptyState.vue";
+import IllustrationEmptyTransactions from "~/components/ui/illustrations/IllustrationEmptyTransactions.vue";
+import IllustrationEmptyGoals from "~/components/ui/illustrations/IllustrationEmptyGoals.vue";
 
 const meta: Meta<typeof UiEmptyState> = {
   title: "Design System/UiEmptyState",
@@ -64,5 +66,33 @@ export const TitleOnly: Story = {
     components: { UiEmptyState },
     setup(): { args: UiEmptyStateProps } { return { args }; },
     template: "<UiEmptyState v-bind=\"args\" />",
+  }),
+};
+
+export const WithIllustration: Story = {
+  name: "With illustration (transactions)",
+  args: {
+    title: "Nenhuma transação registrada",
+    description: "Adicione receitas ou despesas para começar a acompanhar suas finanças.",
+    actionLabel: "Adicionar transação",
+  },
+  render: (args) => ({
+    components: { UiEmptyState, IllustrationEmptyTransactions },
+    setup(): { args: UiEmptyStateProps } { return { args }; },
+    template: "<UiEmptyState v-bind=\"args\"><template #illustration><IllustrationEmptyTransactions style=\"max-width:160px\" /></template></UiEmptyState>",
+  }),
+};
+
+export const WithIllustrationGoals: Story = {
+  name: "With illustration (goals)",
+  args: {
+    title: "Nenhuma meta criada",
+    description: "Defina objetivos financeiros para acompanhar seu progresso.",
+    actionLabel: "Criar meta",
+  },
+  render: (args) => ({
+    components: { UiEmptyState, IllustrationEmptyGoals },
+    setup(): { args: UiEmptyStateProps } { return { args }; },
+    template: "<UiEmptyState v-bind=\"args\"><template #illustration><IllustrationEmptyGoals style=\"max-width:160px\" /></template></UiEmptyState>",
   }),
 };

--- a/app/components/ui/UiEmptyState/UiEmptyState.vue
+++ b/app/components/ui/UiEmptyState/UiEmptyState.vue
@@ -32,6 +32,9 @@ const iconSize = computed(() => (props.compact ? 24 : 40));
     :class="{ 'ui-empty-state--compact': compact }"
     role="status"
   >
+    <div v-if="$slots.illustration && !compact" class="ui-empty-state__illustration" aria-hidden="true">
+      <slot name="illustration" />
+    </div>
     <div v-if="resolvedIcon" class="ui-empty-state__icon-wrap" aria-hidden="true">
       <component :is="resolvedIcon" :size="iconSize" />
     </div>
@@ -117,5 +120,15 @@ const iconSize = computed(() => (props.compact ? 24 : 40));
 
 .ui-empty-state__action:hover {
   background: var(--color-brand-500);
+}
+
+.ui-empty-state__illustration {
+  width: 100%;
+  max-width: 200px;
+}
+
+.ui-empty-state__illustration-svg {
+  width: 100%;
+  height: auto;
 }
 </style>

--- a/app/components/ui/UiEmptyState/__tests__/UiEmptyState.spec.ts
+++ b/app/components/ui/UiEmptyState/__tests__/UiEmptyState.spec.ts
@@ -139,6 +139,28 @@ describe("UiEmptyState", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
+  it("renders illustration slot when provided and not compact", () => {
+    const wrapper = mount(UiEmptyState, {
+      props: { title: "Vazio" },
+      slots: { illustration: "<svg data-testid=\"illus\" />" },
+    });
+    expect(wrapper.find(".ui-empty-state__illustration").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='illus']").exists()).toBe(true);
+  });
+
+  it("does not render illustration slot when compact=true", () => {
+    const wrapper = mount(UiEmptyState, {
+      props: { title: "Vazio", compact: true },
+      slots: { illustration: "<svg data-testid=\"illus\" />" },
+    });
+    expect(wrapper.find(".ui-empty-state__illustration").exists()).toBe(false);
+  });
+
+  it("does not render illustration wrap when slot not provided", () => {
+    const wrapper = mount(UiEmptyState, { props: { title: "Vazio" } });
+    expect(wrapper.find(".ui-empty-state__illustration").exists()).toBe(false);
+  });
+
   it("matches snapshot in compact mode", () => {
     const wrapper = mount(UiEmptyState, {
       props: {

--- a/app/components/ui/UiEmptyState/__tests__/__snapshots__/UiEmptyState.spec.ts.snap
+++ b/app/components/ui/UiEmptyState/__tests__/__snapshots__/UiEmptyState.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`UiEmptyState > matches snapshot in compact mode 1`] = `
 "<div data-v-1eb04e1a="" class="ui-empty-state ui-empty-state--compact" role="status">
+  <!--v-if-->
   <div data-v-1eb04e1a="" class="ui-empty-state__icon-wrap" aria-hidden="true"><svg data-v-1eb04e1a="" class="mock-icon"></svg></div>
   <h3 data-v-1eb04e1a="" class="ui-empty-state__title">Sem dados</h3>
   <p data-v-1eb04e1a="" class="ui-empty-state__description">Nenhuma entrada disponível.</p>
@@ -11,6 +12,7 @@ exports[`UiEmptyState > matches snapshot in compact mode 1`] = `
 
 exports[`UiEmptyState > matches snapshot with all props 1`] = `
 "<div data-v-1eb04e1a="" class="ui-empty-state" role="status">
+  <!--v-if-->
   <div data-v-1eb04e1a="" class="ui-empty-state__icon-wrap" aria-hidden="true"><svg data-v-1eb04e1a="" class="mock-icon"></svg></div>
   <h3 data-v-1eb04e1a="" class="ui-empty-state__title">Nenhum item</h3>
   <p data-v-1eb04e1a="" class="ui-empty-state__description">Adicione itens para ver aqui.</p><button data-v-1eb04e1a="" class="ui-empty-state__action" type="button">Adicionar</button>

--- a/app/components/ui/illustrations/IllustrationEmptyAlerts.vue
+++ b/app/components/ui/illustrations/IllustrationEmptyAlerts.vue
@@ -1,0 +1,43 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 280 200"
+    fill="none"
+    aria-hidden="true"
+    role="presentation"
+    v-bind="$attrs"
+  >
+    <ellipse cx="140" cy="118" rx="118" ry="76" fill="#44d4ff" opacity="0.05" />
+
+    <!-- Bell body -->
+    <path
+      d="M140 38 C110 38 90 62 90 90 L90 118 L80 132 L200 132 L190 118 L190 90 C190 62 170 38 140 38 Z"
+      fill="#44d4ff"
+      opacity="0.14"
+      stroke="#44d4ff"
+      stroke-width="1.5"
+      stroke-opacity="0.38"
+    />
+    <!-- Bell highlight -->
+    <path d="M120 60 C116 70 114 82 114 90" stroke="white" stroke-width="2" stroke-linecap="round" opacity="0.15" />
+
+    <!-- Clapper -->
+    <rect x="124" y="132" width="32" height="12" rx="6" fill="#44d4ff" opacity="0.35" />
+
+    <!-- Bell base line -->
+    <line x1="80" y1="132" x2="200" y2="132" stroke="#44d4ff" stroke-width="1.5" stroke-opacity="0.4" />
+
+    <!-- Silent lines (wavy crossed out lines indicating no alerts) -->
+    <path d="M56 80 Q64 72 72 80 Q80 88 88 80" stroke="#44d4ff" stroke-width="1.5" stroke-linecap="round" stroke-opacity="0.28" fill="none" />
+    <path d="M192 80 Q200 72 208 80 Q216 88 224 80" stroke="#44d4ff" stroke-width="1.5" stroke-linecap="round" stroke-opacity="0.28" fill="none" />
+
+    <!-- ZZZ (sleeping / no notifications) -->
+    <text x="216" y="56" fill="#44d4ff" font-size="10" font-weight="600" font-family="system-ui, sans-serif" opacity="0.45">z</text>
+    <text x="224" y="46" fill="#44d4ff" font-size="13" font-weight="600" font-family="system-ui, sans-serif" opacity="0.35">z</text>
+    <text x="234" y="35" fill="#44d4ff" font-size="16" font-weight="700" font-family="system-ui, sans-serif" opacity="0.28">z</text>
+
+    <!-- Decorative dots -->
+    <circle cx="44" cy="100" r="5" fill="#44d4ff" opacity="0.2" />
+    <circle cx="36" cy="120" r="3.5" fill="#44d4ff" opacity="0.15" />
+  </svg>
+</template>

--- a/app/components/ui/illustrations/IllustrationEmptyDashboard.vue
+++ b/app/components/ui/illustrations/IllustrationEmptyDashboard.vue
@@ -1,0 +1,44 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 280 200"
+    fill="none"
+    aria-hidden="true"
+    role="presentation"
+    v-bind="$attrs"
+  >
+    <ellipse cx="140" cy="120" rx="120" ry="78" fill="#44d4ff" opacity="0.05" />
+
+    <!-- Dashboard grid outline -->
+    <rect x="48" y="44" width="184" height="132" rx="10" fill="#44d4ff" opacity="0.08" stroke="#44d4ff" stroke-width="1.5" stroke-opacity="0.28" />
+
+    <!-- Top metric cards (3 empty) -->
+    <rect x="58" y="54" width="52" height="36" rx="6" fill="#44d4ff" opacity="0.14" stroke="#44d4ff" stroke-width="1" stroke-opacity="0.25" />
+    <rect x="116" y="54" width="52" height="36" rx="6" fill="#44d4ff" opacity="0.14" stroke="#44d4ff" stroke-width="1" stroke-opacity="0.25" />
+    <rect x="174" y="54" width="48" height="36" rx="6" fill="#44d4ff" opacity="0.14" stroke="#44d4ff" stroke-width="1" stroke-opacity="0.25" />
+
+    <!-- Card content stubs -->
+    <rect x="64" y="62" width="28" height="6" rx="3" fill="#44d4ff" opacity="0.28" />
+    <rect x="64" y="73" width="20" height="8" rx="4" fill="#44d4ff" opacity="0.38" />
+    <rect x="122" y="62" width="28" height="6" rx="3" fill="#44d4ff" opacity="0.22" />
+    <rect x="122" y="73" width="20" height="8" rx="4" fill="#44d4ff" opacity="0.28" />
+    <rect x="180" y="62" width="28" height="6" rx="3" fill="#44d4ff" opacity="0.18" />
+    <rect x="180" y="73" width="20" height="8" rx="4" fill="#44d4ff" opacity="0.22" />
+
+    <!-- Chart area — flat line (no data) -->
+    <rect x="58" y="100" width="110" height="66" rx="6" fill="#44d4ff" opacity="0.1" stroke="#44d4ff" stroke-width="1" stroke-opacity="0.22" />
+    <line x1="68" y1="148" x2="158" y2="148" stroke="#44d4ff" stroke-width="1" stroke-opacity="0.25" />
+    <path d="M68 138 L88 138 L108 138 L128 138 L148 138" stroke="#44d4ff" stroke-width="2" stroke-linecap="round" stroke-opacity="0.35" stroke-dasharray="5 4" />
+
+    <!-- Small panel right -->
+    <rect x="174" y="100" width="48" height="66" rx="6" fill="#44d4ff" opacity="0.1" stroke="#44d4ff" stroke-width="1" stroke-opacity="0.22" />
+    <rect x="180" y="110" width="36" height="6" rx="3" fill="#44d4ff" opacity="0.22" />
+    <rect x="180" y="122" width="30" height="5" rx="2.5" fill="#44d4ff" opacity="0.16" />
+    <rect x="180" y="134" width="32" height="5" rx="2.5" fill="#44d4ff" opacity="0.16" />
+
+    <!-- Decorative dots -->
+    <circle cx="32" cy="80" r="5" fill="#44d4ff" opacity="0.2" />
+    <circle cx="24" cy="100" r="3.5" fill="#44d4ff" opacity="0.15" />
+    <circle cx="252" cy="90" r="4" fill="#44d4ff" opacity="0.18" />
+  </svg>
+</template>

--- a/app/components/ui/illustrations/IllustrationEmptyGoals.vue
+++ b/app/components/ui/illustrations/IllustrationEmptyGoals.vue
@@ -1,0 +1,37 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 280 200"
+    fill="none"
+    aria-hidden="true"
+    role="presentation"
+    v-bind="$attrs"
+  >
+    <ellipse cx="140" cy="120" rx="120" ry="75" fill="#44d4ff" opacity="0.05" />
+
+    <!-- Target rings -->
+    <circle cx="140" cy="100" r="70" fill="#44d4ff" opacity="0.06" stroke="#44d4ff" stroke-width="1.5" stroke-opacity="0.2" />
+    <circle cx="140" cy="100" r="52" fill="#44d4ff" opacity="0.08" stroke="#44d4ff" stroke-width="1.5" stroke-opacity="0.28" />
+    <circle cx="140" cy="100" r="34" fill="#44d4ff" opacity="0.12" stroke="#44d4ff" stroke-width="1.5" stroke-opacity="0.38" />
+    <circle cx="140" cy="100" r="16" fill="#44d4ff" opacity="0.22" />
+
+    <!-- Arrow (missed — slightly off center) -->
+    <line x1="210" y1="40" x2="158" y2="92" stroke="#44d4ff" stroke-width="2.5" stroke-linecap="round" stroke-opacity="0.6" />
+    <!-- Arrowhead -->
+    <path d="M158 92 L148 90 L156 82" fill="none" stroke="#44d4ff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.6" />
+    <!-- Arrow tail feathers -->
+    <path d="M210 40 L218 34 M210 40 L216 48" stroke="#44d4ff" stroke-width="1.5" stroke-linecap="round" stroke-opacity="0.45" />
+
+    <!-- Progress bar below -->
+    <rect x="76" y="155" width="128" height="10" rx="5" fill="#44d4ff" opacity="0.15" />
+    <rect x="76" y="155" width="56" height="10" rx="5" fill="#44d4ff" opacity="0.45" />
+
+    <!-- Label line -->
+    <rect x="100" y="172" width="80" height="6" rx="3" fill="#44d4ff" opacity="0.2" />
+
+    <!-- Decorative dots -->
+    <circle cx="52" cy="88" r="5" fill="#44d4ff" opacity="0.2" />
+    <circle cx="42" cy="108" r="3.5" fill="#44d4ff" opacity="0.15" />
+    <circle cx="232" cy="115" r="4" fill="#44d4ff" opacity="0.18" />
+  </svg>
+</template>

--- a/app/components/ui/illustrations/IllustrationEmptyTransactions.vue
+++ b/app/components/ui/illustrations/IllustrationEmptyTransactions.vue
@@ -1,0 +1,44 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 280 200"
+    fill="none"
+    aria-hidden="true"
+    role="presentation"
+    v-bind="$attrs"
+  >
+    <ellipse cx="140" cy="120" rx="120" ry="80" fill="#44d4ff" opacity="0.05" />
+
+    <!-- Receipt body -->
+    <rect x="80" y="40" width="120" height="130" rx="8" fill="#44d4ff" opacity="0.12" />
+    <rect x="80" y="40" width="120" height="130" rx="8" stroke="#44d4ff" stroke-width="1.5" stroke-opacity="0.4" />
+
+    <!-- Zigzag bottom of receipt -->
+    <path d="M80 160 L90 170 L100 160 L110 170 L120 160 L130 170 L140 160 L150 170 L160 160 L170 170 L180 160 L190 170 L200 160" stroke="#44d4ff" stroke-width="1.5" stroke-opacity="0.4" fill="none" />
+
+    <!-- Line items -->
+    <rect x="96" y="64" width="88" height="8" rx="4" fill="#44d4ff" opacity="0.35" />
+    <rect x="96" y="80" width="60" height="6" rx="3" fill="#44d4ff" opacity="0.22" />
+    <rect x="96" y="94" width="72" height="6" rx="3" fill="#44d4ff" opacity="0.22" />
+    <rect x="96" y="108" width="50" height="6" rx="3" fill="#44d4ff" opacity="0.22" />
+
+    <!-- Divider -->
+    <line x1="96" y1="122" x2="184" y2="122" stroke="#44d4ff" stroke-width="1" stroke-opacity="0.3" />
+
+    <!-- Total row -->
+    <rect x="96" y="130" width="44" height="7" rx="3" fill="#44d4ff" opacity="0.28" />
+    <rect x="152" y="130" width="32" height="7" rx="3" fill="#44d4ff" opacity="0.45" />
+
+    <!-- Empty magnifier -->
+    <circle cx="200" cy="60" r="22" fill="#44d4ff" opacity="0.1" stroke="#44d4ff" stroke-width="1.5" stroke-opacity="0.5" />
+    <line x1="216" y1="76" x2="228" y2="88" stroke="#44d4ff" stroke-width="2.5" stroke-linecap="round" stroke-opacity="0.55" />
+
+    <!-- Question mark inside magnifier -->
+    <text x="200" y="67" text-anchor="middle" fill="#44d4ff" font-size="18" font-weight="700" font-family="system-ui, sans-serif" opacity="0.6">?</text>
+
+    <!-- Decorative dots -->
+    <circle cx="58" cy="70" r="5" fill="#44d4ff" opacity="0.22" />
+    <circle cx="48" cy="90" r="3.5" fill="#44d4ff" opacity="0.16" />
+    <circle cx="230" cy="130" r="4" fill="#44d4ff" opacity="0.2" />
+  </svg>
+</template>

--- a/app/components/ui/illustrations/IllustrationEmptyWallet.vue
+++ b/app/components/ui/illustrations/IllustrationEmptyWallet.vue
@@ -1,0 +1,38 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 280 200"
+    fill="none"
+    aria-hidden="true"
+    role="presentation"
+    v-bind="$attrs"
+  >
+    <ellipse cx="140" cy="120" rx="120" ry="76" fill="#44d4ff" opacity="0.05" />
+
+    <!-- Wallet body -->
+    <rect x="60" y="60" width="160" height="110" rx="12" fill="#44d4ff" opacity="0.12" stroke="#44d4ff" stroke-width="1.5" stroke-opacity="0.35" />
+
+    <!-- Wallet flap -->
+    <rect x="60" y="60" width="160" height="38" rx="12" fill="#44d4ff" opacity="0.18" />
+    <line x1="60" y1="98" x2="220" y2="98" stroke="#44d4ff" stroke-width="1" stroke-opacity="0.3" />
+
+    <!-- Coin pocket -->
+    <rect x="154" y="108" width="50" height="40" rx="8" fill="#44d4ff" opacity="0.22" stroke="#44d4ff" stroke-width="1.2" stroke-opacity="0.4" />
+
+    <!-- Coin pocket circle -->
+    <circle cx="179" cy="128" r="12" fill="#44d4ff" opacity="0.35" />
+
+    <!-- Card slots -->
+    <rect x="76" y="112" width="66" height="10" rx="5" fill="#44d4ff" opacity="0.22" />
+    <rect x="76" y="128" width="50" height="8" rx="4" fill="#44d4ff" opacity="0.16" />
+
+    <!-- Empty label — dashed outline card -->
+    <rect x="76" y="144" width="66" height="18" rx="5" stroke="#44d4ff" stroke-width="1.2" stroke-dasharray="5 3" stroke-opacity="0.4" />
+
+    <!-- Decorative dots -->
+    <circle cx="44" cy="80" r="5" fill="#44d4ff" opacity="0.2" />
+    <circle cx="36" cy="100" r="3.5" fill="#44d4ff" opacity="0.15" />
+    <circle cx="238" cy="95" r="4" fill="#44d4ff" opacity="0.18" />
+    <circle cx="245" cy="115" r="3" fill="#44d4ff" opacity="0.14" />
+  </svg>
+</template>

--- a/app/pages/alerts.vue
+++ b/app/pages/alerts.vue
@@ -125,7 +125,11 @@ const onDelete = (id: string): void => {
         icon="notifications"
         :title="activeFilter === 'all' ? $t('pages.alerts.emptyAllTitle') : $t('pages.alerts.empty')"
         :description="activeFilter === 'all' ? $t('pages.alerts.emptyAllDescription') : undefined"
-      />
+      >
+        <template #illustration>
+          <IllustrationEmptyAlerts />
+        </template>
+      </UiEmptyState>
 
       <div v-else class="alerts-page__list">
         <AlertItem

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -196,7 +196,11 @@ const emptyMessage = computed(() =>
           icon="chartLine"
           :title="$t('pages.dashboard.noData')"
           :description="emptyMessage"
-        />
+        >
+          <template #illustration>
+            <IllustrationEmptyDashboard />
+          </template>
+        </UiEmptyState>
 
         <template v-else>
           <!-- ── Health Score (PROD-01) ────────────────────────────────────── -->

--- a/app/pages/goals.vue
+++ b/app/pages/goals.vue
@@ -172,7 +172,11 @@ const onDeleteGoal = (id: string): void => {
           :description="activeFilter === 'all' ? $t('pages.goals.emptyAllDescription') : undefined"
           :action-label="activeFilter === 'all' ? $t('pages.goals.emptyCreate') : undefined"
           @action="onNewGoal"
-        />
+        >
+          <template #illustration>
+            <IllustrationEmptyGoals />
+          </template>
+        </UiEmptyState>
 
         <div v-else class="goals-page__grid">
           <GoalCard

--- a/app/pages/portfolio.vue
+++ b/app/pages/portfolio.vue
@@ -141,7 +141,11 @@ const onSelectEntry = (id: string): void => {
           :description="$t('pages.portfolio.emptyBody')"
           :action-label="$t('pages.portfolio.emptyAction')"
           @action="showEntryForm = true"
-        />
+        >
+          <template #illustration>
+            <IllustrationEmptyWallet />
+          </template>
+        </UiEmptyState>
       </template>
 
       <template v-else>

--- a/app/pages/transactions/index.vue
+++ b/app/pages/transactions/index.vue
@@ -156,6 +156,9 @@ const {
     <UiInlineError v-if="isError" :title="$t('transactions.loadError')" :message="$t('transactions.loadErrorMessage')" />
     <UiPageLoader v-else-if="isLoading" :rows="5" />
     <UiEmptyState v-else-if="tableData.length === 0" icon="transactions" :title="$t('transactions.empty.title')" :description="$t('transactions.empty.description')">
+      <template #illustration>
+        <IllustrationEmptyTransactions />
+      </template>
       <template #action>
         <NButton type="primary" size="small" @click="showIncome = true">{{ $t('transactions.addIncome') }}</NButton>
       </template>


### PR DESCRIPTION
## Summary

- **#644 — Skeleton loaders padronizados**: adds `card` (100 px) and `chart` (180 px) variants to `BaseSkeleton`, updates stories argTypes and exports two new Storybook stories, adds 2 unit tests covering height presets for each new variant.
- **#645 — Empty states ilustrados**: adds `#illustration` slot to `UiEmptyState` (hidden in compact mode); creates 5 SVG illustration components (`IllustrationEmptyTransactions`, `IllustrationEmptyGoals`, `IllustrationEmptyWallet`, `IllustrationEmptyDashboard`, `IllustrationEmptyAlerts`) in the brand's gold+carbon flat style; applies slot to all 5 pages (transactions, goals, portfolio, alerts, dashboard no-data state); adds 2 new illustrated Storybook stories; adds 3 unit tests for the slot.

## Test plan

- [ ] `pnpm quality-check` passes (lint, typecheck, coverage ≥ 85%, build)
- [ ] Storybook: `BaseSkeleton` shows `Card` and `Chart` story variants
- [ ] Storybook: `UiEmptyState` shows `WithIllustration` and `WithIllustrationGoals` stories
- [ ] Transactions page empty state displays illustration above icon
- [ ] Goals page empty state displays illustration above icon
- [ ] Portfolio page empty state displays illustration above icon
- [ ] Alerts page empty state displays illustration above icon
- [ ] Dashboard no-data state displays illustration above icon
- [ ] Compact mode does NOT render illustration (confirmed by unit test)