### PR TITLE
docs(agent): elevate web to 95% agent maturity

### DIFF
--- a/.claude/hooks/pre-tool-use.py
+++ b/.claude/hooks/pre-tool-use.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""auraxis-web pre-tool-use hook."""
+from __future__ import annotations
+import json, re, sys
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
+    if tool_name == "Bash":
+        _check_bash(tool_input.get("command", ""))
+    elif tool_name in ("Write", "Edit"):
+        content = tool_input.get("content", "") or tool_input.get("new_string", "")
+        _check_file_write(tool_input.get("file_path", ""), content=content)
+
+def _check_bash(command: str) -> None:
+    hard_blocks = [
+        (r"git add \.(\s|$)", "BLOQUEADO: 'git add .' proibido. Use: git add <arquivo>"),
+        (r"git add -A(\s|$)", "BLOQUEADO: 'git add -A' proibido."),
+        (r"git add --all(\s|$)", "BLOQUEADO: 'git add --all' proibido."),
+        (r"git push --force", "BLOQUEADO: push --force requer aprovação humana."),
+        (r"git push -f(\s|$)", "BLOQUEADO: push -f requer aprovação humana."),
+        (r"git commit --no-verify", "BLOQUEADO: --no-verify pula quality gates."),
+        (r"git commit -n(\s|$)", "BLOQUEADO: -n pula quality gates."),
+        (r"git push\s+(\S+\s+)?(main|master)(\s|$)", "BLOQUEADO: push direto para main/master. Use PR."),
+    ]
+    soft_warns = [
+        (r"git reset --hard", "⚠️ AVISO: git reset --hard é destrutivo."),
+        (r"rm -rf", "⚠️ AVISO: rm -rf é destrutivo."),
+        (r"git clean -f", "⚠️ AVISO: git clean -f remove arquivos permanentemente."),
+    ]
+    for pattern, msg in hard_blocks:
+        if re.search(pattern, command):
+            print(msg, file=sys.stderr); sys.exit(2)
+    for pattern, msg in soft_warns:
+        if re.search(pattern, command):
+            print(msg, file=sys.stderr)
+
+_ENV_FILE_RE = re.compile(r"(^|/)\.env(?:\.(?!example$)[\w.-]+)?$")
+_SENSITIVE = ("secrets.", "credentials.")
+_TEST_DISABLE = ("skip(", "xit(", "xtest(", "xdescribe(")
+
+def _check_file_write(file_path: str, content: str = "") -> None:
+    for s in _SENSITIVE:
+        if s in file_path:
+            print(f"BLOQUEADO: escrita em '{file_path}' proibida.", file=sys.stderr); sys.exit(2)
+    if _ENV_FILE_RE.search(file_path):
+        print(f"BLOQUEADO: escrita em '{file_path}' proibida (.env).", file=sys.stderr); sys.exit(2)
+    # EN locale freeze
+    if file_path.endswith("locales/en.json"):
+        print("⚠️ AVISO: en.json está CONGELADO (DEC-186).\nPara modificar: adicione '[en-freeze-bypass]' no commit subject E atualize .en-frozen.sha256", file=sys.stderr)
+    # E2E CI gotcha
+    if "ci.yml" in file_path:
+        print("⚠️ AVISO: editando ci.yml.\nNão re-introduza 'download-artifact' no job E2E — ele deve fazer 'pnpm build' local.", file=sys.stderr)
+    # Coverage regression
+    if "vitest.config" in file_path or "nuxt.config" in file_path:
+        print("⚠️ AVISO: editando config de qualidade. Não reduza threshold de 85%.", file=sys.stderr)
+    # Test disable guard
+    is_test = any(file_path.endswith(ext) for ext in (".spec.ts", ".test.ts", ".spec.vue"))
+    if is_test and content:
+        for dp in _TEST_DISABLE:
+            if dp in content and "// reason:" not in content:
+                print(f"BLOQUEADO: '{dp}' sem justificativa. Use // reason:", file=sys.stderr); sys.exit(2)
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/pre-tool-use.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ storybook-test-results/
 
 # Claude Code agent worktrees and session data
 .claude/worktrees/
-.claude/
 
 # pnpm patch files
 *.patch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,60 @@ Ver `.context/quality_gates.md` (local) e `auraxis-platform/.context/25_quality_
 - Commitar sem rodar quality gates
 - Usar `git add .` (sempre staged seletivamente)
 
+## Mapa de estado
+
+| Responsabilidade                  | Solução                   | Localização                                    |
+| --------------------------------- | ------------------------- | ---------------------------------------------- |
+| Server state (dados da API)       | TanStack Query            | `app/features/*/queries/`                      |
+| UI state global (modais, sidebar) | Pinia stores              | `app/stores/` ou `app/features/*/composables/` |
+| Form state                        | `useForm` / Naive UI Form | dentro do componente ou composable             |
+| Session / auth                    | Pinia + localStorage      | `app/features/auth/`                           |
+
+**Regra:** nunca sincronize manualmente server state. Use `queryClient.invalidateQueries()`.
+
+## Design system — Naive UI disponível
+
+Todos os componentes Naive UI estão disponíveis globalmente.
+Antes de criar componente custom, verifique:
+
+- Naive UI docs: https://www.naiveui.com/en-US/os-theme/components
+- `app/shared/components/` — wrappers e extensões customizadas do projeto
+
+Wrappers customizados disponíveis (sempre prefira estes):
+
+- `UiButton`, `UiCard`, `UiMetricCard`, `UiEmptyState`, `UiInlineError`
+- `UiChart` — wrapper ECharts com tema Auraxis
+- `UiImage` — substituto de `<img>` (com lazy loading)
+- `AppSkeleton` — skeleton loader unificado
+- `useToast` — composable unificado para notificações (não use `useMessage` diretamente)
+
+## Padrão de feature layer
+
+```
+app/features/<domain>/
+  contracts/     # DTOs e tipos alinhados ao contrato REST/GraphQL
+  api/           # HTTP client + mapper DTO → domínio
+  queries/       # Vue Query hooks (useQuery / useMutation)
+  composables/   # Estado reativo e orquestração fina
+  components/    # Componentes Vue exclusivos da feature
+  services/      # Regras de negócio puras (sem Vue)
+  model/         # Tipos de domínio e view models
+```
+
+**Sem import lateral entre features.** Reutilizável → `app/shared/`.
+
+## Padrão de composable (Vue 3)
+
+```typescript
+// app/features/<domain>/composables/use<Domain>.ts
+export function use<Domain>() {
+  const query = use<Domain>Query();
+  const mutation = use<Domain>Mutation();
+  // derivar computed
+  return { data: computed(...), isLoading: query.isLoading, submit: mutation.mutate };
+}
+```
+
 ## Integração com platform
 
 Este repo é orchestrado por `auraxis-platform`.

--- a/app/core/CLAUDE.md
+++ b/app/core/CLAUDE.md
@@ -1,0 +1,30 @@
+# CLAUDE.md — `app/core/*`
+
+Infraestrutura não-visual do auraxis-web. Modificações aqui afetam toda a aplicação.
+
+## Módulos
+
+| Módulo                    | Responsabilidade                                        |
+| ------------------------- | ------------------------------------------------------- |
+| `app/core/http/`          | HTTP client com auth interceptors (ver CLAUDE.md local) |
+| `app/core/session/`       | Gerenciamento de sessão e tokens                        |
+| `app/core/observability/` | Sentry, analytics                                       |
+| `app/core/errors/`        | ApiError e helpers de diagnóstico                       |
+| `app/core/config/`        | Wrappers tipados de useRuntimeConfig()                  |
+| `app/core/query/`         | Configuração global do TanStack Query                   |
+| `app/core/validation/`    | Validadores de fronteira (zod schemas)                  |
+| `app/core/security/`      | Helpers de segurança (sanitização, CSP)                 |
+| `app/core/api/`           | Base clients e interceptors compartilhados              |
+
+## Regras
+
+- Nunca importar de `app/features/` dentro de `app/core/`
+- Mudanças em `app/core/http/` exigem testes de integração com interceptors
+- Mudanças em `app/core/session/` exigem aprovação — afeta auth flow
+- Toda adição de módulo novo requer entrada neste arquivo
+
+## O que perguntar antes
+
+- Qualquer modificação em `app/core/session/`
+- Adicionar novo módulo em `app/core/`
+- Mudar interceptors HTTP

--- a/steering.md
+++ b/steering.md
@@ -2,6 +2,43 @@
 
 Documento canônico de direção técnica do `auraxis-web`.
 
+## Decisões de arquitetura
+
+### ADR-001: Nuxt 4 + Naive UI como stack canônico
+
+Stack: Nuxt 4, Vue 3 Composition API, Naive UI, TanStack Query, Pinia, TypeScript strict.
+Não adicionar UI libraries alternativas (Vuetify, PrimeVue, etc.).
+
+### ADR-002: Feature-based architecture
+
+Toda lógica de domínio fica em `app/features/<domain>/`.
+Imports laterais entre features são proibidos.
+Componentes reutilizáveis vão para `app/shared/`.
+
+### ADR-003: TanStack Query como server state
+
+Nunca sincronize dados da API com `ref()` ou Pinia manualmente.
+Use `useQuery`/`useMutation` de `app/features/*/queries/`.
+
+### ADR-004: Locale EN congelado (DEC-186)
+
+`app/i18n/locales/en.json` está congelado durante MVP1.
+Para editar: commit com `[en-freeze-bypass]` no subject + update de `.en-frozen.sha256`.
+
+### ADR-005: E2E job faz build local (não artifact download)
+
+O job `e2e` em `ci.yml` deve sempre fazer `pnpm build` localmente.
+`download-artifact@v4` falha no mesmo run — não re-introduzir.
+
+## Governança
+
+- Branch: `type/scope-description`
+- Quality gate: `pnpm quality-check` antes de todo commit
+- Coverage: ≥ 85% (nunca regredir)
+- PRs: incluir `Closes #<n>` no body
+- Nunca commitar direto em main
+- GitHub Projects é a fonte de backlog
+
 ## Referências obrigatórias
 
 Antes de qualquer trabalho neste repo, ler:


### PR DESCRIPTION
## Summary

- **.claude/hooks/pre-tool-use.py**: safety guards (git add ., push force, .env writes, EN locale freeze warning, E2E CI gotcha, test disable guard)
- **.claude/settings.json**: wires pre-tool-use hook to all tool invocations
- **.gitignore updated**: track `.claude/` (hooks + settings are now committed); keep `worktrees/` excluded
- **steering.md expanded**: 5 ADRs added (Naive UI stack, feature arch, TanStack Query as server state, EN locale freeze DEC-186, E2E local build rule)
- **CLAUDE.md expanded**: state management map, Naive UI component catalogue, feature layer directory pattern, Vue 3 composable pattern
- **app/core/CLAUDE.md (new)**: catalogue of all core modules + modification rules (no feature imports, session changes need approval)

## What this enables

Autonomous agents can now operate in this repo with:
- Hard blocks on destructive git operations (enforced at hook level, not just documented)
- Warnings on known CI pitfalls (EN locale freeze, E2E artifact download anti-pattern)
- Complete state management decision tree (no guessing TanStack vs Pinia vs ref)
- Component catalogue to avoid duplicate UI work
- Feature layer and composable patterns to stay consistent with existing code

## Test plan

- [ ] Verify `.claude/settings.json` loads correctly in a new Claude Code session in this repo
- [ ] Confirm `git add .` triggers hook exit code 2
- [ ] Confirm writing to `.env` triggers hook exit code 2
- [ ] Confirm editing `locales/en.json` prints freeze warning (stderr, not blocking)
- [ ] Confirm `pnpm quality-check` still passes (no product code changed)