### PR TITLE
feat(focus): add Focus Mode page with metric selector and paywall gate

### DIFF
--- a/app/features/focus/components/FocusMetricDisplay.spec.ts
+++ b/app/features/focus/components/FocusMetricDisplay.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import FocusMetricDisplay from "./FocusMetricDisplay.vue";
+import type { FocusMetric } from "../model/focus-metric";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: (): { t: (k: string) => string; n: (v: number, opts?: unknown) => string } => ({
+    t: (k) => k,
+    n: (v: number, opts?: unknown): string => {
+      if (opts && typeof opts === "object" && "style" in opts && (opts as { style: string }).style === "currency") {
+        return `R$ ${Math.round(v)}`;
+      }
+      return String(v);
+    },
+  }),
+}));
+
+/**
+ * Builds a FocusMetric fixture with sensible defaults, overridable per test.
+ *
+ * @param overrides Partial overrides applied on top of the default fixture.
+ * @returns A fully-populated FocusMetric for mounting the display component.
+ */
+function makeMetric(overrides: Partial<FocusMetric> = {}): FocusMetric {
+  return {
+    id: "monthlyBurnRate",
+    value: 3200,
+    unit: "currency",
+    labelKey: "focus.metrics.monthlyBurnRate.label",
+    captionKey: "focus.metrics.monthlyBurnRate.caption",
+    trend: { delta: -8, percent: -8, direction: "down" },
+    unavailable: false,
+    ...overrides,
+  };
+}
+
+describe("FocusMetricDisplay", () => {
+  it("renders a loading label when isLoading is true", () => {
+    const wrapper = mount(FocusMetricDisplay, {
+      props: { metric: makeMetric(), isLoading: true },
+    });
+    expect(wrapper.find(".focus-metric__loading").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='focus-metric-value']").exists()).toBe(false);
+  });
+
+  it("formats currency values via useI18n n()", () => {
+    const wrapper = mount(FocusMetricDisplay, {
+      props: { metric: makeMetric() },
+    });
+    const value = wrapper.get("[data-testid='focus-metric-value']");
+    expect(value.text()).toContain("R$");
+    expect(value.text()).toContain("3200");
+  });
+
+  it("renders em dash for unavailable metrics", () => {
+    const wrapper = mount(FocusMetricDisplay, {
+      props: { metric: makeMetric({ unavailable: true, trend: null }) },
+    });
+    expect(wrapper.get("[data-testid='focus-metric-value']").text()).toBe("—");
+    expect(wrapper.find(".focus-metric__unavailable").exists()).toBe(true);
+  });
+
+  it("formats percent values with % suffix", () => {
+    const wrapper = mount(FocusMetricDisplay, {
+      props: { metric: makeMetric({ unit: "percent", value: 42 }) },
+    });
+    expect(wrapper.get("[data-testid='focus-metric-value']").text()).toBe("42%");
+  });
+
+  it("renders days suffix when unit is days", () => {
+    const wrapper = mount(FocusMetricDisplay, {
+      props: { metric: makeMetric({ unit: "days", value: 10, trend: null }) },
+    });
+    expect(wrapper.find(".focus-metric__suffix").exists()).toBe(true);
+  });
+
+  it("shows a trend chip with the percentage when a trend is present", () => {
+    const wrapper = mount(FocusMetricDisplay, {
+      props: { metric: makeMetric() },
+    });
+    const trend = wrapper.get("[data-testid='focus-metric-trend']");
+    expect(trend.text()).toContain("8%");
+    expect(trend.classes()).toContain("focus-metric__trend--down");
+  });
+
+  it("hides the trend chip when trend is null", () => {
+    const wrapper = mount(FocusMetricDisplay, {
+      props: { metric: makeMetric({ trend: null }) },
+    });
+    expect(wrapper.find("[data-testid='focus-metric-trend']").exists()).toBe(false);
+  });
+});

