### PR TITLE
feat(paywall): gate premium pages by entitlement

### DIFF
--- a/app/components/paywall/PaywallGate.spec.ts
+++ b/app/components/paywall/PaywallGate.spec.ts
@@ -94,4 +94,28 @@ describe("PaywallGate", () => {
     expect(wrapper.find(".locked-slot").exists()).toBe(true);
     expect(wrapper.find(".default-slot").exists()).toBe(false);
   });
+
+  it("renders the default upgrade prompt when no locked slot is provided", () => {
+    useEntitlementQueryMock.mockReturnValue({
+      isLoading: ref(false),
+      data: ref(false),
+    });
+
+    const wrapper = mount(PaywallGate, {
+      props: { feature: "shared_entries" },
+      slots: {
+        default: defaultSlotContent,
+      },
+      global: {
+        stubs: {
+          UiUpgradePrompt: {
+            template: "<div data-testid='upgrade-prompt' />",
+          },
+        },
+      },
+    });
+
+    expect(wrapper.find("[data-testid='upgrade-prompt']").exists()).toBe(true);
+    expect(wrapper.find(".default-slot").exists()).toBe(false);
+  });
 });

--- a/app/components/paywall/PaywallGate.vue
+++ b/app/components/paywall/PaywallGate.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
+import UiUpgradePrompt from "~/components/paywall/UiUpgradePrompt.vue";
 import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
 import type { FeatureKey } from "~/features/paywall/model/entitlement";
 
@@ -16,7 +17,9 @@ const { isLoading, data: hasAccessData } = useEntitlementQuery(props.feature);
   <div class="paywall-gate">
     <BaseSkeleton v-if="isLoading" height="120px" />
     <slot v-else-if="hasAccessData === true" />
-    <slot v-else name="locked" />
+    <slot v-else name="locked">
+      <UiUpgradePrompt />
+    </slot>
   </div>
 </template>
 

--- a/app/components/paywall/UiUpgradePrompt.spec.ts
+++ b/app/components/paywall/UiUpgradePrompt.spec.ts
@@ -81,10 +81,22 @@ describe("UiUpgradePrompt", () => {
     expect(wrapper.find(".n-button").text()).toBe("paywall.upgradePrompt.ctaLabel");
   });
 
-  it("navigates to /plans when CTA is clicked", async () => {
+  it("navigates to /subscription when CTA is clicked", async () => {
     pushMock.mockResolvedValue(undefined);
 
     const wrapper = mount(UiUpgradePrompt, {
+      global: { stubs },
+    });
+
+    await wrapper.find(".n-button").trigger("click");
+    expect(pushMock).toHaveBeenCalledWith("/subscription");
+  });
+
+  it("uses the custom upgrade route when provided", async () => {
+    pushMock.mockResolvedValue(undefined);
+
+    const wrapper = mount(UiUpgradePrompt, {
+      props: { to: "/plans" },
       global: { stubs },
     });
 

--- a/app/components/paywall/UiUpgradePrompt.vue
+++ b/app/components/paywall/UiUpgradePrompt.vue
@@ -23,16 +23,25 @@ interface Props {
    * Falls back to the i18n value when omitted.
    */
   ctaLabel?: string;
+  /**
+   * Route used by the upgrade CTA.
+   */
+  to?: string;
 }
 
-defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  featureName: undefined,
+  description: undefined,
+  ctaLabel: undefined,
+  to: "/subscription",
+});
 
 const router = useRouter();
 const { t } = useI18n();
 
-/** Navigates the user to the plans page. */
+/** Navigates the user to the configured upgrade route. */
 const goToPlanos = (): void => {
-  void router.push("/plans");
+  void router.push(props.to);
 };
 </script>
 

--- a/app/components/ui/UiSidebarNavItem/UiSidebarNavItem.vue
+++ b/app/components/ui/UiSidebarNavItem/UiSidebarNavItem.vue
@@ -11,6 +11,7 @@ const props = withDefaults(defineProps<UiSidebarNavItemProps>(), {
 <template>
   <NuxtLink
     :to="props.to"
+    :prefetch="false"
     class="ui-sidebar-nav-item"
     :class="{
       'ui-sidebar-nav-item--active': props.active,

--- a/app/components/ui/UiSidebarNavItem/__tests__/UiSidebarNavItem.spec.ts
+++ b/app/components/ui/UiSidebarNavItem/__tests__/UiSidebarNavItem.spec.ts
@@ -4,8 +4,8 @@ import { LayoutDashboard } from "lucide-vue-next";
 import UiSidebarNavItem from "../UiSidebarNavItem.vue";
 
 const NuxtLinkStub = {
-  template: "<a :href=\"to\" v-bind=\"$attrs\"><slot /></a>",
-  props: ["to"],
+  template: "<a :href=\"to\" :data-prefetch=\"String(prefetch)\" v-bind=\"$attrs\"><slot /></a>",
+  props: ["to", "prefetch"],
 };
 
 const globalConfig = {
@@ -83,5 +83,13 @@ describe("UiSidebarNavItem", () => {
       global: globalConfig,
     });
     expect(wrapper.find("a").attributes("href")).toBe("/carteira");
+  });
+
+  it("disables route prefetch to avoid eager dashboard chunk requests", () => {
+    const wrapper = mount(UiSidebarNavItem, {
+      props: { label: "Dashboard", to: "/dashboard" },
+      global: globalConfig,
+    });
+    expect(wrapper.find("a").attributes("data-prefetch")).toBe("false");
   });
 });

--- a/app/features/paywall/services/entitlement.client.spec.ts
+++ b/app/features/paywall/services/entitlement.client.spec.ts
@@ -1,0 +1,75 @@
+import type { AxiosInstance } from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EntitlementClient } from "./entitlement.client";
+
+/**
+ * Builds an entitlement client backed by a mocked Axios adapter.
+ *
+ * @returns Test client and mocked get function.
+ */
+const makeClient = (): {
+  readonly client: EntitlementClient;
+  readonly get: ReturnType<typeof vi.fn>;
+} => {
+  const get = vi.fn();
+  const http = { get } as unknown as AxiosInstance;
+
+  return {
+    client: new EntitlementClient(http),
+    get,
+  };
+};
+
+describe("EntitlementClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reads active access from the v2 entitlement envelope", async () => {
+    const { client, get } = makeClient();
+    get.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          feature_key: "advanced_simulations",
+          active: true,
+        },
+      },
+    });
+
+    await expect(client.checkEntitlement("advanced_simulations")).resolves.toBe(true);
+    expect(get).toHaveBeenCalledWith("/entitlements/check", {
+      params: { feature_key: "advanced_simulations" },
+    });
+  });
+
+  it("keeps compatibility with flat active payloads", async () => {
+    const { client, get } = makeClient();
+    get.mockResolvedValue({ data: { active: true } });
+
+    await expect(client.checkEntitlement("export_pdf")).resolves.toBe(true);
+  });
+
+  it("keeps compatibility with legacy has_access payloads", async () => {
+    const { client, get } = makeClient();
+    get.mockResolvedValue({ data: { has_access: true } });
+
+    await expect(client.checkEntitlement("shared_entries")).resolves.toBe(true);
+  });
+
+  it("returns false when the entitlement is inactive", async () => {
+    const { client, get } = makeClient();
+    get.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          feature_key: "advanced_simulations",
+          active: false,
+        },
+      },
+    });
+
+    await expect(client.checkEntitlement("advanced_simulations")).resolves.toBe(false);
+  });
+});

--- a/app/features/paywall/services/entitlement.client.ts
+++ b/app/features/paywall/services/entitlement.client.ts
@@ -4,8 +4,63 @@ import { useHttp } from "~/composables/useHttp";
 import type { FeatureKey } from "~/features/paywall/model/entitlement";
 
 interface EntitlementCheckDto {
-  has_access: boolean;
+  readonly active?: boolean;
+  readonly has_access?: boolean;
 }
