### PR TITLE
[WEB] Lint guard against raw <img> (#786)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -172,6 +172,29 @@ export default withNuxt(
       "no-restricted-syntax": "off",
     },
   },
+  // PERF-6 follow-up: every <img> must go through UiImage so that
+  // loading="lazy" + decoding="async" + intrinsic dims are baked in.
+  // Raw <img> in templates re-introduces CLS and eager-load regressions.
+  {
+    files: ["**/*.vue"],
+    rules: {
+      "vue/no-restricted-html-elements": [
+        "error",
+        {
+          element: "img",
+          message:
+            "Use UiImage from ~/components/ui/UiImage.vue (lazy + async decode + intrinsic dims by default).",
+        },
+      ],
+    },
+  },
+  // The UiImage wrapper itself emits a raw <img>.
+  {
+    files: ["app/components/ui/UiImage.vue"],
+    rules: {
+      "vue/no-restricted-html-elements": "off",
+    },
+  },
   {
     files: ["**/*.{test,spec,e2e}.{js,ts,tsx}", "**/__tests__/**/*.{js,ts,tsx}"],
     rules: {


### PR DESCRIPTION
## Summary

Closes #786.

**Audit revelou que a issue era um falso-positivo.** O web tem `UiImage` (`app/components/ui/UiImage.vue`) wrapping `<img>` com `loading="lazy"`, `decoding="async"`, e `width/height` obrigatórios para evitar CLS. `@nuxt/image` foi **deliberadamente removido** (`PERF-6`) porque a dep `sharp` quebra builds Docker ARM64 — `UiImage.vue` é o substituto canônico.

E o web tem **zero** `<img>` raw em templates de produção fora do próprio `UiImage.vue`.

## Refs

Closes #786
Plano: `auraxis-platform/.context/reports/historical/plan_quality_remediation_2026-05-01.md` fase 4.

## Why no migration

`UiImage` já entrega o que `<NuxtImg>` ofereceria, sem o custo de `sharp`:

```vue
<img
  :src="src"
  :alt="alt"
  :width="width"
  :height="height"
  loading="lazy"        // defer offscreen
  decoding="async"      // off-main-thread decode
  fetchpriority="auto"  // explicit priority hint
>
```

Defaults estão corretos para LCP + CLS. Resize/AVIF responsivo é deferido (decisão consciente: trade-off vs ARM64 builds).

## Scope shipped

1. **`eslint.config.mjs`** — adicionou `vue/no-restricted-html-elements` proibindo `<img>` em qualquer template `.vue`, com exceção apenas para `app/components/ui/UiImage.vue`.

```js
"vue/no-restricted-html-elements": ["error", {
  element: "img",
  message: "Use UiImage from ~/components/ui/UiImage.vue (lazy + async decode + intrinsic dims by default).",
}]
```

2. Removido arquivo duplicado `app/components/ui/UiImage 2.vue` (artefato iCloud que escapou do scan local).

## Test plan

- [x] `pnpm lint` — green (existing code já não usa `<img>` raw em templates)
- [x] `pnpm quality-check` — full chain verde (lint + typecheck + test:coverage + policy:check + contracts:check + build)
- [x] Build size: 20.4 MB total (4.92 MB gzip) — sem regressão.

## Risk

Zero. Apenas adiciona uma regra preventiva. Existing code já compatible.