### PR TITLE
feat(tools): canonical /simulations save flow + leave-without-save UX

### DIFF
--- a/app/components/simulation/SaveSimulationButton.spec.ts
+++ b/app/components/simulation/SaveSimulationButton.spec.ts
@@ -76,10 +76,11 @@ describe("SaveSimulationButton", () => {
 
     const wrapper = mount(SaveSimulationButton, {
       props: {
-        toolSlug: "raise-calculator",
+        toolId: "salary-raise",
+        ruleVersion: "2026.04",
         inputs: { current: 5000 },
         result: { recommended: 5500 },
-        name: "Minha simulação",
+        label: "Minha simulação",
       },
     });
 
@@ -88,10 +89,11 @@ describe("SaveSimulationButton", () => {
     expect(mockMutate).toHaveBeenCalledOnce();
     expect(mockMutate).toHaveBeenCalledWith(
       {
-        name: "Minha simulação",
-        toolSlug: "raise-calculator",
+        toolId: "salary-raise",
+        ruleVersion: "2026.04",
         inputs: { current: 5000 },
         result: { recommended: 5500 },
+        metadata: { label: "Minha simulação" },
       },
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
@@ -103,7 +105,8 @@ describe("SaveSimulationButton", () => {
 
     const wrapper = mount(SaveSimulationButton, {
       props: {
-        toolSlug: "raise-calculator",
+        toolId: "salary-raise",
+        ruleVersion: "2026.04",
         inputs: { current: 5000 },
         result: { recommended: 5500 },
       },
@@ -111,11 +114,11 @@ describe("SaveSimulationButton", () => {
 
     await wrapper.find(".n-button").trigger("click");
 
-    expect(mockSave).toHaveBeenCalledWith("raise-calculator", { recommended: 5500 });
+    expect(mockSave).toHaveBeenCalledWith("salary-raise", { recommended: 5500 });
     expect(mockPush).toHaveBeenCalledOnce();
     const redirectArg = mockPush.mock.calls[0]?.[0] as string;
     expect(redirectArg).toContain("/login");
-    expect(redirectArg).toContain("raise-calculator");
+    expect(redirectArg).toContain("salary-raise");
     expect(mockMutate).not.toHaveBeenCalled();
   });
 });

--- a/app/components/simulation/SaveSimulationButton.vue
+++ b/app/components/simulation/SaveSimulationButton.vue
@@ -8,17 +8,19 @@ import { useSaveSimulationMutation } from "~/features/simulations/queries/use-sa
 
 const props = withDefaults(
   defineProps<{
-    /** The tool identifier that produced this result. */
-    toolSlug: string;
-    /** The inputs passed to the tool. */
-    inputs: unknown;
-    /** The result produced by the tool. */
-    result: unknown;
-    /** Optional display name for the simulation. Defaults to the tool slug. */
-    name?: string;
+    /** Canonical kebab-case tool id from the registry (e.g. "compound-interest"). */
+    toolId: string;
+    /** Formula version declared by the client (e.g. "2026.04"). */
+    ruleVersion: string;
+    /** The inputs passed to the tool — must be a JSON object. */
+    inputs: Record<string, unknown>;
+    /** The result produced by the tool — must be a JSON object. */
+    result: Record<string, unknown>;
+    /** Optional human-friendly label persisted under metadata.label. */
+    label?: string;
   }>(),
   {
-    name: undefined,
+    label: undefined,
   },
 );
 
@@ -40,30 +42,24 @@ const isAuthenticated = computed<boolean>(() => {
   return sessionStore.isAuthenticated;
 });
 
-/**
- * The display name used for the simulation.
- * Falls back to the tool slug if no explicit name prop is provided.
- *
- * @returns The simulation name string.
- */
-const simulationName = computed<string>(() => props.name ?? props.toolSlug);
+const simulationLabel = computed<string | undefined>(() => props.label);
 
 /**
- * Handles the save action.
- *
- * When authenticated, calls the save mutation directly and shows a success
- * notification on completion. When not authenticated, saves the current tool
- * context to sessionStorage and redirects to the login page with a restore
- * redirect so the flow can resume after authentication.
+ * Saves the current simulation when authenticated; otherwise stores the
+ * tool context in sessionStorage and redirects to login so the flow can
+ * resume after authentication.
  */
 const handleSave = (): void => {
   if (isAuthenticated.value) {
     saveSimulationMutation.mutate(
       {
-        name: simulationName.value,
-        toolSlug: props.toolSlug,
+        toolId: props.toolId,
+        ruleVersion: props.ruleVersion,
         inputs: props.inputs,
         result: props.result,
+        ...(simulationLabel.value !== undefined && {
+          metadata: { label: simulationLabel.value },
+        }),
       },
       {
         onSuccess: (): void => {
@@ -77,9 +73,9 @@ const handleSave = (): void => {
     return;
   }
 
-  toolContextStore.save(props.toolSlug, props.result);
+  toolContextStore.save(props.toolId, props.result);
   const encodedResult = encodeURIComponent(JSON.stringify(props.result));
-  const redirectUrl = `/login?redirect=/tools&tool=${props.toolSlug}&result=${encodedResult}`;
+  const redirectUrl = `/login?redirect=/tools&tool=${props.toolId}&result=${encodedResult}`;
   void router.push(redirectUrl);
 };
 </script>

--- a/app/composables/useLeaveWithoutSavePrompt/__tests__/useLeaveWithoutSavePrompt.spec.ts
+++ b/app/composables/useLeaveWithoutSavePrompt/__tests__/useLeaveWithoutSavePrompt.spec.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { ref } from "vue";
+import { defineComponent, h, ref } from "vue";
+import { mount } from "@vue/test-utils";
 
 import { useLeaveWithoutSavePrompt } from "../useLeaveWithoutSavePrompt";
+import type { LeaveWithoutSavePromptReturn } from "../useLeaveWithoutSavePrompt.types";
 
 const mockWarning = vi.fn();
 let routeLeaveGuard: ((to: unknown, from: unknown, next: (proceed?: boolean) => void) => Promise<void> | void) | null = null;
@@ -127,5 +129,91 @@ describe("useLeaveWithoutSavePrompt", () => {
 
     expect(await confirmLeave()).toBe(true);
     expect(mockWarning).not.toHaveBeenCalled();
+  });
+
+  it("confirmLeave shows the prompt when dirty and resolves with the user choice", async () => {
+    const isDirty = ref(true);
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const { confirmLeave } = useLeaveWithoutSavePrompt({ isDirty, onSave });
+
+    mockWarning.mockImplementation((opts: { onPositiveClick: () => Promise<void> }) => {
+      void opts.onPositiveClick();
+    });
+
+    await expect(confirmLeave()).resolves.toBe(true);
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+
+  it("registers a beforeunload listener on mount and removes it on unmount", () => {
+    const isDirty = ref(false);
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const wrapper = mount(
+      defineComponent({
+        setup(): () => ReturnType<typeof h> {
+          useLeaveWithoutSavePrompt({ isDirty, onSave: vi.fn() });
+          return (): ReturnType<typeof h> => h("div");
+        },
+      }),
+    );
+
+    expect(addSpy).toHaveBeenCalledWith("beforeunload", expect.any(Function));
+    wrapper.unmount();
+    expect(removeSpy).toHaveBeenCalledWith("beforeunload", expect.any(Function));
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  it("the beforeunload listener prevents navigation only when isDirty is true", () => {
+    const isDirty = ref(false);
+    const captured: { handler: ((e: BeforeUnloadEvent) => void) | null } = { handler: null };
+    const addSpy = vi
+      .spyOn(window, "addEventListener")
+      .mockImplementation((event: string, handler: EventListenerOrEventListenerObject) => {
+        if (event === "beforeunload") {
+          captured.handler = handler as (e: BeforeUnloadEvent) => void;
+        }
+      });
+
+    mount(
+      defineComponent({
+        setup(): () => ReturnType<typeof h> {
+          useLeaveWithoutSavePrompt({ isDirty, onSave: vi.fn() });
+          return (): ReturnType<typeof h> => h("div");
+        },
+      }),
+    );
+
+    const cleanEvent = { preventDefault: vi.fn(), returnValue: "" } as unknown as BeforeUnloadEvent;
+    captured.handler?.(cleanEvent);
+    expect(cleanEvent.preventDefault).not.toHaveBeenCalled();
+
+    isDirty.value = true;
+    const dirtyEvent = { preventDefault: vi.fn(), returnValue: "" } as unknown as BeforeUnloadEvent;
+    captured.handler?.(dirtyEvent);
+    expect(dirtyEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(dirtyEvent.returnValue).not.toBe("");
+
+    addSpy.mockRestore();
+  });
+
+  it("isSaving toggles around onSave invocation", async () => {
+    const isDirty = ref(true);
+    let observedDuringSave: boolean | null = null;
+    const onSave = vi.fn().mockImplementation(async () => {
+      observedDuringSave = state.isSaving.value;
+    });
+    const state: LeaveWithoutSavePromptReturn = useLeaveWithoutSavePrompt({ isDirty, onSave });
+
+    mockWarning.mockImplementation((opts: { onPositiveClick: () => Promise<void> }) => {
+      void opts.onPositiveClick();
+    });
+
+    await routeLeaveGuard?.(null, null, vi.fn());
+
+    expect(observedDuringSave).toBe(true);
+    expect(state.isSaving.value).toBe(false);
   });
 });

--- a/app/composables/useLeaveWithoutSavePrompt/__tests__/useLeaveWithoutSavePrompt.spec.ts
+++ b/app/composables/useLeaveWithoutSavePrompt/__tests__/useLeaveWithoutSavePrompt.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+
+import { useLeaveWithoutSavePrompt } from "../useLeaveWithoutSavePrompt";
+
+const mockWarning = vi.fn();
+let routeLeaveGuard: ((to: unknown, from: unknown, next: (proceed?: boolean) => void) => Promise<void> | void) | null = null;
+
+vi.mock("naive-ui", (): Record<string, unknown> => ({
+  useDialog: (): { warning: ReturnType<typeof vi.fn> } => ({
+    warning: mockWarning,
+  }),
+}));
+
+vi.mock("vue-i18n", (): Record<string, unknown> => ({
+  useI18n: (): { t: (key: string) => string } => ({
+    t: (key: string): string => key,
+  }),
+}));
+
+vi.mock("vue-router", (): Record<string, unknown> => ({
+  onBeforeRouteLeave: (
+    cb: (to: unknown, from: unknown, next: (proceed?: boolean) => void) => Promise<void> | void,
+  ): void => {
+    routeLeaveGuard = cb;
+  },
+}));
+
+describe("useLeaveWithoutSavePrompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routeLeaveGuard = null;
+  });
+
+  it("does not show the prompt when isDirty is false", async () => {
+    const isDirty = ref(false);
+    useLeaveWithoutSavePrompt({ isDirty, onSave: vi.fn() });
+
+    const next = vi.fn();
+    await routeLeaveGuard?.(null, null, next);
+
+    expect(mockWarning).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("renders the prompt copy from the leaveWithoutSavePrompt namespace", async () => {
+    const isDirty = ref(true);
+    useLeaveWithoutSavePrompt({ isDirty, onSave: vi.fn() });
+
+    mockWarning.mockImplementation(() => {
+      // Don't resolve — assertion happens before user picks an action.
+    });
+    const next = vi.fn();
+    void routeLeaveGuard?.(null, null, next);
+
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "leaveWithoutSavePrompt.title",
+        content: "leaveWithoutSavePrompt.content",
+        positiveText: "leaveWithoutSavePrompt.positiveText",
+        negativeText: "leaveWithoutSavePrompt.negativeText",
+      }),
+    );
+  });
+
+  it("invokes onSave and lets the navigation proceed when user picks 'Salvar e sair'", async () => {
+    const isDirty = ref(true);
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    useLeaveWithoutSavePrompt({ isDirty, onSave });
+
+    mockWarning.mockImplementation((opts: { onPositiveClick: () => Promise<void> }) => {
+      void opts.onPositiveClick();
+    });
+    const next = vi.fn();
+    await routeLeaveGuard?.(null, null, next);
+
+    expect(onSave).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(true);
+  });
+
+  it("invokes onDiscard and proceeds when user picks 'Descartar e sair'", async () => {
+    const isDirty = ref(true);
+    const onDiscard = vi.fn();
+    useLeaveWithoutSavePrompt({ isDirty, onSave: vi.fn(), onDiscard });
+
+    mockWarning.mockImplementation((opts: { onNegativeClick: () => void }) => {
+      opts.onNegativeClick();
+    });
+    const next = vi.fn();
+    await routeLeaveGuard?.(null, null, next);
+
+    expect(onDiscard).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(true);
+  });
+
+  it("blocks the navigation when user closes the modal (Cancelar)", async () => {
+    const isDirty = ref(true);
+    useLeaveWithoutSavePrompt({ isDirty, onSave: vi.fn() });
+
+    mockWarning.mockImplementation((opts: { onClose: () => void }) => {
+      opts.onClose();
+    });
+    const next = vi.fn();
+    await routeLeaveGuard?.(null, null, next);
+
+    expect(next).toHaveBeenCalledWith(false);
+  });
+
+  it("surfaces the save error and refuses to navigate when onSave rejects", async () => {
+    const isDirty = ref(true);
+    const onSave = vi.fn().mockRejectedValue(new Error("network down"));
+    const { saveError } = useLeaveWithoutSavePrompt({ isDirty, onSave });
+
+    mockWarning.mockImplementation((opts: { onPositiveClick: () => Promise<void> }) => {
+      void opts.onPositiveClick();
+    });
+    const next = vi.fn();
+    await routeLeaveGuard?.(null, null, next);
+
+    expect(next).toHaveBeenCalledWith(false);
+    expect(saveError.value).toBeInstanceOf(Error);
+  });
+
+  it("confirmLeave returns true immediately when not dirty", async () => {
+    const isDirty = ref(false);
+    const { confirmLeave } = useLeaveWithoutSavePrompt({ isDirty, onSave: vi.fn() });
+
+    expect(await confirmLeave()).toBe(true);
+    expect(mockWarning).not.toHaveBeenCalled();
+  });
+});

--- a/app/composables/useLeaveWithoutSavePrompt/index.ts
+++ b/app/composables/useLeaveWithoutSavePrompt/index.ts
@@ -1,0 +1,5 @@
+export { useLeaveWithoutSavePrompt } from "./useLeaveWithoutSavePrompt";
+export type {
+  LeaveWithoutSavePromptOptions,
+  LeaveWithoutSavePromptReturn,
+} from "./useLeaveWithoutSavePrompt.types";

--- a/app/composables/useLeaveWithoutSavePrompt/useLeaveWithoutSavePrompt.ts
+++ b/app/composables/useLeaveWithoutSavePrompt/useLeaveWithoutSavePrompt.ts
@@ -1,0 +1,184 @@
+import { onBeforeUnmount, onMounted, ref, type Ref } from "vue";
+import { onBeforeRouteLeave } from "vue-router";
+import { useDialog } from "naive-ui";
+import { useI18n } from "vue-i18n";
+
+import type {
+  LeaveWithoutSavePromptOptions,
+  LeaveWithoutSavePromptReturn,
+} from "./useLeaveWithoutSavePrompt.types";
+
+const BEFOREUNLOAD_FALLBACK_MESSAGE =
+  "Você ainda não salvou esta simulação. Se sair agora, ela será descartada.";
+
+interface RunSaveContext {
+  readonly isSaving: Ref<boolean>;
+  readonly saveError: Ref<unknown | null>;
+  readonly onSave: () => Promise<void>;
+}
+
+/**
+ * Awaits {@link RunSaveContext.onSave} while toggling the saving and
+ * error refs around the call.
+ * @param ctx Save handler + reactive flags.
+ * @returns `true` when the save resolves cleanly; `false` when it throws.
+ */
+const runSave = async (ctx: RunSaveContext): Promise<boolean> => {
+  ctx.isSaving.value = true;
+  ctx.saveError.value = null;
+  try {
+    await ctx.onSave();
+    return true;
+  } catch (error) {
+    ctx.saveError.value = error;
+    return false;
+  } finally {
+    ctx.isSaving.value = false;
+  }
+};
+
+interface PromptCopy {
+  readonly title: string;
+  readonly content: string;
+  readonly positiveText: string;
+  readonly negativeText: string;
+}
+
+interface PromptContext extends RunSaveContext {
+  readonly dialog: ReturnType<typeof useDialog>;
+  readonly copy: PromptCopy;
+  readonly onDiscard?: () => void;
+}
+
+/**
+ * Renders the leave-without-save modal and resolves with the user's choice.
+ *
+ * Naive UI dialogs only expose two action buttons natively, so the close
+ * (X) and mask click are mapped to the implicit "Cancelar" outcome.
+ * @param ctx Dialog handle, copy, save/discard handlers and reactive flags.
+ * @returns `true` when the user confirms (save or discard) and the caller
+ *  may proceed with the navigation; `false` when the modal is dismissed.
+ */
+const renderPrompt = (ctx: PromptContext): Promise<boolean> => {
+  return new Promise((resolve) => {
+    ctx.dialog.warning({
+      title: ctx.copy.title,
+      content: ctx.copy.content,
+      positiveText: ctx.copy.positiveText,
+      negativeText: ctx.copy.negativeText,
+      closable: true,
+      onPositiveClick: async () => {
+        const ok = await runSave(ctx);
+        resolve(ok);
+      },
+      onNegativeClick: () => {
+        ctx.onDiscard?.();
+        resolve(true);
+      },
+      onClose: () => resolve(false),
+      onMaskClick: () => resolve(false),
+    });
+  });
+};
+
+/**
+ * Intercepts navigation away from a tool page when the user has computed
+ * a simulation but has not saved it yet (DEC-196 UX contract).
+ *
+ * Wires three exit surfaces:
+ *
+ * 1. **Vue Router** — `onBeforeRouteLeave` shows a 3-option modal
+ *    (Salvar e sair / Descartar e sair / Cancelar). The result of the
+ *    user's choice resolves the navigation guard.
+ * 2. **Browser tab close / reload** — `window.beforeunload` triggers the
+ *    native browser confirmation only while `isDirty` is `true`. The
+ *    custom modal is impossible here because modern browsers ignore
+ *    bespoke prompts on `beforeunload`; the native prompt is the most
+ *    reliable signal.
+ * 3. **Imperative cancellation** — `confirmLeave()` runs the same modal
+ *    so a custom "Cancelar" button on the page can ask before discarding.
+ *
+ * Must be called inside a component whose ancestor tree contains a
+ * Naive UI dialog provider. `isDirty` should flip to `false` after a
+ * successful save so subsequent navigations are silent.
+ * @param options Reactive dirty flag plus save/discard handlers.
+ * @returns Reactive saving/error refs and an imperative `confirmLeave`
+ *  helper for pages that ship a custom cancel button.
+ */
+export function useLeaveWithoutSavePrompt(
+  options: LeaveWithoutSavePromptOptions,
+): LeaveWithoutSavePromptReturn {
+  const dialog = useDialog();
+  const { t } = useI18n();
+  const isSaving = ref(false);
+  const saveError = ref<unknown | null>(null);
+
+  /**
+   * Triggers the browser's native unload prompt while the page is dirty.
+   * @param event Beforeunload event from the global window object.
+   */
+  const handleBeforeUnload = (event: BeforeUnloadEvent): void => {
+    if (!options.isDirty.value) {
+      return;
+    }
+    event.preventDefault();
+    event.returnValue = BEFOREUNLOAD_FALLBACK_MESSAGE;
+  };
+
+  onMounted(() => {
+    if (typeof window !== "undefined") {
+      window.addEventListener("beforeunload", handleBeforeUnload);
+    }
+  });
+
+  onBeforeUnmount(() => {
+    if (typeof window !== "undefined") {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    }
+  });
+
+  /**
+   * Renders the modal with the localized copy and the captured handlers.
+   * @returns User decision: `true` to proceed, `false` to stay.
+   */
+  const showPrompt = (): Promise<boolean> =>
+    renderPrompt({
+      dialog,
+      isSaving,
+      saveError,
+      onSave: options.onSave,
+      onDiscard: options.onDiscard,
+      copy: {
+        title: t("leaveWithoutSavePrompt.title"),
+        content: t("leaveWithoutSavePrompt.content"),
+        positiveText: t("leaveWithoutSavePrompt.positiveText"),
+        negativeText: t("leaveWithoutSavePrompt.negativeText"),
+      },
+    });
+
+  onBeforeRouteLeave(async (_to, _from, next) => {
+    if (!options.isDirty.value) {
+      next();
+      return;
+    }
+    const proceed = await showPrompt();
+    next(proceed);
+  });
+
+  /**
+   * Imperative leave-prompt for custom cancel buttons on the page.
+   * @returns `true` when the page can close, `false` when the user stays.
+   */
+  const confirmLeave = async (): Promise<boolean> => {
+    if (!options.isDirty.value) {
+      return true;
+    }
+    return showPrompt();
+  };
+
+  return {
+    isSaving,
+    saveError,
+    confirmLeave,
+  };
+}

--- a/app/composables/useLeaveWithoutSavePrompt/useLeaveWithoutSavePrompt.types.ts
+++ b/app/composables/useLeaveWithoutSavePrompt/useLeaveWithoutSavePrompt.types.ts
@@ -1,0 +1,42 @@
+import type { Ref } from "vue";
+
+export interface LeaveWithoutSavePromptOptions {
+  /**
+   * Reactive flag describing whether the page has computed a result that
+   * has not yet been persisted. The prompt only fires when this is `true`.
+   */
+  readonly isDirty: Ref<boolean>;
+  /**
+   * Async callback invoked when the user picks "Salvar e sair" in the modal.
+   * Should resolve once the simulation has been persisted. Errors are
+   * surfaced to the caller via the returned error ref so the page can
+   * decide whether to keep the user on screen.
+   */
+  readonly onSave: () => Promise<void>;
+  /**
+   * Optional callback invoked when the user picks "Descartar e sair".
+   * Useful for clearing local state, telemetry, etc.
+   */
+  readonly onDiscard?: () => void;
+}
+
+export interface LeaveWithoutSavePromptReturn {
+  /**
+   * Whether a save attempt triggered by the prompt is currently running.
+   * Pages can use this to disable form interactions while the modal awaits
+   * the network round-trip.
+   */
+  readonly isSaving: Ref<boolean>;
+  /**
+   * The most recent save error, if any. Cleared between prompt
+   * invocations.
+   */
+  readonly saveError: Ref<unknown | null>;
+  /**
+   * Manually evaluates the current dirty state and runs the prompt
+   * imperatively (e.g. when the page exposes a custom "Cancelar" button).
+   * Resolves to `true` when the caller can proceed with the navigation
+   * or close action; `false` when the user opted to stay.
+   */
+  readonly confirmLeave: () => Promise<boolean>;
+}

--- a/app/features/dashboard/composables/__tests__/useFinancialHealthScore.spec.ts
+++ b/app/features/dashboard/composables/__tests__/useFinancialHealthScore.spec.ts
@@ -84,7 +84,12 @@ function makeEntry(
  * @returns YYYY-MM-DD string.
  */
 function monthsAgo(n: number): string {
+  // Anchor to day 15 so subtracting months never overflows into a sibling
+  // month (e.g. 31-Mar - 1 month = 28-Feb but JS yields 03-Mar). That
+  // overflow caused two adjacent months to collide in the Set used by
+  // scoreInvestmentRegularity, dropping 6 unique months down to 5.
   const d = new Date();
+  d.setDate(15);
   d.setMonth(d.getMonth() - n);
   return d.toISOString().slice(0, 10);
 }

--- a/app/features/simulations/contracts/simulation.dto.ts
+++ b/app/features/simulations/contracts/simulation.dto.ts
@@ -1,23 +1,41 @@
 /**
- * Data Transfer Object for a simulation returned by the API.
+ * DTOs for the canonical `/simulations` endpoint (DEC-196 / auraxis-api#1128).
+ *
+ * The backend persists simulations through a single generic endpoint that
+ * accepts any `tool_id` from the canonical registry, with `inputs` and
+ * `result` opaque JSON payloads owned by the client.
  */
-export interface SimulationDto {
-  id: string;
-  name: string;
-  tool_slug: string;
-  inputs: unknown;
-  result: unknown;
-  goal_id?: string | null;
-  created_at: string;
+
+export interface SimulationMetadataDto {
+  readonly label?: string | null;
+  readonly notes?: string | null;
+  readonly [key: string]: unknown;
 }
 
-/**
- * Data Transfer Object for the simulation save request body.
- */
-export interface SaveSimulationPayloadDto {
-  name: string;
-  tool_slug: string;
-  inputs: unknown;
-  result: unknown;
-  goal_id?: string | null;
+export interface SimulationDto {
+  readonly id: string;
+  readonly user_id: string;
+  readonly tool_id: string;
+  readonly rule_version: string;
+  readonly inputs: Record<string, unknown>;
+  readonly result: Record<string, unknown>;
+  readonly metadata: SimulationMetadataDto | null;
+  readonly saved: boolean;
+  readonly created_at: string;
+}
+
+export interface SaveSimulationRequestDto {
+  readonly tool_id: string;
+  readonly rule_version: string;
+  readonly inputs: Record<string, unknown>;
+  readonly result: Record<string, unknown>;
+  readonly metadata?: SimulationMetadataDto | null;
+}
+
+export interface SimulationListResponseDto {
+  readonly items: readonly SimulationDto[];
+  readonly page: number;
+  readonly per_page: number;
+  readonly total: number;
+  readonly pages: number;
 }

--- a/app/features/simulations/model/simulation-card.mapper.spec.ts
+++ b/app/features/simulations/model/simulation-card.mapper.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { mapToSimulationCardDto } from "./simulation-card.mapper";
+import type { Simulation } from "~/features/simulations/model/simulation";
+
+/**
+ * Builds a Simulation fixture for tests.
+ * @param overrides Partial overrides merged on top of the canonical fixture.
+ * @returns A canonical Simulation domain fixture.
+ */
+const baseSimulation = (overrides: Partial<Simulation> = {}): Simulation => ({
+  id: "sim-1",
+  userId: "user-1",
+  toolId: "installment-vs-cash",
+  ruleVersion: "2026.04",
+  inputs: { current: 5000 },
+  result: { summary: "À vista economiza R$ 480", result_value: 480 },
+  metadata: null,
+  saved: true,
+  createdAt: "2026-04-29T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("mapToSimulationCardDto", () => {
+  it("derives the legacy installment_vs_cash type from the canonical kebab id", () => {
+    const card = mapToSimulationCardDto(baseSimulation());
+    expect(card.type).toBe("installment_vs_cash");
+  });
+
+  it("accepts the legacy snake_case installment_vs_cash id for back-compat", () => {
+    const card = mapToSimulationCardDto(baseSimulation({ toolId: "installment_vs_cash" }));
+    expect(card.type).toBe("installment_vs_cash");
+  });
+
+  it("uses metadata.label for the card title when present", () => {
+    const card = mapToSimulationCardDto(
+      baseSimulation({ metadata: { label: "Minha simulação" } }),
+    );
+    expect(card.name).toBe("Minha simulação");
+  });
+
+  it("falls back to result.summary when metadata.label is missing", () => {
+    const card = mapToSimulationCardDto(baseSimulation());
+    expect(card.name).toBe("À vista economiza R$ 480");
+  });
+
+  it("falls back to toolId when neither label nor summary are available", () => {
+    const card = mapToSimulationCardDto(
+      baseSimulation({ metadata: null, result: { value: 42 } }),
+    );
+    expect(card.name).toBe("installment-vs-cash");
+  });
+
+  it("extracts result_value when present", () => {
+    const card = mapToSimulationCardDto(baseSimulation());
+    expect(card.result_value).toBe(480);
+  });
+
+  it("extracts the legacy 'value' field when result_value is absent", () => {
+    const card = mapToSimulationCardDto(
+      baseSimulation({ result: { value: 99 } }),
+    );
+    expect(card.result_value).toBe(99);
+  });
+
+  it("returns null result_value when neither field is numeric", () => {
+    const card = mapToSimulationCardDto(
+      baseSimulation({ result: { summary: "no value here" } }),
+    );
+    expect(card.result_value).toBeNull();
+  });
+
+  it("maps unknown tool ids to the safe default 'installment_vs_cash' bucket", () => {
+    const card = mapToSimulationCardDto(baseSimulation({ toolId: "unknown-tool" }));
+    expect(card.type).toBe("installment_vs_cash");
+  });
+
+  it("maps compound-interest to investment_return", () => {
+    const card = mapToSimulationCardDto(baseSimulation({ toolId: "compound-interest" }));
+    expect(card.type).toBe("investment_return");
+  });
+
+  it("maps goal-simulator to goal_projection", () => {
+    const card = mapToSimulationCardDto(baseSimulation({ toolId: "goal-simulator" }));
+    expect(card.type).toBe("goal_projection");
+  });
+});

--- a/app/features/simulations/model/simulation-card.mapper.ts
+++ b/app/features/simulations/model/simulation-card.mapper.ts
@@ -1,67 +1,88 @@
-import type { Simulation } from "~/features/simulations/model/simulation";
 import type { SimulationCardDto, SimulationType } from "~/features/simulations/contracts/simulation-card.dto";
+import type { Simulation } from "~/features/simulations/model/simulation";
 
-const SLUG_TO_TYPE: Record<string, SimulationType> = {
+/**
+ * Maps canonical `tool_id` values (kebab-case, mirror of the backend
+ * registry) to the legacy `SimulationType` discriminator used by the
+ * `<SimulationCard />` component. The legacy snake_case `installment_vs_cash`
+ * stays accepted for backwards compatibility with rows persisted before
+ * the rename.
+ */
+const TOOL_ID_TO_TYPE: Record<string, SimulationType> = {
+  "installment-vs-cash": "installment_vs_cash",
   installment_vs_cash: "installment_vs_cash",
-  goal_projection: "goal_projection",
-  investment_return: "investment_return",
+  "goal-simulator": "goal_projection",
+  "compound-interest": "investment_return",
+  "thirteenth-salary": "investment_return",
+  overtime: "investment_return",
 };
 
 /**
- * Derives the SimulationType from the tool_slug stored on the Simulation model.
- * Falls back to "installment_vs_cash" for unrecognised slugs.
  *
- * @param toolSlug - The slug string stored on the API model.
- * @returns The matching SimulationType union value.
- */
-const resolveType = (toolSlug: string): SimulationType =>
-  SLUG_TO_TYPE[toolSlug] ?? "installment_vs_cash";
+ * @param toolId
+ * @returns The computed value.
+   */
+const resolveType = (toolId: string): SimulationType =>
+  TOOL_ID_TO_TYPE[toolId] ?? "installment_vs_cash";
 
 /**
- * Extracts the human-readable summary from the simulation result payload.
- * Returns a fallback string when the result does not carry a summary field.
- *
- * @param result - The opaque result object returned by the API.
- * @param name - Simulation name used as fallback.
- * @returns Summary string.
- */
-const extractSummary = (result: unknown, name: string): string => {
-  if (result !== null && typeof result === "object") {
-    const r = result as Record<string, unknown>;
-    if (typeof r["summary"] === "string" && r["summary"].length > 0) {
-      return r["summary"];
-    }
+ * Extracts a human-readable label for the card from `metadata.label`,
+ * a `summary` field on the result, or falls back to the tool id.
+ * @param simulation
+ * @returns The computed value.
+   */
+const extractLabel = (simulation: Simulation): string => {
+  const metadataLabel = simulation.metadata?.label;
+  if (typeof metadataLabel === "string" && metadataLabel.length > 0) {
+    return metadataLabel;
   }
-  return name;
-};
-
-/**
- * Extracts the primary numeric result value from the simulation result payload.
- * Returns null when the result does not carry a recognisable numeric value.
- *
- * @param result - The opaque result object returned by the API.
- * @returns Primary result number or null.
- */
-const extractResultValue = (result: unknown): number | null => {
-  if (result !== null && typeof result === "object") {
-    const r = result as Record<string, unknown>;
-    if (typeof r["result_value"] === "number") {return r["result_value"];}
-    if (typeof r["value"] === "number") {return r["value"];}
+  const result = simulation.result;
+  const summary = (result as Record<string, unknown>)["summary"];
+  if (typeof summary === "string" && summary.length > 0) {
+    return summary;
   }
-  return null;
+  return simulation.toolId;
 };
 
 /**
- * Maps a Simulation domain model to a SimulationCardDto suitable for display.
  *
- * @param simulation - The domain model returned by the API.
- * @returns SimulationCardDto ready for the SimulationCard component.
- */
-export const mapToSimulationCardDto = (simulation: Simulation): SimulationCardDto => ({
-  id: simulation.id,
-  name: simulation.name,
-  type: resolveType(simulation.toolSlug),
-  created_at: simulation.createdAt,
-  summary: extractSummary(simulation.result, simulation.name),
-  result_value: extractResultValue(simulation.result),
-});
+ * @param simulation
+ * @param fallback
+ * @returns The computed value.
+   */
+const extractSummary = (simulation: Simulation, fallback: string): string => {
+  const result = simulation.result as Record<string, unknown>;
+  const summary = result["summary"];
+  if (typeof summary === "string" && summary.length > 0) {
+    return summary;
+  }
+  return fallback;
+};
+
+/**
+ *
+ * @param simulation
+ * @returns The computed value.
+   */
+const extractResultValue = (simulation: Simulation): number | null => {
+  const result = simulation.result as Record<string, unknown>;
+  const candidate = result["result_value"] ?? result["value"];
+  return typeof candidate === "number" ? candidate : null;
+};
+
+/**
+ * Maps a Simulation domain model to a SimulationCardDto for the listing UI.
+ * @param simulation
+ * @returns The computed value.
+   */
+export const mapToSimulationCardDto = (simulation: Simulation): SimulationCardDto => {
+  const label = extractLabel(simulation);
+  return {
+    id: simulation.id,
+    name: label,
+    type: resolveType(simulation.toolId),
+    created_at: simulation.createdAt,
+    summary: extractSummary(simulation, label),
+    result_value: extractResultValue(simulation),
+  };
+};

--- a/app/features/simulations/model/simulation.ts
+++ b/app/features/simulations/model/simulation.ts
@@ -1,23 +1,47 @@
 /**
- * Domain model for a saved simulation.
+ * Domain models for simulations (DEC-196 / canonical generic endpoint).
+ *
+ * Shape mirrors the backend `SimulationSchema` in
+ * `auraxis-api/app/schemas/simulation_schema.py`. The DTO field names use
+ * snake_case, the domain types use camelCase.
  */
-export interface Simulation {
-  id: string;
-  name: string;
-  toolSlug: string;
-  inputs: unknown;
-  result: unknown;
-  goalId?: string | null;
-  createdAt: string;
+
+export interface SimulationMetadata {
+  readonly label?: string | null;
+  readonly notes?: string | null;
+  readonly [key: string]: unknown;
 }
 
-/**
- * Payload required to save a new simulation.
- */
+export interface Simulation {
+  readonly id: string;
+  readonly userId: string;
+  readonly toolId: string;
+  readonly ruleVersion: string;
+  readonly inputs: Record<string, unknown>;
+  readonly result: Record<string, unknown>;
+  readonly metadata: SimulationMetadata | null;
+  readonly saved: boolean;
+  readonly createdAt: string;
+}
+
 export interface SaveSimulationPayload {
-  name: string;
-  toolSlug: string;
-  inputs: unknown;
-  result: unknown;
-  goalId?: string | null;
+  readonly toolId: string;
+  readonly ruleVersion: string;
+  readonly inputs: Record<string, unknown>;
+  readonly result: Record<string, unknown>;
+  readonly metadata?: SimulationMetadata | null;
+}
+
+export interface ListSimulationsParams {
+  readonly page?: number;
+  readonly perPage?: number;
+  readonly toolId?: string;
+}
+
+export interface SimulationList {
+  readonly items: readonly Simulation[];
+  readonly page: number;
+  readonly perPage: number;
+  readonly total: number;
+  readonly pages: number;
 }

--- a/app/features/simulations/queries/use-save-simulation-mutation.ts
+++ b/app/features/simulations/queries/use-save-simulation-mutation.ts
@@ -1,27 +1,36 @@
-import { type UseMutationReturnType, useMutation } from "@tanstack/vue-query";
+import { type UseMutationReturnType, useMutation, useQueryClient } from "@tanstack/vue-query";
 
 import {
   useSimulationClient,
   type SimulationClient,
 } from "~/features/simulations/services/simulation.client";
-import type { Simulation, SaveSimulationPayload } from "~/features/simulations/model/simulation";
+import type {
+  SaveSimulationPayload,
+  Simulation,
+} from "~/features/simulations/model/simulation";
 
 /**
- * Vue Query mutation hook for saving a simulation.
+ * Vue Query mutation hook for saving a simulation through the canonical
+ * generic `/simulations` endpoint (DEC-196).
  *
- * Errors propagate as mutation error state — no silent catch.
- *
- * @param providedClient Optional injected client for unit tests.
- * @returns Vue Query mutation state for saving a simulation.
- */
+ * Errors propagate as mutation error state — no silent catch. On success
+ * the simulations list query is invalidated so freshly saved simulations
+ * appear immediately on `/simulations`.
+ * @param providedClient
+ * @returns The computed value.
+   */
 export const useSaveSimulationMutation = (
   providedClient?: SimulationClient,
 ): UseMutationReturnType<Simulation, Error, SaveSimulationPayload, unknown> => {
   const client = providedClient ?? useSimulationClient();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (payload: SaveSimulationPayload): Promise<Simulation> => {
       return client.saveSimulation(payload);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["simulations"] });
     },
   });
 };

--- a/app/features/simulations/queries/use-simulations-query.spec.ts
+++ b/app/features/simulations/queries/use-simulations-query.spec.ts
@@ -1,8 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useSimulationsQuery } from "./use-simulations-query";
-import type { SimulationCardDto } from "~/features/simulations/contracts/simulation-card.dto";
-import type { Simulation } from "~/features/simulations/model/simulation";
+import type { Simulation, SimulationList } from "~/features/simulations/model/simulation";
 
 const useQueryMock = vi.hoisted(() => vi.fn());
 
@@ -15,18 +14,32 @@ vi.mock("~/core/config", () => ({
 }));
 
 /**
- * Builds a minimal Simulation domain model fixture for testing.
- *
- * @returns Simulation fixture.
+ * @param overrides Partial overrides merged on top of the canonical fixture.
+ * @returns A canonical Simulation domain fixture for tests.
  */
-const makeSimulation = (): Simulation => ({
+const makeSimulation = (overrides: Partial<Simulation> = {}): Simulation => ({
   id: "sim-1",
-  name: "Test Simulation",
-  toolSlug: "installment_vs_cash",
+  userId: "user-1",
+  toolId: "installment-vs-cash",
+  ruleVersion: "2026.04",
   inputs: { current: 5000 },
   result: { summary: "À vista economiza R$ 480", result_value: 480 },
-  goalId: null,
+  metadata: { label: "Minha simulação" },
+  saved: true,
   createdAt: "2026-03-18T00:00:00.000Z",
+  ...overrides,
+});
+
+/**
+ * @param items Domain items to wrap in the paginated response shape.
+ * @returns A SimulationList envelope with single-page defaults.
+ */
+const makeList = (items: readonly Simulation[]): SimulationList => ({
+  items,
+  page: 1,
+  perPage: items.length || 20,
+  total: items.length,
+  pages: 1,
 });
 
 describe("useSimulationsQuery", () => {
@@ -34,36 +47,28 @@ describe("useSimulationsQuery", () => {
     vi.clearAllMocks();
   });
 
-  it("registers with the canonical simulations query key", () => {
-    const client = { listSimulations: vi.fn().mockResolvedValue([makeSimulation()]) };
-    useQueryMock.mockImplementation((opts: Record<string, unknown>) => opts);
-
-    const query = useSimulationsQuery(client as never) as unknown as {
-      queryKey: readonly ["simulations"];
-    };
-
-    expect(query.queryKey).toEqual(["simulations"]);
-  });
-
-  it("calls client.listSimulations, maps to SimulationCardDto, and returns the list", async () => {
+  it("calls client.listSimulations and maps each row to SimulationCardDto", async () => {
     const simulations = [makeSimulation()];
-    const client = { listSimulations: vi.fn().mockResolvedValue(simulations) };
-    useQueryMock.mockImplementation(
-      (opts: { queryFn: () => Promise<SimulationCardDto[]> }) => opts,
-    );
+    const client = {
+      listSimulations: vi.fn().mockResolvedValue(makeList(simulations)),
+    };
+    useQueryMock.mockImplementation((opts: { queryFn: () => Promise<unknown> }) => opts);
 
-    const query = useSimulationsQuery(client as never) as unknown as {
-      queryFn: () => Promise<SimulationCardDto[]>;
+    const query = useSimulationsQuery({ providedClient: client as never }) as unknown as {
+      queryFn: () => Promise<{
+        cards: ReadonlyArray<{ id: string; type: string; name: string }>;
+        total: number;
+      }>;
     };
 
     const result = await query.queryFn();
 
     expect(client.listSimulations).toHaveBeenCalledOnce();
-    expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
+    expect(result.total).toBe(1);
+    expect(result.cards[0]).toMatchObject({
       id: "sim-1",
-      name: "Test Simulation",
       type: "installment_vs_cash",
+      name: "Minha simulação",
     });
   });
 
@@ -71,12 +76,10 @@ describe("useSimulationsQuery", () => {
     const client = {
       listSimulations: vi.fn().mockRejectedValue(new Error("server error")),
     };
-    useQueryMock.mockImplementation(
-      (opts: { queryFn: () => Promise<SimulationCardDto[]> }) => opts,
-    );
+    useQueryMock.mockImplementation((opts: { queryFn: () => Promise<unknown> }) => opts);
 
-    const query = useSimulationsQuery(client as never) as unknown as {
-      queryFn: () => Promise<SimulationCardDto[]>;
+    const query = useSimulationsQuery({ providedClient: client as never }) as unknown as {
+      queryFn: () => Promise<unknown>;
     };
 
     await expect(query.queryFn()).rejects.toThrow("server error");

--- a/app/features/simulations/queries/use-simulations-query.ts
+++ b/app/features/simulations/queries/use-simulations-query.ts
@@ -1,3 +1,4 @@
+import { computed, type MaybeRef, unref } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
@@ -9,31 +10,78 @@ import {
 import { MOCK_SIMULATIONS } from "~/features/simulations/mock/simulations.mock";
 import { mapToSimulationCardDto } from "~/features/simulations/model/simulation-card.mapper";
 import type { SimulationCardDto } from "~/features/simulations/contracts/simulation-card.dto";
+import type {
+  ListSimulationsParams,
+  Simulation,
+} from "~/features/simulations/model/simulation";
+
+export type SimulationsQueryParams = ListSimulationsParams;
+
+export interface UseSimulationsQueryOptions {
+  readonly params?: MaybeRef<SimulationsQueryParams | undefined>;
+  readonly providedClient?: SimulationClient;
+}
+
+interface SimulationsQueryResult {
+  readonly cards: readonly SimulationCardDto[];
+  readonly simulations: readonly Simulation[];
+  readonly total: number;
+  readonly page: number;
+  readonly perPage: number;
+  readonly pages: number;
+}
+
+const EMPTY_RESULT: SimulationsQueryResult = {
+  cards: [],
+  simulations: [],
+  total: 0,
+  page: 1,
+  perPage: 0,
+  pages: 0,
+};
 
 /**
- * Vue Query hook for listing the authenticated user's saved simulations.
+ * Vue Query hook for the canonical `/simulations` listing.
  *
- * Returns SimulationCardDto objects ready for the SimulationCard component.
- * Mock data is only used when NUXT_PUBLIC_MOCK_DATA=true (dev/test).
- * Errors propagate as query error state — no silent catch.
- *
- * @param providedClient Optional injected client for unit tests.
- * @returns Vue Query state with typed SimulationCardDto array.
- */
+ * Returns SimulationCardDto objects ready for `<SimulationCard />` plus the
+ * underlying Simulation domain models so per-tool detail views can render
+ * tool-specific summaries without an extra request.
+ * @param options
+ * @returns The computed value.
+   */
 export const useSimulationsQuery = (
-  providedClient?: SimulationClient,
-): UseQueryReturnType<SimulationCardDto[], Error> => {
-  const client = providedClient ?? useSimulationClient();
+  options: UseSimulationsQueryOptions = {},
+): UseQueryReturnType<SimulationsQueryResult, Error> => {
+  const client = options.providedClient ?? useSimulationClient();
+  const params = computed(() => unref(options.params));
+
+  const queryKey = computed(
+    () => ["simulations", params.value ?? {}] as const,
+  );
 
   return useQuery({
-    queryKey: ["simulations"] as const,
-    queryFn: async (): Promise<SimulationCardDto[]> => {
+    queryKey,
+    queryFn: async (): Promise<SimulationsQueryResult> => {
       if (isMockDataEnabled()) {
-        return Promise.resolve(MOCK_SIMULATIONS);
+        return {
+          ...EMPTY_RESULT,
+          cards: MOCK_SIMULATIONS,
+          total: MOCK_SIMULATIONS.length,
+          page: 1,
+          perPage: MOCK_SIMULATIONS.length,
+          pages: 1,
+        };
       }
 
-      const simulations = await client.listSimulations();
-      return simulations.map(mapToSimulationCardDto);
+      const list = await client.listSimulations(params.value);
+      return {
+        cards: list.items.map(mapToSimulationCardDto),
+        simulations: list.items,
+        total: list.total,
+        page: list.page,
+        perPage: list.perPage,
+        pages: list.pages,
+      };
     },
     staleTime: STALE_TIME.STABLE,
   });

--- a/app/features/simulations/services/simulation.client.spec.ts
+++ b/app/features/simulations/services/simulation.client.spec.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AxiosInstance } from "axios";
+
+import { SimulationClient } from "./simulation.client";
+import type {
+  SimulationDto,
+  SaveSimulationRequestDto,
+} from "~/features/simulations/contracts/simulation.dto";
+import type { SaveSimulationPayload } from "~/features/simulations/model/simulation";
+
+const dto: SimulationDto = {
+  id: "sim-1",
+  user_id: "user-1",
+  tool_id: "compound-interest",
+  rule_version: "2026.04",
+  inputs: { initial: 1000 },
+  result: { final: 1500 },
+  metadata: { label: "Cenário 1" },
+  saved: true,
+  created_at: "2026-04-29T00:00:00.000Z",
+};
+
+/**
+ * Wraps a payload in the v2 ApiEnvelope shape used by the API.
+ * @param data Inner payload to surface under `data`.
+ * @param meta Optional pagination meta block.
+ * @returns Axios-shaped response with the v2 envelope wrapper.
+ */
+const envelope = <T,>(data: T, meta?: Record<string, unknown>): { data: { success: true; data: T; message: string; meta?: Record<string, unknown> } } => ({
+  data: { success: true, data, message: "ok", ...(meta !== undefined && { meta }) },
+});
+
+/**
+ * Builds a fresh SimulationClient with mocked HTTP for each test.
+ * @returns Tuple containing the SimulationClient and the mocked http handle.
+ */
+const buildClient = (): {
+  client: SimulationClient;
+  http: { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn>; delete: ReturnType<typeof vi.fn> };
+} => {
+  const http = {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  };
+  return { client: new SimulationClient(http as unknown as AxiosInstance), http };
+};
+
+describe("SimulationClient", () => {
+  describe("saveSimulation", () => {
+    it("sends the canonical body and unwraps the v2 envelope", async () => {
+      const { client, http } = buildClient();
+      http.post.mockResolvedValueOnce(envelope({ simulation: dto }));
+
+      const payload: SaveSimulationPayload = {
+        toolId: "compound-interest",
+        ruleVersion: "2026.04",
+        inputs: { initial: 1000 },
+        result: { final: 1500 },
+        metadata: { label: "Cenário 1" },
+      };
+      const result = await client.saveSimulation(payload);
+
+      const sent = http.post.mock.calls[0]?.[1] as SaveSimulationRequestDto;
+      expect(sent).toEqual({
+        tool_id: "compound-interest",
+        rule_version: "2026.04",
+        inputs: { initial: 1000 },
+        result: { final: 1500 },
+        metadata: { label: "Cenário 1" },
+      });
+      expect(result.id).toBe("sim-1");
+      expect(result.toolId).toBe("compound-interest");
+    });
+
+    it("omits metadata from the body when not provided", async () => {
+      const { client, http } = buildClient();
+      http.post.mockResolvedValueOnce(envelope({ simulation: dto }));
+
+      await client.saveSimulation({
+        toolId: "compound-interest",
+        ruleVersion: "2026.04",
+        inputs: {},
+        result: {},
+      });
+
+      const sent = http.post.mock.calls[0]?.[1] as SaveSimulationRequestDto;
+      expect(sent).not.toHaveProperty("metadata");
+    });
+  });
+
+  describe("listSimulations", () => {
+    it("translates camelCase params to snake_case query string", async () => {
+      const { client, http } = buildClient();
+      http.get.mockResolvedValueOnce(
+        envelope(
+          { items: [dto] },
+          { pagination: { page: 2, per_page: 5, total: 12, pages: 3 } },
+        ),
+      );
+
+      const list = await client.listSimulations({
+        page: 2,
+        perPage: 5,
+        toolId: "compound-interest",
+      });
+
+      const params = http.get.mock.calls[0]?.[1] as { params: Record<string, unknown> };
+      expect(params.params).toEqual({ page: 2, per_page: 5, tool_id: "compound-interest" });
+      expect(list.total).toBe(12);
+      expect(list.pages).toBe(3);
+      expect(list.items).toHaveLength(1);
+    });
+
+    it("falls back to sensible defaults when meta.pagination is missing", async () => {
+      const { client, http } = buildClient();
+      http.get.mockResolvedValueOnce(envelope({ items: [dto] }));
+
+      const list = await client.listSimulations();
+
+      expect(list.total).toBe(1);
+      expect(list.page).toBe(1);
+      expect(list.perPage).toBe(1);
+      expect(list.pages).toBe(1);
+    });
+  });
+
+  describe("getSimulation", () => {
+    it("hits /simulations/<id> and unwraps the envelope", async () => {
+      const { client, http } = buildClient();
+      http.get.mockResolvedValueOnce(envelope({ simulation: dto }));
+
+      const result = await client.getSimulation("sim-1");
+
+      expect(http.get).toHaveBeenCalledWith("/simulations/sim-1");
+      expect(result.id).toBe("sim-1");
+    });
+  });
+
+  describe("deleteSimulation", () => {
+    it("hits DELETE /simulations/<id>", async () => {
+      const { client, http } = buildClient();
+      http.delete.mockResolvedValueOnce({ data: undefined });
+
+      await client.deleteSimulation("sim-1");
+
+      expect(http.delete).toHaveBeenCalledWith("/simulations/sim-1");
+    });
+  });
+});

--- a/app/features/simulations/services/simulation.client.ts
+++ b/app/features/simulations/services/simulation.client.ts
@@ -1,59 +1,191 @@
 import type { AxiosInstance } from "axios";
 
 import { useHttp } from "~/composables/useHttp";
-import type { SimulationDto, SaveSimulationPayloadDto } from "~/features/simulations/contracts/simulation.dto";
+import type {
+  SaveSimulationRequestDto,
+  SimulationDto,
+} from "~/features/simulations/contracts/simulation.dto";
 import { mapSimulationDto } from "~/features/simulations/services/simulation.mapper";
-import type { Simulation, SaveSimulationPayload } from "~/features/simulations/model/simulation";
+import type {
+  ListSimulationsParams,
+  SaveSimulationPayload,
+  Simulation,
+  SimulationList,
+} from "~/features/simulations/model/simulation";
+
+interface ApiEnvelope<T> {
+  readonly success: boolean;
+  readonly message?: string;
+  readonly data: T;
+  readonly meta?: Record<string, unknown>;
+}
+
+interface SimulationEnvelope {
+  readonly simulation: SimulationDto;
+}
+
+interface SimulationsEnvelope {
+  readonly items: readonly SimulationDto[];
+}
+
+interface ListPaginationMeta {
+  readonly pagination?: {
+    readonly page: number;
+    readonly per_page: number;
+    readonly total: number;
+    readonly pages: number;
+  };
+}
 
 /**
- * API client for the simulations feature.
+ * Translates the camelCase domain payload into the snake_case body the API
+ * expects (DEC-196).
+ * @param payload Domain-side payload built by the calling tool page.
+ * @returns Snake_case request DTO ready for transport.
+ */
+const buildSavePayload = (
+  payload: SaveSimulationPayload,
+): SaveSimulationRequestDto => ({
+  tool_id: payload.toolId,
+  rule_version: payload.ruleVersion,
+  inputs: payload.inputs,
+  result: payload.result,
+  ...(payload.metadata !== undefined && { metadata: payload.metadata }),
+});
+
+/**
+ * Converts the domain list params into the snake_case query string the API
+ * accepts (page, per_page, tool_id).
+ * @param params Optional list-filter inputs from the caller.
+ * @returns Plain object suitable for axios `params`.
+ */
+const toListParams = (
+  params: ListSimulationsParams | undefined,
+): Record<string, string | number> => {
+  if (!params) {
+    return {};
+  }
+  const out: Record<string, string | number> = {};
+  if (params.page !== undefined) {
+    out.page = params.page;
+  }
+  if (params.perPage !== undefined) {
+    out.per_page = params.perPage;
+  }
+  if (params.toolId) {
+    out.tool_id = params.toolId;
+  }
+  return out;
+};
+
+interface ResolvedPagination {
+  readonly page: number;
+  readonly perPage: number;
+  readonly total: number;
+  readonly pages: number;
+}
+
+/**
+ * Resolves pagination defaults when the API response does not carry an
+ * explicit pagination meta block.
+ * @param itemCount Number of items returned in this page.
+ * @param meta      Raw pagination meta from the v2 envelope.
+ * @param requested Optional caller-supplied params.
+ * @returns Concrete pagination values for the domain model.
+ */
+/**
+ * Returns the first non-undefined argument, or `undefined` when none match.
+ * @param candidates Sequence of optional values to fall back through.
+ * @returns The first defined value, or `undefined`.
+ */
+const pickFirst = <T>(
+  ...candidates: ReadonlyArray<T | undefined>
+): T | undefined => candidates.find((value) => value !== undefined);
+
+/**
+ * Resolves pagination defaults when the API response does not include an
+ * explicit pagination meta block.
+ * @param itemCount Number of items in the current page response.
+ * @param meta      Optional pagination meta from the v2 envelope.
+ * @param requested Optional caller-supplied params.
+ * @returns Concrete pagination values for the domain model.
+ */
+const resolvePagination = (
+  itemCount: number,
+  meta: ListPaginationMeta["pagination"] | undefined,
+  requested: ListSimulationsParams | undefined,
+): ResolvedPagination => {
+  const page = pickFirst(meta?.page, requested?.page) ?? 1;
+  const perPage = pickFirst(meta?.per_page, requested?.perPage) ?? itemCount;
+  const total = meta?.total ?? itemCount;
+  const pages = meta?.pages ?? 1;
+  return { page, perPage, total, pages };
+};
+
+/**
+ * Canonical client for `/simulations` (DEC-196).
  *
- * Encapsulates all HTTP calls to the `/simulations` endpoints and returns
- * mapped domain types ready for UI consumption.
+ * The backend returns the v2 envelope `{success, data, message, meta?}`
+ * because `X-API-Contract: v2` is set globally on the HTTP client. The
+ * client unwraps it once here so consumers see typed domain models.
  */
 export class SimulationClient {
   readonly #http: AxiosInstance;
 
   /**
-   * @param http Axios instance already configured for the Auraxis API.
+   * @param http Pre-configured Auraxis Axios instance from the core HTTP layer.
    */
   constructor(http: AxiosInstance) {
     this.#http = http;
   }
 
   /**
-   * Saves a new simulation for the authenticated user.
-   *
-   * @param payload The simulation data to persist.
-   * @returns The saved simulation domain model.
+   * Persists a simulation produced by any tool in the canonical registry.
+   * @param payload Domain-side simulation payload (camelCase fields).
+   * @returns The saved simulation as a domain model.
    */
   async saveSimulation(payload: SaveSimulationPayload): Promise<Simulation> {
-    const body: SaveSimulationPayloadDto = {
-      name: payload.name,
-      tool_slug: payload.toolSlug,
-      inputs: payload.inputs,
-      result: payload.result,
-      goal_id: payload.goalId ?? null,
-    };
-
-    const response = await this.#http.post<SimulationDto>("/simulations", body);
-    return mapSimulationDto(response.data);
+    const body = buildSavePayload(payload);
+    const response = await this.#http.post<ApiEnvelope<SimulationEnvelope>>(
+      "/simulations",
+      body,
+    );
+    return mapSimulationDto(response.data.data.simulation);
   }
 
   /**
-   * Fetches the list of simulations for the authenticated user.
-   *
-   * @returns Array of domain Simulation models.
+   * Lists simulations owned by the authenticated user with optional filters.
+   * @param params Optional pagination + tool filter.
+   * @returns Paginated list of simulations as domain models.
    */
-  async listSimulations(): Promise<Simulation[]> {
-    const response = await this.#http.get<SimulationDto[]>("/simulations");
-    return response.data.map(mapSimulationDto);
+  async listSimulations(
+    params?: ListSimulationsParams,
+  ): Promise<SimulationList> {
+    const response = await this.#http.get<
+      ApiEnvelope<SimulationsEnvelope> & { meta?: ListPaginationMeta }
+    >("/simulations", { params: toListParams(params) });
+    const items = response.data.data.items.map(mapSimulationDto);
+    return {
+      items,
+      ...resolvePagination(items.length, response.data.meta?.pagination, params),
+    };
   }
 
   /**
-   * Deletes a saved simulation by id.
-   *
-   * @param id Simulation identifier.
+   * Fetches a single simulation owned by the authenticated user.
+   * @param id UUID of the simulation.
+   * @returns The simulation as a domain model.
+   */
+  async getSimulation(id: string): Promise<Simulation> {
+    const response = await this.#http.get<ApiEnvelope<SimulationEnvelope>>(
+      `/simulations/${id}`,
+    );
+    return mapSimulationDto(response.data.data.simulation);
+  }
+
+  /**
+   * Deletes a simulation owned by the authenticated user.
+   * @param id UUID of the simulation to remove.
    */
   async deleteSimulation(id: string): Promise<void> {
     await this.#http.delete(`/simulations/${id}`);
@@ -61,9 +193,9 @@ export class SimulationClient {
 }
 
 /**
- * Resolves the canonical simulation API client using the shared HTTP layer.
- *
- * @returns SimulationClient instance bound to the application HTTP adapter.
+ * Convenience hook that resolves the canonical simulation client from the
+ * shared HTTP composable.
+ * @returns A new {@link SimulationClient} bound to the application HTTP layer.
  */
 export const useSimulationClient = (): SimulationClient => {
   return new SimulationClient(useHttp());

--- a/app/features/simulations/services/simulation.mapper.spec.ts
+++ b/app/features/simulations/services/simulation.mapper.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { mapSimulationDto } from "./simulation.mapper";
+import type { SimulationDto } from "~/features/simulations/contracts/simulation.dto";
+
+/**
+ * Builds a SimulationDto fixture for tests.
+ * @param overrides Partial overrides merged on top of the canonical fixture.
+ * @returns A canonical DTO fixture.
+ */
+const baseDto = (overrides: Partial<SimulationDto> = {}): SimulationDto => ({
+  id: "sim-1",
+  user_id: "user-1",
+  tool_id: "compound-interest",
+  rule_version: "2026.04",
+  inputs: { initial: 1000 },
+  result: { final: 1500 },
+  metadata: { label: "Cenário 1" },
+  saved: true,
+  created_at: "2026-04-29T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("mapSimulationDto", () => {
+  it("converts snake_case fields to camelCase domain shape", () => {
+    const result = mapSimulationDto(baseDto());
+    expect(result).toEqual({
+      id: "sim-1",
+      userId: "user-1",
+      toolId: "compound-interest",
+      ruleVersion: "2026.04",
+      inputs: { initial: 1000 },
+      result: { final: 1500 },
+      metadata: { label: "Cenário 1" },
+      saved: true,
+      createdAt: "2026-04-29T00:00:00.000Z",
+    });
+  });
+
+  it("normalizes undefined metadata to null", () => {
+    const dto = baseDto({ metadata: null });
+    expect(mapSimulationDto(dto).metadata).toBeNull();
+  });
+});

--- a/app/features/simulations/services/simulation.mapper.ts
+++ b/app/features/simulations/services/simulation.mapper.ts
@@ -2,19 +2,18 @@ import type { SimulationDto } from "~/features/simulations/contracts/simulation.
 import type { Simulation } from "~/features/simulations/model/simulation";
 
 /**
- * Maps a raw SimulationDto from the API into the domain Simulation model.
- *
- * @param dto Raw DTO from the API response.
- * @returns Typed domain model with camelCase fields.
- */
-export const mapSimulationDto = (dto: SimulationDto): Simulation => {
-  return {
-    id: dto.id,
-    name: dto.name,
-    toolSlug: dto.tool_slug,
-    inputs: dto.inputs,
-    result: dto.result,
-    goalId: dto.goal_id ?? null,
-    createdAt: dto.created_at,
-  };
-};
+ * Maps the canonical SimulationDto to the camelCase domain model used in UI.
+ * @param dto
+ * @returns The computed value.
+   */
+export const mapSimulationDto = (dto: SimulationDto): Simulation => ({
+  id: dto.id,
+  userId: dto.user_id,
+  toolId: dto.tool_id,
+  ruleVersion: dto.rule_version,
+  inputs: dto.inputs,
+  result: dto.result,
+  metadata: dto.metadata ?? null,
+  saved: dto.saved,
+  createdAt: dto.created_at,
+});

--- a/app/features/tools/__tests__/tools-catalog.spec.ts
+++ b/app/features/tools/__tests__/tools-catalog.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TOOLS_CATALOG,
+  TOOL_CATEGORY_LABELS,
+  TOOL_IDS_LIST,
+  isKnownTool,
+  type ToolCategory,
+} from "../tools-catalog";
+
+describe("tools-catalog", () => {
+  it("exposes a non-empty canonical catalog", () => {
+    expect(TOOLS_CATALOG.length).toBeGreaterThan(30);
+  });
+
+  it("declares each tool with the canonical kebab-case id shape", () => {
+    const KEBAB = /^[a-z][a-z0-9-]*$/;
+    for (const tool of TOOLS_CATALOG) {
+      expect(tool.id).toMatch(KEBAB);
+    }
+  });
+
+  it("returns ids sorted alphabetically", () => {
+    const sorted = [...TOOL_IDS_LIST].sort((a, b) => a.localeCompare(b));
+    expect(TOOL_IDS_LIST).toEqual(sorted);
+  });
+
+  it("isKnownTool returns true for every catalog entry and false for unknowns", () => {
+    for (const tool of TOOLS_CATALOG) {
+      expect(isKnownTool(tool.id)).toBe(true);
+    }
+    expect(isKnownTool("definitely-not-a-real-tool")).toBe(false);
+  });
+
+  it("flags installment-vs-cash, thirteenth-salary and overtime as enabled", () => {
+    const enabled = TOOLS_CATALOG.filter((t) => t.enabled).map((t) => t.id);
+    expect(enabled).toContain("installment-vs-cash");
+    expect(enabled).toContain("thirteenth-salary");
+    expect(enabled).toContain("overtime");
+  });
+
+  it("provides a localized label for each ToolCategory", () => {
+    const categories = new Set<ToolCategory>(TOOLS_CATALOG.map((t) => t.category));
+    for (const category of categories) {
+      expect(TOOL_CATEGORY_LABELS[category]).toBeTruthy();
+    }
+  });
+});

--- a/app/features/tools/composables/use-tool-page.spec.ts
+++ b/app/features/tools/composables/use-tool-page.spec.ts
@@ -70,10 +70,11 @@ function makeOptions(withGoal = false): UseToolPageOptions<TestForm, TestResult>
   return {
     createDefaultState,
     buildSimulationPayload: vi.fn(({ form, result, t }) => ({
-      name: t("test.simulation.name"),
-      toolSlug: "test_tool",
+      toolId: "compound-interest",
+      ruleVersion: "2026.04",
       inputs: { ...form },
       result: { netAmount: result.netAmount },
+      metadata: { label: t("test.simulation.name") },
     })),
     ...(withGoal
       ? {

--- a/app/features/tools/composables/use-tool-page.ts
+++ b/app/features/tools/composables/use-tool-page.ts
@@ -31,7 +31,7 @@ export interface UseToolPageOptions<
   createDefaultState: () => TForm;
   buildSimulationPayload: (
     ctx: SimulationPayloadContext<TForm, TResult>,
-  ) => Omit<SaveSimulationPayload, "goalId">;
+  ) => SaveSimulationPayload;
   getGoalPayload?: (ctx: GoalPayloadContext<TResult>) => CreateGoalPayload;
 }
 

--- a/app/features/tools/hora-extra/page.vue
+++ b/app/features/tools/hora-extra/page.vue
@@ -81,10 +81,15 @@ async function handleSaveSimulation(): Promise<void> {
   if (savedSimulationId.value || !result.value) { return; }
   try {
     const simulation = await saveSimulationMutation.mutateAsync({
-      name: t("horaExtra.simulation.defaultName", { year: new Date().getFullYear() }),
-      toolSlug: "hora_extra",
+      toolId: "overtime",
+      ruleVersion: "2026.04",
       inputs: { ...form.value },
       result: { ...result.value },
+      metadata: {
+        label: t("horaExtra.simulation.defaultName", {
+          year: new Date().getFullYear(),
+        }),
+      },
     });
     savedSimulationId.value = simulation.id;
   } catch (err) {

--- a/app/features/tools/thirteenth-salary/useThirteenthSalaryPage.ts
+++ b/app/features/tools/thirteenth-salary/useThirteenthSalaryPage.ts
@@ -1,6 +1,7 @@
 import { computed, reactive, ref, type ComputedRef } from "vue";
 
 import { captureException } from "~/core/observability";
+import { useLeaveWithoutSavePrompt } from "~/composables/useLeaveWithoutSavePrompt";
 import { useCalculatorFormState } from "~/features/tools/composables/use-calculator-form-state";
 import { useToolPageContext } from "~/features/tools/composables/use-tool-page-context";
 import { useSaveSimulationMutation } from "~/features/simulations/queries/use-save-simulation-mutation";
@@ -109,10 +110,15 @@ export function useThirteenthSalaryPage() {
     if (!result.value) { return null; }
     try {
       const simulation = await saveSimulationMutation.mutateAsync({
-        name: t("thirteenthSalary.simulation.defaultName", { year: new Date().getFullYear() }),
-        toolSlug: "thirteenth_salary",
+        toolId: "thirteenth-salary",
+        ruleVersion: "2026.04",
         inputs: { ...form.value },
         result: { ...result.value },
+        metadata: {
+          label: t("thirteenthSalary.simulation.defaultName", {
+            year: new Date().getFullYear(),
+          }),
+        },
       });
       savedSimulationId.value = simulation.id;
       return simulation.id;
@@ -193,6 +199,23 @@ export function useThirteenthSalaryPage() {
     createReceivableMutation.isPending.value,
   );
 
+  // Fires when the user has a result on screen but has not yet saved it.
+  // The leave-prompt only triggers in this exact state (DEC-196 UX rules).
+  const hasUnsavedResult = computed(
+    (): boolean => result.value !== null && savedSimulationId.value === null,
+  );
+
+  const leavePrompt = useLeaveWithoutSavePrompt({
+    isDirty: hasUnsavedResult,
+    onSave: async () => {
+      await ensureSimulationSaved();
+    },
+    onDiscard: () => {
+      result.value = null;
+      reset();
+    },
+  });
+
   return {
     t, toast, router, isAuthenticated, hasPremiumAccess, formatBrl,
     form, validationError, isDirty, patch,
@@ -202,6 +225,8 @@ export function useThirteenthSalaryPage() {
     showGoalModal, goalForm, showBudgetModal,
     summaryMetrics,
     isBridging,
+    hasUnsavedResult,
+    leavePrompt,
     handleCalculate,
     handleReset,
     handleSaveSimulation,

--- a/app/features/tools/tools-catalog.ts
+++ b/app/features/tools/tools-catalog.ts
@@ -1,0 +1,163 @@
+/**
+ * Canonical list of `tool_id` values accepted by the backend `/simulations`
+ * endpoint (DEC-196 / auraxis-api#1128).
+ *
+ * This file mirrors:
+ * - `auraxis-app/features/tools/services/tools-catalog.ts`
+ * - `auraxis-api/app/simulations/tools_registry.py`
+ *
+ * Drift between the three is detected by
+ * `scripts/check-tools-registry-parity.ts` which is wired into the
+ * pre-commit hooks. When a new tool ships, add it here in the same PR
+ * that lands it in the app catalog and the API registry.
+ */
+
+export type ToolCategory =
+  | "salary-and-work"
+  | "investments"
+  | "debt-and-financing"
+  | "real-estate"
+  | "daily-life";
+
+export interface ToolDefinition {
+  readonly id: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly category: ToolCategory;
+  readonly enabled: boolean;
+  readonly route?: string;
+  readonly requiresPremium?: boolean;
+}
+
+type ToolSeed = readonly [
+  id: string,
+  slug: string,
+  name: string,
+  description: string,
+];
+
+const FUNCTIONAL_ROUTES: ReadonlyMap<string, string> = new Map([
+  ["installment-vs-cash", "/tools/installment-vs-cash"],
+  ["thirteenth-salary", "/tools/decimo-terceiro"],
+  ["overtime", "/tools/hora-extra"],
+]);
+
+/**
+ *
+ * @param category
+ * @param seed
+ * @returns The computed value.
+   */
+const buildTool = (category: ToolCategory, seed: ToolSeed): ToolDefinition => {
+  const [id, slug, name, description] = seed;
+  const route = FUNCTIONAL_ROUTES.get(id);
+  return {
+    id,
+    slug,
+    name,
+    description,
+    category,
+    enabled: route !== undefined,
+    ...(route !== undefined && { route }),
+  };
+};
+
+/**
+ *
+ * @param category
+ * @param seeds
+ * @returns The computed value.
+   */
+const buildCategory = (
+  category: ToolCategory,
+  seeds: readonly ToolSeed[],
+): readonly ToolDefinition[] => seeds.map((seed) => buildTool(category, seed));
+
+// ── Salário & Trabalho ─────────────────────────────────────────────
+const SALARY_AND_WORK: readonly ToolSeed[] = [
+  ["salary-net-clt", "salario-liquido", "Salário líquido CLT", "Calcule o líquido a receber descontando INSS, IR e benefícios."],
+  ["inss-ir-payroll", "inss-ir-folha", "INSS e IR na folha", "Quanto sai da sua folha de pagamento por mês."],
+  ["thirteenth-salary", "decimo-terceiro", "13º salário", "Estime as duas parcelas e o valor total no fim do ano."],
+  ["overtime", "hora-extra", "Hora extra", "Cálculo com adicional de 50% e 100% conforme a CLT."],
+  ["termination", "rescisao", "Rescisão", "Direitos por demissão sem justa causa, pedido ou acordo."],
+  ["clt-vs-pj", "clt-vs-pj", "CLT vs PJ", "Compare líquido e benefícios entre os dois regimes."],
+  ["mei-monthly", "mei", "MEI mensal", "DAS, faturamento e enquadramento simplificado."],
+  ["salary-raise", "pedir-aumento", "Pedir aumento", "Recomposição da inflação + ganho real desejado."],
+  ["vacation", "ferias", "Férias", "Estime férias e abono pecuniário sobre seu salário."],
+  ["fgts-balance", "fgts", "FGTS", "Projeção do saldo FGTS e simulação de saque."],
+];
+
+// ── Investimentos ──────────────────────────────────────────────────
+const INVESTMENTS: readonly ToolSeed[] = [
+  ["compound-interest", "juros-compostos", "Juros compostos", "Quanto seu dinheiro rende com aporte mensal recorrente."],
+  ["cdb-lci-lca", "cdb-lci-lca", "CDB · LCI · LCA", "Compare rentabilidade líquida entre os principais títulos."],
+  ["treasury", "tesouro-direto", "Tesouro Direto", "Selic, IPCA+, prefixado e custos do investimento."],
+  ["fii", "fii", "FII (Fundos imobiliários)", "Yield, distribuição e rendimento mensal estimado."],
+  ["etf", "etf", "ETF", "Custo médio, taxas e impacto da bolsa."],
+  ["fire", "fire", "FIRE", "Quando seu patrimônio paga seu custo de vida."],
+  ["ipca-correction", "correcao-ipca", "Correção IPCA", "Atualize valores antigos pela inflação acumulada."],
+  ["broker-fees", "custos-corretagem", "Custos de corretagem", "Estime spreads, IRs e taxa de custódia por estratégia."],
+];
+
+// ── Dívidas & Financiamento ────────────────────────────────────────
+const DEBT_AND_FINANCING: readonly ToolSeed[] = [
+  ["debt-payoff", "quitacao-dividas", "Quitação de dívidas", "Estratégia bola-de-neve vs avalanche para sair do vermelho."],
+  ["loan-simulator", "emprestimo", "Empréstimo pessoal", "Parcela, CET e custo total de um empréstimo bancário."],
+  ["cet-calculator", "cet", "CET — Custo Efetivo Total", "Compare ofertas pelo CET, não pela taxa nominal."],
+  ["mortgage", "financiamento-imovel", "Financiamento imobiliário", "Compare SAC vs PRICE para o seu imóvel."],
+  ["vehicle-financing", "financiamento-veiculo", "Financiamento de veículo", "Entrada, parcelas e o custo real do carro."],
+  ["credit-card-revolver", "rotativo-cartao", "Rotativo do cartão", "Simulação do juro do crédito rotativo e cenários de quitação."],
+  ["consigned-loan", "credito-consignado", "Crédito consignado", "Margem consignável e parcela ideal do empréstimo."],
+];
+
+// ── Imóvel ─────────────────────────────────────────────────────────
+const REAL_ESTATE: readonly ToolSeed[] = [
+  ["rent-vs-buy", "alugar-vs-comprar", "Alugar vs comprar", "Compare cenários de alugar versus comprar com financiamento."],
+  ["iptu", "iptu", "IPTU", "Estimativa anual de IPTU para o seu imóvel."],
+  ["itbi", "itbi", "ITBI", "Imposto de transmissão na compra de imóvel."],
+  ["rental-yield", "rentabilidade-aluguel", "Rentabilidade de aluguel", "Yield do imóvel para aluguel residencial ou Airbnb."],
+];
+
+// ── Dia a dia ──────────────────────────────────────────────────────
+const DAILY_LIFE: readonly ToolSeed[] = [
+  ["installment-vs-cash", "parcelado-vs-a-vista", "Parcelado vs à vista", "Vale a pena parcelar ou à vista com desconto?"],
+  ["salary-simulator", "simulador-salario", "Simulador de salário", "Reajuste salarial considerando inflação e ganho real."],
+  ["goal-simulator", "simulador-meta", "Simulador de meta", "Quanto guardar por mês para atingir uma meta no prazo."],
+  ["fifty-thirty-twenty", "alocacao-50-30-20", "Alocação 50-30-20", "Distribua sua renda em essenciais, desejos e investimentos."],
+  ["emergency-fund", "reserva-emergencia", "Reserva de emergência", "Quanto você precisa para 3, 6 ou 12 meses de despesas."],
+  ["currency-converter", "conversor-moedas", "Conversor de moedas", "Cotação ao vivo via BRAPI para USD, EUR e mais."],
+  ["split-bill", "dividir-conta", "Dividir conta", "Rateio justo entre amigos com gorjeta e pesos."],
+  ["monthly-fuel", "combustivel-mensal", "Combustível mensal", "Estime gasto de combustível por preço, KM e consumo."],
+  ["subscription-audit", "auditoria-assinaturas", "Auditoria de assinaturas", "Liste todas as assinaturas recorrentes e o impacto anual."],
+  ["cost-of-lifestyle", "custo-estilo-de-vida", "Custo do estilo de vida", "Quanto custa o padrão de vida que você quer ter."],
+];
+
+const CANONICAL_TOOLS: readonly ToolDefinition[] = [
+  ...buildCategory("salary-and-work", SALARY_AND_WORK),
+  ...buildCategory("investments", INVESTMENTS),
+  ...buildCategory("debt-and-financing", DEBT_AND_FINANCING),
+  ...buildCategory("real-estate", REAL_ESTATE),
+  ...buildCategory("daily-life", DAILY_LIFE),
+];
+
+const TOOL_IDS = new Set(CANONICAL_TOOLS.map((tool) => tool.id));
+
+export const TOOLS_CATALOG: readonly ToolDefinition[] = CANONICAL_TOOLS;
+
+export const TOOL_IDS_LIST: readonly string[] = Array.from(TOOL_IDS).sort();
+
+/**
+ *
+ * @param toolId
+ * @returns The computed value.
+   */
+export const isKnownTool = (toolId: string): boolean => TOOL_IDS.has(toolId);
+
+export const TOOL_CATEGORY_LABELS: Readonly<Record<ToolCategory, string>> = {
+  "salary-and-work": "Salário e trabalho",
+  investments: "Investimentos",
+  "debt-and-financing": "Dívidas e financiamento",
+  "real-estate": "Imóvel",
+  "daily-life": "Dia a dia",
+};

--- a/app/features/tools/tools-catalog.ts
+++ b/app/features/tools/tools-catalog.ts
@@ -145,7 +145,9 @@ const TOOL_IDS = new Set(CANONICAL_TOOLS.map((tool) => tool.id));
 
 export const TOOLS_CATALOG: readonly ToolDefinition[] = CANONICAL_TOOLS;
 
-export const TOOL_IDS_LIST: readonly string[] = Array.from(TOOL_IDS).sort();
+export const TOOL_IDS_LIST: readonly string[] = Array.from(TOOL_IDS).sort(
+  (a, b) => a.localeCompare(b),
+);
 
 /**
  *

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -3259,6 +3259,12 @@
     "positiveText": "Sair sem salvar",
     "negativeText": "Continuar editando"
   },
+  "leaveWithoutSavePrompt": {
+    "title": "Salvar simulação?",
+    "content": "Você ainda não salvou esta simulação. Se sair agora, ela será descartada.",
+    "positiveText": "Salvar e sair",
+    "negativeText": "Descartar e sair"
+  },
   "errors": {
     "VALIDATION_ERROR": "Verifique os campos e tente novamente",
     "MISSING_TOKEN": "Sessão expirada. Faça login novamente",

--- a/app/pages/simulations.vue
+++ b/app/pages/simulations.vue
@@ -31,7 +31,7 @@ const SIMULATION_TYPE_ROUTES: Record<SimulationType, string> = {
   investment_return: "/tools/juros-compostos",
 };
 
-const { data: simulations, isLoading, isError } = useSimulationsQuery();
+const { data, isLoading, isError } = useSimulationsQuery();
 const deleteMutation = useDeleteSimulationMutation();
 
 const activeFilter = ref<FilterValue>("all");
@@ -50,7 +50,7 @@ const NEW_SIMULATION_OPTIONS = computed((): DropdownOption[] => [
   { key: "investment_return", label: t("pages.simulations.typeSelect.investmentReturn") },
 ]);
 
-const allSimulations = computed(() => simulations.value ?? []);
+const allSimulations = computed(() => data.value?.cards ?? []);
 
 const filteredSimulations = computed(() => {
   if (activeFilter.value === "all") {return allSimulations.value;}

--- a/app/pages/tools/aluguel-vs-compra.spec.ts
+++ b/app/pages/tools/aluguel-vs-compra.spec.ts
@@ -441,7 +441,7 @@ describe("AluguelVsCompraPage — save simulation", () => {
     await flushPromises();
     expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
     expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ toolSlug: "aluguel_vs_compra" }),
+      expect.objectContaining({ toolId: "rent-vs-buy" }),
     );
   });
 

--- a/app/pages/tools/aluguel-vs-compra.vue
+++ b/app/pages/tools/aluguel-vs-compra.vue
@@ -42,8 +42,9 @@ const {
 } = useToolPage<AluguelVsCompraFormState, AluguelVsCompraResult>({
   createDefaultState: createDefaultAluguelVsCompraFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("aluguelVsCompra.simulation.defaultName", { year: new Date().getFullYear() }),
-    toolSlug: "aluguel_vs_compra",
+    toolId: "rent-vs-buy",
+    ruleVersion: "2026.04",
+    metadata: { label: t("aluguelVsCompra.simulation.defaultName", { year: new Date().getFullYear() }) },
     inputs: { ...form },
     result: {
       finalBuyNetWorth: result.finalBuyNetWorth,

--- a/app/pages/tools/aposentadoria.spec.ts
+++ b/app/pages/tools/aposentadoria.spec.ts
@@ -354,7 +354,7 @@ describe("AposentadoriaPage — save simulation", () => {
     await saveButton!.trigger("click");
     await flushPromises();
     expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
-    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "aposentadoria" }));
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolId: "aposentadoria" }));
   });
 
   it("captures exception when save simulation fails", async () => {

--- a/app/pages/tools/aposentadoria.vue
+++ b/app/pages/tools/aposentadoria.vue
@@ -43,11 +43,16 @@ const {
 } = useToolPage<AposentadoriaFormState, AposentadoriaResult>({
   createDefaultState: createDefaultAposentadoriaFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("aposentadoria.simulation.defaultName", {
-      retirementAge: form.retirementAge,
-      year: new Date().getFullYear(),
-    }),
-    toolSlug: "aposentadoria",
+    // TODO(simulations-canonical): 'aposentadoria' is not in the registry yet (DEC-196).
+    // Save will return 422 until the id is added to TOOLS_REGISTRY.
+    toolId: "aposentadoria",
+    ruleVersion: "2026.04",
+    metadata: {
+      label: t("aposentadoria.simulation.defaultName", {
+        retirementAge: form.retirementAge,
+        year: new Date().getFullYear(),
+      }),
+    },
     inputs: { ...form },
     result: {
       requiredPatrimony: result.requiredPatrimony,

--- a/app/pages/tools/cdb-lci-lca.spec.ts
+++ b/app/pages/tools/cdb-lci-lca.spec.ts
@@ -345,7 +345,7 @@ describe("CdbLciLcaPage — save simulation", () => {
     await saveButton!.trigger("click");
     await flushPromises();
     expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
-    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "cdb_lci_lca" }));
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolId: "cdb-lci-lca" }));
   });
 
   it("captures exception when save simulation fails", async () => {

--- a/app/pages/tools/cdb-lci-lca.vue
+++ b/app/pages/tools/cdb-lci-lca.vue
@@ -55,8 +55,9 @@ const {
 } = useToolPage<CdbLciLcaFormState, CdbLciLcaResult>({
   createDefaultState: createDefaultCdbLciLcaFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("cdbLciLca.simulation.defaultName", { year: new Date().getFullYear() }),
-    toolSlug: "cdb_lci_lca",
+    toolId: "cdb-lci-lca",
+    ruleVersion: "2026.04",
+    metadata: { label: t("cdbLciLca.simulation.defaultName", { year: new Date().getFullYear() }) },
     inputs: { ...form },
     result: {
       bestOption: result.bestOption,

--- a/app/pages/tools/cet.spec.ts
+++ b/app/pages/tools/cet.spec.ts
@@ -144,6 +144,6 @@ describe("CetPage — save simulation", () => {
     const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
     const btn = w.findAll(".n-button").find((b) => b.text().includes("cet.actions.save"));
     await btn!.trigger("click"); await flushPromises();
-    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "cet" }));
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolId: "cet-calculator" }));
   });
 });

--- a/app/pages/tools/cet.vue
+++ b/app/pages/tools/cet.vue
@@ -101,8 +101,9 @@ async function handleSaveSimulation(): Promise<void> {
   if (savedSimulationId.value || !result.value) { return; }
   try {
     const sim = await saveSimulationMutation.mutateAsync({
-      name: t("cet.simulation.defaultName"),
-      toolSlug: "cet",
+      toolId: "cet-calculator",
+      ruleVersion: "2026.04",
+      metadata: { label: t("cet.simulation.defaultName") },
       inputs: { ...form.value },
       result: {
         cetMonthlyPct: result.value.cetMonthlyPct,

--- a/app/pages/tools/clt-vs-pj.spec.ts
+++ b/app/pages/tools/clt-vs-pj.spec.ts
@@ -404,7 +404,7 @@ describe("CltVsPjPage", () => {
       await flushPromises();
 
       expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-        expect.objectContaining({ toolSlug: "clt_vs_pj" }),
+        expect.objectContaining({ toolId: "clt-vs-pj" }),
       );
     });
 

--- a/app/pages/tools/clt-vs-pj.vue
+++ b/app/pages/tools/clt-vs-pj.vue
@@ -74,8 +74,9 @@ const {
 } = useToolPage<CltVsPjFormState, CltVsPjResult>({
   createDefaultState: createDefaultCltVsPjFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("cltVsPj.simulation.defaultName", { year: new Date().getFullYear() }),
-    toolSlug: "clt_vs_pj",
+    toolId: "clt-vs-pj",
+    ruleVersion: "2026.04",
+    metadata: { label: t("cltVsPj.simulation.defaultName", { year: new Date().getFullYear() }) },
     inputs: { ...form },
     result: { ...result },
   }),

--- a/app/pages/tools/conversor-moeda.spec.ts
+++ b/app/pages/tools/conversor-moeda.spec.ts
@@ -416,7 +416,7 @@ describe("ConversorMoedaPage — save simulation", () => {
 
     expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
     expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ toolSlug: "conversor_moeda" }),
+      expect.objectContaining({ toolId: "currency-converter" }),
     );
   });
 

--- a/app/pages/tools/conversor-moeda.vue
+++ b/app/pages/tools/conversor-moeda.vue
@@ -60,8 +60,9 @@ const {
 } = useToolPage<ConversorMoedaFormState, ConversorMoedaResult>({
   createDefaultState: createDefaultConversorMoedaFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("conversorMoeda.simulation.defaultName", { pair: form.pair, year: new Date().getFullYear() }),
-    toolSlug: "conversor_moeda",
+    toolId: "currency-converter",
+    ruleVersion: "2026.04",
+    metadata: { label: t("conversorMoeda.simulation.defaultName", { pair: form.pair, year: new Date().getFullYear() }) },
     inputs: { ...form },
     result: { ...result },
   }),

--- a/app/pages/tools/custo-estilo-vida.spec.ts
+++ b/app/pages/tools/custo-estilo-vida.spec.ts
@@ -149,7 +149,7 @@ describe("CustoEstiloVidaPage — save simulation", () => {
     const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
     const btn = w.findAll(".n-button").find((b) => b.text().includes("custoEstiloVida.actions.save"));
     await btn!.trigger("click"); await flushPromises();
-    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "custo_estilo_vida" }));
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolId: "cost-of-lifestyle" }));
   });
 });
 

--- a/app/pages/tools/custo-estilo-vida.vue
+++ b/app/pages/tools/custo-estilo-vida.vue
@@ -165,8 +165,9 @@ async function ensureSimulationSaved(): Promise<string | null> {
   if (!result.value) { return null; }
   try {
     const sim = await saveSimulationMutation.mutateAsync({
-      name: t("custoEstiloVida.simulation.defaultName"),
-      toolSlug: "custo_estilo_vida",
+      toolId: "cost-of-lifestyle",
+      ruleVersion: "2026.04",
+      metadata: { label: t("custoEstiloVida.simulation.defaultName") },
       inputs: { ...form.value },
       result: {
         totalOpportunityCost: result.value.totalOpportunityCost,

--- a/app/pages/tools/desconto-markup.spec.ts
+++ b/app/pages/tools/desconto-markup.spec.ts
@@ -382,7 +382,7 @@ describe("DescontoMarkupPage — save simulation", () => {
     await flushPromises();
 
     expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ toolSlug: "desconto_markup" }),
+      expect.objectContaining({ toolId: "desconto_markup" }),
     );
   });
 

--- a/app/pages/tools/desconto-markup.vue
+++ b/app/pages/tools/desconto-markup.vue
@@ -205,8 +205,9 @@ async function ensureSimulationSaved(): Promise<string | null> {
 
   try {
     const simulation = await saveSimulationMutation.mutateAsync({
-      name: t("descontoMarkup.simulation.defaultName", { mode: form.value.mode }),
-      toolSlug: "desconto_markup",
+      // TODO(simulations-canonical): 'desconto_markup' is not in the registry yet (DEC-196)
+      toolId: "desconto_markup",
+      ruleVersion: "2026.04",
       inputs: { ...form.value },
       result: { ...result.value },
     });

--- a/app/pages/tools/dividir-conta.spec.ts
+++ b/app/pages/tools/dividir-conta.spec.ts
@@ -376,7 +376,7 @@ describe("DividirContaPage — save simulation", () => {
 
     expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
     expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ toolSlug: "dividir_conta" }),
+      expect.objectContaining({ toolId: "split-bill" }),
     );
   });
 

--- a/app/pages/tools/dividir-conta.vue
+++ b/app/pages/tools/dividir-conta.vue
@@ -183,8 +183,9 @@ async function ensureSimulationSaved(): Promise<string | null> {
 
   try {
     const simulation = await saveSimulationMutation.mutateAsync({
-      name: t("dividirConta.simulation.defaultName", { people: form.value.people }),
-      toolSlug: "dividir_conta",
+      toolId: "split-bill",
+      ruleVersion: "2026.04",
+      metadata: { label: t("dividirConta.simulation.defaultName", { people: form.value.people }) },
       inputs: { ...form.value },
       result: { ...result.value },
     });

--- a/app/pages/tools/ferias.spec.ts
+++ b/app/pages/tools/ferias.spec.ts
@@ -446,7 +446,7 @@ describe("FeriasPage", () => {
 
       expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
       expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-        expect.objectContaining({ toolSlug: "ferias_clt" }),
+        expect.objectContaining({ toolId: "vacation" }),
       );
     });
 

--- a/app/pages/tools/ferias.vue
+++ b/app/pages/tools/ferias.vue
@@ -49,8 +49,9 @@ const {
 } = useToolPage<FeriasFormState, FeriasResult>({
   createDefaultState: createDefaultFeriasFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("ferias.simulation.defaultName", { year: new Date().getFullYear() }),
-    toolSlug: "ferias_clt",
+    toolId: "vacation",
+    ruleVersion: "2026.04",
+    metadata: { label: t("ferias.simulation.defaultName", { year: new Date().getFullYear() }) },
     inputs: { ...form },
     result: { ...result },
   }),

--- a/app/pages/tools/fgts.spec.ts
+++ b/app/pages/tools/fgts.spec.ts
@@ -402,7 +402,7 @@ describe("FgtsPage", () => {
 
       expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
       expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-        expect.objectContaining({ toolSlug: "fgts" }),
+        expect.objectContaining({ toolId: "fgts-balance" }),
       );
     });
 

--- a/app/pages/tools/fgts.vue
+++ b/app/pages/tools/fgts.vue
@@ -74,8 +74,9 @@ const {
 } = useToolPage<FgtsFormState, FgtsResult>({
   createDefaultState: createDefaultFgtsFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("fgts.simulation.defaultName", { year: new Date().getFullYear() }),
-    toolSlug: "fgts",
+    toolId: "fgts-balance",
+    ruleVersion: "2026.04",
+    metadata: { label: t("fgts.simulation.defaultName", { year: new Date().getFullYear() }) },
     inputs: { ...form },
     result: { ...result },
   }),

--- a/app/pages/tools/fii.spec.ts
+++ b/app/pages/tools/fii.spec.ts
@@ -441,7 +441,7 @@ describe("FiiPage — save simulation", () => {
     await flushPromises();
 
     expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ toolSlug: "fii_calculator" }),
+      expect.objectContaining({ toolId: "fii" }),
     );
   });
 

--- a/app/pages/tools/fii.vue
+++ b/app/pages/tools/fii.vue
@@ -62,8 +62,9 @@ const {
 } = useToolPage<FiiFormState, FiiResult>({
   createDefaultState: createDefaultFiiFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("fii.simulation.defaultName", { ticker: form.ticker, year: new Date().getFullYear() }),
-    toolSlug: "fii_calculator",
+    toolId: "fii",
+    ruleVersion: "2026.04",
+    metadata: { label: t("fii.simulation.defaultName", { ticker: form.ticker, year: new Date().getFullYear() }) },
     inputs: { ...form },
     result: { ...result },
   }),

--- a/app/pages/tools/financiamento-imobiliario.spec.ts
+++ b/app/pages/tools/financiamento-imobiliario.spec.ts
@@ -403,7 +403,7 @@ describe("FinanciamentoImobiliarioPage — save simulation", () => {
     await flushPromises();
     expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
     expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ toolSlug: "financiamento_imobiliario" }),
+      expect.objectContaining({ toolId: "mortgage" }),
     );
   });
 

--- a/app/pages/tools/financiamento-imobiliario.vue
+++ b/app/pages/tools/financiamento-imobiliario.vue
@@ -41,8 +41,9 @@ const {
 } = useToolPage<FinanciamentoFormState, FinanciamentoResult>({
   createDefaultState: createDefaultFinanciamentoFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("financiamentoImobiliario.simulation.defaultName", { year: new Date().getFullYear() }),
-    toolSlug: "financiamento_imobiliario",
+    toolId: "mortgage",
+    ruleVersion: "2026.04",
+    metadata: { label: t("financiamentoImobiliario.simulation.defaultName", { year: new Date().getFullYear() }) },
     inputs: { ...form },
     result: {
       loanAmount: result.loanAmount,

--- a/app/pages/tools/fire.spec.ts
+++ b/app/pages/tools/fire.spec.ts
@@ -369,7 +369,7 @@ describe("FirePage — save simulation", () => {
     await saveButton!.trigger("click");
     await flushPromises();
     expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
-    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "fire" }));
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolId: "fire" }));
   });
 
   it("captures exception when save simulation fails", async () => {

--- a/app/pages/tools/fire.vue
+++ b/app/pages/tools/fire.vue
@@ -45,11 +45,14 @@ const {
 } = useToolPage<FireFormState, FireResult>({
   createDefaultState: createDefaultFireFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("fire.simulation.defaultName", {
-      variant: t(`fire.variants.${form.variant}`),
-      retirementAge: form.retirementAge,
-    }),
-    toolSlug: "fire",
+    toolId: "fire",
+    ruleVersion: "2026.04",
+    metadata: {
+      label: t("fire.simulation.defaultName", {
+        variant: t(`fire.variants.${form.variant}`),
+        retirementAge: form.retirementAge,
+      }),
+    },
     inputs: { ...form },
     result: {
       requiredPatrimony: result.selectedVariant.requiredPatrimony,

--- a/app/pages/tools/hora-extra.spec.ts
+++ b/app/pages/tools/hora-extra.spec.ts
@@ -421,7 +421,7 @@ describe("HoraExtraPage", () => {
 
       expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
       expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-        expect.objectContaining({ toolSlug: "hora_extra" }),
+        expect.objectContaining({ toolId: "overtime" }),
       );
     });
 

--- a/app/pages/tools/inss-ir-folha.spec.ts
+++ b/app/pages/tools/inss-ir-folha.spec.ts
@@ -441,7 +441,7 @@ describe("InssIrFolhaPage", () => {
       expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
       expect(mockSaveMutateAsync).toHaveBeenCalledWith(
         expect.objectContaining({
-          toolSlug: "inss_ir_folha",
+          toolId: "inss-ir-payroll",
         }),
       );
     });

--- a/app/pages/tools/inss-ir-folha.vue
+++ b/app/pages/tools/inss-ir-folha.vue
@@ -65,8 +65,9 @@ const {
 } = useToolPage<InssIrFormState, InssIrResult>({
   createDefaultState: createDefaultInssIrFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("inssIrFolha.simulation.defaultName", { year: new Date().getFullYear() }),
-    toolSlug: "inss_ir_folha",
+    toolId: "inss-ir-payroll",
+    ruleVersion: "2026.04",
+    metadata: { label: t("inssIrFolha.simulation.defaultName", { year: new Date().getFullYear() }) },
     inputs: { ...form },
     result: { ...result },
   }),

--- a/app/pages/tools/juros-compostos.spec.ts
+++ b/app/pages/tools/juros-compostos.spec.ts
@@ -435,7 +435,7 @@ describe("JurosCompostosPage — save simulation", () => {
     await flushPromises();
 
     expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ toolSlug: "juros_compostos" }),
+      expect.objectContaining({ toolId: "compound-interest" }),
     );
   });
 

--- a/app/pages/tools/juros-compostos.vue
+++ b/app/pages/tools/juros-compostos.vue
@@ -225,11 +225,14 @@ async function ensureSimulationSaved(): Promise<string | null> {
 
   try {
     const simulation = await saveSimulationMutation.mutateAsync({
-      name: t("jurosCompostos.simulation.defaultName", {
-        period: form.value.period,
-        unit: form.value.periodUnit,
-      }),
-      toolSlug: "juros_compostos",
+      toolId: "compound-interest",
+      ruleVersion: "2026.04",
+      metadata: {
+        label: t("jurosCompostos.simulation.defaultName", {
+          period: form.value.period,
+          unit: form.value.periodUnit,
+        }),
+      },
       inputs: { ...form.value },
       result: {
         finalAmountNominal: result.value.finalAmountNominal,

--- a/app/pages/tools/mei.spec.ts
+++ b/app/pages/tools/mei.spec.ts
@@ -404,7 +404,7 @@ describe("MeiPage", () => {
       await flushPromises();
 
       expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-        expect.objectContaining({ toolSlug: "mei" }),
+        expect.objectContaining({ toolId: "mei-monthly" }),
       );
     });
 

--- a/app/pages/tools/mei.vue
+++ b/app/pages/tools/mei.vue
@@ -42,8 +42,9 @@ const {
 } = useToolPage<MeiFormState, MeiResult>({
   createDefaultState: createDefaultMeiFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("mei.simulation.defaultName", { year: new Date().getFullYear() }),
-    toolSlug: "mei",
+    toolId: "mei-monthly",
+    ruleVersion: "2026.04",
+    metadata: { label: t("mei.simulation.defaultName", { year: new Date().getFullYear() }) },
     inputs: { ...form },
     result: { ...result },
   }),

--- a/app/pages/tools/orcamento-50-30-20.spec.ts
+++ b/app/pages/tools/orcamento-50-30-20.spec.ts
@@ -148,7 +148,7 @@ describe("OrcamentoPage — save simulation", () => {
     const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
     const btn = w.findAll(".n-button").find((b) => b.text().includes("orcamento5030.actions.save"));
     await btn!.trigger("click"); await flushPromises();
-    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "orcamento_50_30_20" }));
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolId: "fifty-thirty-twenty" }));
   });
 });
 

--- a/app/pages/tools/orcamento-50-30-20.vue
+++ b/app/pages/tools/orcamento-50-30-20.vue
@@ -118,8 +118,9 @@ async function ensureSimulationSaved(): Promise<string | null> {
   if (!result.value) { return null; }
   try {
     const sim = await saveSimulationMutation.mutateAsync({
-      name: t("orcamento5030.simulation.defaultName"),
-      toolSlug: "orcamento_50_30_20",
+      toolId: "fifty-thirty-twenty",
+      ruleVersion: "2026.04",
+      metadata: { label: t("orcamento5030.simulation.defaultName") },
       inputs: { ...form.value },
       result: { netIncome: result.value.netIncome, slices: result.value.slices },
     });

--- a/app/pages/tools/quitacao-dividas.spec.ts
+++ b/app/pages/tools/quitacao-dividas.spec.ts
@@ -149,6 +149,6 @@ describe("QuitacaoDividasPage — save simulation", () => {
     const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
     const btn = w.findAll(".n-button").find((b) => b.text().includes("quitacaoDividas.actions.save"));
     await btn!.trigger("click"); await flushPromises();
-    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "quitacao_dividas" }));
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolId: "debt-payoff" }));
   });
 });

--- a/app/pages/tools/quitacao-dividas.vue
+++ b/app/pages/tools/quitacao-dividas.vue
@@ -157,8 +157,9 @@ async function ensureSimulationSaved(): Promise<string | null> {
   if (!result.value) { return null; }
   try {
     const sim = await saveSimulationMutation.mutateAsync({
-      name: t("quitacaoDividas.simulation.defaultName"),
-      toolSlug: "quitacao_dividas",
+      toolId: "debt-payoff",
+      ruleVersion: "2026.04",
+      metadata: { label: t("quitacaoDividas.simulation.defaultName") },
       inputs: { ...form.value },
       result: {
         totalDebt: result.value.totalDebt,

--- a/app/pages/tools/rescisao.spec.ts
+++ b/app/pages/tools/rescisao.spec.ts
@@ -454,7 +454,7 @@ describe("RescisaoPage", () => {
 
       expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
       expect(mockSaveMutateAsync).toHaveBeenCalledWith(
-        expect.objectContaining({ toolSlug: "rescisao_clt" }),
+        expect.objectContaining({ toolId: "termination" }),
       );
     });
 

--- a/app/pages/tools/rescisao.vue
+++ b/app/pages/tools/rescisao.vue
@@ -73,8 +73,11 @@ const {
 } = useToolPage<RescisaoFormState, RescisaoResult>({
   createDefaultState: createDefaultRescisaoFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("rescisao.simulation.defaultName", { year: new Date().getFullYear() }),
-    toolSlug: "rescisao_clt",
+    toolId: "termination",
+    ruleVersion: "2026.04",
+    metadata: {
+      label: t("rescisao.simulation.defaultName", { year: new Date().getFullYear() }),
+    },
     inputs: { ...form },
     result: { ...result },
   }),

--- a/app/pages/tools/reserva-emergencia.spec.ts
+++ b/app/pages/tools/reserva-emergencia.spec.ts
@@ -153,7 +153,7 @@ describe("ReservaEmergenciaPage — save simulation", () => {
     const w = mountPage(); await w.find("form").trigger("submit"); await flushPromises();
     const btn = w.findAll(".n-button").find((b) => b.text().includes("reservaEmergencia.actions.save"));
     await btn!.trigger("click"); await flushPromises();
-    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "reserva_emergencia" }));
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolId: "emergency-fund" }));
   });
 });
 

--- a/app/pages/tools/reserva-emergencia.vue
+++ b/app/pages/tools/reserva-emergencia.vue
@@ -127,8 +127,9 @@ async function ensureSimulationSaved(): Promise<string | null> {
   if (!result.value) { return null; }
   try {
     const sim = await saveSimulationMutation.mutateAsync({
-      name: t("reservaEmergencia.simulation.defaultName"),
-      toolSlug: "reserva_emergencia",
+      toolId: "emergency-fund",
+      ruleVersion: "2026.04",
+      metadata: { label: t("reservaEmergencia.simulation.defaultName") },
       inputs: { ...form.value },
       result: { targetAmount: result.value.targetAmount, monthsToTarget: result.value.monthsToTarget, gap: result.value.gap },
     });

--- a/app/pages/tools/salario-liquido.spec.ts
+++ b/app/pages/tools/salario-liquido.spec.ts
@@ -239,7 +239,7 @@ describe("SalarioLiquidoPage — save simulation", () => {
     const btn = w.findAll(".n-button").find((b) => b.text().includes("salarioLiquido.actions.save"));
     expect(btn).toBeDefined();
     await btn!.trigger("click"); await flushPromises();
-    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "salario_liquido" }));
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolId: "salary-net-clt" }));
   });
 
   it("captures exception on save failure", async () => {

--- a/app/pages/tools/salario-liquido.vue
+++ b/app/pages/tools/salario-liquido.vue
@@ -100,8 +100,9 @@ async function handleSaveSimulation(): Promise<void> {
   if (savedSimulationId.value || !result.value) { return; }
   try {
     const sim = await saveSimulationMutation.mutateAsync({
-      name: t("salarioLiquido.simulation.defaultName"),
-      toolSlug: "salario_liquido",
+      toolId: "salary-net-clt",
+      ruleVersion: "2026.04",
+      metadata: { label: t("salarioLiquido.simulation.defaultName") },
       inputs: { ...form.value },
       result: {
         netSalary: result.value.netSalary,

--- a/app/pages/tools/tesouro-direto.spec.ts
+++ b/app/pages/tools/tesouro-direto.spec.ts
@@ -352,7 +352,7 @@ describe("TesouroDiretoPage — save simulation", () => {
     await saveButton!.trigger("click");
     await flushPromises();
     expect(mockSaveMutateAsync).toHaveBeenCalledOnce();
-    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolSlug: "tesouro_direto" }));
+    expect(mockSaveMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ toolId: "treasury" }));
   });
 
   it("captures exception when save simulation fails", async () => {

--- a/app/pages/tools/tesouro-direto.vue
+++ b/app/pages/tools/tesouro-direto.vue
@@ -67,11 +67,14 @@ const {
 } = useToolPage<TesouroDiretoFormState, TesouroDiretoResult>({
   createDefaultState: createDefaultTesouroDiretoFormState,
   buildSimulationPayload: ({ form, result, t }) => ({
-    name: t("tesouroDireto.simulation.defaultName", {
-      type: form.type,
-      year: new Date().getFullYear(),
-    }),
-    toolSlug: "tesouro_direto",
+    toolId: "treasury",
+    ruleVersion: "2026.04",
+    metadata: {
+      label: t("tesouroDireto.simulation.defaultName", {
+        type: form.type,
+        year: new Date().getFullYear(),
+      }),
+    },
     inputs: { ...form },
     result: {
       netAmount: result.netAmount,


### PR DESCRIPTION
## Summary

Implements the web side of DEC-196: every tool page now talks to the canonical `/simulations` endpoint shipped in [auraxis-api#1130](https://github.com/italofelipe/auraxis-api/pull/1130) and adopts the leave-without-save UX prompt.

Closes #783.

## Why this PR is mandatory

After the API merge, the legacy body shape `{name, tool_slug, goal_id}` started returning **422 VALIDATION_ERROR** on every save: `tool_slug` is no longer accepted and `tool_id` must come from the canonical registry. Without this PR, **save-simulation breaks for every tool on web**.

## What changed

### 1. Canonical contracts (`features/simulations/`)
- `contracts/simulation.dto.ts` — new `SimulationDto`, `SaveSimulationRequestDto`, `SimulationListResponseDto`, `SimulationMetadataDto`.
- `model/simulation.ts` — domain types now expose `toolId`, `ruleVersion`, `metadata`, `saved` and a `SimulationList` envelope.
- `services/simulation.client.ts` — rewritten to unwrap the v2 envelope (`response.data.data...`), accept `ListSimulationsParams` (page, perPage, toolId), and expose `getSimulation(id)`.
- `model/simulation-card.mapper.ts` — derives the legacy `SimulationType` from `toolId` via a kebab-case lookup. Falls back to `metadata.label > result.summary > toolId` for the card title.
- `queries/use-save-simulation-mutation.ts` — invalidates the simulations query on success.
- `queries/use-simulations-query.ts` — returns `{cards, simulations, total, page, perPage, pages}` so the listing page can drive both the visual cards and per-tool detail views from a single query.
- `pages/simulations.vue` — reads cards from the new query result shape.

### 2. Tools catalog mirror + leave-prompt composable
- `features/tools/tools-catalog.ts` — mirror of the app catalog and the backend `TOOLS_REGISTRY`. Drift will be detected by the per-repo parity check the next time a tool is added.
- `composables/useLeaveWithoutSavePrompt/` — implements the DEC-196 UX rule. Hooks both Vue Router `onBeforeRouteLeave` and the browser's `beforeunload` event so tab close, reload and route change all go through the same prompt. `confirmLeave()` is exposed for pages that need a custom Cancelar button. Copy stored under `leaveWithoutSavePrompt.*` in the pt locale (en stays frozen).

### 3. Tool page migration (23 tools)
Every tool page that called `useSaveSimulationMutation` now sends the canonical body `{toolId, ruleVersion, inputs, result, metadata.label}`. Tools whose legacy slug does not yet exist in the canonical registry (`aposentadoria`, `desconto-markup`) keep the legacy id with a `TODO(simulations-canonical)` comment — save will return 422 from the backend until the id is added to all three mirrors. Tracked as follow-up.

`SaveSimulationButton.vue` props were renamed: `toolSlug → toolId`, `name → label`, plus a new `ruleVersion`.

`thirteenth-salary` adopts `useLeaveWithoutSavePrompt` as the canonical example of the UX contract — the prompt only fires when `result` is set and `savedSimulationId` is null, and discarding clears state.

## Tests

- 24 tool page specs migrated from `toolSlug:"x_y"` assertions to `toolId:"x-y"`.
- `SaveSimulationButton.spec` exercises the new `toolId/ruleVersion/metadata.label` props.
- `useToolPage.spec` produces a canonical payload from `buildSimulationPayload`.
- `use-simulations-query.spec` rebuilt around the new `Simulation/SimulationList` shape and `{cards, simulations, total, ...}` return value.

```
Test Files  299 passed | 1 failed (300)
Tests       3097 passed | 2 failed (3099)
```

## Pre-existing failures (NOT caused by this PR)

The 2 failing assertions live in `useFinancialHealthScore.spec` (`scores at 20...`, `reaches >= 80...`) and were verified as failing on `main` via `git stash`. They appear to be a regression on the score algorithm since #586 introduced them. Out of scope for this PR — to be addressed in a follow-up.

Pushed with `--no-verify` after the user explicitly authorized it on this single push, since the pre-push hook fails on the same pre-existing tests.

## Pre-existing legacy bug surfaced (not fixed here)

`features/goals/services/goals.client.ts` returns `response.data` directly while the backend returns the v2 envelope `{success, data, message}` — the same drift my new client fixes for simulations. Left untouched here to keep this PR focused; tracked separately.

## Bridge between repos

- Backend contract: [auraxis-api#1130](https://github.com/italofelipe/auraxis-api/pull/1130) (merged) — `TOOLS_REGISTRY`, body cap 16 KB, rate limit 60/min/user, GraphQL queries.
- Mobile counterpart: [auraxis-app#326](https://github.com/italofelipe/auraxis-app/issues/326) (next PR — Lote B Investments).

## Test plan
- [ ] `pnpm lint` — green
- [ ] `pnpm typecheck` — green
- [ ] `pnpm test` — 3097 pass; 2 pre-existing health-score failures unchanged
- [ ] Manual: `/tools/decimo-terceiro` → calculate → leave page without saving → modal appears with 3 options
- [ ] Manual: `/simulations` lists rows with `tool_id` mapped correctly to legacy `SimulationType`