+
+interface EntitlementCheckEnvelopeDto {
+  readonly success?: boolean;
+  readonly message?: string;
+  readonly data?: EntitlementCheckDto | null;
+}
+
+type EntitlementCheckResponseDto = EntitlementCheckDto | EntitlementCheckEnvelopeDto;
+
+/**
+ * Detects the standard v2 response envelope used by the backend.
+ *
+ * @param payload Entitlement check response body.
+ * @returns True when the payload wraps data inside `data`.
+ */
+const isEntitlementEnvelope = (
+  payload: EntitlementCheckResponseDto,
+): payload is EntitlementCheckEnvelopeDto => {
+  return (
+    payload !== null &&
+    typeof payload === "object" &&
+    "data" in payload
+  );
+};
+
+/**
+ * Extracts the entitlement payload while preserving legacy flat responses.
+ *
+ * @param payload Entitlement check response body.
+ * @returns Flat entitlement payload.
+ */
+const unwrapEntitlementCheck = (
+  payload: EntitlementCheckResponseDto,
+): EntitlementCheckDto => {
+  if (isEntitlementEnvelope(payload)) {
+    return payload.data ?? {};
+  }
+
+  return payload;
+};
+
+/**
+ * Converts backend entitlement fields into the boolean consumed by UI gates.
+ *
+ * @param payload Flat entitlement payload.
+ * @returns True when the feature is available to the current user.
+ */
+const toAccessBoolean = (payload: EntitlementCheckDto): boolean => {
+  if (typeof payload.active === "boolean") {
+    return payload.active;
+  }
+
+  return payload.has_access === true;
+};
 
 /**
  * API client for the entitlements feature.
@@ -29,11 +84,12 @@ export class EntitlementClient {
    * @returns True when the user has access to the feature.
    */
   async checkEntitlement(featureKey: FeatureKey): Promise<boolean> {
-    const response = await this.#http.get<EntitlementCheckDto>(
+    const response = await this.#http.get<EntitlementCheckResponseDto>(
       "/entitlements/check",
       { params: { feature_key: featureKey } },
     );
-    return response.data.has_access;
+
+    return toAccessBoolean(unwrapEntitlementCheck(response.data));
   }
 }
 

--- a/app/features/shared-entries/queries/use-shared-by-me-query.spec.ts
+++ b/app/features/shared-entries/queries/use-shared-by-me-query.spec.ts
@@ -1,3 +1,4 @@
+import { ref } from "vue";
 import { describe, it, expect, vi } from "vitest";
 
 import { useSharedByMeQuery } from "./use-shared-by-me-query";
@@ -45,6 +46,25 @@ describe("useSharedByMeQuery", () => {
     };
 
     expect(result.queryKey).toEqual(["shared-entries", "by-me"]);
+  });
+
+  it("honors the enabled flag so premium gates can stop free-user fetches", () => {
+    const client = { getSharedByMe: vi.fn().mockResolvedValue([]) };
+    const enabled = ref(false);
+
+    useQueryMock.mockImplementation((opts: Record<string, unknown>) => opts);
+
+    const result = useSharedByMeQuery(client as never, enabled) as unknown as {
+      enabled: { value: boolean } | boolean;
+    };
+
+    const enabledValue =
+      typeof result.enabled === "object" && result.enabled !== null
+        ? result.enabled.value
+        : result.enabled;
+
+    expect(enabledValue).toBe(false);
+    expect(client.getSharedByMe).not.toHaveBeenCalled();
   });
 
   it("delegates to client.getSharedByMe when mock data is disabled", async () => {

--- a/app/features/shared-entries/queries/use-shared-by-me-query.ts
+++ b/app/features/shared-entries/queries/use-shared-by-me-query.ts
@@ -1,3 +1,4 @@
+import { computed, type MaybeRef, unref } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
@@ -16,12 +17,15 @@ import type { SharedEntryDto } from "~/features/shared-entries/contracts/shared-
  * Errors propagate as query error state — no silent catch.
  *
  * @param providedClient Optional injected client for unit tests.
+ * @param enabled Reactive flag that controls whether the API query should run.
  * @returns Vue Query state with typed SharedEntryDto[] data.
  */
 export const useSharedByMeQuery = (
   providedClient?: SharedEntriesClient,
+  enabled: MaybeRef<boolean> = true,
 ): UseQueryReturnType<SharedEntryDto[], Error> => {
   const client = providedClient ?? useSharedEntriesClient();
+  const isEnabled = computed(() => unref(enabled));
 
   return useQuery({
     queryKey: ["shared-entries", "by-me"] as const,
@@ -31,6 +35,7 @@ export const useSharedByMeQuery = (
       }
       return client.getSharedByMe();
     },
+    enabled: isEnabled,
     staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/shared-entries/queries/use-shared-with-me-query.spec.ts
+++ b/app/features/shared-entries/queries/use-shared-with-me-query.spec.ts
@@ -1,3 +1,4 @@
+import { ref } from "vue";
 import { describe, it, expect, vi } from "vitest";
 
 import { useSharedWithMeQuery } from "./use-shared-with-me-query";
@@ -45,6 +46,25 @@ describe("useSharedWithMeQuery", () => {
     };
 
     expect(result.queryKey).toEqual(["shared-entries", "with-me"]);
+  });
+
+  it("honors the enabled flag so premium gates can stop free-user fetches", () => {
+    const client = { getSharedWithMe: vi.fn().mockResolvedValue([]) };
+    const enabled = ref(false);
+
+    useQueryMock.mockImplementation((opts: Record<string, unknown>) => opts);
+
+    const result = useSharedWithMeQuery(client as never, enabled) as unknown as {
+      enabled: { value: boolean } | boolean;
+    };
+
+    const enabledValue =
+      typeof result.enabled === "object" && result.enabled !== null
+        ? result.enabled.value
+        : result.enabled;
+
+    expect(enabledValue).toBe(false);
+    expect(client.getSharedWithMe).not.toHaveBeenCalled();
   });
 
   it("delegates to client.getSharedWithMe when mock data is disabled", async () => {

--- a/app/features/shared-entries/queries/use-shared-with-me-query.ts
+++ b/app/features/shared-entries/queries/use-shared-with-me-query.ts
@@ -1,3 +1,4 @@
+import { computed, type MaybeRef, unref } from "vue";
 import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
 
 import { isMockDataEnabled } from "~/core/config";
@@ -16,12 +17,15 @@ import type { SharedEntryDto } from "~/features/shared-entries/contracts/shared-
  * Errors propagate as query error state — no silent catch.
  *
  * @param providedClient Optional injected client for unit tests.
+ * @param enabled Reactive flag that controls whether the API query should run.
  * @returns Vue Query state with typed SharedEntryDto[] data.
  */
 export const useSharedWithMeQuery = (
   providedClient?: SharedEntriesClient,
+  enabled: MaybeRef<boolean> = true,
 ): UseQueryReturnType<SharedEntryDto[], Error> => {
   const client = providedClient ?? useSharedEntriesClient();
+  const isEnabled = computed(() => unref(enabled));
 
   return useQuery({
     queryKey: ["shared-entries", "with-me"] as const,
@@ -31,6 +35,7 @@ export const useSharedWithMeQuery = (
       }
       return client.getSharedWithMe();
     },
+    enabled: isEnabled,
     staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/simulations/queries/use-simulations-query.spec.ts
+++ b/app/features/simulations/queries/use-simulations-query.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
 
 import { useSimulationsQuery } from "./use-simulations-query";
 import type { Simulation, SimulationList } from "~/features/simulations/model/simulation";
@@ -70,6 +71,29 @@ describe("useSimulationsQuery", () => {
       type: "installment_vs_cash",
       name: "Minha simulação",
     });
+  });
+
+  it("honors the enabled flag so premium gates can stop free-user fetches", () => {
+    const client = {
+      listSimulations: vi.fn().mockResolvedValue(makeList([])),
+    };
+    const enabled = ref(false);
+    useQueryMock.mockImplementation((opts: Record<string, unknown>) => opts);
+
+    const query = useSimulationsQuery({
+      providedClient: client as never,
+      enabled,
+    }) as unknown as {
+      enabled: { value: boolean } | boolean;
+    };
+
+    const enabledValue =
+      typeof query.enabled === "object" && query.enabled !== null
+        ? query.enabled.value
+        : query.enabled;
+
+    expect(enabledValue).toBe(false);
+    expect(client.listSimulations).not.toHaveBeenCalled();
   });
 
   it("propagates error from client.listSimulations without catching it", async () => {

--- a/app/features/simulations/queries/use-simulations-query.ts
+++ b/app/features/simulations/queries/use-simulations-query.ts
@@ -20,6 +20,7 @@ export type SimulationsQueryParams = ListSimulationsParams;
 export interface UseSimulationsQueryOptions {
   readonly params?: MaybeRef<SimulationsQueryParams | undefined>;
   readonly providedClient?: SimulationClient;
+  readonly enabled?: MaybeRef<boolean>;
 }
 
 interface SimulationsQueryResult {
@@ -54,6 +55,9 @@ export const useSimulationsQuery = (
 ): UseQueryReturnType<SimulationsQueryResult, Error> => {
   const client = options.providedClient ?? useSimulationClient();
   const params = computed(() => unref(options.params));
+  const isEnabled = computed(() =>
+    options.enabled === undefined ? true : unref(options.enabled),
+  );
 
   const queryKey = computed(
     () => ["simulations", params.value ?? {}] as const,
@@ -83,6 +87,7 @@ export const useSimulationsQuery = (
         pages: list.pages,
       };
     },
+    enabled: isEnabled,
     staleTime: STALE_TIME.STABLE,
   });
 };

--- a/app/features/subscription/contracts/subscription.dto.ts
+++ b/app/features/subscription/contracts/subscription.dto.ts
@@ -13,12 +13,19 @@
 
 // ── Original API-bound DTOs (used by subscription.client + subscription.mapper) ──
 
-export type SubscriptionStatusDto = "active" | "trialing" | "past_due" | "canceled";
+export type SubscriptionStatusDto =
+  | "active"
+  | "trialing"
+  | "past_due"
+  | "canceled"
+  | "free"
+  | "expired";
 
 /** @deprecated Use SubscriptionDto (view-layer) for page/component usage. */
 export interface ApiSubscriptionDto {
   readonly id: string;
-  readonly plan_slug: string;
+  readonly plan_slug?: string;
+  readonly plan_code?: string;
   readonly status: SubscriptionStatusDto;
   readonly trial_ends_at: string | null;
   readonly current_period_end: string | null;

--- a/app/features/subscription/services/subscription.client.spec.ts
+++ b/app/features/subscription/services/subscription.client.spec.ts
@@ -1,0 +1,101 @@
+import type { AxiosInstance } from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SubscriptionClient } from "./subscription.client";
+
+/**
+ * Builds a subscription client backed by mocked Axios methods.
+ *
+ * @returns Test client and mocked HTTP methods.
+ */
+const makeClient = (): {
+  readonly client: SubscriptionClient;
+  readonly get: ReturnType<typeof vi.fn>;
+  readonly post: ReturnType<typeof vi.fn>;
+} => {
+  const get = vi.fn();
+  const post = vi.fn();
+  const http = { get, post } as unknown as AxiosInstance;
+
+  return {
+    client: new SubscriptionClient(http),
+    get,
+    post,
+  };
+};
+
+describe("SubscriptionClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("unwraps the current v2 /subscriptions/me envelope", async () => {
+    const { client, get } = makeClient();
+    get.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          subscription: {
+            id: "sub-premium",
+            plan_code: "premium",
+            offer_code: "premium_annual",
+            status: "active",
+            billing_cycle: "annual",
+            trial_ends_at: null,
+            current_period_end: "2036-05-16T17:08:02.072692",
+            provider: "manual_override",
+            provider_subscription_id: null,
+          },
+        },
+      },
+    });
+
+    await expect(client.getMySubscription()).resolves.toMatchObject({
+      id: "sub-premium",
+      planSlug: "premium",
+      status: "active",
+      provider: "manual_override",
+    });
+  });
+
+  it("keeps compatibility with flat subscription payloads", async () => {
+    const { client, get } = makeClient();
+    get.mockResolvedValue({
+      data: {
+        id: "sub-legacy",
+        plan_slug: "premium",
+        status: "trialing",
+        trial_ends_at: "2026-06-01T00:00:00.000Z",
+        current_period_end: "2026-06-30T00:00:00.000Z",
+        provider: null,
+        provider_subscription_id: null,
+      },
+    });
+
+    await expect(client.getMySubscription()).resolves.toMatchObject({
+      id: "sub-legacy",
+      planSlug: "premium",
+      status: "trialing",
+    });
+  });
+
+  it("unwraps checkout URLs from the v2 envelope", async () => {
+    const { client, post } = makeClient();
+    post.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          checkout_url: "https://billing.example/checkout",
+        },
+      },
+    });
+
+    await expect(client.createCheckout("premium", "annual")).resolves.toBe(
+      "https://billing.example/checkout",
+    );
+    expect(post).toHaveBeenCalledWith("/subscriptions/checkout", {
+      plan_slug: "premium",
+      billing_cycle: "annual",
+    });
+  });
+});

