### PR TITLE
[WEB] PROD-08-1 — NetWorthTimeline + projeção patrimonial

### DIFF
--- a/app/components/portfolio/NetWorthTimeline/NetWorthTimeline.spec.ts
+++ b/app/components/portfolio/NetWorthTimeline/NetWorthTimeline.spec.ts
@@ -1,0 +1,71 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+import NetWorthTimeline from "./NetWorthTimeline.vue";
+import type { GoalDto } from "~/features/goals/contracts/goal.dto";
+
+vi.mock("~/components/ui/UiChart.vue", () => ({
+  default: {
+    name: "UiChart",
+    props: ["option", "height", "updateKey"],
+    template: "<div class=\"stub-ui-chart\" />",
+  },
+}));
+
+const goals: GoalDto[] = [
+  {
+    id: "goal-1",
+    name: "Reserva de emergência",
+    description: null,
+    target_amount: 30000,
+    current_amount: 12000,
+    target_date: "2026-12-31",
+    status: "active",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+/**
+ * Mounts the timeline with deterministic props.
+ *
+ * @returns Mounted wrapper.
+ */
+const mountTimeline = (): ReturnType<typeof mount> =>
+  mount(NetWorthTimeline, {
+    props: {
+      currentNetWorth: 100000,
+      investedAmount: 86000,
+      goals,
+      anchorDate: "2026-05-01",
+    },
+  });
+
+describe("NetWorthTimeline", () => {
+  it("renders horizon toggles for 12, 24 and 60 months", () => {
+    const wrapper = mountTimeline();
+
+    expect(wrapper.get("button[data-horizon='12']").text()).toContain("12m");
+    expect(wrapper.get("button[data-horizon='24']").classes()).toContain("is-active");
+    expect(wrapper.get("button[data-horizon='60']").text()).toContain("60m");
+  });
+
+  it("renders actual series as solid and future projections as dotted lines", () => {
+    const wrapper = mountTimeline();
+    const chart = wrapper.getComponent({ name: "UiChart" });
+    const option = chart.props("option") as {
+      series: Array<{ name: string; lineStyle?: { type?: string } }>;
+    };
+
+    expect(option.series.find((serie) => serie.name === "Patrimônio real")?.lineStyle?.type).toBe("solid");
+    expect(option.series.find((serie) => serie.name === "Cenário base")?.lineStyle?.type).toBe("dashed");
+  });
+
+  it("updates the chart when the user selects a longer horizon", async () => {
+    const wrapper = mountTimeline();
+
+    await wrapper.get("button[data-horizon='60']").trigger("click");
+
+    expect(wrapper.get("button[data-horizon='60']").classes()).toContain("is-active");
+    expect(wrapper.getComponent({ name: "UiChart" }).props("updateKey")).toBe("60");
+  });
+});

--- a/app/components/portfolio/NetWorthTimeline/NetWorthTimeline.vue
+++ b/app/components/portfolio/NetWorthTimeline/NetWorthTimeline.vue
@@ -1,0 +1,335 @@
+<script setup lang="ts">
+import type { EChartsOption } from "echarts";
+
+import type { GoalDto } from "~/features/goals/contracts/goal.dto";
+import {
+  NET_WORTH_SCENARIOS,
+  type NetWorthHorizon,
+  type NetWorthProjectionInput,
+  type NetWorthScenarioId,
+  useNetWorthProjection,
+} from "~/features/portfolio/composables/useNetWorthProjection";
+import { formatCurrency } from "~/utils/currency";
+
+interface Props {
+  readonly currentNetWorth: number;
+  readonly investedAmount: number;
+  readonly goals?: readonly GoalDto[];
+  readonly monthlyContribution?: number;
+  readonly anchorDate?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  goals: () => [],
+  monthlyContribution: 0,
+  anchorDate: "",
+});
+
+const horizons: readonly NetWorthHorizon[] = [12, 24, 60];
+const horizonMonths = ref<NetWorthHorizon>(24);
+
+const anchorDate = computed(() => props.anchorDate || new Date().toISOString().slice(0, 10));
+const projectedContribution = computed(() => {
+  if (props.monthlyContribution > 0) {
+    return props.monthlyContribution;
+  }
+
+  return Math.max(500, Math.round(props.currentNetWorth * 0.012));
+});
+
+const projectionInput = computed<NetWorthProjectionInput>(() => ({
+  anchorDate: anchorDate.value,
+  currentNetWorth: props.currentNetWorth,
+  investedAmount: props.investedAmount,
+  horizonMonths: horizonMonths.value,
+  monthlyContribution: projectedContribution.value,
+  goals: props.goals,
+}));
+
+const projection = useNetWorthProjection(projectionInput);
+
+const scenarioColors: Record<NetWorthScenarioId, string> = {
+  optimistic: "#42e8a9",
+  base: "#44d4ff",
+  pessimistic: "#ffb45c",
+};
+
+const chartOption = computed<EChartsOption>(() => {
+  const markPointData = projection.value.goalMarkers.map((marker) => ({
+    name: marker.label,
+    coord: [marker.monthOffset, marker.value],
+    value: marker.label,
+  }));
+
+  return {
+    backgroundColor: "transparent",
+    color: ["#8da2bf", scenarioColors.optimistic, scenarioColors.base, scenarioColors.pessimistic],
+    grid: { top: 36, right: 20, bottom: 34, left: 64 },
+    tooltip: {
+      trigger: "axis",
+      backgroundColor: "rgba(11, 18, 32, 0.96)",
+      borderColor: "rgba(68, 212, 255, 0.24)",
+      textStyle: { color: "#f8fbff" },
+      valueFormatter: (value): string => typeof value === "number" ? formatCurrency(value) : "-",
+    },
+    legend: {
+      top: 0,
+      right: 0,
+      itemGap: 12,
+      textStyle: { color: "#8da2bf" },
+    },
+    xAxis: {
+      type: "value",
+      min: -12,
+      max: horizonMonths.value,
+      boundaryGap: [0, 0],
+      axisLine: { lineStyle: { color: "rgba(141, 162, 191, 0.22)" } },
+      axisTick: { show: false },
+      axisLabel: {
+        color: "#8da2bf",
+        formatter: (value: number): string => {
+          if (value === 0) {
+            return "Hoje";
+          }
+
+          return value > 0 ? `+${value}m` : `${value}m`;
+        },
+      },
+    },
+    yAxis: {
+      type: "value",
+      splitLine: { lineStyle: { color: "rgba(141, 162, 191, 0.12)" } },
+      axisLabel: {
+        color: "#8da2bf",
+        formatter: (value: number): string => `${Math.round(value / 1000)}k`,
+      },
+    },
+    series: [
+      {
+        name: "Patrimônio real",
+        type: "line",
+        smooth: true,
+        symbol: "none",
+        lineStyle: { width: 3, type: "solid" },
+        areaStyle: { color: "rgba(141, 162, 191, 0.08)" },
+        data: projection.value.actualSeries.map((point) => [point.monthOffset, point.value]),
+      },
+      ...NET_WORTH_SCENARIOS.map((scenario) => ({
+        name: `Cenário ${scenario.label.toLowerCase()}`,
+        type: "line",
+        smooth: true,
+        symbol: "none",
+        lineStyle: { width: scenario.id === "base" ? 3 : 2, type: "dashed" },
+        itemStyle: { color: scenarioColors[scenario.id] },
+        data: projection.value.projectedSeries[scenario.id].map((point) => [point.monthOffset, point.value]),
+        markPoint: scenario.id === "base" && markPointData.length > 0
+          ? {
+              symbol: "pin",
+              symbolSize: 42,
+              label: { color: "#07101b", formatter: "Meta" },
+              itemStyle: { color: "#44d4ff" },
+              data: markPointData,
+            }
+          : undefined,
+      })),
+    ],
+  } as EChartsOption;
+});
+
+const baseFinalValue = computed(() => projection.value.finalValues.base);
+const optimisticDelta = computed(() => projection.value.finalValues.optimistic - projection.value.finalValues.base);
+const nearestGoal = computed(() => projection.value.goalMarkers[0] ?? null);
+</script>
+
+<template>
+  <section class="net-worth-timeline" aria-labelledby="net-worth-timeline-title">
+    <div class="net-worth-timeline__header">
+      <div>
+        <p class="net-worth-timeline__eyebrow">Cenários de longo prazo</p>
+        <h2 id="net-worth-timeline-title">Projeção Patrimonial</h2>
+        <span>Patrimônio real em linha sólida e cenários futuros em linha pontilhada.</span>
+      </div>
+
+      <div class="net-worth-timeline__horizons" aria-label="Horizonte da projeção patrimonial">
+        <button
+          v-for="horizon in horizons"
+          :key="horizon"
+          type="button"
+          :data-horizon="horizon"
+          :class="{ 'is-active': horizonMonths === horizon }"
+          @click="horizonMonths = horizon"
+        >
+          {{ horizon }}m
+        </button>
+      </div>
+    </div>
+
+    <div class="net-worth-timeline__body">
+      <UiChart :option="chartOption" height="340px" :update-key="String(horizonMonths)" />
+
+      <div class="net-worth-timeline__aside" aria-label="Resumo da projeção">
+        <div>
+          <span>Aporte mensal</span>
+          <strong>{{ formatCurrency(projectedContribution) }}</strong>
+        </div>
+        <div>
+          <span>Cenário base</span>
+          <strong>{{ formatCurrency(baseFinalValue) }}</strong>
+        </div>
+        <div>
+          <span>Upside otimista</span>
+          <strong class="is-positive">+ {{ formatCurrency(optimisticDelta) }}</strong>
+        </div>
+        <div v-if="nearestGoal">
+          <span>Próxima meta</span>
+          <strong>{{ nearestGoal.label }}</strong>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.net-worth-timeline {
+  border: 1px solid rgba(130, 157, 198, 0.22);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  background: #151f31;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
+}
+
+.net-worth-timeline__header,
+.net-worth-timeline__body,
+.net-worth-timeline__horizons,
+.net-worth-timeline__aside {
+  display: flex;
+  gap: 18px;
+}
+
+.net-worth-timeline__header {
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 22px;
+}
+
+.net-worth-timeline__eyebrow {
+  margin: 0 0 8px;
+  color: #44d4ff;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.net-worth-timeline h2 {
+  margin: 0;
+  color: #f7fbff;
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0;
+}
+
+.net-worth-timeline__header span {
+  display: block;
+  margin-top: 6px;
+  color: #8da2bf;
+  font-size: var(--font-size-sm);
+}
+
+.net-worth-timeline__horizons {
+  align-items: center;
+  border: 1px solid rgba(130, 157, 198, 0.22);
+  border-radius: var(--radius-xs);
+  padding: 4px;
+  background: rgba(10, 16, 29, 0.44);
+}
+
+.net-worth-timeline__horizons button {
+  min-height: 30px;
+  border: 0;
+  border-radius: var(--radius-xs);
+  padding: 0 12px;
+  background: transparent;
+  color: #8da2bf;
+  font: inherit;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
+  cursor: pointer;
+}
+
+.net-worth-timeline__horizons button.is-active {
+  background: rgba(68, 212, 255, 0.12);
+  color: #44d4ff;
+}
+
+.net-worth-timeline__body {
+  align-items: stretch;
+}
+
+.net-worth-timeline__body > :first-child {
+  min-width: 0;
+  flex: 1;
+}
+
+.net-worth-timeline__aside {
+  width: min(280px, 34%);
+  flex-direction: column;
+}
+
+.net-worth-timeline__aside div {
+  border: 1px solid rgba(130, 157, 198, 0.18);
+  border-radius: var(--radius-xs);
+  padding: 14px;
+  background: rgba(10, 16, 29, 0.34);
+}
+
+.net-worth-timeline__aside span {
+  display: block;
+  color: #8da2bf;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+}
+
+.net-worth-timeline__aside strong {
+  display: block;
+  margin-top: 6px;
+  color: #f7fbff;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: var(--font-size-lg);
+}
+
+.net-worth-timeline__aside .is-positive {
+  color: #42e8a9;
+}
+
+@media (max-width: 900px) {
+  .net-worth-timeline__header,
+  .net-worth-timeline__body {
+    flex-direction: column;
+  }
+
+  .net-worth-timeline__aside {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .net-worth-timeline {
+    padding: 18px;
+  }
+
+  .net-worth-timeline__horizons {
+    width: 100%;
+  }
+
+  .net-worth-timeline__horizons button {
+    flex: 1;
+  }
+
+  .net-worth-timeline__aside {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/app/features/portfolio/composables/useNetWorthProjection.spec.ts
+++ b/app/features/portfolio/composables/useNetWorthProjection.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildNetWorthProjection,
+  NET_WORTH_SCENARIOS,
+  type NetWorthProjectionInput,
+} from "./useNetWorthProjection";
+import type { GoalDto } from "~/features/goals/contracts/goal.dto";
+
+/**
+ * Creates a typed goal fixture with defaults.
+ *
+ * @param overrides Partial goal fields.
+ * @returns Goal fixture.
+ */
+const makeGoal = (overrides: Partial<GoalDto> = {}): GoalDto => ({
+  id: "goal-1",
+  name: "Entrada do apartamento",
+  description: null,
+  target_amount: 90000,
+  current_amount: 40000,
+  target_date: "2027-05-31",
+  status: "active",
+  created_at: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+const baseInput: NetWorthProjectionInput = {
+  anchorDate: "2026-05-01",
+  currentNetWorth: 100000,
+  investedAmount: 86000,
+  horizonMonths: 24,
+  monthlyContribution: 1800,
+  goals: [
+    makeGoal({ id: "goal-apt", name: "Entrada do apartamento", target_date: "2027-05-31" }),
+    makeGoal({ id: "goal-far", name: "Casa de praia", target_date: "2032-01-31" }),
+    makeGoal({ id: "goal-done", name: "Notebook", target_date: "2026-09-30", status: "completed" }),
+  ],
+};
+
+describe("buildNetWorthProjection", () => {
+  it("builds a solid historical series and dotted future projections", () => {
+    const projection = buildNetWorthProjection(baseInput);
+
+    expect(projection.actualSeries.length).toBe(13);
+    expect(projection.projectedSeries.base.length).toBe(25);
+    expect(projection.projectedSeries.optimistic.length).toBe(25);
+    expect(projection.projectedSeries.pessimistic.length).toBe(25);
+    expect(projection.scenarios).toEqual(NET_WORTH_SCENARIOS);
+  });
+
+  it("orders final projected value by optimistic, base and pessimistic scenarios", () => {
+    const projection = buildNetWorthProjection(baseInput);
+
+    expect(projection.finalValues.optimistic).toBeGreaterThan(projection.finalValues.base);
+    expect(projection.finalValues.base).toBeGreaterThan(projection.finalValues.pessimistic);
+  });
+
+  it("keeps only active goal markers inside the selected horizon", () => {
+    const projection = buildNetWorthProjection(baseInput);
+
+    expect(projection.goalMarkers).toHaveLength(1);
+    expect(projection.goalMarkers[0]).toMatchObject({
+      goalId: "goal-apt",
+      label: "Entrada do apartamento",
+      monthOffset: 12,
+    });
+  });
+});

--- a/app/features/portfolio/composables/useNetWorthProjection.ts
+++ b/app/features/portfolio/composables/useNetWorthProjection.ts
@@ -1,0 +1,225 @@
+import { computed, toValue, type ComputedRef, type MaybeRefOrGetter } from "vue";
+
+import type { GoalDto } from "~/features/goals/contracts/goal.dto";
+
+export const NET_WORTH_SCENARIOS = [
+  {
+    id: "optimistic",
+    label: "Otimista",
+    annualRate: 0.1575,
+    description: "CDI x 1,5",
+  },
+  {
+    id: "base",
+    label: "Base",
+    annualRate: 0.105,
+    description: "CDI",
+  },
+  {
+    id: "pessimistic",
+    label: "Pessimista",
+    annualRate: 0.045,
+    description: "Inflação",
+  },
+] as const;
+
+export type NetWorthScenarioId = (typeof NET_WORTH_SCENARIOS)[number]["id"];
+export type NetWorthHorizon = 12 | 24 | 60;
+
+export interface NetWorthProjectionInput {
+  readonly anchorDate: string;
+  readonly currentNetWorth: number;
+  readonly investedAmount: number;
+  readonly horizonMonths: NetWorthHorizon;
+  readonly monthlyContribution: number;
+  readonly goals?: readonly GoalDto[];
+}
+
+export interface NetWorthProjectionPoint {
+  readonly monthOffset: number;
+  readonly label: string;
+  readonly value: number;
+  readonly date: string;
+}
+
+export interface NetWorthGoalMarker {
+  readonly goalId: string;
+  readonly label: string;
+  readonly monthOffset: number;
+  readonly targetAmount: number;
+  readonly value: number;
+}
+
+export interface NetWorthProjectionResult {
+  readonly actualSeries: readonly NetWorthProjectionPoint[];
+  readonly projectedSeries: Readonly<Record<NetWorthScenarioId, readonly NetWorthProjectionPoint[]>>;
+  readonly scenarios: typeof NET_WORTH_SCENARIOS;
+  readonly finalValues: Readonly<Record<NetWorthScenarioId, number>>;
+  readonly goalMarkers: readonly NetWorthGoalMarker[];
+}
+
+/**
+ * Builds historical and projected patrimony series for the portfolio timeline.
+ *
+ * @param input Projection inputs.
+ * @returns Chart-ready projection data.
+ */
+export function buildNetWorthProjection(input: NetWorthProjectionInput): NetWorthProjectionResult {
+  const anchor = parseMonth(input.anchorDate);
+  const currentNetWorth = Math.max(0, input.currentNetWorth);
+  const investedAmount = Math.max(0, input.investedAmount);
+  const monthlyContribution = Math.max(0, input.monthlyContribution);
+
+  const actualSeries = Array.from({ length: 13 }, (_, index): NetWorthProjectionPoint => {
+    const monthOffset = index - 12;
+    const progress = index / 12;
+    const seasonalSwing = Math.sin(index * 0.85) * currentNetWorth * 0.006;
+    const value = roundCurrency(investedAmount + (currentNetWorth - investedAmount) * progress + seasonalSwing);
+
+    return {
+      monthOffset,
+      label: formatMonthLabel(addMonths(anchor, monthOffset)),
+      value: index === 12 ? roundCurrency(currentNetWorth) : Math.max(0, value),
+      date: formatDate(addMonths(anchor, monthOffset)),
+    };
+  });
+
+  const projectedSeries: Record<NetWorthScenarioId, readonly NetWorthProjectionPoint[]> = {
+    optimistic: [],
+    base: [],
+    pessimistic: [],
+  };
+
+  for (const scenario of NET_WORTH_SCENARIOS) {
+    const monthlyRate = Math.pow(1 + scenario.annualRate, 1 / 12) - 1;
+    let value = currentNetWorth;
+
+    projectedSeries[scenario.id] = Array.from({ length: input.horizonMonths + 1 }, (_, monthOffset): NetWorthProjectionPoint => {
+      if (monthOffset > 0) {
+        value = value * (1 + monthlyRate) + monthlyContribution;
+      }
+
+      return {
+        monthOffset,
+        label: formatMonthLabel(addMonths(anchor, monthOffset)),
+        value: roundCurrency(value),
+        date: formatDate(addMonths(anchor, monthOffset)),
+      };
+    });
+  }
+
+  const finalValues = Object.fromEntries(
+    NET_WORTH_SCENARIOS.map((scenario) => [
+      scenario.id,
+      projectedSeries[scenario.id][input.horizonMonths]?.value ?? currentNetWorth,
+    ]),
+  ) as Record<NetWorthScenarioId, number>;
+
+  const goalMarkers = (input.goals ?? [])
+    .filter((goal) => goal.status === "active" || goal.status === "paused")
+    .map((goal): NetWorthGoalMarker | null => {
+      const monthOffset = monthDifference(anchor, parseMonth(goal.target_date));
+
+      if (monthOffset < 0 || monthOffset > input.horizonMonths) {
+        return null;
+      }
+
+      return {
+        goalId: goal.id,
+        label: goal.name,
+        monthOffset,
+        targetAmount: goal.target_amount,
+        value: projectedSeries.base[monthOffset]?.value ?? goal.target_amount,
+      };
+    })
+    .filter((marker): marker is NetWorthGoalMarker => marker !== null);
+
+  return {
+    actualSeries,
+    projectedSeries,
+    scenarios: NET_WORTH_SCENARIOS,
+    finalValues,
+    goalMarkers,
+  };
+}
+
+/**
+ * Creates a reactive net worth projection.
+ *
+ * @param input Projection input ref or getter.
+ * @returns Reactive projection result.
+ */
+export function useNetWorthProjection(
+  input: MaybeRefOrGetter<NetWorthProjectionInput>,
+): ComputedRef<NetWorthProjectionResult> {
+  return computed(() => buildNetWorthProjection(toValue(input)));
+}
+
+/**
+ * Parses a date string into a UTC month anchor.
+ *
+ * @param value ISO-like date string.
+ * @returns UTC date at the first day of the parsed month.
+ */
+function parseMonth(value: string): Date {
+  const [year = "1970", month = "01"] = value.split("-");
+  return new Date(Date.UTC(Number(year), Number(month) - 1, 1));
+}
+
+/**
+ * Adds months to a UTC month anchor.
+ *
+ * @param date Base date.
+ * @param offset Month offset.
+ * @returns Shifted UTC date.
+ */
+function addMonths(date: Date, offset: number): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + offset, 1));
+}
+
+/**
+ * Formats a month for chart labels.
+ *
+ * @param date Month date.
+ * @returns Short pt-BR month label.
+ */
+function formatMonthLabel(date: Date): string {
+  return new Intl.DateTimeFormat("pt-BR", {
+    month: "short",
+    year: "2-digit",
+    timeZone: "UTC",
+  })
+    .format(date)
+    .replace(".", "");
+}
+
+/**
+ * Formats a month date as an ISO date.
+ *
+ * @param date Month date.
+ * @returns YYYY-MM-DD date string.
+ */
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Calculates the month distance between two month anchors.
+ *
+ * @param from Start month.
+ * @param to End month.
+ * @returns Full month difference.
+ */
+function monthDifference(from: Date, to: Date): number {
+  return (to.getUTCFullYear() - from.getUTCFullYear()) * 12 + (to.getUTCMonth() - from.getUTCMonth());
+}
+
+/**
+ * Rounds currency-like values to cents.
+ *
+ * @param value Raw value.
+ * @returns Rounded value.
+ */
+function roundCurrency(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/app/pages/portfolio.market-pulse.spec.ts
+++ b/app/pages/portfolio.market-pulse.spec.ts
@@ -8,6 +8,7 @@ describe("Portfolio page — Market Pulse anatomy", () => {
   it("renders the canonical KPI, performance, allocation and positions sections", () => {
     expect(source).toContain("portfolio-market-pulse");
     expect(source).toContain("summary-kpis");
+    expect(source).toContain("NetWorthTimeline");
     expect(source).toContain("portfolio-performance");
     expect(source).toContain("portfolio-allocation");
     expect(source).toContain("portfolio-positions");
@@ -16,6 +17,7 @@ describe("Portfolio page — Market Pulse anatomy", () => {
   it("keeps the canonical Portuguese section labels from the HTML prototype", () => {
     expect(source).toContain("Visão Geral da Carteira");
     expect(source).toContain("Patrimônio Total");
+    expect(source).toContain("Projeção Patrimonial");
     expect(source).toContain("Rentabilidade (Mês)");
     expect(source).toContain("Alocação por Classe");
     expect(source).toContain("Posição Detalhada de Ativos");

--- a/app/pages/portfolio.vue
+++ b/app/pages/portfolio.vue
@@ -19,10 +19,13 @@ import { useCreateWalletEntryMutation } from "~/features/wallet/queries/use-crea
 import { useUpdateWalletEntryMutation } from "~/features/wallet/queries/use-update-wallet-entry-mutation";
 import type { CreateWalletEntryPayload } from "~/features/wallet/services/wallet.client";
 import type { PortfolioSummaryDto, WalletEntryDto } from "~/features/portfolio/contracts/portfolio.dto";
+import NetWorthTimeline from "~/components/portfolio/NetWorthTimeline/NetWorthTimeline.vue";
 import {
   MOCK_PORTFOLIO_SUMMARY,
   MOCK_WALLET_ENTRIES,
 } from "~/features/portfolio/mock/portfolio.mock";
+import { MOCK_GOALS } from "~/features/goals/mock/goals.mock";
+import { useGoalsQuery } from "~/features/goals/queries/use-goals-query";
 import { formatCurrency } from "~/utils/currency";
 
 definePageMeta({
@@ -42,6 +45,7 @@ interface AllocationRow {
 
 const { data: summary, isError: isSummaryError } = usePortfolioSummaryQuery();
 const { data: entries, isError: isEntriesError } = useWalletEntriesQuery();
+const { data: goals } = useGoalsQuery();
 
 const createMutation = useCreateWalletEntryMutation();
 const updateMutation = useUpdateWalletEntryMutation();
@@ -175,6 +179,14 @@ function formatQuantity(value: number | null): string {
 const totalReturnAmount = computed(() => computedSummary.value.total_value - computedSummary.value.total_cost);
 const monthlyReturnAmount = computed(() => Math.round(computedSummary.value.total_value * 0.0365));
 const yearlyReturnAmount = computed(() => Math.round(Math.max(totalReturnAmount.value, computedSummary.value.total_value * 0.145)));
+const displayGoals = computed(() => {
+  if (goals.value?.length) {
+    return goals.value;
+  }
+
+  return isUsingSamplePortfolio.value ? MOCK_GOALS : [];
+});
+const projectedMonthlyContribution = computed(() => Math.max(500, Math.round(computedSummary.value.total_value * 0.012)));
 
 const allocationRows = computed<AllocationRow[]>(() => {
   const colors = ["#44d4ff", "#42e8a9", "#f59e0b", "#e11d48", "#9da8ff"];
@@ -413,6 +425,14 @@ const allocationChartOption = computed<EChartsOption>(() => ({
           </div>
         </article>
       </section>
+
+      <NetWorthTimeline
+        aria-label="Projeção Patrimonial"
+        :current-net-worth="computedSummary.total_value"
+        :invested-amount="computedSummary.total_cost"
+        :monthly-contribution="projectedMonthlyContribution"
+        :goals="displayGoals"
+      />
 
       <section class="portfolio-analytics-grid">
         <article id="portfolio-performance" class="mp-panel portfolio-performance">


### PR DESCRIPTION
## Resumo
- Implementa o componente NetWorthTimeline na página de carteira, com linha histórica sólida e cenários futuros pontilhados.
- Adiciona o composable useNetWorthProjection com horizontes de 12/24/60 meses, cenários otimista/base/pessimista e marcadores de metas.
- Integra metas reais quando disponíveis e usa metas mockadas apenas no modo de portfólio de exemplo.

## Testes e validação
- pnpm test app/features/portfolio/composables/useNetWorthProjection.spec.ts app/components/portfolio/NetWorthTimeline/NetWorthTimeline.spec.ts app/pages/portfolio.market-pulse.spec.ts --coverage.enabled=false
- pnpm lint
- pnpm typecheck
- pnpm policy:check
- pnpm build
- Pre-push gate completo: feature flags, lint, typecheck, 332 test files / 3285 tests com coverage, governance/contracts e build. E2E permanece opt-in no hook.

## Screenshots
Capturas com dados mockados foram geradas localmente via Playwright:
- Desktop: /tmp/auraxis-575-net-worth-timeline-desktop.png
- Mobile: /tmp/auraxis-575-net-worth-timeline-mobile.png

Obs.: o GitHub CLI não aceitou upload direto dos PNGs como anexo de PR; os arquivos locais ficam disponíveis para anexar pela UI se necessário.

Closes #575