### PR TITLE
feat(goals): add AI goal projection context

### DIFF
--- a/app/components/goal/GoalAiContextPanel/GoalAiContextPanel.vue
+++ b/app/components/goal/GoalAiContextPanel/GoalAiContextPanel.vue
@@ -1,0 +1,449 @@
+<script setup lang="ts">
+import { AlertCircle, Bot, Loader2, Save, Sparkles } from "lucide-vue-next";
+
+import UiUpgradePrompt from "~/components/paywall/UiUpgradePrompt.vue";
+import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
+import type {
+  GoalAIProjectionResponseDto,
+  GoalDto,
+} from "~/features/goals/contracts/goal.dto";
+import { useGoalAIProjectionMutation } from "~/features/goals/queries/use-goal-ai-projection-mutation";
+import { buildGoalAIProjectionContext } from "~/features/goals/model/goal-ai-projection";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import { formatCurrency } from "~/utils/currency";
+
+const MAX_CONTEXT_LENGTH = 500;
+
+const props = defineProps<{
+  readonly goal: GoalDto;
+  readonly monthlyContribution: number;
+  readonly recentTransactions?: readonly TransactionDto[];
+}>();
+
+const emit = defineEmits<{
+  (event: "save-note", value: GoalAIProjectionResponseDto): void;
+}>();
+
+const context = ref("");
+const entitlementQuery = useEntitlementQuery("advanced_simulations");
+const projectionMutation = useGoalAIProjectionMutation();
+
+const hasPremiumAccess = computed(() => entitlementQuery.data.value === true);
+const isCheckingAccess = computed(() => entitlementQuery.isLoading.value === true);
+const isContextTooLong = computed(() => context.value.length > MAX_CONTEXT_LENGTH);
+const canSubmit = computed(
+  () =>
+    hasPremiumAccess.value &&
+    !projectionMutation.isPending.value &&
+    !isContextTooLong.value,
+);
+
+const projection = computed(() => projectionMutation.data.value?.projection ?? null);
+const generatedProjection = computed(() => projectionMutation.data.value ?? null);
+
+const monthsToCompletionLabel = computed(() => {
+  const months = projection.value?.months_to_completion;
+
+  if (typeof months !== "number") {
+    return "Sem estimativa";
+  }
+
+  return `${months} meses`;
+});
+
+const projectedDateLabel = computed(() => {
+  const date = projection.value?.projected_completion_date;
+
+  if (!date) {
+    return "Sem data";
+  }
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    month: "short",
+    year: "numeric",
+  }).format(new Date(`${date}T00:00:00`));
+});
+
+const suggestedContributionLabel = computed(() => {
+  const suggestion = projection.value?.suggested_monthly_contribution;
+
+  if (!suggestion) {
+    return "Aporte atual suficiente";
+  }
+
+  return formatCurrency(Number(suggestion));
+});
+
+/**
+ * Sends the current goal context to the AI projection mutation.
+ */
+const generateProjection = (): void => {
+  if (!canSubmit.value) {
+    return;
+  }
+
+  projectionMutation.mutate({
+    goalId: props.goal.id,
+    payload: {
+      monthly_contribution: props.monthlyContribution,
+      user_context: buildGoalAIProjectionContext({
+        userContext: context.value,
+        recentTransactions: props.recentTransactions ?? [],
+      }),
+    },
+  });
+};
+
+/**
+ * Emits the generated projection so the page can persist or display it as a note.
+ */
+const saveGeneratedProjection = (): void => {
+  if (generatedProjection.value) {
+    emit("save-note", generatedProjection.value);
+  }
+};
+</script>
+
+<template>
+  <section class="goal-ai-panel" aria-labelledby="goal-ai-panel-title">
+    <div class="goal-ai-panel__header">
+      <span class="goal-ai-panel__icon" aria-hidden="true">
+        <Bot :size="20" />
+      </span>
+      <div>
+        <h2 id="goal-ai-panel-title">Projecao de meta com IA</h2>
+        <p>Use contexto livre e movimentacoes recentes para ajustar o plano desta meta.</p>
+      </div>
+    </div>
+
+    <div v-if="isCheckingAccess" class="goal-ai-panel__loading" aria-live="polite">
+      <span />
+      <span />
+      <span />
+    </div>
+
+    <UiUpgradePrompt
+      v-else-if="!hasPremiumAccess"
+      feature-name="Projecao de meta com IA"
+      description="Usuarios free recebem apenas os insights automaticos mensais. Assine o Premium para gerar novas projecoes quando quiser."
+      cta-label="Assinar Premium"
+      to="/plans"
+    />
+
+    <template v-else>
+      <form class="goal-ai-panel__form" @submit.prevent="generateProjection">
+        <label for="goal-ai-context">Contexto para a IA</label>
+        <textarea
+          id="goal-ai-context"
+          v-model="context"
+          rows="3"
+          maxlength="500"
+          placeholder="Ex.: recebi bonus este mes, mas quero preservar liquidez para emergencias."
+        />
+        <div class="goal-ai-panel__form-footer">
+          <span :class="{ 'is-danger': isContextTooLong }">
+            {{ context.length }}/{{ MAX_CONTEXT_LENGTH }}
+          </span>
+          <button class="goal-ai-panel__submit" type="submit" :disabled="!canSubmit">
+            <Loader2 v-if="projectionMutation.isPending.value" :size="16" aria-hidden="true" />
+            <Sparkles v-else :size="16" aria-hidden="true" />
+            Gerar nova projecao
+          </button>
+        </div>
+      </form>
+
+      <div v-if="projectionMutation.isPending.value" class="goal-ai-panel__skeleton" aria-live="polite">
+        <span />
+        <span />
+        <span />
+      </div>
+
+      <div v-else-if="projectionMutation.isError.value" class="goal-ai-panel__error" role="alert">
+        <AlertCircle :size="18" aria-hidden="true" />
+        <span>Nao foi possivel gerar a projecao agora. Tente novamente em instantes.</span>
+      </div>
+
+      <article v-if="generatedProjection" class="goal-ai-result">
+        <div class="goal-ai-result__topline">
+          <span>Analise gerada</span>
+          <strong>{{ generatedProjection.model }}</strong>
+        </div>
+
+        <p class="goal-ai-result__narrative">
+          {{ generatedProjection.narrative }}
+        </p>
+
+        <dl class="goal-ai-result__metrics">
+          <div>
+            <dt>Conclusao estimada</dt>
+            <dd>{{ monthsToCompletionLabel }}</dd>
+          </div>
+          <div>
+            <dt>Nova data</dt>
+            <dd>{{ projectedDateLabel }}</dd>
+          </div>
+          <div>
+            <dt>Aporte sugerido</dt>
+            <dd>{{ suggestedContributionLabel }}</dd>
+          </div>
+        </dl>
+
+        <button
+          class="goal-ai-result__note"
+          type="button"
+          data-testid="save-goal-ai-note"
+          @click="saveGeneratedProjection"
+        >
+          <Save :size="15" aria-hidden="true" />
+          Salvar como nota da meta
+        </button>
+      </article>
+    </template>
+  </section>
+</template>
+
+<style scoped>
+.goal-ai-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+  padding: 24px;
+  border: 1px solid rgba(68, 212, 255, 0.18);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(135deg, rgba(68, 212, 255, 0.08), transparent 38%),
+    #111827;
+  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.26);
+}
+
+.goal-ai-panel__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  min-width: 0;
+}
+
+.goal-ai-panel__icon {
+  display: inline-flex;
+  width: 40px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border: 1px solid rgba(68, 212, 255, 0.26);
+  border-radius: var(--radius-sm);
+  color: #44d4ff;
+  background: rgba(68, 212, 255, 0.1);
+}
+
+.goal-ai-panel h2,
+.goal-ai-panel p {
+  margin: 0;
+}
+
+.goal-ai-panel h2 {
+  color: #f7fbff;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-extrabold);
+}
+
+.goal-ai-panel__header p {
+  margin-top: 4px;
+  color: #8da2bf;
+  line-height: 1.5;
+}
+
+.goal-ai-panel__form {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.goal-ai-panel__form label {
+  color: #dce8f8;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+}
+
+.goal-ai-panel textarea {
+  width: 100%;
+  min-width: 0;
+  min-height: 92px;
+  padding: 14px 16px;
+  resize: vertical;
+  border: 1px solid rgba(141, 162, 191, 0.26);
+  border-radius: var(--radius-sm);
+  color: #f7fbff;
+  background: rgba(8, 13, 24, 0.72);
+  line-height: 1.5;
+  outline: none;
+}
+
+.goal-ai-panel textarea:focus {
+  border-color: rgba(68, 212, 255, 0.68);
+  box-shadow: 0 0 0 3px rgba(68, 212, 255, 0.12);
+}
+
+.goal-ai-panel__form-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.goal-ai-panel__form-footer span {
+  color: #8da2bf;
+  font-size: var(--font-size-sm);
+}
+
+.goal-ai-panel__form-footer .is-danger {
+  color: #ff7a8a;
+}
+
+.goal-ai-panel__submit,
+.goal-ai-result__note {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 0;
+  border-radius: var(--radius-full);
+  font-weight: var(--font-weight-extrabold);
+  cursor: pointer;
+}
+
+.goal-ai-panel__submit {
+  padding: 0 18px;
+  color: #06111f;
+  background: linear-gradient(135deg, #44d4ff, #42e8a9);
+}
+
+.goal-ai-panel__submit:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
+}
+
+.goal-ai-panel__loading,
+.goal-ai-panel__skeleton {
+  display: grid;
+  gap: 10px;
+}
+
+.goal-ai-panel__loading span,
+.goal-ai-panel__skeleton span {
+  height: 16px;
+  border-radius: var(--radius-full);
+  background: linear-gradient(90deg, rgba(141, 162, 191, 0.12), rgba(141, 162, 191, 0.25), rgba(141, 162, 191, 0.12));
+}
+
+.goal-ai-panel__loading span:nth-child(2),
+.goal-ai-panel__skeleton span:nth-child(2) {
+  width: 82%;
+}
+
+.goal-ai-panel__loading span:nth-child(3),
+.goal-ai-panel__skeleton span:nth-child(3) {
+  width: 58%;
+}
+
+.goal-ai-panel__error {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 122, 138, 0.28);
+  border-radius: var(--radius-sm);
+  color: #ffd1d7;
+  background: rgba(255, 122, 138, 0.08);
+}
+
+.goal-ai-result {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+  padding: 18px;
+  border: 1px solid rgba(141, 162, 191, 0.18);
+  border-radius: var(--radius-md);
+  background: rgba(8, 13, 24, 0.54);
+}
+
+.goal-ai-result__topline,
+.goal-ai-result__metrics {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.goal-ai-result__topline span {
+  color: #42e8a9;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
+  text-transform: uppercase;
+}
+
+.goal-ai-result__topline strong {
+  color: #8da2bf;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+}
+
+.goal-ai-result__narrative {
+  color: #dce8f8;
+  line-height: 1.62;
+}
+
+.goal-ai-result__metrics {
+  margin: 0;
+  min-width: 0;
+}
+
+.goal-ai-result__metrics div {
+  flex: 1;
+  min-width: 0;
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  background: rgba(141, 162, 191, 0.08);
+}
+
+.goal-ai-result__metrics dt {
+  color: #8da2bf;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+}
+
+.goal-ai-result__metrics dd {
+  margin: 6px 0 0;
+  color: #f7fbff;
+  font-weight: var(--font-weight-extrabold);
+}
+
+.goal-ai-result__note {
+  width: fit-content;
+  padding: 0 16px;
+  color: #dce8f8;
+  background: rgba(141, 162, 191, 0.12);
+}
+
+@media (max-width: 700px) {
+  .goal-ai-panel {
+    padding: 20px;
+    border-radius: var(--radius-md);
+  }
+
+  .goal-ai-panel__form-footer,
+  .goal-ai-result__metrics {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .goal-ai-panel__submit,
+  .goal-ai-result__note {
+    width: 100%;
+  }
+}
+</style>

--- a/app/components/goal/GoalAiContextPanel/__tests__/GoalAiContextPanel.spec.ts
+++ b/app/components/goal/GoalAiContextPanel/__tests__/GoalAiContextPanel.spec.ts
@@ -1,0 +1,174 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import GoalAiContextPanel from "../GoalAiContextPanel.vue";
+import type { GoalDto } from "~/features/goals/contracts/goal.dto";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+
+const useEntitlementQueryMock = vi.hoisted(() => vi.fn());
+const useGoalAIProjectionMutationMock = vi.hoisted(() => vi.fn());
+const mutateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
+  useEntitlementQuery: useEntitlementQueryMock,
+}));
+
+vi.mock("~/features/goals/queries/use-goal-ai-projection-mutation", () => ({
+  useGoalAIProjectionMutation: useGoalAIProjectionMutationMock,
+}));
+
+/**
+ * Builds a goal fixture used by the AI context panel tests.
+ *
+ * @returns Goal DTO fixture.
+ */
+const makeGoal = (): GoalDto => ({
+  id: "goal-001",
+  name: "Reserva de emergencia",
+  description: "6 meses de despesas",
+  target_amount: 30000,
+  current_amount: 12500,
+  target_date: "2027-01-31",
+  status: "active",
+  created_at: "2026-01-01T00:00:00Z",
+});
+
+/**
+ * Builds a transaction fixture for prompt-enrichment assertions.
+ *
+ * @param overrides Optional transaction fields to override.
+ * @returns Transaction DTO fixture.
+ */
+const makeTransaction = (
+  overrides: Partial<TransactionDto> = {},
+): TransactionDto => ({
+  id: "tx-1",
+  title: "Salario",
+  amount: "5000.00",
+  type: "income",
+  due_date: "2026-05-01",
+  description: null,
+  observation: null,
+  is_recurring: false,
+  is_installment: false,
+  installment_count: null,
+  currency: "BRL",
+  status: "paid",
+  start_date: null,
+  end_date: null,
+  tag_id: null,
+  account_id: null,
+  credit_card_id: null,
+  installment_group_id: null,
+  paid_at: null,
+  created_at: null,
+  updated_at: null,
+  ...overrides,
+});
+
+/**
+ * Mounts the panel with a goal, simulated monthly contribution and recent transactions.
+ *
+ * @returns Mounted Vue wrapper.
+ */
+const mountPanel = (): ReturnType<typeof mount> =>
+  mount(GoalAiContextPanel, {
+    props: {
+      goal: makeGoal(),
+      monthlyContribution: 1200,
+      recentTransactions: [
+        makeTransaction({ amount: "5000.00", type: "income" }),
+        makeTransaction({ id: "tx-2", amount: "1800.00", type: "expense" }),
+      ],
+    },
+    global: {
+      stubs: {
+        UiUpgradePrompt: {
+          props: ["featureName", "description", "ctaLabel", "to"],
+          template: "<div class=\"upgrade-prompt\"><span>{{ featureName }}</span><button>{{ ctaLabel }}</button></div>",
+        },
+      },
+    },
+  });
+
+describe("GoalAiContextPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useEntitlementQueryMock.mockReturnValue({ data: ref(true), isLoading: ref(false) });
+    useGoalAIProjectionMutationMock.mockReturnValue({
+      mutate: mutateMock,
+      data: ref(null),
+      isPending: ref(false),
+      isError: ref(false),
+      error: ref(null),
+    });
+  });
+
+  it("shows the premium upgrade prompt for users without advanced simulations entitlement", () => {
+    useEntitlementQueryMock.mockReturnValue({ data: ref(false), isLoading: ref(false) });
+
+    const wrapper = mountPanel();
+
+    expect(wrapper.find(".upgrade-prompt").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Projecao de meta com IA");
+    expect(wrapper.find("textarea").exists()).toBe(false);
+  });
+
+  it("submits user context enriched with recent transactions for premium users", async () => {
+    const wrapper = mountPanel();
+
+    await wrapper.find("textarea").setValue("Quero manter liquidez alta.");
+    await wrapper.find("form").trigger("submit");
+
+    expect(mutateMock).toHaveBeenCalledWith({
+      goalId: "goal-001",
+      payload: {
+        monthly_contribution: 1200,
+        user_context: expect.stringContaining("Ultimos 90 dias"),
+      },
+    });
+    expect(mutateMock).toHaveBeenCalledWith({
+      goalId: "goal-001",
+      payload: {
+        monthly_contribution: 1200,
+        user_context: expect.stringContaining("entradas R$ 5.000,00"),
+      },
+    });
+  });
+
+  it("renders the generated narrative and exposes a save-as-note action", async () => {
+    useGoalAIProjectionMutationMock.mockReturnValue({
+      mutate: mutateMock,
+      data: ref({
+        narrative: "A meta segue viavel se o aporte mensal for mantido.",
+        tokens_used: 420,
+        cost_usd: 0.000062,
+        model: "gpt-4o-mini",
+        projection: {
+          goal_id: "goal-001",
+          current_amount: "12500.00",
+          target_amount: "30000.00",
+          remaining_amount: "17500.00",
+          monthly_contribution: "1200.00",
+          portfolio_monthly_return_rate: "0.008",
+          portfolio_annual_return_rate_pct: "10.00",
+          months_to_completion: 14,
+          projected_completion_date: "2027-07-01",
+          on_track: true,
+          months_until_deadline: 18,
+          suggested_monthly_contribution: null,
+        },
+      }),
+      isPending: ref(false),
+      isError: ref(false),
+      error: ref(null),
+    });
+    const wrapper = mountPanel();
+
+    await wrapper.get("[data-testid=\"save-goal-ai-note\"]").trigger("click");
+
+    expect(wrapper.text()).toContain("A meta segue viavel");
+    expect(wrapper.emitted("save-note")).toHaveLength(1);
+  });
+});