--- a/app/features/focus/components/FocusMetricDisplay.vue
+++ b/app/features/focus/components/FocusMetricDisplay.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { TrendingUp, TrendingDown, Minus } from "lucide-vue-next";
+import type { FocusMetric } from "../model/focus-metric";
+
+interface Props {
+  readonly metric: FocusMetric;
+  readonly isLoading?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), { isLoading: false });
+
+const { t, n } = useI18n();
+
+const formattedValue = computed<string>(() => {
+  const { unit, value, unavailable } = props.metric;
+  if (unavailable) { return "—"; }
+  if (unit === "currency") {
+    return n(value, { style: "currency", currency: "BRL", maximumFractionDigits: 0 });
+  }
+  if (unit === "percent") {
+    return `${Math.round(value)}%`;
+  }
+  return String(Math.round(value));
+});
+
+const suffixKey = computed<string | null>(() => {
+  if (props.metric.unavailable) { return null; }
+  if (props.metric.unit === "days") { return "focus.display.suffix.days"; }
+  return null;
+});
+
+const trendIcon = computed(() => {
+  if (!props.metric.trend) { return null; }
+  if (props.metric.trend.direction === "up") { return TrendingUp; }
+  if (props.metric.trend.direction === "down") { return TrendingDown; }
+  return Minus;
+});
+
+/**
+ * Picks the prefix used to render a signed trend delta.
+ *
+ * @param delta Signed trend delta.
+ * @returns "+" for positive, "" for negative (Math.abs strips the sign), "±" for zero.
+ */
+function trendSign(delta: number): string {
+  if (delta > 0) { return "+"; }
+  if (delta < 0) { return ""; }
+  return "±";
+}
+
+const trendText = computed<string | null>(() => {
+  const trend = props.metric.trend;
+  if (!trend) { return null; }
+  const sign = trendSign(trend.delta);
+  if (trend.percent !== null) {
+    return `${sign}${Math.round(Math.abs(trend.percent))}%`;
+  }
+  return null;
+});
+
+const trendDirectionClass = computed(() => {
+  if (!props.metric.trend) { return ""; }
+  return `focus-metric__trend--${props.metric.trend.direction}`;
+});
+</script>
+
+<template>
+  <div class="focus-metric" data-testid="focus-metric-display">
+    <template v-if="isLoading">
+      <span class="focus-metric__loading" aria-live="polite">{{ t("focus.display.loading") }}</span>
+    </template>
+    <template v-else>
+      <span class="focus-metric__label">{{ t(metric.labelKey) }}</span>
+      <div class="focus-metric__value-row">
+        <span class="focus-metric__value" data-testid="focus-metric-value">{{ formattedValue }}</span>
+        <span v-if="suffixKey" class="focus-metric__suffix">{{ t(suffixKey) }}</span>
+      </div>
+      <div v-if="trendIcon && trendText" class="focus-metric__trend" :class="trendDirectionClass" data-testid="focus-metric-trend">
+        <component :is="trendIcon" :size="16" />
+        <span>{{ trendText }}</span>
+      </div>
+      <p v-if="metric.unavailable" class="focus-metric__unavailable">
+        {{ t(`focus.metrics.${metric.id}.unavailable`) }}
+      </p>
+      <p v-else-if="metric.captionKey" class="focus-metric__caption">
+        {{ t(metric.captionKey) }}
+      </p>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.focus-metric {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  text-align: center;
+  color: var(--color-text-primary);
+}
+
+.focus-metric__label {
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.focus-metric__value-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.focus-metric__value {
+  font-family: var(--font-heading);
+  font-size: clamp(4rem, 12vw, 8rem);
+  font-weight: var(--font-weight-bold);
+  line-height: 1;
+  color: var(--color-text-primary);
+}
+
+.focus-metric__suffix {
+  font-size: var(--font-size-lg);
+  color: var(--color-text-muted);
+  font-weight: var(--font-weight-medium);
+}
+
+.focus-metric__trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: var(--color-bg-elevated);
+}
+
+.focus-metric__trend--up { color: var(--color-positive); }
+.focus-metric__trend--down { color: var(--color-negative); }
+.focus-metric__trend--flat { color: var(--color-text-muted); }
+
+.focus-metric__caption,
+.focus-metric__unavailable {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+  max-width: 32ch;
+}
+
+.focus-metric__loading {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+</style>

--- a/app/features/focus/components/FocusMetricSelector.spec.ts
+++ b/app/features/focus/components/FocusMetricSelector.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { FOCUS_METRIC_IDS } from "../model/focus-metric";
+import FocusMetricSelector from "./FocusMetricSelector.vue";
+
+vi.mock("vue-i18n");
+
+const { NModalStub } = vi.hoisted(() => ({
+  NModalStub: {
+    name: "NModal",
+    props: { show: Boolean },
+    template: "<div v-if=\"show\" data-testid=\"n-modal-stub\"><slot /></div>",
+  },
+}));
+
+vi.mock("naive-ui", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, NModal: NModalStub };
+});
+
+/**
+ * Mounts FocusMetricSelector with the stubbed NModal teleport-free shell.
+ *
+ * @param open Whether the selector is open.
+ * @param selectedId Currently selected focus metric id.
+ * @returns A Vue Test Utils wrapper for the mounted component.
+ */
+function mountSelector(
+  open = true,
+  selectedId: (typeof FOCUS_METRIC_IDS)[number] = "freeBalanceAfterFixed",
+): VueWrapper {
+  return mount(FocusMetricSelector, {
+    props: { open, selectedId },
+    global: {
+      stubs: {
+        NModal: NModalStub,
+      },
+    },
+  });
+}
+
+describe("FocusMetricSelector", () => {
+  it("renders an option for every canonical metric id", () => {
+    const wrapper = mountSelector();
+    for (const id of FOCUS_METRIC_IDS) {
+      expect(wrapper.find(`[data-testid='focus-metric-option-${id}']`).exists()).toBe(true);
+    }
+  });
+
+  it("marks the currently selected option as active", () => {
+    const wrapper = mountSelector(true, "monthlyBurnRate");
+    const active = wrapper.get("[data-testid='focus-metric-option-monthlyBurnRate']");
+    expect(active.classes()).toContain("focus-selector__option--active");
+  });
+
+  it("emits 'select' and 'close' when an option is clicked", async () => {
+    const wrapper = mountSelector();
+    await wrapper.get("[data-testid='focus-metric-option-primaryGoalProgress']").trigger("click");
+    expect(wrapper.emitted("select")).toBeTruthy();
+    expect(wrapper.emitted("select")![0]).toEqual(["primaryGoalProgress"]);
+    expect(wrapper.emitted("close")).toBeTruthy();
+  });
+});