--- a/app/features/subscription/services/subscription.client.ts
+++ b/app/features/subscription/services/subscription.client.ts
@@ -9,6 +9,73 @@ import type {
 import { mapSubscriptionDto } from "~/features/subscription/services/subscription.mapper";
 import type { Subscription } from "~/features/subscription/model/subscription";
 
+interface SubscriptionDataEnvelopeDto {
+  readonly subscription?: ApiSubscriptionDto | null;
+}
+
+interface V2EnvelopeDto<T> {
+  readonly success?: boolean;
+  readonly message?: string;
+  readonly data?: T | null;
+}
+
+type SubscriptionResponseDto =
+  | ApiSubscriptionDto
+  | V2EnvelopeDto<ApiSubscriptionDto | SubscriptionDataEnvelopeDto>;
+
+type CheckoutResponseBodyDto =
+  | CheckoutResponseDto
+  | V2EnvelopeDto<CheckoutResponseDto>;
+
+/**
+ * Narrows unknown payloads to plain object-like records.
+ *
+ * @param value Candidate value.
+ * @returns True when the value can be inspected as a record.
+ */
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return value !== null && typeof value === "object";
+};
+
+/**
+ * Extracts the subscription DTO from the v2 envelope while keeping legacy
+ * flat payload compatibility.
+ *
+ * @param payload Subscription endpoint response body.
+ * @returns Raw subscription DTO.
+ */
+const unwrapSubscription = (
+  payload: SubscriptionResponseDto,
+): ApiSubscriptionDto => {
+  if (isRecord(payload) && "data" in payload) {
+    const data = payload.data;
+
+    if (isRecord(data) && "subscription" in data && isRecord(data.subscription)) {
+      return data.subscription as unknown as ApiSubscriptionDto;
+    }
+
+    if (isRecord(data)) {
+      return data as unknown as ApiSubscriptionDto;
+    }
+  }
+
+  return payload as ApiSubscriptionDto;
+};
+
+/**
+ * Extracts the checkout DTO from the v2 envelope while keeping legacy payloads.
+ *
+ * @param payload Checkout endpoint response body.
+ * @returns Raw checkout DTO.
+ */
+const unwrapCheckout = (payload: CheckoutResponseBodyDto): CheckoutResponseDto => {
+  if (isRecord(payload) && "data" in payload && isRecord(payload.data)) {
+    return payload.data as unknown as CheckoutResponseDto;
+  }
+
+  return payload as CheckoutResponseDto;
+};
+
 /**
  * API client for the subscription feature.
  *
@@ -31,8 +98,8 @@ export class SubscriptionClient {
    * @returns Mapped subscription view model.
    */
   async getMySubscription(): Promise<Subscription> {
-    const response = await this.#http.get<ApiSubscriptionDto>("/subscriptions/me");
-    return mapSubscriptionDto(response.data);
+    const response = await this.#http.get<SubscriptionResponseDto>("/subscriptions/me");
+    return mapSubscriptionDto(unwrapSubscription(response.data));
   }
 
   /**
@@ -43,11 +110,11 @@ export class SubscriptionClient {
    * @returns Checkout URL to redirect the user to.
    */
   async createCheckout(planSlug: string, billingCycle: BillingCycle = "monthly"): Promise<string> {
-    const response = await this.#http.post<CheckoutResponseDto>("/subscriptions/checkout", {
+    const response = await this.#http.post<CheckoutResponseBodyDto>("/subscriptions/checkout", {
       plan_slug: planSlug,
       billing_cycle: billingCycle,
     });