--- a/app/components/goal/GoalProjectionPanel/GoalProjectionPanel.vue
+++ b/app/components/goal/GoalProjectionPanel/GoalProjectionPanel.vue
@@ -286,6 +286,7 @@ const chartOption = computed((): EChartsOption => {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+  min-width: 0;
 }
 
 .goal-projection-panel__header {
@@ -309,6 +310,7 @@ const chartOption = computed((): EChartsOption => {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: var(--space-3);
+  min-width: 0;
 }
 
 .goal-projection-panel__slider-section {

--- a/app/features/goals/contracts/goal.dto.ts
+++ b/app/features/goals/contracts/goal.dto.ts
@@ -29,6 +29,11 @@ export type CreateGoalPayload = {
 
 export type UpdateGoalPayload = Partial<CreateGoalPayload>;
 
+export type GoalAIProjectionPayload = {
+  readonly user_context: string;
+  readonly monthly_contribution: number;
+};
+
 /**
  * Compound-interest projection for a single goal.
  * Mirrors the API response from GET /goals/:id/projection.
@@ -66,4 +71,12 @@ export type GoalProjectionDto = {
 export type GoalProjectionResponseDto = {
   readonly goal: GoalDto;
   readonly projection: GoalProjectionDto;
+};
+
+export type GoalAIProjectionResponseDto = {
+  readonly narrative: string;
+  readonly tokens_used: number;
+  readonly cost_usd: number;
+  readonly projection: GoalProjectionDto;
+  readonly model: string;
 };

--- a/app/features/goals/model/goal-ai-projection.spec.ts
+++ b/app/features/goals/model/goal-ai-projection.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGoalAIProjectionContext,
+  summarizeGoalAITransactions,
+} from "./goal-ai-projection";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+
+/**
+ * Builds a transaction fixture for goal AI projection model tests.
+ *
+ * @param overrides Optional transaction fields to override.
+ * @returns Transaction DTO fixture.
+ */
+const makeTransaction = (
+  overrides: Partial<TransactionDto> = {},
+): TransactionDto => ({
+  id: "tx-1",
+  title: "Salario",
+  amount: "5000.00",
+  type: "income",
+  due_date: "2026-05-10",
+  description: null,
+  observation: null,
+  is_recurring: false,
+  is_installment: false,
+  installment_count: null,
+  currency: "BRL",
+  status: "paid",
+  start_date: null,
+  end_date: null,
+  tag_id: null,
+  account_id: null,
+  credit_card_id: null,
+  installment_group_id: null,
+  paid_at: null,
+  created_at: null,
+  updated_at: null,
+  ...overrides,
+});
+
+describe("goal AI projection model", () => {
+  it("summarizes recent transactions into income, expenses and net flow", () => {
+    const summary = summarizeGoalAITransactions([
+      makeTransaction({ amount: "5000.00", type: "income" }),
+      makeTransaction({ id: "tx-2", amount: "1200.50", type: "expense" }),
+      makeTransaction({ id: "tx-3", amount: "300.00", type: "expense" }),
+    ]);
+
+    expect(summary).toEqual({
+      incomeTotal: 5000,
+      expenseTotal: 1500.5,
+      netFlow: 3499.5,
+      transactionCount: 3,
+    });
+  });
+
+  it("builds an AI context containing user notes and the 90-day transaction summary", () => {
+    const context = buildGoalAIProjectionContext({
+      userContext: "Quero manter liquidez e evitar aportes agressivos.",
+      recentTransactions: [
+        makeTransaction({ amount: "5000.00", type: "income" }),
+        makeTransaction({ id: "tx-2", amount: "1800.00", type: "expense" }),
+      ],
+    });
+
+    expect(context).toContain("Quero manter liquidez");
+    expect(context).toContain("Ultimos 90 dias");
+    expect(context).toContain("entradas R$ 5.000,00");
+    expect(context).toContain("saidas R$ 1.800,00");
+    expect(context).toContain("saldo R$ 3.200,00");
+  });
+});

--- a/app/features/goals/model/goal-ai-projection.ts
+++ b/app/features/goals/model/goal-ai-projection.ts
@@ -1,0 +1,94 @@
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import { formatCurrency } from "~/utils/currency";
+
+export type GoalAITransactionSummary = {
+  readonly incomeTotal: number;
+  readonly expenseTotal: number;
+  readonly netFlow: number;
+  readonly transactionCount: number;
+};
+
+type BuildGoalAIProjectionContextInput = {
+  readonly userContext: string;
+  readonly recentTransactions: readonly TransactionDto[];
+};
+
+/**
+ * Parses backend decimal strings into numbers for prompt summaries.
+ *
+ * @param value Decimal string received in a transaction DTO.
+ * @returns Numeric amount, or zero when invalid.
+ */
+const parseAmount = (value: string): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+/**
+ * Formats currency with regular spaces so AI prompts and tests stay stable.
+ *
+ * @param value Monetary value.
+ * @returns Currency label with non-breaking spaces normalized.
+ */
+const formatContextCurrency = (value: number): string => {
+  return formatCurrency(value).replace(/\u00A0/g, " ");
+};
+
+/**
+ * Summarizes recent transactions into the financial context sent to AI.
+ *
+ * @param transactions Transactions fetched for the last 90 days.
+ * @returns Income, expense and net-flow summary.
+ */
+export const summarizeGoalAITransactions = (
+  transactions: readonly TransactionDto[],
+): GoalAITransactionSummary => {
+  return transactions.reduce<GoalAITransactionSummary>(
+    (summary, transaction) => {
+      const amount = parseAmount(transaction.amount);
+
+      if (transaction.type === "income") {
+        const incomeTotal = summary.incomeTotal + amount;
+        return {
+          ...summary,
+          incomeTotal,
+          netFlow: incomeTotal - summary.expenseTotal,
+        };
+      }
+
+      const expenseTotal = summary.expenseTotal + amount;
+      return {
+        ...summary,
+        expenseTotal,
+        netFlow: summary.incomeTotal - expenseTotal,
+      };
+    },
+    {
+      incomeTotal: 0,
+      expenseTotal: 0,
+      netFlow: 0,
+      transactionCount: transactions.length,
+    },
+  );
+};
+
+/**
+ * Builds the free-form context payload consumed by the goal projection endpoint.
+ *
+ * @param input User note and recent transaction list.
+ * @param input.userContext Free-form user note.
+ * @param input.recentTransactions Transactions fetched for the last 90 days.
+ * @returns Prompt context containing user note plus 90-day transaction summary.
+ */
+export const buildGoalAIProjectionContext = ({
+  userContext,
+  recentTransactions,
+}: BuildGoalAIProjectionContextInput): string => {
+  const summary = summarizeGoalAITransactions(recentTransactions);
+  const userNote = userContext.trim() || "Usuario nao informou contexto adicional.";
+
+  return [
+    `Contexto informado pelo usuario: ${userNote}`,
+    `Ultimos 90 dias: ${summary.transactionCount} transacoes; entradas ${formatContextCurrency(summary.incomeTotal)}; saidas ${formatContextCurrency(summary.expenseTotal)}; saldo ${formatContextCurrency(summary.netFlow)}`,
+  ].join("\n");
+};

--- a/app/features/goals/queries/use-goal-ai-projection-mutation.spec.ts
+++ b/app/features/goals/queries/use-goal-ai-projection-mutation.spec.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GOAL_AI_PROJECTION_CACHE_TTL_MS,
+  buildGoalAIProjectionCacheKey,
+  useGoalAIProjectionMutation,
+} from "./use-goal-ai-projection-mutation";
+import type {
+  GoalAIProjectionPayload,
+  GoalAIProjectionResponseDto,
+} from "~/features/goals/contracts/goal.dto";
+
+const useMutationMock = vi.hoisted(() => vi.fn());
+const getQueryDataMock = vi.hoisted(() => vi.fn());
+const setQueryDataMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/vue-query", () => ({
+  useMutation: useMutationMock,
+  useQueryClient: (): {
+    getQueryData: typeof getQueryDataMock;
+    setQueryData: typeof setQueryDataMock;
+  } => ({
+    getQueryData: getQueryDataMock,
+    setQueryData: setQueryDataMock,
+  }),
+}));
+
+/**
+ * Builds a projection mutation payload fixture.
+ *
+ * @returns Goal AI projection payload.
+ */
+const makePayload = (): GoalAIProjectionPayload => ({
+  monthly_contribution: 1200,
+  user_context: "Contexto enriquecido com transacoes recentes",
+});
+
+/**
+ * Builds an AI projection response fixture.
+ *
+ * @returns Goal AI projection response.
+ */
+const makeResponse = (): GoalAIProjectionResponseDto => ({
+  narrative: "A meta segue viavel com aporte mensal de R$ 1.200.",
+  tokens_used: 420,
+  cost_usd: 0.000062,
+  model: "gpt-4o-mini",
+  projection: {
+    goal_id: "goal-001",
+    current_amount: "10000.00",
+    target_amount: "30000.00",
+    remaining_amount: "20000.00",
+    monthly_contribution: "1200.00",
+    portfolio_monthly_return_rate: "0.008",
+    portfolio_annual_return_rate_pct: "10.00",
+    months_to_completion: 16,
+    projected_completion_date: "2027-09-01",
+    on_track: true,
+    months_until_deadline: 18,
+    suggested_monthly_contribution: null,
+  },
+});
+
+describe("useGoalAIProjectionMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    useMutationMock.mockImplementation((options: unknown) => options);
+  });
+
+  it("builds a stable cache key from goal id and projection payload", () => {
+    expect(buildGoalAIProjectionCacheKey("goal-001", makePayload())).toEqual([
+      "goals",
+      "goal-001",
+      "ai-projection",
+      1200,
+      "Contexto enriquecido com transacoes recentes",
+    ]);
+  });
+
+  it("calls client.generateGoalAIProjection and stores the response in a 1-hour cache", async () => {
+    vi.setSystemTime(new Date("2026-05-17T12:00:00Z"));
+    const response = makeResponse();
+    const client = { generateGoalAIProjection: vi.fn().mockResolvedValue(response) };
+    getQueryDataMock.mockReturnValue(undefined);
+
+    const mutation = useGoalAIProjectionMutation(client as never) as unknown as {
+      mutationFn: (vars: { goalId: string; payload: GoalAIProjectionPayload }) => Promise<GoalAIProjectionResponseDto>;
+    };
+
+    const result = await mutation.mutationFn({ goalId: "goal-001", payload: makePayload() });
+
+    expect(client.generateGoalAIProjection).toHaveBeenCalledWith("goal-001", makePayload());
+    expect(setQueryDataMock).toHaveBeenCalledWith(
+      buildGoalAIProjectionCacheKey("goal-001", makePayload()),
+      { data: response, cachedAt: Date.now() },
+    );
+    expect(result).toEqual(response);
+  });
+
+  it("returns cached data without calling the API when the cache is still fresh", async () => {
+    vi.setSystemTime(new Date("2026-05-17T12:30:00Z"));
+    const response = makeResponse();
+    const client = { generateGoalAIProjection: vi.fn() };
+    getQueryDataMock.mockReturnValue({
+      data: response,
+      cachedAt: Date.now() - GOAL_AI_PROJECTION_CACHE_TTL_MS + 1000,
+    });
+
+    const mutation = useGoalAIProjectionMutation(client as never) as unknown as {
+      mutationFn: (vars: { goalId: string; payload: GoalAIProjectionPayload }) => Promise<GoalAIProjectionResponseDto>;
+    };
+
+    const result = await mutation.mutationFn({ goalId: "goal-001", payload: makePayload() });
+
+    expect(client.generateGoalAIProjection).not.toHaveBeenCalled();
+    expect(result).toEqual(response);
+  });
+});