--- a/app/features/focus/components/FocusMetricSelector.vue
+++ b/app/features/focus/components/FocusMetricSelector.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { NModal } from "naive-ui";
+import { Check } from "lucide-vue-next";
+import { FOCUS_METRIC_IDS, type FocusMetricId } from "../model/focus-metric";
+
+interface Props {
+  readonly open: boolean;
+  readonly selectedId: FocusMetricId;
+}
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+  select: [id: FocusMetricId];
+  close: [];
+}>();
+
+const { t } = useI18n();
+
+const show = computed<boolean>({
+  get: () => props.open,
+  set: (v) => {
+    if (!v) { emit("close"); }
+  },
+});
+
+/**
+ * Emits the chosen metric id and closes the selector modal.
+ *
+ * @param id Focus metric id the user clicked.
+ */
+const onSelect = (id: FocusMetricId): void => {
+  emit("select", id);
+  emit("close");
+};
+</script>
+
+<template>
+  <NModal
+    v-model:show="show"
+    preset="card"
+    :title="t('focus.selector.title')"
+    :bordered="false"
+    size="small"
+    style="max-width: 480px;"
+    data-testid="focus-metric-selector"
+  >
+    <p class="focus-selector__description">{{ t("focus.selector.description") }}</p>
+    <ul class="focus-selector__list">
+      <li v-for="id in FOCUS_METRIC_IDS" :key="id">
+        <button
+          type="button"
+          class="focus-selector__option"
+          :class="{ 'focus-selector__option--active': id === selectedId }"
+          :data-testid="`focus-metric-option-${id}`"
+          @click="onSelect(id)"
+        >
+          <span class="focus-selector__option-text">
+            <span class="focus-selector__option-label">{{ t(`focus.metrics.${id}.label`) }}</span>
+            <span class="focus-selector__option-caption">{{ t(`focus.metrics.${id}.caption`) }}</span>
+          </span>
+          <Check v-if="id === selectedId" :size="18" class="focus-selector__check" />
+        </button>
+      </li>
+    </ul>
+  </NModal>
+</template>
+
+<style scoped>
+.focus-selector__description {
+  margin: 0 0 var(--space-3);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.focus-selector__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.focus-selector__option {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 12px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+
+.focus-selector__option:hover {
+  border-color: var(--color-primary);
+  background: var(--color-bg-highlight, var(--color-bg-elevated));
+}
+
+.focus-selector__option--active {
+  border-color: var(--color-primary);
+  background: var(--color-bg-highlight, var(--color-bg-elevated));
+}
+
+.focus-selector__option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.focus-selector__option-label {
+  font-weight: var(--font-weight-medium);
+}
+
+.focus-selector__option-caption {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.focus-selector__check {
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+</style>

--- a/app/features/focus/composables/useFocusMetric.spec.ts
+++ b/app/features/focus/composables/useFocusMetric.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ref, nextTick } from "vue";
+import { useFocusMetric } from "./useFocusMetric";
+import {
+  FOCUS_SELECTED_METRIC_STORAGE_KEY,
+  DEFAULT_FOCUS_METRIC_ID,
+  type FocusMetricId,
+} from "../model/focus-metric";
+import type { DashboardOverview } from "~/features/dashboard/model/dashboard-overview";
+
+type OverviewRef = { value: DashboardOverview | undefined };
+
+const overviewRef: OverviewRef = { value: undefined };
+const isLoadingRef = ref(false);
+const isErrorRef = ref(false);
+
+vi.mock("~/features/dashboard/queries/use-dashboard-overview-query", () => ({
+  useDashboardOverviewQuery: (): unknown => ({
+    data: overviewRef,
+    isLoading: isLoadingRef,
+    isError: isErrorRef,
+  }),
+}));
+
+/**
+ * Builds a DashboardOverview fixture with sensible defaults, overridable per test.
+ *
+ * @param partial Partial overrides applied on top of the baseline fixture.
+ * @returns A fully-populated DashboardOverview suitable for computeMetric tests.
+ */
+function makeOverview(partial: Partial<DashboardOverview> = {}): DashboardOverview {
+  return {
+    period: { key: "current_month", start: "2026-04-01", end: "2026-04-30", label: "Abril/2026" },
+    summary: { income: 8000, expense: 3200, balance: 12_500, upcomingDueTotal: 1500, netWorth: 45_000 },
+    comparison: {
+      incomeVsPreviousMonthPercent: 5,
+      expenseVsPreviousMonthPercent: -8,
+      balanceVsPreviousMonthPercent: 12,
+    },
+    timeseries: [],
+    expensesByCategory: [],
+    upcomingDues: [],
+    goals: [],
+    portfolio: { currentValue: 0, changePercent: null },
+    alerts: [],
+    ...partial,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  overviewRef.value = undefined;
+  isLoadingRef.value = false;
+  isErrorRef.value = false;
+});
+
+describe("useFocusMetric — selection + persistence", () => {
+  it("falls back to the default metric when storage is empty", () => {
+    const { selectedId } = useFocusMetric();
+    expect(selectedId.value).toBe(DEFAULT_FOCUS_METRIC_ID);
+  });
+
+  it("reads a previously persisted metric id on init", () => {
+    localStorage.setItem(FOCUS_SELECTED_METRIC_STORAGE_KEY, "monthlyBurnRate");
+    const { selectedId } = useFocusMetric();
+    expect(selectedId.value).toBe<FocusMetricId>("monthlyBurnRate");
+  });
+
+  it("ignores invalid persisted ids and falls back to default", () => {
+    localStorage.setItem(FOCUS_SELECTED_METRIC_STORAGE_KEY, "not-a-real-metric");
+    const { selectedId } = useFocusMetric();
+    expect(selectedId.value).toBe(DEFAULT_FOCUS_METRIC_ID);
+  });
+
+  it("persists selection via selectMetric()", () => {
+    const { selectMetric, selectedId } = useFocusMetric();
+    selectMetric("primaryGoalProgress");
+    expect(selectedId.value).toBe<FocusMetricId>("primaryGoalProgress");
+    expect(localStorage.getItem(FOCUS_SELECTED_METRIC_STORAGE_KEY)).toBe("primaryGoalProgress");
+  });
+});
+
+describe("useFocusMetric — computeMetric outputs", () => {
+  it("marks all metrics unavailable while overview is undefined", () => {
+    const { metric } = useFocusMetric();
+    expect(metric.value.unavailable).toBe(true);
+    expect(metric.value.value).toBe(0);
+  });
+
+  it("monthlyBurnRate uses overview.summary.expense with trend", () => {
+    overviewRef.value = makeOverview();
+    localStorage.setItem(FOCUS_SELECTED_METRIC_STORAGE_KEY, "monthlyBurnRate");
+    const { metric } = useFocusMetric();
+    expect(metric.value.value).toBe(3200);
+    expect(metric.value.unit).toBe("currency");
+    expect(metric.value.trend).toEqual({ delta: -8, percent: -8, direction: "down" });
+    expect(metric.value.unavailable).toBe(false);
+  });
+
+  it("freeBalanceAfterFixed subtracts upcoming dues from balance", () => {
+    overviewRef.value = makeOverview();
+    localStorage.setItem(FOCUS_SELECTED_METRIC_STORAGE_KEY, "freeBalanceAfterFixed");
+    const { metric } = useFocusMetric();
+    expect(metric.value.value).toBe(11_000);
+    expect(metric.value.unit).toBe("currency");
+  });
+
+  it("primaryGoalProgress picks the active goal with the earliest targetDate", () => {
+    overviewRef.value = makeOverview({
+      goals: [
+        { id: "a", name: "Meta A", progressPercent: 10, currentAmount: 100, targetAmount: 1000, targetDate: "2027-01-01" },
+        { id: "b", name: "Meta B", progressPercent: 55, currentAmount: 550, targetAmount: 1000, targetDate: "2026-06-01" },
+        { id: "c", name: "Meta C", progressPercent: 100, currentAmount: 1000, targetAmount: 1000, targetDate: "2026-05-01" },
+      ],
+    });
+    localStorage.setItem(FOCUS_SELECTED_METRIC_STORAGE_KEY, "primaryGoalProgress");
+    const { metric } = useFocusMetric();
+    expect(metric.value.value).toBe(55);
+    expect(metric.value.unit).toBe("percent");
+    expect(metric.value.unavailable).toBe(false);
+  });
+
+  it("primaryGoalProgress is unavailable when there are no goals", () => {
+    overviewRef.value = makeOverview({ goals: [] });
+    localStorage.setItem(FOCUS_SELECTED_METRIC_STORAGE_KEY, "primaryGoalProgress");
+    const { metric } = useFocusMetric();
+    expect(metric.value.unavailable).toBe(true);
+  });
+
+  it("daysUntilPrimaryGoal returns a non-negative day count", () => {
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    overviewRef.value = makeOverview({
+      goals: [
+        { id: "g", name: "Meta", progressPercent: 25, currentAmount: 250, targetAmount: 1000, targetDate: future },
+      ],
+    });
+    localStorage.setItem(FOCUS_SELECTED_METRIC_STORAGE_KEY, "daysUntilPrimaryGoal");
+    const { metric } = useFocusMetric();
+    expect(metric.value.unit).toBe("days");
+    expect(metric.value.value).toBeGreaterThanOrEqual(6);
+    expect(metric.value.value).toBeLessThanOrEqual(8);
+  });
+
+  it("daysUntilPrimaryGoal is unavailable when no goal has a targetDate", () => {
+    overviewRef.value = makeOverview({
+      goals: [
+        { id: "g", name: "Meta", progressPercent: 0, currentAmount: 0, targetAmount: 1000, targetDate: null },
+      ],
+    });
+    localStorage.setItem(FOCUS_SELECTED_METRIC_STORAGE_KEY, "daysUntilPrimaryGoal");
+    const { metric } = useFocusMetric();
+    expect(metric.value.unavailable).toBe(true);
+  });
+
+  it("savingsVsPreviousMonth is unavailable when comparison percent is null", () => {
+    overviewRef.value = makeOverview({
+      comparison: {
+        incomeVsPreviousMonthPercent: null,
+        expenseVsPreviousMonthPercent: null,
+        balanceVsPreviousMonthPercent: null,
+      },
+    });
+    localStorage.setItem(FOCUS_SELECTED_METRIC_STORAGE_KEY, "savingsVsPreviousMonth");
+    const { metric } = useFocusMetric();
+    expect(metric.value.unavailable).toBe(true);
+  });
+
+  it("reacts to selection changes", async () => {
+    overviewRef.value = makeOverview();
+    const { metric, selectMetric } = useFocusMetric();
+    selectMetric("monthlyBurnRate");
+    await nextTick();
+    expect(metric.value.id).toBe<FocusMetricId>("monthlyBurnRate");
+    selectMetric("freeBalanceAfterFixed");
+    await nextTick();
+    expect(metric.value.id).toBe<FocusMetricId>("freeBalanceAfterFixed");
+  });
+});

--- a/app/features/focus/composables/useFocusMetric.ts
+++ b/app/features/focus/composables/useFocusMetric.ts
@@ -1,0 +1,283 @@
+import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
+import { useDashboardOverviewQuery } from "~/features/dashboard/queries/use-dashboard-overview-query";
+import type { DashboardOverview, DashboardGoalSummary } from "~/features/dashboard/model/dashboard-overview";
+import {
+  DEFAULT_FOCUS_METRIC_ID,
+  FOCUS_METRIC_IDS,
+  FOCUS_SELECTED_METRIC_STORAGE_KEY,
+  type FocusMetric,
+  type FocusMetricId,
+  type FocusMetricTrend,
+  type FocusMetricUnit,
+} from "../model/focus-metric";
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Reads the persisted metric id, guarding against SSR and storage being unavailable.
+ *
+ * Returning the default when the storage read throws is deliberate: the UI must
+ * always pick *some* metric, and a broken preference should never propagate to
+ * a crash on a page that has no other fallback state.
+ *
+ * @returns The persisted metric id or the canonical default.
+ */
+function readPersistedMetricId(): FocusMetricId {
+  if (typeof localStorage === "undefined") { return DEFAULT_FOCUS_METRIC_ID; }
+  try {
+    const stored = localStorage.getItem(FOCUS_SELECTED_METRIC_STORAGE_KEY);
+    if (stored && (FOCUS_METRIC_IDS as readonly string[]).includes(stored)) {
+      return stored as FocusMetricId;
+    }
+  } catch {
+    return DEFAULT_FOCUS_METRIC_ID;
+  }
+  return DEFAULT_FOCUS_METRIC_ID;
+}
+
+/**
+ * Persists the selected metric id to localStorage when available.
+ *
+ * @param id The metric id to persist.
+ */
+function persistMetricId(id: FocusMetricId): void {
+  if (typeof localStorage === "undefined") { return; }
+  try {
+    localStorage.setItem(FOCUS_SELECTED_METRIC_STORAGE_KEY, id);
+  } catch {
+    // Storage quota or privacy mode — selection simply won't persist this turn.
+  }
+}
+
+/**
+ * Picks the primary goal — the active one with the earliest target date.
+ *
+ * @param goals Dashboard goal summaries.
+ * @returns The primary goal or null when none exists.
+ */
+function pickPrimaryGoal(goals: readonly DashboardGoalSummary[]): DashboardGoalSummary | null {
+  if (goals.length === 0) { return null; }
+  const active = goals.filter((g) => g.progressPercent < 100 && g.targetDate);
+  if (active.length === 0) { return goals[0] ?? null; }
+  active.sort((a, b) => {
+    const aDate = a.targetDate ? new Date(a.targetDate).getTime() : Number.POSITIVE_INFINITY;
+    const bDate = b.targetDate ? new Date(b.targetDate).getTime() : Number.POSITIVE_INFINITY;
+    return aDate - bDate;
+  });
+  return active[0] ?? null;
+}
+
+/**
+ * Computes whole-day distance between now and an ISO target date, floored at 0.
+ *
+ * @param targetIso Target date in ISO-8601 format.
+ * @returns Non-negative integer of days until the target.
+ */
+function daysBetween(targetIso: string): number {
+  const target = new Date(targetIso).getTime();
+  const now = Date.now();
+  return Math.max(0, Math.ceil((target - now) / MS_PER_DAY));
+}
+
+/**
+ * Resolves the trend direction for a signed numeric value.
+ *
+ * @param signed Positive, negative or zero signal.
+ * @returns Direction enum matching the sign.
+ */
+function resolveDirection(signed: number): FocusMetricTrend["direction"] {
+  if (signed > 0) { return "up"; }
+  if (signed < 0) { return "down"; }
+  return "flat";
+}
+
+/**
+ * Builds a trend from a percent delta or null when the comparison is not meaningful.
+ *
+ * @param percent Signed percentage change.
+ * @returns Trend object or null when percent is null.
+ */
+function trendFromPercent(percent: number | null): FocusMetricTrend | null {
+  if (percent === null) { return null; }
+  return { delta: percent, percent, direction: resolveDirection(percent) };
+}
+
+/**
+ * Builds a trend from a raw signed delta, without a percent counterpart.
+ *
+ * @param delta Signed delta value.
+ * @returns Trend object describing the delta direction.
+ */
+function trendFromDelta(delta: number): FocusMetricTrend {
+  return { delta, percent: null, direction: resolveDirection(delta) };
+}
+
+interface ComputedFocusMetric {
+  readonly value: number;
+  readonly unit: FocusMetricUnit;
+  readonly trend: FocusMetricTrend | null;
+  readonly unavailable: boolean;
+}
+
+/**
+ * Computes the numeric + trend payload for the selected metric from the overview.
+ *
+ * @param id The selected focus metric id.
+ * @param overview Dashboard overview to derive values from.
+ * @returns Computed value + trend + availability flag.
+ */
+function computeMetric(id: FocusMetricId, overview: DashboardOverview): ComputedFocusMetric {
+  switch (id) {
+    case "daysUntilPrimaryGoal": {
+      const primary = pickPrimaryGoal(overview.goals);
+      if (!primary?.targetDate) {
+        return { value: 0, unit: "days", trend: null, unavailable: true };
+      }
+      return { value: daysBetween(primary.targetDate), unit: "days", trend: null, unavailable: false };
+    }
+    case "monthlyBurnRate":
+      return {
+        value: overview.summary.expense,
+        unit: "currency",
+        trend: trendFromPercent(overview.comparison.expenseVsPreviousMonthPercent),
+        unavailable: false,
+      };
+    case "freeBalanceAfterFixed": {
+      const free = overview.summary.balance - overview.summary.upcomingDueTotal;
+      return {
+        value: free,
+        unit: "currency",
+        trend: trendFromPercent(overview.comparison.balanceVsPreviousMonthPercent),
+        unavailable: false,
+      };
+    }
+    case "primaryGoalProgress": {
+      const primary = pickPrimaryGoal(overview.goals);
+      if (!primary) {
+        return { value: 0, unit: "percent", trend: null, unavailable: true };
+      }
+      return { value: primary.progressPercent, unit: "percent", trend: null, unavailable: false };
+    }
+    case "savingsVsPreviousMonth": {
+      const percent = overview.comparison.balanceVsPreviousMonthPercent;
+      if (percent === null) {
+        return { value: 0, unit: "percent", trend: null, unavailable: true };
+      }
+      return {
+        value: percent,
+        unit: "percent",
+        trend: trendFromDelta(percent),
+        unavailable: false,
+      };
+    }
+    default:
+      return { value: 0, unit: "currency", trend: null, unavailable: true };
+  }
+}
+
+export interface UseFocusMetricReturn {
+  readonly selectedId: Ref<FocusMetricId>;
+  readonly metric: ComputedRef<FocusMetric>;
+  readonly availableIds: ComputedRef<readonly FocusMetricId[]>;
+  readonly isLoading: Ref<boolean>;
+  readonly isError: Ref<boolean>;
+  readonly selectMetric: (id: FocusMetricId) => void;
+}
+
+const PERCENT_METRIC_IDS: ReadonlySet<FocusMetricId> = new Set([
+  "primaryGoalProgress",
+  "savingsVsPreviousMonth",
+]);
+
+/**
+ * Resolves the unit to display before the overview query resolves.
+ *
+ * @param id The currently selected metric id.
+ * @returns Unit to use for the placeholder (unavailable) metric payload.
+ */
+function placeholderUnit(id: FocusMetricId): FocusMetricUnit {
+  if (id === "daysUntilPrimaryGoal") { return "days"; }
+  if (PERCENT_METRIC_IDS.has(id)) { return "percent"; }
+  return "currency";
+}
+
+/**
+ * Builds the i18n label key for a metric id.
+ *
+ * @param id Focus metric id.
+ * @returns Canonical label i18n key.
+ */
+const labelKeyFor = (id: FocusMetricId): string => `focus.metrics.${id}.label`;
+
+/**
+ * Builds the i18n caption key for a metric id.
+ *
+ * @param id Focus metric id.
+ * @returns Canonical caption i18n key.
+ */
+const captionKeyFor = (id: FocusMetricId): string => `focus.metrics.${id}.caption`;
+
+/**
+ * Focus Mode composable. Wraps the dashboard overview query and exposes the
+ * currently-selected "one number that matters" plus the helpers the Focus
+ * page needs (select, list available metrics).
+ *
+ * The selection is persisted per browser (not per user — the storage key is
+ * global). This matches the issue spec #551, which says "persistência da
+ * métrica escolhida em localStorage" without scoping to uid; revisit if we
+ * hear the opposite from product.
+ *
+ * @returns Reactive state and helpers for the Focus Mode page.
+ */
+export function useFocusMetric(): UseFocusMetricReturn {
+  const selectedId = ref<FocusMetricId>(readPersistedMetricId());
+  const overviewQuery = useDashboardOverviewQuery();
+
+  const overview = computed<DashboardOverview | undefined>(() => overviewQuery.data.value);
+
+  const metric = computed<FocusMetric>(() => {
+    const id = selectedId.value;
+    if (!overview.value) {
+      return {
+        id,
+        value: 0,
+        unit: placeholderUnit(id),
+        labelKey: labelKeyFor(id),
+        captionKey: captionKeyFor(id),
+        trend: null,
+        unavailable: true,
+      };
+    }
+    const computed_ = computeMetric(id, overview.value);
+    return {
+      id,
+      value: computed_.value,
+      unit: computed_.unit,
+      labelKey: labelKeyFor(id),
+      captionKey: captionKeyFor(id),
+      trend: computed_.trend,
+      unavailable: computed_.unavailable,
+    };
+  });
+
+  /**
+   * Commits a new selection and persists it to localStorage.
+   *
+   * @param id The metric id to select.
+   */
+  const selectMetric = (id: FocusMetricId): void => {
+    selectedId.value = id;
+    persistMetricId(id);
+  };
+
+  watch(selectedId, (id) => persistMetricId(id));
+
+  return {
+    selectedId,
+    metric,
+    availableIds: computed(() => FOCUS_METRIC_IDS),
+    isLoading: overviewQuery.isLoading,
+    isError: overviewQuery.isError,
+    selectMetric,
+  };
+}

--- a/app/features/focus/model/focus-metric.ts
+++ b/app/features/focus/model/focus-metric.ts
@@ -1,0 +1,50 @@
+/**
+ * Focus Mode metric catalog.
+ *
+ * Each metric represents one "number that matters" the user can pin as the
+ * single focus of the dedicated `/focus` page. The UI shows one at a time;
+ * the selection persists in localStorage.
+ */
+
+export const FOCUS_METRIC_IDS = [
+  "daysUntilPrimaryGoal",
+  "monthlyBurnRate",
+  "freeBalanceAfterFixed",
+  "primaryGoalProgress",
+  "savingsVsPreviousMonth",
+] as const;
+
+export type FocusMetricId = (typeof FOCUS_METRIC_IDS)[number];
+
+export type FocusMetricUnit = "days" | "currency" | "percent";
+
+export type FocusMetricTrendDirection = "up" | "down" | "flat";
+
+export interface FocusMetricTrend {
+  /** Signed change vs. the previous reference point, in the metric's native unit. */
+  readonly delta: number;
+  /** Percentage change vs. the previous reference point, when meaningful. */
+  readonly percent: number | null;
+  readonly direction: FocusMetricTrendDirection;
+}
+
+export interface FocusMetric {
+  readonly id: FocusMetricId;
+  readonly value: number;
+  readonly unit: FocusMetricUnit;
+  /** Stable i18n key under `focus.metrics.<id>`. */
+  readonly labelKey: string;
+  /** Subtitle / hint i18n key, optional. */
+  readonly captionKey?: string;
+  readonly trend: FocusMetricTrend | null;
+  /**
+   * `true` when the metric cannot be computed with the current data
+   * (e.g. no primary goal set). UI renders a helper instead of the number.
+   */
+  readonly unavailable: boolean;
+}
+
+/** localStorage key that stores the currently selected metric id per user. */
+export const FOCUS_SELECTED_METRIC_STORAGE_KEY = "auraxis:focus:selected-metric";
+
+export const DEFAULT_FOCUS_METRIC_ID: FocusMetricId = "freeBalanceAfterFixed";

--- a/app/features/paywall/model/entitlement.ts
+++ b/app/features/paywall/model/entitlement.ts
@@ -6,10 +6,12 @@
  * - advanced_simulations: requires premium subscription
  * - export_pdf: requires premium subscription
  * - shared_entries: requires premium subscription
+ * - focus_mode: requires premium subscription
  */
 export type FeatureKey =
   | "basic_simulations"
   | "advanced_simulations"
   | "export_pdf"
   | "shared_entries"
-  | "wallet_read";
+  | "wallet_read"
+  | "focus_mode";

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -67,7 +67,8 @@
     "tools": "Tools",
     "subscription": "Subscription",
     "personalData": "Personal Data",
-    "transactions": "Transactions"
+    "transactions": "Transactions",
+    "focus": "Focus"
   },
   "user": {
     "fallbackName": "User",
@@ -3586,6 +3587,56 @@
     },
     "disclaimer": {
       "note": "Based on constant compound return. Actual results may vary."
+    }
+  },
+  "focus": {
+    "page": {
+      "title": "Focus",
+      "subtitle": "One number. The one that matters right now.",
+      "change": "Change metric",
+      "footerHint": "Pick one metric to focus on. Your choice is saved in this browser."
+    },
+    "display": {
+      "loading": "Calculating…",
+      "suffix": {
+        "days": "days"
+      }
+    },
+    "selector": {
+      "title": "Pick your focus metric",
+      "description": "Just one at a time. The rest of the app stays put for when you need it."
+    },
+    "paywall": {
+      "title": "Focus is a Premium feature",
+      "description": "Strip away the dashboard noise and leave only the number that moves your month.",
+      "cta": "See plans"
+    },
+    "metrics": {
+      "daysUntilPrimaryGoal": {
+        "label": "Days until primary goal",
+        "caption": "Countdown to the target date of your nearest active goal.",
+        "unavailable": "Set a goal with a target date to see the countdown."
+      },
+      "monthlyBurnRate": {
+        "label": "Monthly burn rate",
+        "caption": "Total expenses in the current period.",
+        "unavailable": "No expenses recorded for this period yet."
+      },
+      "freeBalanceAfterFixed": {
+        "label": "Free balance after fixed",
+        "caption": "Current balance minus what's still due this month.",
+        "unavailable": "Log income and expenses to see your free balance."
+      },
+      "primaryGoalProgress": {
+        "label": "Primary goal progress",
+        "caption": "Percentage of your nearest active goal.",
+        "unavailable": "Create a goal to track its progress."
+      },
+      "savingsVsPreviousMonth": {
+        "label": "Savings vs previous month",
+        "caption": "Balance change compared to last month.",
+        "unavailable": "Not enough history yet to compare months."
+      }
     }
   }
 }

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -67,7 +67,8 @@
     "tools": "Ferramentas",
     "subscription": "Assinatura",
     "personalData": "Dados Pessoais",