-    return response.data.checkout_url;
+    return unwrapCheckout(response.data).checkout_url;
   }
 
   /**

--- a/app/features/subscription/services/subscription.mapper.spec.ts
+++ b/app/features/subscription/services/subscription.mapper.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { mapSubscriptionDto } from "./subscription.mapper";
+
+describe("mapSubscriptionDto", () => {
+  it("maps the current backend plan_code field into planSlug", () => {
+    expect(
+      mapSubscriptionDto({
+        id: "sub-1",
+        plan_code: "premium",
+        status: "active",
+        trial_ends_at: null,
+        current_period_end: "2036-05-16T17:08:02.072692",
+        provider: "manual_override",
+        provider_subscription_id: null,
+      }),
+    ).toMatchObject({
+      id: "sub-1",
+      planSlug: "premium",
+      status: "active",
+      provider: "manual_override",
+    });
+  });
+
+  it("normalizes free backend status for existing UI badges", () => {
+    expect(
+      mapSubscriptionDto({
+        id: "sub-free",
+        plan_code: "free",
+        status: "free",
+        trial_ends_at: null,
+        current_period_end: null,
+        provider: null,
+        provider_subscription_id: null,
+      }),
+    ).toMatchObject({
+      planSlug: "free",
+      status: "active",
+    });
+  });
+});

--- a/app/features/subscription/services/subscription.mapper.ts
+++ b/app/features/subscription/services/subscription.mapper.ts
@@ -8,10 +8,20 @@ import type { Subscription } from "~/features/subscription/model/subscription";
  * @returns Mapped Subscription view model (camelCase).
  */
 export const mapSubscriptionDto = (dto: ApiSubscriptionDto): Subscription => {
+  let normalizedStatus: Subscription["status"];
+
+  if (dto.status === "expired") {
+    normalizedStatus = "canceled";
+  } else if (dto.status === "free") {
+    normalizedStatus = "active";
+  } else {
+    normalizedStatus = dto.status;
+  }
+
   return {
     id: dto.id,
-    planSlug: dto.plan_slug,
-    status: dto.status,
+    planSlug: dto.plan_slug ?? dto.plan_code ?? "free",
+    status: normalizedStatus,
     trialEndsAt: dto.trial_ends_at,
     currentPeriodEnd: dto.current_period_end,
     provider: dto.provider,

--- a/app/pages/focus.vue
+++ b/app/pages/focus.vue
@@ -38,7 +38,7 @@ const onSelect = (id: FocusMetricId): void => {
   selectMetric(id);
 };
 
-const upgradeHref = computed<string>(() => "/plans");
+const upgradeHref = computed<string>(() => "/subscription");
 </script>
 
 <template>

--- a/app/pages/shared-entries.entitlement.spec.ts
+++ b/app/pages/shared-entries.entitlement.spec.ts
@@ -1,0 +1,180 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { computed, ref, type App } from "vue";
+
+import SharedEntriesPage from "./shared-entries.vue";
+
+const useSharedByMeQueryMock = vi.hoisted(() => vi.fn());
+const useSharedWithMeQueryMock = vi.hoisted(() => vi.fn());
+const useRevokeSharedEntryMutationMock = vi.hoisted(() => vi.fn());
+const useEntitlementQueryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("#imports", () => ({
+  computed,
+  definePageMeta: vi.fn(),
+  ref,
+  useHead: vi.fn(),
+  useI18n: (): { t: (key: string) => string } => ({
+    t: (key: string): string => key,
+  }),
+}));
+
+vi.mock("~/features/shared-entries/queries/use-shared-by-me-query", () => ({
+  useSharedByMeQuery: useSharedByMeQueryMock,
+}));
+
+vi.mock("~/features/shared-entries/queries/use-shared-with-me-query", () => ({
+  useSharedWithMeQuery: useSharedWithMeQueryMock,
+}));
+
+vi.mock("~/features/shared-entries/queries/use-revoke-shared-entry-mutation", () => ({
+  useRevokeSharedEntryMutation: useRevokeSharedEntryMutationMock,
+}));
+
+vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
+  useEntitlementQuery: useEntitlementQueryMock,
+}));
+
+vi.mock("~/components/paywall/PaywallGate.vue", () => ({
+  default: {
+    props: ["feature"],
+    template: `
+      <section data-testid="paywall-gate" :data-feature="feature">
+        <slot />
+        <slot name="locked" />
+      </section>
+    `,
+  },
+}));
+
+vi.mock("~/components/paywall/UiUpgradePrompt.vue", () => ({
+  default: {
+    props: ["featureName", "description", "ctaLabel"],
+    template: `
+      <div data-testid="upgrade-prompt">
+        <span>{{ featureName }}</span>
+        <span>{{ description }}</span>
+        <span>{{ ctaLabel }}</span>
+      </div>
+    `,
+  },
+}));
+
+const stubs = {
+  NPageHeader: {
+    props: ["title", "subtitle"],
+    template: "<header><h1>{{ title }}</h1><p>{{ subtitle }}</p></header>",
+  },
+  NCard: {
+    template: "<section><slot /></section>",
+  },
+  NStatistic: {
+    props: ["label", "value"],
+    template: "<div>{{ label }} {{ value }}</div>",
+  },
+  NTabs: {
+    template: "<div><slot /></div>",
+  },
+  NTabPane: {
+    props: ["name", "tab"],
+    template: "<section><slot /></section>",
+  },
+  UiInlineError: {
+    template: "<div data-testid='inline-error' />",
+  },
+  UiPageLoader: {
+    template: "<div data-testid='page-loader' />",
+  },
+  UiEmptyState: {
+    props: ["title", "description"],
+    template: "<div data-testid='empty-state'>{{ title }} {{ description }}</div>",
+  },
+  SharedEntryRow: {
+    template: "<div data-testid='shared-entry-row' />",
+  },
+};
+
+/**
+ * Installs the minimal Nuxt app context required by useHead in page tests.
+ *
+ * @param app Vue test app instance.
+ */
+function nuxtContextPlugin(app: App): void {
+  Reflect.set(app, "$nuxt", {
+    _route: {
+      path: "/shared-entries",
+      meta: {},
+      params: {},
+      query: {},
+    },
+    $config: { public: {} },
+    payload: { serverRendered: false },
+    ssrContext: {
+      head: {
+        push: vi.fn(() => ({
+          patch: vi.fn(),
+          dispose: vi.fn(),
+        })),
+      },
+    },
+    static: { data: {} },
+    isHydrating: false,
+    deferHydration: (): void => {},
+    runWithContext: <T>(callback: () => T): T => callback(),
+    hooks: { callHook: vi.fn(), hook: vi.fn() },
+    _asyncDataPromises: {},
+    _asyncData: {},
+  });
+}
+
+describe("SharedEntriesPage — entitlement gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSharedByMeQueryMock.mockReturnValue({
+      data: ref([]),
+      isLoading: ref(false),
+      isError: ref(false),
+    });
+    useSharedWithMeQueryMock.mockReturnValue({
+      data: ref([]),
+      isLoading: ref(false),
+      isError: ref(false),
+    });
+    useRevokeSharedEntryMutationMock.mockReturnValue({
+      mutate: vi.fn(),
+    });
+    useEntitlementQueryMock.mockReturnValue({
+      data: ref(false),
+      isLoading: ref(false),
+      isError: ref(false),
+    });
+  });
+
+  it("wraps the page content in the shared_entries paywall gate", () => {
+    const wrapper = mount(SharedEntriesPage, {
+      global: {
+        plugins: [{ install: nuxtContextPlugin }],
+        stubs,
+        mocks: { $t: (key: string): string => key },
+      },
+    });
+
+    const gate = wrapper.find("[data-testid='paywall-gate']");
+    expect(gate.exists()).toBe(true);
+    expect(gate.attributes("data-feature")).toBe("shared_entries");
+  });
+
+  it("renders an upgrade prompt for the locked shared entries state", () => {
+    const wrapper = mount(SharedEntriesPage, {
+      global: {
+        plugins: [{ install: nuxtContextPlugin }],
+        stubs,
+        mocks: { $t: (key: string): string => key },
+      },
+    });
+
+    const prompt = wrapper.find("[data-testid='upgrade-prompt']");
+    expect(prompt.exists()).toBe(true);
+    expect(prompt.text()).toContain("pages.sharedEntries.title");
+  });
+});

