### PR TITLE
fix(tools,ci): register vue-i18n currency format + wire BRAPI key at build

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -86,6 +86,8 @@ jobs:
           NUXT_PUBLIC_APP_ENV: staging
           NUXT_PUBLIC_SITE_URL: https://${{ env.STAGING_HOSTNAME }}
           NUXT_PUBLIC_BUILD_ID: "${{ github.run_id }}-${{ github.sha }}"
+          # Brapi public market-data API key (see deploy.yml for rationale).
+          NUXT_PUBLIC_BRAPI_API_KEY: ${{ secrets.NUXT_PUBLIC_BRAPI_API_KEY }}
         run: pnpm generate
 
       - name: Validate output

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,10 @@ jobs:
           # The smoke test reads this tag to confirm CloudFront is serving
           # the current build and not a stale cached snapshot.
           NUXT_PUBLIC_BUILD_ID: "${{ github.run_id }}-${{ github.sha }}"
+          # Brapi public market-data API key (wallet quotes, FII dividends,
+          # currency conversion). Without it brapi.dev replies 401 and the
+          # wallet + tools pages log Unauthorized errors in the browser.
+          NUXT_PUBLIC_BRAPI_API_KEY: ${{ secrets.NUXT_PUBLIC_BRAPI_API_KEY }}
         run: pnpm generate
 
       - name: Validate output

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -106,6 +106,8 @@ jobs:
           NUXT_PUBLIC_SITE_URL: ${{ steps.paths.outputs.preview_url }}
           NUXT_PUBLIC_BUILD_ID: "pr-${{ github.event.pull_request.number }}-${{ github.sha }}"
           NUXT_PUBLIC_SENTRY_DSN: ${{ secrets.NUXT_PUBLIC_SENTRY_DSN }}
+          # Brapi public market-data API key (see deploy.yml for rationale).
+          NUXT_PUBLIC_BRAPI_API_KEY: ${{ secrets.NUXT_PUBLIC_BRAPI_API_KEY }}
         run: pnpm generate
 
       - name: Validate output

--- a/app/i18n/__tests__/i18n.config.spec.ts
+++ b/app/i18n/__tests__/i18n.config.spec.ts
@@ -1,0 +1,37 @@
+import { createI18n, type Composer } from "vue-i18n";
+import { describe, expect, it } from "vitest";
+
+import createI18nOptions from "../i18n.config";
+
+/**
+ * Returns the composition-API composer exposed by an i18n instance created
+ * with `legacy: false`. vue-i18n's default types assume Legacy mode, so we
+ * narrow here once instead of casting at every call site.
+ *
+ * @param i18n vue-i18n instance produced by `createI18n`.
+ * @returns The Composer backing the `global` property of the instance.
+ */
+function composerOf(i18n: ReturnType<typeof createI18n>): Composer {
+  return i18n.global as unknown as Composer;
+}
+
+describe("i18n.config numberFormats", () => {
+  const global = composerOf(createI18n({ ...createI18nOptions(), legacy: false }));
+
+  it("formata currency em pt-BR como BRL (R$)", () => {
+    global.locale.value = "pt-BR";
+    expect(global.n(1234.56, "currency")).toMatch(/^R\$\s?1\.234,56$/);
+  });
+
+  it("formata currency em en como BRL (app é BR-only)", () => {
+    global.locale.value = "en";
+    expect(global.n(1234.56, "currency")).toMatch(/1,234\.56/);
+  });
+
+  it("nunca retorna string vazia para named format 'currency'", () => {
+    global.locale.value = "pt-BR";
+    expect(global.n(0, "currency")).not.toBe("");
+    global.locale.value = "en";
+    expect(global.n(0, "currency")).not.toBe("");
+  });
+});

--- a/app/i18n/i18n.config.ts
+++ b/app/i18n/i18n.config.ts
@@ -8,8 +8,25 @@
 // would silently fail and leave the vue-i18n Composer without messages.
 import type { I18nOptions } from "vue-i18n";
 
