### PR TITLE
fix(tags): strip alpha channel from picker hex before submit

### DIFF
--- a/app/components/tag/CreateTagModal/CreateTagModal.vue
+++ b/app/components/tag/CreateTagModal/CreateTagModal.vue
@@ -9,6 +9,7 @@ import {
   NSpace,
 } from "naive-ui";
 import { useCreateTagMutation } from "~/features/tags/queries/use-create-tag-mutation";
+import { stripHexAlpha } from "~/features/tags/utils/normalize-color";
 
 const { t } = useI18n();
 
@@ -59,7 +60,7 @@ async function onSubmit(): Promise<void> {
 
   await createMutation.mutateAsync({
     name,
-    color: formColor.value || null,
+    color: stripHexAlpha(formColor.value),
     icon: formIcon.value.trim() || null,
   });
 
@@ -92,6 +93,7 @@ async function onSubmit(): Promise<void> {
             v-model:value="formColor"
             :swatches="TAG_COLOR_SWATCHES"
             :modes="['hex']"
+            :show-alpha="false"
             size="small"
           />
           <div v-if="formColor" class="create-tag-modal__preview">

--- a/app/features/tags/utils/__tests__/normalize-color.spec.ts
+++ b/app/features/tags/utils/__tests__/normalize-color.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { stripHexAlpha } from "../normalize-color";
+
+describe("stripHexAlpha", () => {
+  it("returns null for null input", () => {
+    expect(stripHexAlpha(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(stripHexAlpha(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(stripHexAlpha("")).toBeNull();
+  });
+
+  it("strips alpha channel from #RRGGBBAA", () => {
+    expect(stripHexAlpha("#C21717FF")).toBe("#C21717");
+    expect(stripHexAlpha("#9B59B6CC")).toBe("#9B59B6");
+    expect(stripHexAlpha("#abcdef00")).toBe("#abcdef");
+  });
+
+  it("preserves canonical 6-digit hex", () => {
+    expect(stripHexAlpha("#FF6B6B")).toBe("#FF6B6B");
+    expect(stripHexAlpha("#000000")).toBe("#000000");
+  });
+
+  it("returns malformed input unchanged for backend validation to reject", () => {
+    expect(stripHexAlpha("red")).toBe("red");
+    expect(stripHexAlpha("#XYZ")).toBe("#XYZ");
+  });
+});

--- a/app/features/tags/utils/normalize-color.ts
+++ b/app/features/tags/utils/normalize-color.ts
@@ -1,0 +1,12 @@
+/**
+ * Drops alpha channel from #RRGGBBAA so backend (which only accepts #RRGGBB) is happy.
+ * Returns null for empty input. Returns the value unchanged if it doesn't match
+ * either canonical form — server-side validation will surface the error.
+ *
+ * @param hex - Raw color string from the picker (may be 6- or 8-digit hex, or null).
+ * @returns Canonical #RRGGBB hex, or null when input is empty.
+ */
+export function stripHexAlpha(hex: string | null | undefined): string | null {
+  if (!hex) { return null; }
+  return /^#[0-9A-Fa-f]{8}$/.test(hex) ? hex.slice(0, 7) : hex;
+}

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -484,9 +484,9 @@
         "remove": "Remove",
         "placeholder": "Tag name",
         "fields": {
-          "color": "Color",
+          "color": "Color (optional)",
           "colorPlaceholder": "#FF5733",
-          "icon": "Icon",
+          "icon": "Icon (optional)",
           "iconPlaceholder": "🏷️"
         }
       },

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -484,9 +484,9 @@
         "remove": "Remove",
         "placeholder": "Tag name",
         "fields": {
-          "color": "Color (optional)",
+          "color": "Color",
           "colorPlaceholder": "#FF5733",
-          "icon": "Icon (optional)",
+          "icon": "Icon",
           "iconPlaceholder": "🏷️"
         }
       },

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -509,9 +509,9 @@
         "remove": "Remover",
         "placeholder": "Nome da tag",
         "fields": {
-          "color": "Cor",
+          "color": "Cor (opcional)",
           "colorPlaceholder": "#FF5733",
-          "icon": "Ícone",
+          "icon": "Ícone (opcional)",
           "iconPlaceholder": "🏷️"
         }
       },
@@ -1707,8 +1707,8 @@
       "title": "Nova Tag",
       "name": "Nome da tag",
       "namePlaceholder": "Ex: Urgência, Investimento...",
-      "color": "Cor",
-      "icon": "Ícone (emoji)",
+      "color": "Cor (opcional)",
+      "icon": "Ícone (opcional)",
       "iconPlaceholder": "🏷️",
       "previewLabel": "Exemplo",
       "create": "Criar tag"

--- a/app/pages/settings/tags.vue
+++ b/app/pages/settings/tags.vue
@@ -19,6 +19,7 @@ import { useTagsQuery } from "~/features/tags/queries/use-tags-query";
 import { useCreateTagMutation } from "~/features/tags/queries/use-create-tag-mutation";
 import { useUpdateTagMutation } from "~/features/tags/queries/use-update-tag-mutation";
 import { useDeleteTagMutation } from "~/features/tags/queries/use-delete-tag-mutation";
+import { stripHexAlpha } from "~/features/tags/utils/normalize-color";
 
 const { t } = useI18n();
 
@@ -82,7 +83,7 @@ async function submitForm(): Promise<void> {
   const name = formName.value.trim();
   if (!name) {return;}
 
-  const color = formColor.value.trim() || null;
+  const color = stripHexAlpha(formColor.value.trim() || null);
   const icon = formIcon.value.trim() || null;
 
   if (editingTag.value) {
@@ -215,6 +216,7 @@ const columns = computed((): DataTableColumns<TagDto> => [
             v-model:value="formColor"
             :swatches="['#FF6B6B','#E67E22','#F1C40F','#2ECC71','#4ECDC4','#3498DB','#9B59B6','#DDA0DD','#96CEB4','#D3D3D3']"
             :modes="['hex']"
+            :show-alpha="false"
             size="small"
           />
         </NFormItem>


### PR DESCRIPTION
## Summary

- `NColorPicker` (Naive UI) defaults to `show-alpha=true`, so it emitted 8-digit hex `#RRGGBBAA` when the user picked a color via the inline picker. The backend's tag schema only accepted `#RRGGBB` and rejected with `INVALID_COLOR` (400). Repro from production cURL: `color: "#C21717FF"` → 400.
- Disable alpha mode on both `NColorPicker` instances (CreateTagModal + settings/tags page) and add a defensive `stripHexAlpha` normalizer that drops the alpha byte before submit.
- Mark color and icon as opcional in the i18n labels — both fields are already optional client- and server-side, but the labels read as if required.

## Changes

- `app/components/tag/CreateTagModal/CreateTagModal.vue`: `:show-alpha="false"` + uses `stripHexAlpha` on submit.
- `app/pages/settings/tags.vue`: same change for the create/edit form on the settings page.
- `app/features/tags/utils/normalize-color.ts`: new pure helper.
- `app/features/tags/utils/__tests__/normalize-color.spec.ts`: 6 unit tests covering all branches.
- `app/i18n/locales/pt.json` and `en.json`: append "(opcional)" / "(optional)" to color and icon labels.

## Coordination

- Companion fix on backend: italofelipe/auraxis-api#1125 — relaxes the regex to accept `#RRGGBBAA` and normalizes server-side. Defense in depth: even legacy clients that send 8-digit hex stop failing.

## Test plan

- [ ] CI lint + typecheck + vitest pass
- [ ] Manual smoke: create a tag with the picker, confirm 201
- [ ] Manual smoke: edit a tag, confirm 200
- [ ] Verify labels show "(opcional)" / "(optional)" in both locales