--- a/app/pages/shared-entries.vue
+++ b/app/pages/shared-entries.vue
@@ -9,6 +9,9 @@ import {
 import { useSharedByMeQuery } from "~/features/shared-entries/queries/use-shared-by-me-query";
 import { useSharedWithMeQuery } from "~/features/shared-entries/queries/use-shared-with-me-query";
 import { useRevokeSharedEntryMutation } from "~/features/shared-entries/queries/use-revoke-shared-entry-mutation";
+import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
+import PaywallGate from "~/components/paywall/PaywallGate.vue";
+import UiUpgradePrompt from "~/components/paywall/UiUpgradePrompt.vue";
 
 definePageMeta({
   layout: "default",
@@ -19,8 +22,15 @@ definePageMeta({
 
 useHead({ title: "Entradas Compartilhadas | Auraxis" });
 
-const { data: sharedByMe, isLoading: isByMeLoading, isError: isByMeError } = useSharedByMeQuery();
-const { data: sharedWithMe, isLoading: isWithMeLoading, isError: isWithMeError } = useSharedWithMeQuery();
+const sharedEntriesAccessQuery = useEntitlementQuery("shared_entries");
+const hasSharedEntriesAccess = computed(
+  () => sharedEntriesAccessQuery.data.value === true,
+);
+
+const { data: sharedByMe, isLoading: isByMeLoading, isError: isByMeError } =
+  useSharedByMeQuery(undefined, hasSharedEntriesAccess);
+const { data: sharedWithMe, isLoading: isWithMeLoading, isError: isWithMeError } =
+  useSharedWithMeQuery(undefined, hasSharedEntriesAccess);
 const revokeMutation = useRevokeSharedEntryMutation();
 
 const isLoading = computed(() => isByMeLoading.value || isWithMeLoading.value);
@@ -58,64 +68,75 @@ const onRevoke = (id: string): void => {
       :subtitle="$t('pages.sharedEntries.subtitle')"
     />
 
-    <UiInlineError
-      v-if="isError"
-      :title="$t('pages.sharedEntries.loadError')"
-      :message="$t('pages.sharedEntries.loadErrorMessage')"
-    />
+    <PaywallGate feature="shared_entries">
+      <UiInlineError
+        v-if="isError"
+        :title="$t('pages.sharedEntries.loadError')"
+        :message="$t('pages.sharedEntries.loadErrorMessage')"
+      />
 
-    <template v-else>
-      <NCard :bordered="true" class="shared-entries-page__summary-card">
-        <div class="shared-entries-page__summary-stats">
-          <NStatistic :label="$t('pages.sharedEntries.total')" :value="String(totalCount)" />
-          <NStatistic :label="$t('pages.sharedEntries.pending')" :value="String(pendingCount)" />
-          <NStatistic :label="$t('pages.sharedEntries.accepted')" :value="String(acceptedCount)" />
-        </div>
-      </NCard>
-
-      <UiPageLoader v-if="isLoading" :rows="3" />
-
-      <NTabs v-else type="line" animated>
-        <NTabPane name="by-me" :tab="$t('pages.sharedEntries.byMe')">
-          <div class="shared-entries-page__tab-content">
-            <UiEmptyState
-              v-if="byMeList.length === 0"
-              icon="transactions"
-              :title="$t('pages.sharedEntries.emptyByMeTitle')"
-              :description="$t('pages.sharedEntries.emptyByMe')"
-            />
-            <div v-else class="shared-entries-page__list">
-              <SharedEntryRow
-                v-for="entry in byMeList"
-                :key="entry.id"
-                :entry="entry"
-                mode="by-me"
-                @revoke="onRevoke"
-              />
-            </div>
+      <template v-else>
+        <NCard :bordered="true" class="shared-entries-page__summary-card">
+          <div class="shared-entries-page__summary-stats">
+            <NStatistic :label="$t('pages.sharedEntries.total')" :value="String(totalCount)" />
+            <NStatistic :label="$t('pages.sharedEntries.pending')" :value="String(pendingCount)" />
+            <NStatistic :label="$t('pages.sharedEntries.accepted')" :value="String(acceptedCount)" />
           </div>
-        </NTabPane>
+        </NCard>
 
-        <NTabPane name="with-me" :tab="$t('pages.sharedEntries.withMe')">
-          <div class="shared-entries-page__tab-content">
-            <UiEmptyState
-              v-if="withMeList.length === 0"
-              icon="transactions"
-              :title="$t('pages.sharedEntries.emptyWithMeTitle')"
-              :description="$t('pages.sharedEntries.emptyWithMe')"
-            />
-            <div v-else class="shared-entries-page__list">
-              <SharedEntryRow
-                v-for="entry in withMeList"
-                :key="entry.id"
-                :entry="entry"
-                mode="with-me"
+        <UiPageLoader v-if="isLoading" :rows="3" />
+
+        <NTabs v-else type="line" animated>
+          <NTabPane name="by-me" :tab="$t('pages.sharedEntries.byMe')">
+            <div class="shared-entries-page__tab-content">
+              <UiEmptyState
+                v-if="byMeList.length === 0"
+                icon="transactions"
+                :title="$t('pages.sharedEntries.emptyByMeTitle')"
+                :description="$t('pages.sharedEntries.emptyByMe')"
               />
+              <div v-else class="shared-entries-page__list">
+                <SharedEntryRow
+                  v-for="entry in byMeList"
+                  :key="entry.id"
+                  :entry="entry"
+                  mode="by-me"
+                  @revoke="onRevoke"
+                />
+              </div>
             </div>
-          </div>
-        </NTabPane>
-      </NTabs>
-    </template>
+          </NTabPane>
+
+          <NTabPane name="with-me" :tab="$t('pages.sharedEntries.withMe')">
+            <div class="shared-entries-page__tab-content">
+              <UiEmptyState
+                v-if="withMeList.length === 0"
+                icon="transactions"
+                :title="$t('pages.sharedEntries.emptyWithMeTitle')"
+                :description="$t('pages.sharedEntries.emptyWithMe')"
+              />
+              <div v-else class="shared-entries-page__list">
+                <SharedEntryRow
+                  v-for="entry in withMeList"
+                  :key="entry.id"
+                  :entry="entry"
+                  mode="with-me"
+                />
+              </div>
+            </div>
+          </NTabPane>
+        </NTabs>
+      </template>
+
+      <template #locked>
+        <section class="shared-entries-page__paywall-card">
+          <UiUpgradePrompt
+            :feature-name="$t('pages.sharedEntries.title')"
+            :description="$t('pages.sharedEntries.subtitle')"
+          />
+        </section>
+      </template>
+    </PaywallGate>
   </div>
 </template>
 
@@ -141,5 +162,11 @@ const onRevoke = (id: string): void => {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+}
+
+.shared-entries-page__paywall-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
 }
 </style>

--- a/app/pages/simulations.entitlement.spec.ts
+++ b/app/pages/simulations.entitlement.spec.ts
@@ -1,0 +1,180 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { computed, ref, type App } from "vue";
+
+import SimulationsPage from "./simulations.vue";
+
+const useSimulationsQueryMock = vi.hoisted(() => vi.fn());
+const useDeleteSimulationMutationMock = vi.hoisted(() => vi.fn());
+const navigateToMock = vi.hoisted(() => vi.fn());
+const useEntitlementQueryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("#imports", () => ({
+  computed,
+  definePageMeta: vi.fn(),
+  navigateTo: navigateToMock,
+  ref,
+  useHead: vi.fn(),
+  useI18n: (): { t: (key: string) => string } => ({
+    t: (key: string): string => key,
+  }),
+}));
+
+vi.mock("~/features/simulations/queries/use-simulations-query", () => ({
+  useSimulationsQuery: useSimulationsQueryMock,
+}));
+
+vi.mock("~/features/simulations/queries/use-delete-simulation-mutation", () => ({
+  useDeleteSimulationMutation: useDeleteSimulationMutationMock,
+}));
+
+vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
+  useEntitlementQuery: useEntitlementQueryMock,
+}));
+
+vi.mock("~/components/paywall/PaywallGate.vue", () => ({
+  default: {
+    props: ["feature"],
+    template: `
+      <section data-testid="paywall-gate" :data-feature="feature">
+        <slot />
+        <slot name="locked" />
+      </section>
+    `,
+  },
+}));
+
+vi.mock("~/components/paywall/UiUpgradePrompt.vue", () => ({
+  default: {
+    props: ["featureName", "description", "ctaLabel"],
+    template: `
+      <div data-testid="upgrade-prompt">
+        <span>{{ featureName }}</span>
+        <span>{{ description }}</span>
+        <span>{{ ctaLabel }}</span>
+      </div>
+    `,
+  },
+}));
+
+const stubs = {
+  NPageHeader: {
+    props: ["title", "subtitle"],
+    template: "<header><h1>{{ title }}</h1><p>{{ subtitle }}</p></header>",
+  },
+  NButton: {
+    template: "<button class='n-button' @click=\"$emit('click')\"><slot /></button>",
+    emits: ["click"],
+  },
+  NDropdown: {
+    props: ["options"],
+    template: "<div><slot /></div>",
+  },
+  NRadioGroup: {
+    template: "<div><slot /></div>",
+  },
+  NRadioButton: {
+    props: ["value", "label"],
+    template: "<button>{{ label }}</button>",
+  },
+  UiInlineError: {
+    template: "<div data-testid='inline-error' />",
+  },
+  UiPageLoader: {
+    template: "<div data-testid='page-loader' />",
+  },
+  UiEmptyState: {
+    props: ["title", "description"],
+    template: "<div data-testid='empty-state'>{{ title }} {{ description }}</div>",
+  },
+  SimulationCard: {
+    template: "<article data-testid='simulation-card' />",
+  },
+};
+
+/**
+ * Installs the minimal Nuxt app context required by useHead in page tests.
+ *
+ * @param app Vue test app instance.
+ */
+function nuxtContextPlugin(app: App): void {
+  Reflect.set(app, "$nuxt", {
+    _route: {
+      path: "/simulations",
+      meta: {},
+      params: {},
+      query: {},
+    },
+    $config: { public: {} },
+    payload: { serverRendered: false },
+    ssrContext: {
+      head: {
+        push: vi.fn(() => ({
+          patch: vi.fn(),
+          dispose: vi.fn(),
+        })),
+      },
+    },
+    static: { data: {} },
+    isHydrating: false,
+    deferHydration: (): void => {},
+    runWithContext: <T>(callback: () => T): T => callback(),
+    hooks: { callHook: vi.fn(), hook: vi.fn() },
+    _asyncDataPromises: {},
+    _asyncData: {},
+  });
+}
+
+describe("SimulationsPage — entitlement gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSimulationsQueryMock.mockReturnValue({
+      data: ref({
+        cards: [],
+        simulations: [],
+        total: 0,
+        page: 1,
+        perPage: 0,
+        pages: 0,
+      }),
+      isLoading: ref(false),
+      isError: ref(false),
+    });
+    useDeleteSimulationMutationMock.mockReturnValue({
+      mutate: vi.fn(),
+    });
+    useEntitlementQueryMock.mockReturnValue({
+      data: ref(false),
+      isLoading: ref(false),
+      isError: ref(false),
+    });
+  });
+
+  it("wraps the page content in the advanced_simulations paywall gate", () => {
+    const wrapper = mount(SimulationsPage, {
+      global: {
+        plugins: [{ install: nuxtContextPlugin }],
+        stubs,
+        mocks: { $t: (key: string): string => key },
+      },
+    });
+
+    const gate = wrapper.find("[data-testid='paywall-gate']");
+    expect(gate.exists()).toBe(true);
+    expect(gate.attributes("data-feature")).toBe("advanced_simulations");
+  });
+
+  it("renders an upgrade prompt for the locked simulations state", () => {
+    const wrapper = mount(SimulationsPage, {
+      global: {
+        plugins: [{ install: nuxtContextPlugin }],
+        stubs,
+        mocks: { $t: (key: string): string => key },
+      },
+    });
+
+    const prompt = wrapper.find("[data-testid='upgrade-prompt']");
+    expect(prompt.exists()).toBe(true);
+    expect(prompt.text()).toContain("pages.simulations.title");
+  });
+});