+// numberFormats is mandatory when callers use named formats — `n(value, "currency")`.
+// Without a registered named format, vue-i18n v9+ returns an empty string silently,
+// which surfaced as blank result boxes in every calculator tool (13º salário, férias,
+// rescisão, etc.). Amounts across the app are always in BRL (Brazilian financial app),
+// so both locales share the same currency configuration.
+const currencyFormats: I18nOptions["numberFormats"] = {
+  "pt-BR": {
+    currency: { style: "currency", currency: "BRL" },
+    percent: { style: "percent", minimumFractionDigits: 2, maximumFractionDigits: 2 },
+  },
+  "en": {
+    currency: { style: "currency", currency: "BRL" },
+    percent: { style: "percent", minimumFractionDigits: 2, maximumFractionDigits: 2 },
+  },
+};
+
 export default (): I18nOptions => ({
   legacy: false,
   locale: "pt-BR",
   fallbackLocale: "pt-BR",
+  numberFormats: currencyFormats,
 });


### PR DESCRIPTION
## Summary

Two production bugs surfaced after #767 (drop `'unsafe-eval'`) + #769 (allow brapi.dev in CSP) went live:

### 1. Empty values in every calculator tool

User report: *"os valores nas ferramentas de cálculos não são exibidos. Se eu calculo o 13º salário por exemplo, a caixa onde deveria ficar o valor aparece vazia, o mesmo para as outras tools todas."*

- Every tool (13º salário, férias, rescisão, hora extra, installment-vs-cash, INSS/IR folha, FII dividends, conversor de moeda, …) formats amounts through `useI18n().n(value, "currency")`.
- `app/i18n/i18n.config.ts` never registered `numberFormats`.
- In vue-i18n 11, calling a **named** format that has no registered configuration returns `""` silently (reproduced locally with the exact runtime config — see the new regression test). → every `R$ …` slot on the calculators rendered empty.
- This has likely been broken since `n(value, "currency")` was introduced but only became visible once the ship of mandatory-result tools made it obvious.

Fix:

- `app/i18n/i18n.config.ts`: register `currency` (BRL) and `percent` formats for both locales. App is BR-only on the money side, so both `pt-BR` and `en` use BRL (Intl emits `R$ …` vs `BRL …` respectively; still non-empty).
- New test `app/i18n/__tests__/i18n.config.spec.ts` asserts `n(value, "currency")` never returns `""` and that the BR formatting is correct. This pins the regression.

### 2. Brapi 401 with empty token

User report: `https://brapi.dev/api/quote/ITSA4?token=&interval=1d 401 (Unauthorized)` — the `token=` is empty.

- `nuxt.config.ts` reads `NUXT_PUBLIC_BRAPI_API_KEY` with a `?? ""` fallback.
- None of the deploy workflows (`deploy.yml`, `deploy-staging.yml`, `preview-deploy.yml`) forwarded the secret to the `pnpm generate` step, so the static bundle baked in `brapiApiKey: ""`.

Fix: add `NUXT_PUBLIC_BRAPI_API_KEY: \${{ secrets.NUXT_PUBLIC_BRAPI_API_KEY }}` to the Generate step in all three workflows.

> ⚠️ **Secret required**: `NUXT_PUBLIC_BRAPI_API_KEY` must be populated on the `web-official-prod`, `web-official-staging` and `preview` GitHub environments before the next deploy (otherwise the wallet/tools quote calls keep 401ing).

## Test plan

- [x] `pnpm quality-check` — flags, i18n parity, lint, typecheck, test:coverage (290 files, 3023 passed), policy, contracts, build.
- [x] Reproduced Bug 1 in isolation: `n(1234.56, "currency")` → `""` without numberFormats → `"R$ 1.234,56"` after fix.
- [ ] After merge + deploy with secret set: hit `/tools/thirteenth-salary`, calculate, verify summary + installment rows show `R$ …` values.
- [ ] After merge + deploy with secret set: add ITSA4 to wallet, confirm no `token=` 401 on `brapi.dev/api/quote/...` in DevTools console.