-    "transactions": "Transações"
+    "transactions": "Transações",
+    "focus": "Foco"
   },
   "user": {
     "fallbackName": "Usuário",
@@ -3646,6 +3647,56 @@
     },
     "disclaimer": {
       "note": "Simulação baseada em rentabilidade composta constante. Resultados reais podem variar."
+    }
+  },
+  "focus": {
+    "page": {
+      "title": "Foco",
+      "subtitle": "Um número. Aquele que importa agora.",
+      "change": "Trocar métrica",
+      "footerHint": "Escolha uma métrica para focar. A sua seleção fica salva neste navegador."
+    },
+    "display": {
+      "loading": "Calculando…",
+      "suffix": {
+        "days": "dias"
+      }
+    },
+    "selector": {
+      "title": "Escolha sua métrica-foco",
+      "description": "Apenas uma por vez. O resto do app continua ali para quando você precisar."
+    },
+    "paywall": {
+      "title": "Foco é uma feature Premium",
+      "description": "Tire todo o ruído do dashboard e deixe na tela só o número que move seu mês.",
+      "cta": "Ver planos"
+    },
+    "metrics": {
+      "daysUntilPrimaryGoal": {
+        "label": "Dias até a meta principal",
+        "caption": "Contagem até o prazo da sua meta ativa mais próxima.",
+        "unavailable": "Defina uma meta com data-alvo para acompanhar a contagem."
+      },
+      "monthlyBurnRate": {
+        "label": "Gasto do mês",
+        "caption": "Total de despesas no período atual.",
+        "unavailable": "Ainda não há despesas registradas neste período."
+      },
+      "freeBalanceAfterFixed": {
+        "label": "Saldo livre após fixos",
+        "caption": "Saldo atual menos o que ainda vence neste mês.",
+        "unavailable": "Registre receitas e despesas para ver seu saldo livre."
+      },
+      "primaryGoalProgress": {
+        "label": "Progresso da meta principal",
+        "caption": "Percentual da meta ativa mais próxima.",
+        "unavailable": "Crie uma meta para acompanhar o progresso."
+      },
+      "savingsVsPreviousMonth": {
+        "label": "Economia vs mês anterior",
+        "caption": "Variação do seu saldo em relação ao mês passado.",
+        "unavailable": "Ainda não há histórico suficiente para comparar meses."
+      }
     }
   }
 }

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -11,6 +11,7 @@ import {
   User,
   ArrowLeftRight,
   PiggyBank,
+  Focus as FocusIcon,
 } from "lucide-vue-next";
 // UiAppShell and ProfileCompletionModal are auto-imported from app/components/.
 // Feature-owned components in app/features/*/components/ are NOT auto-imported