--- a/app/pages/simulations.vue
+++ b/app/pages/simulations.vue
@@ -10,6 +10,9 @@ import {
 import { useSimulationsQuery } from "~/features/simulations/queries/use-simulations-query";
 import { useDeleteSimulationMutation } from "~/features/simulations/queries/use-delete-simulation-mutation";
 import type { SimulationType } from "~/features/simulations/contracts/simulation-card.dto";
+import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
+import PaywallGate from "~/components/paywall/PaywallGate.vue";
+import UiUpgradePrompt from "~/components/paywall/UiUpgradePrompt.vue";
 
 const { t } = useI18n();
 
@@ -31,7 +34,14 @@ const SIMULATION_TYPE_ROUTES: Record<SimulationType, string> = {
   investment_return: "/tools/juros-compostos",
 };
 
-const { data, isLoading, isError } = useSimulationsQuery();
+const simulationsAccessQuery = useEntitlementQuery("advanced_simulations");
+const hasSimulationsAccess = computed(
+  () => simulationsAccessQuery.data.value === true,
+);
+
+const { data, isLoading, isError } = useSimulationsQuery({
+  enabled: hasSimulationsAccess,
+});
 const deleteMutation = useDeleteSimulationMutation();
 
 const activeFilter = ref<FilterValue>("all");
@@ -81,61 +91,77 @@ const onDelete = (id: string): void => {
 
 <template>
   <div class="simulations-page">
-    <div class="simulations-page__header">
-      <NPageHeader
-        :title="$t('pages.simulations.title')"
-        :subtitle="$t('pages.simulations.subtitle')"
-        class="simulations-page__page-header"
-      />
-      <NDropdown
-        :options="NEW_SIMULATION_OPTIONS"
-        trigger="click"
-        @select="onNewSimulation"
-      >
-        <NButton type="primary" size="medium">
-          {{ $t('pages.simulations.newSimulation') }}
-        </NButton>
-      </NDropdown>
-    </div>
-
-    <UiInlineError
-      v-if="isError"
-      :title="$t('pages.simulations.loadError')"
-      :message="$t('pages.simulations.loadErrorMessage')"
-    />
-
-    <template v-else>
-      <div class="simulations-page__filter-bar">
-        <NRadioGroup v-model:value="activeFilter" size="medium">
-          <NRadioButton
-            v-for="opt in FILTER_OPTIONS"
-            :key="opt.value"
-            :value="opt.value"
-            :label="opt.label"
-          />
-        </NRadioGroup>
+    <PaywallGate feature="advanced_simulations">
+      <div class="simulations-page__header">
+        <NPageHeader
+          :title="$t('pages.simulations.title')"
+          :subtitle="$t('pages.simulations.subtitle')"
+          class="simulations-page__page-header"
+        />
+        <NDropdown
+          :options="NEW_SIMULATION_OPTIONS"
+          trigger="click"
+          @select="onNewSimulation"
+        >
+          <NButton type="primary" size="medium">
+            {{ $t('pages.simulations.newSimulation') }}
+          </NButton>
+        </NDropdown>
       </div>
 
-      <UiPageLoader v-if="isLoading" :rows="3" />
+      <UiInlineError
+        v-if="isError"
+        :title="$t('pages.simulations.loadError')"
+        :message="$t('pages.simulations.loadErrorMessage')"
+      />
 
       <template v-else>
-        <UiEmptyState
-          v-if="filteredSimulations.length === 0"
-          icon="analytics"
-          :title="activeFilter === 'all' ? $t('pages.simulations.emptyAllTitle') : $t('pages.simulations.empty')"
-          :description="activeFilter === 'all' ? $t('pages.simulations.emptyAllDescription') : undefined"
-        />
-
-        <div v-else class="simulations-page__grid">
-          <SimulationCard
-            v-for="sim in filteredSimulations"
-            :key="sim.id"
-            :simulation="sim"
-            @delete="onDelete"
-          />
+        <div class="simulations-page__filter-bar">
+          <NRadioGroup v-model:value="activeFilter" size="medium">
+            <NRadioButton
+              v-for="opt in FILTER_OPTIONS"
+              :key="opt.value"
+              :value="opt.value"
+              :label="opt.label"
+            />
+          </NRadioGroup>
         </div>
+
+        <UiPageLoader v-if="isLoading" :rows="3" />
+
+        <template v-else>
+          <UiEmptyState
+            v-if="filteredSimulations.length === 0"
+            icon="analytics"
+            :title="activeFilter === 'all' ? $t('pages.simulations.emptyAllTitle') : $t('pages.simulations.empty')"
+            :description="activeFilter === 'all' ? $t('pages.simulations.emptyAllDescription') : undefined"
+          />
+
+          <div v-else class="simulations-page__grid">
+            <SimulationCard
+              v-for="sim in filteredSimulations"
+              :key="sim.id"
+              :simulation="sim"
+              @delete="onDelete"
+            />
+          </div>
+        </template>
       </template>
-    </template>
+
+      <template #locked>
+        <section class="simulations-page__paywall-card">
+          <NPageHeader
+            :title="$t('pages.simulations.title')"
+            :subtitle="$t('pages.simulations.subtitle')"
+            class="simulations-page__page-header"
+          />
+          <UiUpgradePrompt
+            :feature-name="$t('pages.simulations.title')"
+            :description="$t('pages.simulations.subtitle')"
+          />
+        </section>
+      </template>
+    </PaywallGate>
   </div>
 </template>
 
@@ -180,6 +206,15 @@ const onDelete = (id: string): void => {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: var(--space-3);
+}
+
+.simulations-page__paywall-card {
+  display: grid;
+  gap: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  padding: var(--space-3);
 }
 
 @media (max-width: 480px) {

--- a/app/shared/types/generated/graphql.ts
+++ b/app/shared/types/generated/graphql.ts
@@ -361,6 +361,37 @@ export type DeleteWalletEntryMutation = {
   ok: Scalars['Boolean']['output'];
 };
 
+export type FiscalDocumentListType = {
+  __typename?: 'FiscalDocumentListType';
+  fiscalDocuments: Array<FiscalDocumentType>;
+  total: Scalars['Int']['output'];
+};
+
+export type FiscalDocumentPayload = {
+  __typename?: 'FiscalDocumentPayload';
+  data?: Maybe<FiscalDocumentType>;
+  /** Field-level validation errors (empty on success). */
+  errors: Array<ValidationError>;
+  /** Human-readable status message. */
+  message: Scalars['String']['output'];
+  /** True when the mutation completed without errors. */
+  ok: Scalars['Boolean']['output'];
+};
+
+export type FiscalDocumentType = {
+  __typename?: 'FiscalDocumentType';
+  counterparty: Scalars['String']['output'];
+  createdAt: Scalars['String']['output'];
+  currency: Scalars['String']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  externalId: Scalars['String']['output'];
+  grossAmount: Scalars['DecimalScalar']['output'];
+  id: Scalars['ID']['output'];
+  issuedAt: Scalars['String']['output'];
+  status: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+};
+
 export type GoalListPayloadType = {
   __typename?: 'GoalListPayloadType';
   items: Array<Maybe<GoalTypeObject>>;
@@ -614,6 +645,8 @@ export type Mutation = {
   addTicker?: Maybe<AddTickerPayload>;
   /** @deprecated ADR-0002: use POST /wallet */
   addWalletEntry?: Maybe<AddWalletEntryMutation>;
+  /** @deprecated ADR-0002: use DELETE /fiscal/receivables/{id} */
+  cancelReceivable?: Maybe<ReceivablePayload>;
   /** @deprecated ADR-0004: use POST /subscription/cancel */
   cancelSubscription?: Maybe<CancelSubscriptionMutation>;
   /**
@@ -632,10 +665,14 @@ export type Mutation = {
   createBudget?: Maybe<CreateBudgetMutation>;
   /** @deprecated ADR-0004: use POST /subscription/checkout */
   createCheckoutSession?: Maybe<CreateCheckoutSessionMutation>;
+  /** @deprecated ADR-0002: use POST /fiscal/fiscal-documents */
+  createFiscalDocument?: Maybe<FiscalDocumentPayload>;
   /** @deprecated ADR-0002: use POST /goals */
   createGoal?: Maybe<CreateGoalMutation>;
   createGoalFromInstallmentVsCashSimulation?: Maybe<CreateGoalFromInstallmentVsCashSimulationMutation>;
   createPlannedExpenseFromInstallmentVsCashSimulation?: Maybe<CreatePlannedExpenseFromInstallmentVsCashSimulationMutation>;
+  /** @deprecated ADR-0002: use POST /fiscal/receivables */
+  createReceivable?: Maybe<ReceivablePayload>;
   createTag?: Maybe<TagPayload>;
   /** @deprecated ADR-0002: use POST /transactions */
   createTransaction?: Maybe<CreateTransactionMutation>;
@@ -655,6 +692,8 @@ export type Mutation = {
   forgotPassword?: Maybe<AuthPayloadType>;
   login?: Maybe<AuthPayloadType>;
   logout?: Maybe<LogoutMutation>;
+  /** @deprecated ADR-0002: use PATCH /fiscal/receivables/{id}/receive */
+  markReceivableReceived?: Maybe<ReceivablePayload>;
   /**
    * Parse a bank statement text and return a deduplication preview.
    *
@@ -719,6 +758,11 @@ export type MutationAddWalletEntryArgs = {
 };
 
 
+export type MutationCancelReceivableArgs = {
+  entryId: Scalars['UUID']['input'];
+};
+
+
 export type MutationConfirmBankImportArgs = {
   bankName: Scalars['String']['input'];
   mode: Scalars['String']['input'];
@@ -754,6 +798,15 @@ export type MutationCreateBudgetArgs = {
 export type MutationCreateCheckoutSessionArgs = {
   billingCycle?: InputMaybe<BillingCycle>;
   planSlug: Scalars['String']['input'];
+};
+
+
+export type MutationCreateFiscalDocumentArgs = {
+  amount: Scalars['String']['input'];
+  counterpartName?: InputMaybe<Scalars['String']['input']>;
+  externalId?: InputMaybe<Scalars['String']['input']>;
+  issuedAt: Scalars['String']['input'];
+  type: Scalars['String']['input'];
 };
 
 
@@ -795,6 +848,14 @@ export type MutationCreatePlannedExpenseFromInstallmentVsCashSimulationArgs = {
   tagId?: InputMaybe<Scalars['UUID']['input']>;
   title: Scalars['String']['input'];
   upfrontDueDate?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type MutationCreateReceivableArgs = {
+  amount: Scalars['String']['input'];
+  category?: InputMaybe<Scalars['String']['input']>;
+  description: Scalars['String']['input'];
+  expectedDate: Scalars['String']['input'];
 };
 
 
@@ -875,6 +936,13 @@ export type MutationForgotPasswordArgs = {
 export type MutationLoginArgs = {
   email: Scalars['String']['input'];
   password: Scalars['String']['input'];
+};
+
+
+export type MutationMarkReceivableReceivedArgs = {
+  entryId: Scalars['UUID']['input'];
+  receivedAmount?: InputMaybe<Scalars['String']['input']>;
+  receivedDate: Scalars['String']['input'];
 };
 
 
@@ -1146,6 +1214,7 @@ export type Query = {
   budgetSummary?: Maybe<BudgetSummaryType>;
   budgets?: Maybe<BudgetListPayloadType>;
   dashboardOverview?: Maybe<TransactionDashboardPayloadType>;
+  fiscalDocuments?: Maybe<FiscalDocumentListType>;
   goal?: Maybe<GoalTypeObject>;
   goalPlan?: Maybe<GoalPlanType>;
   goals?: Maybe<GoalListPayloadType>;
@@ -1160,6 +1229,8 @@ export type Query = {
   notificationPreferences?: Maybe<NotificationPreferencesType>;
   portfolioValuation?: Maybe<PortfolioValuationPayloadType>;
   portfolioValuationHistory?: Maybe<PortfolioHistoryPayloadType>;
+  receivables?: Maybe<ReceivableListType>;
+  receivablesSummary?: Maybe<ReceivableSummaryType>;
   simulation?: Maybe<SimulationType>;
   simulations: SimulationListPayloadType;
   tag?: Maybe<TagType>;
@@ -1195,6 +1266,11 @@ export type QueryBudgetArgs = {
 
 export type QueryDashboardOverviewArgs = {
   month: Scalars['String']['input'];
+};
+
+
+export type QueryFiscalDocumentsArgs = {
+  type?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1261,6 +1337,11 @@ export type QueryInvestmentValuationArgs = {
 export type QueryPortfolioValuationHistoryArgs = {
   finalDate?: InputMaybe<Scalars['String']['input']>;
   startDate?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryReceivablesArgs = {
+  status?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1346,6 +1427,52 @@ export type QueryWeeklySummaryArgs = {
   endDate?: InputMaybe<Scalars['String']['input']>;
   period?: InputMaybe<Scalars['String']['input']>;
   startDate?: InputMaybe<Scalars['String']['input']>;
+};
+
+/**
+ * IMPORTANT: expected_net_amount is advisory-only. Clients MUST display
+ * the ``disclaimer`` field alongside any monetary value derived from it.
+ */
+export type ReceivableEntryType = {
+  __typename?: 'ReceivableEntryType';
+  createdAt: Scalars['String']['output'];
+  disclaimer: Scalars['String']['output'];
+  expectedNetAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  fiscalDocumentId: Scalars['ID']['output'];
+  id: Scalars['ID']['output'];
+  outstandingAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  receivedAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  receivedAt?: Maybe<Scalars['String']['output']>;
+  reconciliationStatus: Scalars['String']['output'];
+};
+
+export type ReceivableListType = {
+  __typename?: 'ReceivableListType';
+  receivables: Array<ReceivableEntryType>;
+  total: Scalars['Int']['output'];
+};
+
+export type ReceivablePayload = {
+  __typename?: 'ReceivablePayload';
+  data?: Maybe<ReceivableEntryType>;
+  /** Field-level validation errors (empty on success). */
+  errors: Array<ValidationError>;
+  /** Human-readable status message. */
+  message: Scalars['String']['output'];
+  /** True when the mutation completed without errors. */
+  ok: Scalars['Boolean']['output'];
+};
+
+/**
+ * IMPORTANT: all monetary values are advisory-only estimates.
+ * Always display the ``disclaimer`` field.
+ */
+export type ReceivableSummaryType = {
+  __typename?: 'ReceivableSummaryType';
+  disclaimer: Scalars['String']['output'];
+  expectedTotal: Scalars['String']['output'];
+  pendingTotal: Scalars['String']['output'];
+  receivedTotal: Scalars['String']['output'];
 };
 
 /** Revoke all active sessions — global logout (#1028). */

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -256,8 +256,8 @@
       "createdAt": "2026-04-03",
       "removeBy": "2027-12-31",
       "type": "release",
-      "status": "draft",
-      "description": "Página de simulações salvas. Freezada para MVP — habilitar após validação da feature.",
+      "status": "enabled-prod",
+      "description": "Página de simulações salvas. Acesso liberado com gate premium por entitlement.",
       "repositories": ["auraxis-web"]
     },
     {
@@ -266,8 +266,8 @@
       "createdAt": "2026-04-03",
       "removeBy": "2027-12-31",
       "type": "release",
-      "status": "draft",
-      "description": "Página de entradas compartilhadas (divisão de contas). Freezada para MVP.",
+      "status": "enabled-prod",
+      "description": "Página de entradas compartilhadas (divisão de contas). Acesso liberado com gate premium por entitlement.",
       "repositories": ["auraxis-web"]
     },
     {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -374,8 +374,9 @@ export default defineNuxtConfig({
   // ── PWA (@vite-pwa/nuxt) ─────────────────────────────────────────────
   //
   // Strategy: generateSW — Workbox generates a service worker at build time.
-  // The SW pre-caches the app shell (HTML, CSS, JS bundles) so the dashboard
-  // loads instantly on repeat visits and remains accessible offline.
+  // Keep the eager precache small. Browser/CDN caching handles Nuxt chunks as
+  // users actually visit routes; pre-caching every lazy bundle/font causes
+  // hundreds of background requests after a dashboard refresh.
   //
   // API routes are NEVER cached — financial data must always be fresh.
   // The manifest is managed by the webmanifest file in /public/.
@@ -386,8 +387,14 @@ export default defineNuxtConfig({
     // Disable PWA's own manifest injection — we manage /public/manifest.webmanifest
     manifest: false,
     workbox: {
-      // Pre-cache the Nuxt app shell (JS, CSS, fonts).
-      globPatterns: ["**/*.{js,css,woff2}"],
+      // Pre-cache only install/offline shell assets, not the whole app bundle.
+      globPatterns: [
+        "offline.html",
+        "manifest.webmanifest",
+        "favicon.ico",
+        "apple-touch-icon.png",
+        "icons/*.{png,svg}",
+      ],
       // Network-first for HTML — always try to fetch fresh page shell.
       runtimeCaching: [
         {

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
       "picomatch": ">=4.0.4",
       "node-forge": ">=1.4.0",
       "defu": ">=6.1.5",
+      "devalue": "5.8.1",
       "vite": "7.3.3",
       "serialize-javascript": ">=7.0.5",
       "protobufjs": ">=7.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   picomatch: '>=4.0.4'
   node-forge: '>=1.4.0'
   defu: '>=6.1.5'
+  devalue: 5.8.1
   vite: 7.3.3
   serialize-javascript: '>=7.0.5'
   protobufjs: '>=7.5.5'
@@ -6340,8 +6341,8 @@ packages:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
 
-  devalue@5.8.0:
-    resolution: {integrity: sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -14167,7 +14168,7 @@ snapshots:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
-      devalue: 5.8.0
+      devalue: 5.8.1
       h3: 1.15.11
       html-validate: 10.15.0(@jest/globals@30.3.0)(jest-diff@30.3.0)(jest-snapshot@30.3.0)(jest@30.3.0(@types/node@25.6.2)(esbuild-register@3.6.0(esbuild@0.25.12)))(vitest@4.1.6)
       knitwork: 1.3.0
@@ -14389,7 +14390,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
-      devalue: 5.8.0
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -14714,7 +14715,7 @@ snapshots:
       '@rollup/plugin-yaml': 4.1.2(rollup@4.60.3)
       '@vue/compiler-sfc': 3.5.34
       defu: 6.1.7
-      devalue: 5.8.0
+      devalue: 5.8.1
       h3: 1.15.11
       knitwork: 1.3.0
       magic-string: 0.30.21
@@ -18528,7 +18529,7 @@ snapshots:
 
   detect-newline@3.1.0: {}
 
-  devalue@5.8.0: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:
@@ -21861,7 +21862,7 @@ snapshots:
       consola: 3.4.2
       culori: 4.0.2
       defu: 6.1.7
-      devalue: 5.8.0
+      devalue: 5.8.1
       exsolve: 1.0.8
       lightningcss: 1.32.0
       magic-string: 0.30.21
@@ -22013,7 +22014,7 @@ snapshots:
       consola: 3.4.2
       cookie-es: 2.0.1
       defu: 6.1.7
-      devalue: 5.8.0
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8


### PR DESCRIPTION
## Summary

Closes #829

Implements the premium entitlement gates requested for protected frontend experiences, focusing on the current premium-only pages and shared paywall primitives.

## What changed

- Added entitlement-aware gates to `/shared-entries` using `shared_entries`, including a locked upgrade state for free users and premium content rendering for entitled users.
- Added entitlement-aware gates to `/simulations` using `advanced_simulations`, including a locked upgrade state for free users and premium content rendering for entitled users.
- Kept `/focus` aligned with the accepted upgrade destination by pointing its locked-state CTA to `/subscription`.
- Updated `PaywallGate` to provide a default `UiUpgradePrompt` fallback when a page does not define a custom locked slot.
- Updated `UiUpgradePrompt` to use `/subscription` by default while still supporting a custom route via `to`.
- Added `enabled` support to shared-entries and simulations queries so free users do not trigger premium API fetches behind the paywall.
- Enabled the `web.pages.simulations` and `web.pages.shared-entries` flags now that both pages are protected by entitlement gates instead of the coming-soon guard.
- Regenerated GraphQL types to match the current schema used by `pnpm codegen:check`.

## Tests and validation

- `pnpm quality-check`
  - `flags:check` OK
  - `i18n:check` OK, with existing DEC-186 PT-only warnings only
  - `lint` OK
  - `typecheck` OK
  - `test:coverage` OK: 320 files / 3244 tests, 92.37% statements, 86.16% branches, 87.74% functions, 93.93% lines
  - `policy:check` OK
  - `contracts:check` OK
  - `codegen:check` OK
  - `build` OK
- `git push` pre-push CI parity gate OK
  - E2E remains skipped by local hook unless `RUN_E2E=1` is set, as configured by the repo hook.

## Screenshots

Captured locally with mocked entitlement states during visual QA:

- Free user, shared entries paywall: `test-results/issue-829-screenshots/shared-entries-free-paywall.png`
- Premium user, shared entries content: `test-results/issue-829-screenshots/shared-entries-premium-content.png`
- Free user, simulations paywall: `test-results/issue-829-screenshots/simulations-free-paywall.png`
- Premium user, simulations content: `test-results/issue-829-screenshots/simulations-premium-content.png`

Note: the screenshots were captured from the local preview environment. The GitHub CLI does not provide a native attachment upload flow for PR bodies, so the filenames are documented here and the local artifacts are available in the workspace for review.
