### PR TITLE
feat(onboarding): UX-01 micro-onboarding copy for empty states

### DIFF
--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -204,9 +204,9 @@
         "paused": "Paused"
       },
       "empty": "No goals found for the selected filter.",
-      "emptyCreate": "Create first goal",
-      "emptyAllTitle": "Start by creating your first goal",
-      "emptyAllDescription": "Financial goals help you visualize and achieve your objectives with clarity and discipline."
+      "emptyCreate": "Create your first goal in 30 seconds",
+      "emptyAllTitle": "Set your first financial goal",
+      "emptyAllDescription": "Goals give direction to your money — the first step takes less than a minute."
     },
     "budgets": {
       "meta": {
@@ -261,9 +261,9 @@
       "addAsset": "Add asset",
       "loadError": "Could not load portfolio",
       "loadErrorMessage": "Please reload the page.",
-      "emptyTitle": "No assets in portfolio",
-      "emptyBody": "Add your first investment to start tracking your net worth.",
-      "emptyAction": "Add first asset"
+      "emptyTitle": "No assets in your portfolio",
+      "emptyBody": "Investing is the natural next step once the basics are set — start with a single asset.",
+      "emptyAction": "Add your first investment"
     },
     "alerts": {
       "title": "Alerts",
@@ -1662,8 +1662,9 @@
       "expense": "Total Expenses"
     },
     "empty": {
-      "title": "No transactions found",
-      "description": "Add your first income or expense to get started."
+      "title": "No transactions yet",
+      "description": "Start with the basics — a single income or expense unlocks the entire dashboard.",
+      "action": "Log your first income or expense"
     },
     "table": {
       "status": "Status",

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -216,9 +216,9 @@
         "paused": "Pausadas"
       },
       "empty": "Nenhuma meta encontrada para o filtro selecionado.",
-      "emptyCreate": "Criar primeira meta",
-      "emptyAllTitle": "Comece criando sua primeira meta",
-      "emptyAllDescription": "Metas financeiras ajudam você a visualizar e alcançar seus objetivos com clareza e disciplina."
+      "emptyCreate": "Crie sua primeira meta em 30 segundos",
+      "emptyAllTitle": "Defina seu primeiro objetivo financeiro",
+      "emptyAllDescription": "Metas dão direção à sua rotina financeira — e o primeiro passo leva menos de um minuto."
     },
     "budgets": {
       "meta": {
@@ -274,8 +274,8 @@
       "loadError": "Não foi possível carregar a carteira",
       "loadErrorMessage": "Tente recarregar a página.",
       "emptyTitle": "Nenhum ativo na carteira",
-      "emptyBody": "Adicione seu primeiro investimento para começar a acompanhar seu patrimônio.",
-      "emptyAction": "Adicionar primeiro ativo"
+      "emptyBody": "Investir é o próximo passo depois de organizar o básico — começa com um único ativo.",
+      "emptyAction": "Adicione seu primeiro investimento"
     },
     "alerts": {
       "title": "Alertas",
@@ -1698,8 +1698,9 @@
       "expense": "Total Despesas"
     },
     "empty": {
-      "title": "Nenhuma transação encontrada",
-      "description": "Adicione sua primeira receita ou despesa para começar."
+      "title": "Nenhuma transação registrada",
+      "description": "Comece pelo básico: uma receita ou uma despesa já destrava todo o dashboard.",
+      "action": "Registre sua primeira receita ou despesa"
     },
     "table": {
       "status": "Status",

--- a/app/pages/transactions/index.vue
+++ b/app/pages/transactions/index.vue
@@ -160,7 +160,7 @@ const {
         <IllustrationEmptyTransactions />
       </template>
       <template #action>
-        <NButton type="primary" size="small" @click="showIncome = true">{{ $t('transactions.addIncome') }}</NButton>
+        <NButton type="primary" size="small" data-testid="transactions-empty-cta" @click="showIncome = true">{{ $t('transactions.empty.action') }}</NButton>
       </template>
     </UiEmptyState>
 


### PR DESCRIPTION
## Summary

- Aligns `/goals`, `/portfolio` and `/transactions` empty-state copy with the UX-01 micro-onboarding framing from the parent umbrella (#529).
- Titles are now action-first and promise a short time-to-first-value ("em 30 segundos" on goals) instead of describing the empty status.
- CTAs describe the outcome ("Adicione seu primeiro investimento", "Registre sua primeira receita ou despesa") rather than the button verb, matching the acceptance copy spelled out in #549 and #550.
- Adds a dedicated `transactions.empty.action` key so the empty CTA stops borrowing `transactions.addIncome` (which is also used by the toolbar — coupling them was a semantic drift).
- Adds `data-testid="transactions-empty-cta"` to make the empty CTA addressable in Playwright without relying on the mutable label.

## Locale parity

- Both PT and EN updated in the same commit. `pnpm i18n:check` passes; no new PT-only keys introduced beyond the DEC-186 EN-freeze deferrals that already existed.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 3032 passing, coverage unchanged (lines 93.33%)
- [x] `pnpm i18n:check`
- [ ] Visual smoke on Chromatic (no component structure changed; only string props)
- [ ] Verify CTA still opens income quick-add modal on `/transactions` and the goal form / wallet entry form on the other two pages

Closes #549
Closes #550
Refs #529