--- a/app/features/goals/queries/use-goal-ai-projection-mutation.ts
+++ b/app/features/goals/queries/use-goal-ai-projection-mutation.ts
@@ -1,0 +1,82 @@
+import {
+  type QueryKey,
+  type UseMutationReturnType,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/vue-query";
+
+import {
+  type GoalsClient,
+  useGoalsClient,
+} from "~/features/goals/services/goals.client";
+import type {
+  GoalAIProjectionPayload,
+  GoalAIProjectionResponseDto,
+} from "~/features/goals/contracts/goal.dto";
+
+export const GOAL_AI_PROJECTION_CACHE_TTL_MS = 60 * 60 * 1000;
+
+type GoalAIProjectionCacheEntry = {
+  readonly data: GoalAIProjectionResponseDto;
+  readonly cachedAt: number;
+};
+
+export type GenerateGoalAIProjectionVariables = {
+  readonly goalId: string;
+  readonly payload: GoalAIProjectionPayload;
+};
+
+/**
+ * Builds the cache key for an AI goal projection request.
+ *
+ * @param goalId Goal identifier.
+ * @param payload Projection request payload.
+ * @returns Vue Query cache key scoped to the exact request.
+ */
+export const buildGoalAIProjectionCacheKey = (
+  goalId: string,
+  payload: GoalAIProjectionPayload,
+): QueryKey => [
+  "goals",
+  goalId,
+  "ai-projection",
+  payload.monthly_contribution,
+  payload.user_context,
+];
+
+/**
+ * Generates a premium goal projection narrative and caches identical requests.
+ *
+ * @param providedClient Optional client injection for unit tests.
+ * @returns Vue Query mutation state for AI goal projection.
+ */
+export const useGoalAIProjectionMutation = (
+  providedClient?: GoalsClient,
+): UseMutationReturnType<
+  GoalAIProjectionResponseDto,
+  Error,
+  GenerateGoalAIProjectionVariables,
+  unknown
+> => {
+  const client = providedClient ?? useGoalsClient();
+  const queryClient = useQueryClient();
+
+  return useMutation<GoalAIProjectionResponseDto, Error, GenerateGoalAIProjectionVariables>({
+    mutationFn: async ({ goalId, payload }) => {
+      const cacheKey = buildGoalAIProjectionCacheKey(goalId, payload);
+      const cached = queryClient.getQueryData<GoalAIProjectionCacheEntry>(cacheKey);
+
+      if (cached && Date.now() - cached.cachedAt < GOAL_AI_PROJECTION_CACHE_TTL_MS) {
+        return cached.data;
+      }
+
+      const data = await client.generateGoalAIProjection(goalId, payload);
+      queryClient.setQueryData<GoalAIProjectionCacheEntry>(cacheKey, {
+        data,
+        cachedAt: Date.now(),
+      });
+
+      return data;
+    },
+  });
+};

--- a/app/features/goals/services/goals.client.spec.ts
+++ b/app/features/goals/services/goals.client.spec.ts
@@ -27,7 +27,7 @@ describe("GoalsClient", () => {
   let client: GoalsClient;
 
   beforeEach(() => {
-    http = { get: vi.fn() } as unknown as AxiosInstance;
+    http = { get: vi.fn(), post: vi.fn() } as unknown as AxiosInstance;
     client = new GoalsClient(http);
   });
 
@@ -48,6 +48,43 @@ describe("GoalsClient", () => {
       const result = await client.listGoals();
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe("generateGoalAIProjection", () => {
+    it("posts the AI context to POST /ai/goals/:id/projection and unwraps a v2 envelope", async () => {
+      const response = {
+        narrative: "Aumente o aporte para manter a meta no prazo.",
+        tokens_used: 431,
+        cost_usd: 0.000064,
+        model: "gpt-4o-mini",
+        projection: {
+          goal_id: "goal-001",
+          current_amount: "18500.00",
+          target_amount: "30000.00",
+          remaining_amount: "11500.00",
+          monthly_contribution: "1200.00",
+          portfolio_monthly_return_rate: "0.008",
+          portfolio_annual_return_rate_pct: "10.00",
+          months_to_completion: 9,
+          projected_completion_date: "2026-02-01",
+          on_track: true,
+          months_until_deadline: 10,
+          suggested_monthly_contribution: null,
+        },
+      };
+      vi.mocked(http.post).mockResolvedValueOnce({ data: { success: true, data: response } });
+
+      const result = await client.generateGoalAIProjection("goal-001", {
+        monthly_contribution: 1200,
+        user_context: "Contexto livre do usuário",
+      });
+
+      expect(http.post).toHaveBeenCalledWith("/ai/goals/goal-001/projection", {
+        monthly_contribution: 1200,
+        user_context: "Contexto livre do usuário",
+      });
+      expect(result).toEqual(response);
     });
   });
 });

--- a/app/features/goals/services/goals.client.ts
+++ b/app/features/goals/services/goals.client.ts
@@ -3,11 +3,37 @@ import type { AxiosInstance } from "axios";
 import { useHttp } from "~/composables/useHttp";
 import type {
   GoalDto,
+  GoalAIProjectionPayload,
+  GoalAIProjectionResponseDto,
   GoalPlanDto,
   GoalProjectionResponseDto,
   CreateGoalPayload,
   UpdateGoalPayload,
 } from "~/features/goals/contracts/goal.dto";
+
+type ApiEnvelope<T> = {
+  readonly data?: T;
+  readonly success?: boolean;
+};
+
+/**
+ * Extracts the payload from the v2 API envelope while accepting legacy flat mocks.
+ *
+ * @param payload Raw response body.
+ * @returns Unwrapped response payload.
+ */
+const unwrapApiEnvelope = <T>(payload: ApiEnvelope<T> | T): T => {
+  if (
+    payload !== null &&
+    typeof payload === "object" &&
+    "data" in payload &&
+    (payload as ApiEnvelope<T>).data !== undefined
+  ) {
+    return (payload as ApiEnvelope<T>).data as T;
+  }
+
+  return payload as T;
+};
 
 /**
  * API client for the goals feature.
@@ -93,6 +119,26 @@ export class GoalsClient {
       `/goals/${id}/projection`,
     );
     return response.data;
+  }
+
+  /**
+   * Generates a premium AI narrative for a goal projection.
+   *
+   * The backend endpoint is scoped by goal id and receives the free-form user
+   * context plus the monthly contribution used in the projection.
+   *
+   * @param id Goal identifier.
+   * @param payload Context and contribution sent to the AI projection endpoint.
+   * @returns Unwrapped AI projection response.
+   */
+  async generateGoalAIProjection(
+    id: string,
+    payload: GoalAIProjectionPayload,
+  ): Promise<GoalAIProjectionResponseDto> {
+    const response = await this.#http.post<
+      ApiEnvelope<GoalAIProjectionResponseDto> | GoalAIProjectionResponseDto
+    >(`/ai/goals/${id}/projection`, payload);
+    return unwrapApiEnvelope<GoalAIProjectionResponseDto>(response.data);
   }
 }
 

--- a/app/pages/goals.detail-ai.spec.ts
+++ b/app/pages/goals.detail-ai.spec.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(join(process.cwd(), "app/pages/goals/[id]/index.vue"), "utf8");
+const aiPanelSource = readFileSync(
+  join(process.cwd(), "app/components/goal/GoalAiContextPanel/GoalAiContextPanel.vue"),
+  "utf8",
+);
+
+describe("Goal detail page — AI projection integration", () => {
+  it("renders the dedicated AI context panel with the selected goal", () => {
+    expect(source).toContain("GoalAiContextPanel");
+    expect(source).toContain(":goal=\"selectedGoal\"");
+    expect(source).toContain(":monthly-contribution=\"monthlyContribution\"");
+  });
+
+  it("loads recent transactions from the last 90 days to enrich the AI prompt", () => {
+    expect(source).toContain("useListTransactionsQuery");
+    expect(source).toContain("start_date");
+    expect(source).toContain("end_date");
+  });
+
+  it("allows the AI panel to shrink on mobile without horizontal overflow", () => {
+    expect(source).toContain("grid-template-columns: minmax(0, 1fr);");
+    expect(source).toContain("min-width: 0;");
+    expect(aiPanelSource).toContain(".goal-ai-panel textarea");
+    expect(aiPanelSource).toContain("min-width: 0;");
+  });
+});

--- a/app/pages/goals.market-pulse.spec.ts
+++ b/app/pages/goals.market-pulse.spec.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const source = readFileSync(join(process.cwd(), "app/pages/goals.vue"), "utf8");
+const source = readFileSync(join(process.cwd(), "app/pages/goals/index.vue"), "utf8");
 
 describe("Goals page — Market Pulse anatomy", () => {
   it("renders the canonical action, status, projection and simulator sections", () => {
@@ -18,5 +18,10 @@ describe("Goals page — Market Pulse anatomy", () => {
     expect(source).toContain("Status das Metas");
     expect(source).toContain("Projeção de Evolução Patrimonial");
     expect(source).toContain("Simulador de Aporte");
+  });
+
+  it("links goal cards to the dedicated goal detail route", () => {
+    expect(source).toContain("Ver detalhes");
+    expect(source).toContain("navigateTo(`/goals/${goal.id}`)");
   });
 });

--- a/app/pages/goals/[id]/index.vue
+++ b/app/pages/goals/[id]/index.vue
@@ -1,0 +1,462 @@
+<script setup lang="ts">
+import { ArrowLeft, CalendarClock, PiggyBank, Target, TrendingUp } from "lucide-vue-next";
+
+import GoalAiContextPanel from "~/components/goal/GoalAiContextPanel/GoalAiContextPanel.vue";
+import GoalProjectionPanel from "~/components/goal/GoalProjectionPanel/GoalProjectionPanel.vue";
+import { useGoalProjectionQuery } from "~/features/goals/queries/use-goal-projection-query";
+import { useGoalsQuery } from "~/features/goals/queries/use-goals-query";
+import type { GoalDto } from "~/features/goals/contracts/goal.dto";
+import { useListTransactionsQuery } from "~/features/transactions/queries/use-list-transactions-query";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import { formatCurrency } from "~/utils/currency";
+
+definePageMeta({
+  middleware: ["authenticated"],
+  pageTitle: "Detalhe da meta",
+  pageSubtitle: "Projeção, contexto e recomendações.",
+});
+
+useHead({ title: "Detalhe da Meta | Auraxis" });
+
+const DEMO_GOALS: GoalDto[] = [
+  {
+    id: "market-pulse-emergency",
+    name: "Reserva de Emergência",
+    description: "Liquidez para seis meses de despesas essenciais.",
+    target_amount: 30000,
+    current_amount: 24500,
+    target_date: "2026-12-31",
+    status: "active",
+    created_at: "2026-01-10T10:00:00Z",
+  },
+  {
+    id: "market-pulse-car",
+    name: "Carro Novo SUV",
+    description: "Entrada planejada com proteção contra inflação do veículo.",
+    target_amount: 120000,
+    current_amount: 45000,
+    target_date: "2027-03-31",
+    status: "active",
+    created_at: "2026-02-18T10:00:00Z",
+  },
+  {
+    id: "market-pulse-trip",
+    name: "Viagem Europa",
+    description: "Viagem familiar com passagens, hospedagem e reservas.",
+    target_amount: 35000,
+    current_amount: 15200,
+    target_date: "2026-07-31",
+    status: "paused",
+    created_at: "2026-03-12T10:00:00Z",
+  },
+];
+
+const route = useRoute();
+const goalId = computed(() => String(route.params.id ?? ""));
+const goalIdRef = computed<string | null>(() => goalId.value || null);
+const savedNote = ref<string | null>(null);
+
+const goalsQuery = useGoalsQuery();
+const projectionQuery = useGoalProjectionQuery(goalIdRef);
+
+const endDate = computed(() => new Date().toISOString().slice(0, 10));
+const startDate = computed(() => {
+  const date = new Date();
+  date.setDate(date.getDate() - 90);
+  return date.toISOString().slice(0, 10);
+});
+
+const recentTransactionFilters = computed(() => ({
+  start_date: startDate.value,
+  end_date: endDate.value,
+}));
+
+const transactionsQuery = useListTransactionsQuery(recentTransactionFilters);
+
+const selectedGoal = computed<GoalDto | null>(() => {
+  const goals = goalsQuery.data.value ?? [];
+  return goals.find((goal) => goal.id === goalId.value)
+    ?? DEMO_GOALS.find((goal) => goal.id === goalId.value)
+    ?? null;
+});
+
+const isLoading = computed(() => goalsQuery.isLoading.value && selectedGoal.value === null);
+const hasError = computed(() => goalsQuery.isError.value);
+
+const progress = computed(() => {
+  if (!selectedGoal.value || selectedGoal.value.target_amount <= 0) {
+    return 0;
+  }
+
+  return Math.min(
+    100,
+    Math.max(0, Math.round((selectedGoal.value.current_amount / selectedGoal.value.target_amount) * 100)),
+  );
+});
+
+const remainingAmount = computed(() => {
+  if (!selectedGoal.value) {
+    return 0;
+  }
+
+  return Math.max(selectedGoal.value.target_amount - selectedGoal.value.current_amount, 0);
+});
+
+const monthlyContribution = computed(() => {
+  const raw = projectionQuery.data.value?.projection.monthly_contribution;
+  const parsed = raw ? Number(raw) : 0;
+
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+
+  if (!selectedGoal.value) {
+    return 0;
+  }
+
+  const deadline = selectedGoal.value.target_date
+    ? new Date(`${selectedGoal.value.target_date}T00:00:00`)
+    : null;
+  const now = new Date();
+  const monthsUntilDeadline = deadline
+    ? Math.max(1, (deadline.getFullYear() - now.getFullYear()) * 12 + (deadline.getMonth() - now.getMonth()))
+    : 12;
+
+  return Math.max(100, Math.ceil(remainingAmount.value / monthsUntilDeadline));
+});
+
+const recentTransactions = computed<readonly TransactionDto[]>(() => transactionsQuery.data.value ?? []);
+
+const targetDateLabel = computed(() => {
+  const date = selectedGoal.value?.target_date;
+
+  if (!date) {
+    return "Sem prazo";
+  }
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  }).format(new Date(`${date}T00:00:00`));
+});
+
+/**
+ * Stores the generated narrative as an in-page note preview.
+ *
+ * @param projection Generated AI projection payload.
+ * @param projection.narrative Narrative returned by the AI provider.
+ */
+const onSaveNote = (projection: { narrative: string }): void => {
+  savedNote.value = projection.narrative;
+};
+</script>
+
+<template>
+  <div class="goal-detail-page">
+    <button class="goal-detail-page__back" type="button" @click="navigateTo('/goals')">
+      <ArrowLeft :size="16" aria-hidden="true" />
+      Voltar para metas
+    </button>
+
+    <UiInlineError
+      v-if="hasError"
+      title="Não foi possível carregar a meta"
+      message="Atualize a página ou tente novamente em instantes."
+    />
+
+    <UiPageLoader v-else-if="isLoading" :rows="4" :with-title="true" />
+
+    <UiInlineError
+      v-else-if="!selectedGoal"
+      title="Meta não encontrada"
+      message="Essa meta não existe ou não está disponível para sua conta."
+    />
+
+    <template v-else>
+      <section class="goal-detail-hero">
+        <div>
+          <span class="goal-detail-hero__eyebrow">Meta financeira</span>
+          <h1>{{ selectedGoal.name }}</h1>
+          <p>{{ selectedGoal.description ?? "Acompanhe o progresso e ajuste o plano com IA." }}</p>
+        </div>
+
+        <div class="goal-detail-hero__progress" aria-label="Progresso da meta">
+          <strong>{{ progress }}%</strong>
+          <span>concluído</span>
+        </div>
+      </section>
+
+      <section class="goal-detail-metrics" aria-label="Resumo da meta">
+        <article>
+          <Target :size="18" aria-hidden="true" />
+          <span>Objetivo</span>
+          <strong>{{ formatCurrency(selectedGoal.target_amount) }}</strong>
+        </article>
+        <article>
+          <PiggyBank :size="18" aria-hidden="true" />
+          <span>Acumulado</span>
+          <strong>{{ formatCurrency(selectedGoal.current_amount) }}</strong>
+        </article>
+        <article>
+          <TrendingUp :size="18" aria-hidden="true" />
+          <span>Aporte base</span>
+          <strong>{{ formatCurrency(monthlyContribution) }}</strong>
+        </article>
+        <article>
+          <CalendarClock :size="18" aria-hidden="true" />
+          <span>Prazo</span>
+          <strong>{{ targetDateLabel }}</strong>
+        </article>
+      </section>
+
+      <section class="goal-detail-progress">
+        <div class="goal-detail-progress__track" aria-hidden="true">
+          <span :style="{ width: `${progress}%` }" />
+        </div>
+        <div>
+          <span>Faltam {{ formatCurrency(remainingAmount) }}</span>
+          <strong>{{ recentTransactions.length }} transações recentes consideradas</strong>
+        </div>
+      </section>
+
+      <details class="goal-detail-ai" open>
+        <summary>Contexto e projeção com IA</summary>
+        <GoalAiContextPanel
+          :goal="selectedGoal"
+          :monthly-contribution="monthlyContribution"
+          :recent-transactions="recentTransactions"
+          @save-note="onSaveNote"
+        />
+      </details>
+
+      <section v-if="savedNote" class="goal-detail-note" aria-live="polite">
+        <h2>Nota salva nesta sessão</h2>
+        <p>{{ savedNote }}</p>
+      </section>
+
+      <GoalProjectionPanel :goal-id="goalId" />
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.goal-detail-page {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 24px;
+  width: 100%;
+  min-width: 0;
+  color: #f7fbff;
+}
+
+.goal-detail-page > * {
+  min-width: 0;
+}
+
+.goal-detail-page__back {
+  display: inline-flex;
+  width: fit-content;
+  min-height: 38px;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgba(130, 157, 198, 0.24);
+  border-radius: var(--radius-full);
+  padding: 0 14px;
+  color: #8da2bf;
+  background: #111827;
+  font-weight: var(--font-weight-extrabold);
+  cursor: pointer;
+}
+
+.goal-detail-hero,
+.goal-detail-metrics article,
+.goal-detail-progress,
+.goal-detail-ai,
+.goal-detail-note {
+  min-width: 0;
+  border: 1px solid rgba(130, 157, 198, 0.22);
+  border-radius: var(--radius-lg);
+  background: #111827;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.22);
+}
+
+.goal-detail-hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 28px;
+  background:
+    radial-gradient(circle at 100% 0%, rgba(68, 212, 255, 0.12), transparent 30%),
+    #111827;
+}
+
+.goal-detail-hero__eyebrow {
+  color: #44d4ff;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
+  text-transform: uppercase;
+}
+
+.goal-detail-hero h1,
+.goal-detail-note h2 {
+  margin: 8px 0 0;
+  color: #f7fbff;
+  font-weight: var(--font-weight-extrabold);
+  letter-spacing: 0;
+}
+
+.goal-detail-hero h1 {
+  font-size: clamp(var(--font-size-heading-xl), 4vw, var(--font-size-4xl));
+  overflow-wrap: anywhere;
+}
+
+.goal-detail-hero p,
+.goal-detail-note p {
+  max-width: 680px;
+  margin: 10px 0 0;
+  color: #8da2bf;
+  font-size: var(--font-size-md);
+  line-height: 1.6;
+}
+
+.goal-detail-hero__progress {
+  display: grid;
+  min-width: 132px;
+  place-items: center;
+  border: 1px solid rgba(66, 232, 169, 0.28);
+  border-radius: var(--radius-md);
+  padding: 18px;
+  background: rgba(66, 232, 169, 0.08);
+}
+
+.goal-detail-hero__progress strong {
+  color: #42e8a9;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: var(--font-size-heading-xl);
+}
+
+.goal-detail-hero__progress span {
+  color: #8da2bf;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
+  text-transform: uppercase;
+}
+
+.goal-detail-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  min-width: 0;
+}
+
+.goal-detail-metrics article {
+  display: grid;
+  gap: 8px;
+  padding: 18px;
+}
+
+.goal-detail-metrics svg {
+  color: #44d4ff;
+}
+
+.goal-detail-metrics span {
+  color: #8da2bf;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
+  text-transform: uppercase;
+}
+
+.goal-detail-metrics strong {
+  color: #f7fbff;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: var(--font-size-lg);
+}
+
+.goal-detail-progress {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+}
+
+.goal-detail-progress__track {
+  overflow: hidden;
+  height: 10px;
+  border-radius: var(--radius-full);
+  background: #202b3e;
+}
+
+.goal-detail-progress__track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #44d4ff, #42e8a9);
+}
+
+.goal-detail-progress div:last-child {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: #8da2bf;
+  font-size: var(--font-size-sm);
+}
+
+.goal-detail-progress strong {
+  color: #dce8f8;
+}
+
+.goal-detail-ai {
+  overflow: hidden;
+}
+
+.goal-detail-ai summary {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  border-bottom: 1px solid rgba(130, 157, 198, 0.2);
+  padding: 0 24px;
+  color: #dce8f8;
+  font-weight: var(--font-weight-extrabold);
+  cursor: pointer;
+}
+
+.goal-detail-ai :deep(.goal-ai-panel) {
+  min-width: 0;
+  border: 0;
+  border-radius: var(--radius-none);
+  box-shadow: none;
+}
+
+.goal-detail-note {
+  padding: 20px;
+}
+
+.goal-detail-note h2 {
+  font-size: var(--font-size-md);
+}
+
+@media (max-width: 900px) {
+  .goal-detail-hero,
+  .goal-detail-progress div:last-child {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .goal-detail-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .goal-detail-hero,
+  .goal-detail-progress,
+  .goal-detail-note {
+    padding: 18px;
+  }
+
+  .goal-detail-metrics {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/app/pages/goals/index.vue
+++ b/app/pages/goals/index.vue
@@ -252,6 +252,15 @@ const selectedGoal = computed(() => {
   return goalCards.value.find((goal) => goal.id === selectedGoalId.value) ?? goalCards.value[0] ?? null;
 });
 
+/**
+ * Opens the dedicated detail route for a selected goal card.
+ *
+ * @param goal Goal selected in the status grid.
+ */
+const openGoalDetails = (goal: GoalViewModel): void => {
+  void navigateTo(`/goals/${goal.id}`);
+};
+
 watch(
   goalCards,
   (items) => {
@@ -513,9 +522,19 @@ const simulatedImpact = computed(() => {
                 Aporte mensal atual:
                 <strong>{{ formatCurrency(goal.monthlyContribution) }}</strong>
               </span>
-              <button type="button" aria-label="Mais opções da meta">
-                <MoreVertical :size="16" aria-hidden="true" />
-              </button>
+              <div class="goal-status-card__footer-actions">
+                <button
+                  class="goal-status-card__details"
+                  type="button"
+                  @click.stop="openGoalDetails(goal)"
+                >
+                  <ArrowUpRight :size="15" aria-hidden="true" />
+                  Ver detalhes
+                </button>
+                <button type="button" aria-label="Mais opções da meta" @click.stop>
+                  <MoreVertical :size="16" aria-hidden="true" />
+                </button>
+              </div>
             </div>
           </article>
         </div>
@@ -1045,11 +1064,30 @@ const simulatedImpact = computed(() => {
   color: var(--mp-text);
 }
 
+.goal-status-card__footer-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .goal-status-card__footer button {
   border: 0;
   padding: 4px;
   background: transparent;
   color: var(--mp-muted);
+}
+
+.goal-status-card__details {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid rgba(68, 212, 255, 0.25) !important;
+  border-radius: var(--radius-full);
+  padding: 0 10px !important;
+  color: var(--mp-cyan) !important;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
 }
 
 .goals-analytics-grid {


### PR DESCRIPTION
## Summary

Closes #827.

This PR adds the AI-assisted goal projection experience for the goals area:

- adds a dedicated goal detail route at `/goals/:id`, keeping the goals list at `/goals` through the Nuxt nested route structure;
- adds `GoalAiContextPanel` with premium entitlement handling, free-user upgrade prompt, free-form context input, generation state, error state, result metrics, and save-as-note action;
- enriches the AI request context with a 90-day transaction summary before sending it to the backend;
- adds the goals API client contract for `POST /ai/goals/{goal_id}/projection`, including v2 envelope unwrapping;
- adds a cached mutation layer so repeated identical projection requests are reused briefly;
- adds “Ver detalhes” navigation from the goals list;
- hardens the existing goal projection panel against mobile overflow when embedded in the new detail page.

## Screenshots

Captured locally with mocked data during visual QA:

- Goals list: `/tmp/auraxis-goal-ai-list.png`
- Goal detail before generation: `/tmp/auraxis-goal-ai-before.png`
- Goal detail after AI projection: `/tmp/auraxis-goal-ai-after.png`
- Mobile result: `/tmp/auraxis-goal-ai-mobile-result.png`

Note: `gh gist create` does not accept binary PNG uploads, so the screenshots are referenced here by local QA artifact path and included in the Codex handoff.

## Validation

- `pnpm policy:check`
- `pnpm vitest run app/features/goals/services/goals.client.spec.ts app/features/goals/model/goal-ai-projection.spec.ts app/features/goals/queries/use-goal-ai-projection-mutation.spec.ts app/components/goal/GoalAiContextPanel/__tests__/GoalAiContextPanel.spec.ts app/components/goal/GoalProjectionPanel/__tests__/GoalProjectionPanel.spec.ts app/pages/goals.market-pulse.spec.ts app/pages/goals.detail-ai.spec.ts --coverage.enabled=false`
- `pnpm typecheck && pnpm lint`
- `pnpm build`
- pre-push parity gate:
  - feature flags hygiene OK
  - lint OK
  - TypeScript OK
  - unit tests with coverage: 330 files / 3279 tests passed, coverage 92.4%
  - frontend governance OK
  - contracts check OK
  - production build OK
  - E2E skipped by hook because it is opt-in with `RUN_E2E=1 git push`

## Notes

The build still prints existing locale fallback warnings and the known large chunk warning; this PR does not touch locale files because the English locale is frozen.
