### PR TITLE
security(csp): drop 'unsafe-eval' from production CSP (SEC-AUD-01 partial)

### DIFF
--- a/app/core/security/__tests__/csp.spec.ts
+++ b/app/core/security/__tests__/csp.spec.ts
@@ -65,6 +65,14 @@ describe("PRODUCTION_CSP", () => {
   it("bloqueia iframes via frame-ancestors 'none'", () => {
     expect(PRODUCTION_CSP).toContain("frame-ancestors 'none'");
   });
+
+  it("NÃO permite 'unsafe-eval' em script-src (SEC-AUD-01)", () => {
+    const scriptDirective = PRODUCTION_CSP.split(";")
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith("script-src"));
+    expect(scriptDirective).toBeDefined();
+    expect(scriptDirective).not.toContain("'unsafe-eval'");
+  });
 });
 
 describe("buildCsp — development", () => {

--- a/app/core/security/csp.ts
+++ b/app/core/security/csp.ts
@@ -65,7 +65,11 @@ const STAGING_CSP = [
  */
 export const PRODUCTION_CSP = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  // SEC-AUD-01 (partial) — 'unsafe-eval' removed; Vue/Vite production
+  // bundles don't require eval. 'unsafe-inline' remains temporarily
+  // because Naive UI's @css-render/vue3-ssr emits inline <style> blocks;
+  // tracked by the follow-up issue for hash-based CSP migration.
+  "script-src 'self' 'unsafe-inline'",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob:",
   "font-src 'self'",


### PR DESCRIPTION
## Summary

Closes the script-eval XSS amplification vector described in SEC-AUD-01 by removing `'unsafe-eval'` from `PRODUCTION_CSP.script-src`. Vue/Vite production bundles don't require eval, so this is safe for the current frontend.

`'unsafe-inline'` remains temporarily because Naive UI's `@css-render/vue3-ssr` emits inline `<style>` blocks and Nuxt hints inline an `env` script at build time. Hash-based CSP + Naive UI extraction will be tracked as a separate follow-up issue.

## Changes

- `app/core/security/csp.ts` — drop `'unsafe-eval'` from `PRODUCTION_CSP.script-src`.
- `app/core/security/__tests__/csp.spec.ts` — regression test asserting `PRODUCTION_CSP.script-src` never re-introduces `'unsafe-eval'`.

## Pair PR

The CloudFront CSP is emitted at the edge from `infra/web/main.tf` in `auraxis-platform`. A matching PR updates `local.web_csp` there so the edge policy stays byte-identical to `PRODUCTION_CSP`.

## Test plan

- [x] `pnpm vitest run app/core/security` — 28/28 passing (incl. new regression test)
- [x] `pnpm quality-check` — green locally
- [ ] CI green
- [ ] After merge + terraform apply: verify response header on `https://app.auraxis.com.br/`

## Rollout

1. Merge this PR (source-of-truth constant + regression test)
2. Merge the paired `auraxis-platform` PR
3. `terraform apply` on `infra/web` → CloudFront starts serving CSP without `unsafe-eval`
4. Verify via `curl -I https://app.auraxis.com.br/` that the `content-security-policy` header no longer contains `unsafe-eval`

## Follow-up

Tracked in a new issue: hash-based CSP (move CSP to per-build meta tag with computed hashes), migrate off Naive UI inline styles to enable dropping `'unsafe-inline'`, finishing SEC-AUD-01.