@@ -46,6 +47,7 @@ interface NavItemDefinition extends AppShellNavItem {
 
 const ALL_NAV_ITEMS = computed<NavItemDefinition[]>(() => [
   { key: "dashboard", label: t("nav.dashboard"), to: "/dashboard", icon: LayoutDashboard },
+  { key: "focus", label: t("nav.focus"), to: "/focus", icon: FocusIcon, flagKey: "web.pages.focus" },
   { key: "transactions", label: t("nav.transactions"), to: "/transactions", icon: ArrowLeftRight },
   { key: "portfolio", label: t("nav.portfolio"), to: "/portfolio", icon: Briefcase, flagKey: "web.pages.portfolio" },
   { key: "goals", label: t("nav.goals"), to: "/goals", icon: Target, flagKey: "web.pages.goals" },

--- a/app/pages/focus.vue
+++ b/app/pages/focus.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { NButton } from "naive-ui";
+import { Sparkles } from "lucide-vue-next";
+import PaywallGate from "~/components/paywall/PaywallGate.vue";
+import { useFocusMetric } from "~/features/focus/composables/useFocusMetric";
+import FocusMetricDisplay from "~/features/focus/components/FocusMetricDisplay.vue";
+import FocusMetricSelector from "~/features/focus/components/FocusMetricSelector.vue";
+import type { FocusMetricId } from "~/features/focus/model/focus-metric";
+
+definePageMeta({
+  layout: "default",
+  middleware: ["authenticated"],
+  pageTitle: "Foco",
+  pageSubtitle: "Um número. Aquele que importa agora.",
+});
+
+const { t } = useI18n();
+
+useHead({ title: "Foco | Auraxis" });
+
+const { selectedId, metric, isLoading, selectMetric } = useFocusMetric();
+
+const selectorOpen = ref<boolean>(false);
+
+/** Opens the focus-metric selector modal. */
+const openSelector = (): void => { selectorOpen.value = true; };
+
+/** Closes the focus-metric selector modal. */
+const closeSelector = (): void => { selectorOpen.value = false; };
+
+/**
+ * Commits a new focus metric selection.
+ *
+ * @param id Focus metric id chosen in the selector.
+ */
+const onSelect = (id: FocusMetricId): void => {
+  selectMetric(id);
+};
+
+const upgradeHref = computed<string>(() => "/plans");
+</script>
+
+<template>
+  <div class="focus-page" data-testid="focus-page">
+    <PaywallGate feature="focus_mode">
+      <section class="focus-page__stage" data-testid="focus-page-granted">
+        <FocusMetricDisplay :metric="metric" :is-loading="isLoading" />
+        <NButton quaternary size="small" class="focus-page__change" data-testid="focus-page-change" @click="openSelector">
+          {{ t("focus.page.change") }}
+        </NButton>
+        <p class="focus-page__hint">{{ t("focus.page.footerHint") }}</p>
+        <FocusMetricSelector
+          :open="selectorOpen"
+          :selected-id="selectedId"
+          @select="onSelect"
+          @close="closeSelector"
+        />
+      </section>
+
+      <template #locked>
+        <section class="focus-page__paywall" data-testid="focus-page-paywall">
+          <Sparkles :size="36" class="focus-page__paywall-icon" />
+          <h2 class="focus-page__paywall-title">{{ t("focus.paywall.title") }}</h2>
+          <p class="focus-page__paywall-description">{{ t("focus.paywall.description") }}</p>
+          <NButton type="primary" size="medium" tag="a" :href="upgradeHref" data-testid="focus-page-upgrade-cta">
+            {{ t("focus.paywall.cta") }}
+          </NButton>
+        </section>
+      </template>
+    </PaywallGate>
+  </div>
+</template>
+
+<style scoped>
+.focus-page {
+  min-height: calc(100vh - 120px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  background: var(--color-bg-subtle, var(--color-bg));
+}
+
+.focus-page__stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  max-width: 640px;
+  width: 100%;
+  text-align: center;
+}
+
+.focus-page__change {
+  margin-top: var(--space-2);
+}
+
+.focus-page__hint {
+  margin-top: var(--space-3);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  max-width: 42ch;
+}
+
+.focus-page__paywall {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 480px;
+  text-align: center;
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+}
+
+.focus-page__paywall-icon {
+  color: var(--color-primary);
+}
+
+.focus-page__paywall-title {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-xl);
+  margin: 0;
+  color: var(--color-text-primary);
+}
+
+.focus-page__paywall-description {
+  margin: 0 0 var(--space-2);
+  color: var(--color-text-muted);
+  max-width: 36ch;
+}
+</style>

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -421,6 +421,16 @@
       "repositories": ["auraxis-web"]
     },
     {
+      "key": "web.pages.focus",
+      "owner": "growth",
+      "createdAt": "2026-04-24",
+      "removeBy": "2027-12-31",
+      "type": "release",
+      "status": "enabled-prod",
+      "description": "Página Focus Mode: número único da jornada financeira do usuário. Gated por entitlement focus_mode.",
+      "repositories": ["auraxis-web"]
+    },
+    {
       "key": "web.dashboard.new-layout",
       "owner": "growth",
       "createdAt": "2026-04-21",


### PR DESCRIPTION
## Summary

Focus Mode page at `/focus` delivering the "one number that matters" experience — a full-screen primary metric (balance post-fixed, burn rate, goal progress, days to goal, savings-vs-previous-month) with an optional trend chip, gated by a `focus_mode` entitlement so free users see a paywall teaser and premium/trial see the live metric.

Closes #551
Closes #552

## Changes

- **app/features/focus/**
  - `model/focus-metric.ts` — `FocusMetricId` union (5 canonical metrics), `FocusMetricTrend`, `FocusMetric` view-model, `FOCUS_SELECTED_METRIC_STORAGE_KEY`, `DEFAULT_FOCUS_METRIC_ID`
  - `composables/useFocusMetric.ts` — SSR-safe localStorage persistence with guard + try/catch, dashboard-overview-query wrapper, `computeMetric()` covering currency/percent/days units, graceful `unavailable` placeholders
  - `components/FocusMetricDisplay.vue` — clamped heading (`clamp(4rem, 12vw, 8rem)`), currency/percent/days formatting via `useI18n().n()`, trend chip with lucide `TrendingUp/Down/Minus` icons, em-dash placeholder for unavailable metrics
  - `components/FocusMetricSelector.vue` — `NModal` list with active-state check + i18n label/caption per id
  - Full spec coverage (3055 tests total pass, no regressions; focus files cover selection+persistence, all 5 metric branches, display units, selector a11y)
- **app/pages/focus.vue** — `PaywallGate feature="focus_mode"` wrapping the stage; `locked` slot renders paywall teaser with Sparkles icon + `/plans` CTA
- **app/features/paywall/model/entitlement.ts** — add `focus_mode` to `FeatureKey`
- **config/feature-flags.json** — `web.pages.focus` at status `enabled-prod`
- **app/layouts/default.vue** — nav entry "Foco"/"Focus" between dashboard and transactions, flag-gated via `isFeatureEnabled("web.pages.focus")`
- **i18n parity (pt + en)** — `nav.focus` + full `focus.*` tree (page/display/selector/paywall + labels/captions/unavailable strings per metric id)

### Cross-repo companion (auraxis-api)

`focus_mode` added to `PLAN_FEATURES` premium + trial lists and `docs/entitlement-matrix.md`. Tracked in the companion API PR — web side works locally because `PaywallGate` falls back to locked when the entitlement check fails, and is fully unlocked once the API PR lands.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 294 files, 3055 tests passing
- [x] `pnpm quality-check` — full CI-parity passes (flags:check, lint, typecheck, test:coverage, policy:check, contracts:check, build)
- [x] Coverage above thresholds (focus composable/components at >90% lines)
- [ ] Manual: free user → paywall teaser; premium user → metric renders; metric selector persists to localStorage