### PR TITLE
feat(ci): production watchdog (Sentry + CloudWatch)

### DIFF
--- a/.github/workflows/agent-watchdog-prod.yml
+++ b/.github/workflows/agent-watchdog-prod.yml
@@ -1,0 +1,110 @@
+name: Agent — Production Watchdog
+
+on:
+  repository_dispatch:
+    types: [sentry-alert, cloudwatch-alarm]
+  workflow_dispatch:
+    inputs:
+      event_type:
+        description: "Tipo do evento (sentry-alert | cloudwatch-alarm)"
+        required: true
+        default: sentry-alert
+      payload:
+        description: "JSON payload do evento"
+        required: false
+        default: '{}'
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  prod-watchdog:
+    name: Production Watchdog — Create Incident Issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse event payload
+        id: payload
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            EVENT_TYPE="${{ github.event.action }}"
+            PAYLOAD='${{ toJson(github.event.client_payload) }}'
+          else
+            EVENT_TYPE="${{ inputs.event_type }}"
+            PAYLOAD='${{ inputs.payload }}'
+          fi
+          echo "event_type=$EVENT_TYPE" >> $GITHUB_OUTPUT
+          echo "payload=$PAYLOAD" >> $GITHUB_OUTPUT
+
+      - name: Check for existing open production incident
+        id: existing
+        run: |
+          EXISTING=$(gh issue list \
+            --repo ${{ github.repository }} \
+            --label "incident,production" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          echo "number=$EXISTING" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN_GITHUB_ADMIN }}
+
+      - name: Create production incident issue
+        if: steps.existing.outputs.number == ''
+        run: |
+          EVENT_TYPE="${{ steps.payload.outputs.event_type }}"
+          PAYLOAD='${{ steps.payload.outputs.payload }}'
+          TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
+
+          TITLE=$(echo "$PAYLOAD" | python3 -c "
+          import json,sys
+          d=json.loads(sys.stdin.read())
+          print(d.get('title') or d.get('alarm_name') or d.get('issue_title') or 'unknown')
+          " 2>/dev/null || echo "unknown")
+
+          URL=$(echo "$PAYLOAD" | python3 -c "
+          import json,sys
+          d=json.loads(sys.stdin.read())
+          print(d.get('url') or d.get('web_url') or '')
+          " 2>/dev/null || echo "")
+
+          gh issue create \
+            --repo ${{ github.repository }} \
+            --title "incident(prod): ${EVENT_TYPE} — ${TITLE}" \
+            --label "incident,production,bug,agent:claude" \
+            --body "## Production Incident Detected
+
+          **Event type:** \`${EVENT_TYPE}\`
+          **Detected at:** ${TIMESTAMP}
+          **Source URL:** ${URL}
+
+          ## Raw payload
+          \`\`\`json
+          ${PAYLOAD}
+          \`\`\`
+
+          ## Investigation steps (agent)
+
+          1. Verificar logs de produção no Sentry: issues mais recentes
+          2. Verificar CloudWatch metrics: CPU, Memory, 5xx rate, latência p95
+          3. Identificar commit causador: \`git log --oneline -20\`
+          4. Se regressão identificada: abrir PR de fix com label \`agent:claude\`
+          5. Se não identificado: comentar nesta issue com achados e escalar para humano
+
+          > Issue criada automaticamente pelo Production Watchdog.
+          > Label \`agent:claude\` adicionada — o agente irá investigar."
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN_GITHUB_ADMIN }}
+
+      - name: Comment on existing incident
+        if: steps.existing.outputs.number != ''
+        run: |
+          gh issue comment ${{ steps.existing.outputs.number }} \
+            --repo ${{ github.repository }} \
+            --body "Novo evento detectado: \`${{ steps.payload.outputs.event_type }}\` @ $(date -u '+%Y-%m-%d %H:%M UTC')"
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN_GITHUB_ADMIN }}


### PR DESCRIPTION
Closes #801

## O que muda
- Adiciona `.github/workflows/agent-watchdog-prod.yml`
- Trigger: `repository_dispatch` com `sentry-alert` ou `cloudwatch-alarm`
- Cria issue de incidente com labels `incident,production,bug,agent:claude`
- Comenta em incidente existente se já houver um aberto
- Fecha o loop autônomo: erro em prod → issue automática → agente investiga

## Sem conflitos
Branch baseado em `main` após PR #804 (E2E) já mergeado.