### PR TITLE
security(deps): pin lodash-es@4.17.23 + point allowlist to SEC-AUD-11

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
       "unhead": ">=2.1.13",
       "nuxt-og-image": ">=6.2.5",
       "js-yaml": ">=4.1.1",
-      "dompurify": ">=3.4.0"
+      "dompurify": ">=3.4.0",
+      "lodash-es": "4.17.23"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   nuxt-og-image: '>=6.2.5'
   js-yaml: '>=4.1.1'
   dompurify: '>=3.4.0'
+  lodash-es: 4.17.23
 
 importers:
 

--- a/scripts/ci-audit-gate.cjs
+++ b/scripts/ci-audit-gate.cjs
@@ -15,8 +15,13 @@ const allowedIds = new Set([
   // within the current nuxt major. Tracked for resolution on nuxt upgrade.
   "GHSA-3vj8-jmxq-cgj5",
   "GHSA-22cc-p3c6-wpvm",
-  // lodash / lodash-es — affects all 4.x; 4.17.23 is the latest patch available.
-  // No 5.x release exists. Tracked for resolution when a patched version ships.
+  // lodash / lodash-es — GHSA-r5fr-rjxr-66jc (HIGH) affects all 4.x; 4.17.23
+  // is the latest patch available and there is no 5.x release yet. Allowlisted
+  // because Auraxis does not use _.template directly and naive-ui's transitive
+  // usage is not reachable by user input. Tracked via:
+  //   - Issue: italofelipe/auraxis-platform#627 (SEC-AUD-11)
+  //   - ADR:   auraxis-platform/.context/adr/lodash_es_high_strategy.md
+  //   - Cron:  auraxis-platform/.github/workflows/lodash-es-upstream-check.yml
   "GHSA-r5fr-rjxr-66jc",
 ]);
 const isBlockingSeverity = (severity) => severity === "high" || severity === "critical";


### PR DESCRIPTION
## Summary
- Adds `lodash-es: "4.17.23"` to `pnpm.overrides` so future lockfile regenerations cannot silently downgrade the pinned patch.
- Rewrites the allowlist comment for `GHSA-r5fr-rjxr-66jc` in `scripts/ci-audit-gate.cjs` to point at the tracking issue (auraxis-platform#627), the new ADR, and the monthly upstream-check workflow.
- Zero runtime change — `pnpm why lodash-es` already resolved to 4.17.23 before this commit.

Part of SEC-AUD-11 (auraxis-platform#627). Closes the web-side of the DoD; the platform-side PR adds the ADR and the cron workflow.

## Test plan
- [x] `node scripts/ci-audit-gate.cjs` — passes (only allowlisted advisory)
- [x] `pnpm why lodash-es` — shows 4.17.23 resolved via override
- [ ] CI quality-check green