### PR TITLE
[WEB] Cookies — banner e preferências granulares

### DIFF
--- a/__tests__/plugins/web-vitals.client.spec.ts
+++ b/__tests__/plugins/web-vitals.client.spec.ts
@@ -114,9 +114,9 @@ describe("emit", () => {
     mockSetTag.mockClear();
   });
 
-  it("forwards the metric to PostHog and Sentry", async () => {
+  it("forwards the metric to PostHog and Sentry when analytics consent is granted", async () => {
     const { emit } = await import("../../app/plugins/web-vitals.client");
-    emit(baseMetric({ name: "FCP", value: 900 }));
+    emit(baseMetric({ name: "FCP", value: 900 }), true);
     expect(mockCapture).toHaveBeenCalledTimes(1);
     expect(mockSetMeasurement).toHaveBeenCalledTimes(1);
     expect(mockSetTag).toHaveBeenCalledTimes(1);

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { NConfigProvider, NMessageProvider, NDialogProvider } from "naive-ui";
+import CookieConsentBanner from "~/components/privacy/CookieConsentBanner.vue";
 import { useNaiveTheme } from "~/composables/useNaiveTheme";
 import { useTheme } from "~/composables/useTheme";
 
@@ -26,6 +27,7 @@ const { naiveTheme } = useTheme();
         <NuxtLayout>
           <NuxtPage />
         </NuxtLayout>
+        <CookieConsentBanner />
       </NDialogProvider>
     </NMessageProvider>
   </NConfigProvider>

--- a/app/components/privacy/CookieConsentBanner.spec.ts
+++ b/app/components/privacy/CookieConsentBanner.spec.ts
@@ -1,0 +1,72 @@
+/* eslint-disable jsdoc/require-jsdoc */
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it } from "vitest";
+import { nextTick } from "vue";
+
+import {
+  COOKIE_CONSENT_KEY,
+  readCookieConsent,
+  rejectOptionalCookieConsent,
+} from "~/shared/privacy/cookie-consent";
+import CookieConsentBanner from "./CookieConsentBanner.vue";
+
+const clearConsentCookie = (): void => {
+  document.cookie = `${COOKIE_CONSENT_KEY}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+};
+
+describe("CookieConsentBanner", () => {
+  beforeEach(() => {
+    clearConsentCookie();
+  });
+
+  it("renders the cookie banner when no preference was saved", async () => {
+    const wrapper = mount(CookieConsentBanner);
+    await nextTick();
+
+    expect(wrapper.get("[role='region']").text()).toContain("Controle seus cookies");
+    expect(wrapper.text()).toContain("Aceitar todos");
+    expect(wrapper.text()).toContain("Rejeitar opcionais");
+  });
+
+  it("stays hidden when the visitor already chose preferences", () => {
+    rejectOptionalCookieConsent(new Date("2026-05-17T10:00:00.000Z"));
+
+    const wrapper = mount(CookieConsentBanner);
+
+    expect(wrapper.find("[role='region']").exists()).toBe(false);
+  });
+
+  it("accepts all optional cookies from the banner", async () => {
+    const wrapper = mount(CookieConsentBanner);
+    await nextTick();
+
+    await wrapper.get("button[data-testid='cookie-accept-all']").trigger("click");
+
+    expect(readCookieConsent()).toMatchObject({ analytics: true, marketing: true });
+    expect(wrapper.find("[role='region']").exists()).toBe(false);
+  });
+
+  it("rejects optional cookies from the banner", async () => {
+    const wrapper = mount(CookieConsentBanner);
+    await nextTick();
+
+    await wrapper.get("button[data-testid='cookie-reject-optional']").trigger("click");
+    wrapper.unmount();
+
+    expect(readCookieConsent()).toMatchObject({ analytics: false, marketing: false });
+    expect(wrapper.find("[role='region']").exists()).toBe(false);
+  });
+
+  it("saves granular preferences", async () => {
+    const wrapper = mount(CookieConsentBanner);
+    await nextTick();
+
+    await wrapper.get("button[data-testid='cookie-configure']").trigger("click");
+    await wrapper.get("input[data-testid='cookie-marketing']").setValue(true);
+    await wrapper.get("input[data-testid='cookie-analytics']").setValue(false);
+    await wrapper.get("button[data-testid='cookie-save-preferences']").trigger("click");
+
+    expect(readCookieConsent()).toMatchObject({ analytics: false, marketing: true });
+    expect(wrapper.find("[role='region']").exists()).toBe(false);
+  });
+});

--- a/app/components/privacy/CookieConsentBanner.vue
+++ b/app/components/privacy/CookieConsentBanner.vue
@@ -1,0 +1,316 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, reactive, ref } from "vue";
+
+import {
+  acceptAllCookieConsent,
+  readCookieConsent,
+  rejectOptionalCookieConsent,
+  saveCookieConsent,
+  subscribeToCookieConsentChanges,
+  type CookieConsentPreferences,
+} from "~/shared/privacy/cookie-consent";
+
+const isReady = ref(false);
+const savedPreferences = ref<CookieConsentPreferences | null>(null);
+const isConfiguring = ref(false);
+const granularPreferences = reactive({
+  analytics: true,
+  marketing: false,
+});
+
+let unsubscribe: (() => void) | null = null;
+
+const isVisible = computed(() => isReady.value && savedPreferences.value === null);
+
+/**
+ * Mirrors persisted preferences into the local banner state.
+ *
+ * @param preferences Persisted cookie preferences, or null when none exist.
+ */
+const syncFromSavedPreferences = (preferences: CookieConsentPreferences | null): void => {
+  savedPreferences.value = preferences;
+
+  if (preferences) {
+    granularPreferences.analytics = preferences.analytics;
+    granularPreferences.marketing = preferences.marketing;
+  }
+};
+
+/** Accepts all optional cookie categories and hides the banner. */
+const acceptAll = (): void => {
+  syncFromSavedPreferences(acceptAllCookieConsent());
+};
+
+/** Rejects every optional cookie category and hides the banner. */
+const rejectOptional = (): void => {
+  syncFromSavedPreferences(rejectOptionalCookieConsent());
+};
+
+/** Persists the granular category choices selected by the visitor. */
+const saveGranularPreferences = (): void => {
+  syncFromSavedPreferences(saveCookieConsent({
+    analytics: granularPreferences.analytics,
+    marketing: granularPreferences.marketing,
+  }));
+};
+
+onMounted(() => {
+  syncFromSavedPreferences(readCookieConsent());
+  isReady.value = true;
+  unsubscribe = subscribeToCookieConsentChanges(syncFromSavedPreferences);
+});
+
+onBeforeUnmount(() => {
+  unsubscribe?.();
+});
+</script>
+
+<template>
+  <section
+    v-if="isVisible"
+    class="cookie-consent"
+    role="region"
+    aria-label="Preferências de cookies"
+  >
+    <div class="cookie-consent__content">
+      <p class="cookie-consent__eyebrow">LGPD</p>
+      <h2 class="cookie-consent__title">Controle seus cookies</h2>
+      <p class="cookie-consent__text">
+        Usamos cookies necessários para manter o Auraxis seguro. Analytics e
+        marketing só ficam ativos com o seu consentimento.
+      </p>
+      <a class="cookie-consent__policy" href="/privacy-policy">
+        Ver política de privacidade
+      </a>
+    </div>
+
+    <div v-if="isConfiguring" class="cookie-consent__preferences">
+      <label class="cookie-consent__option cookie-consent__option--disabled">
+        <input type="checkbox" checked disabled>
+        <span>
+          <strong>Necessários</strong>
+          <small>Login, segurança e preferências essenciais.</small>
+        </span>
+      </label>
+
+      <label class="cookie-consent__option">
+        <input
+          v-model="granularPreferences.analytics"
+          data-testid="cookie-analytics"
+          type="checkbox"
+        >
+        <span>
+          <strong>Analytics e performance</strong>
+          <small>Métricas de uso, estabilidade e Core Web Vitals.</small>
+        </span>
+      </label>
+
+      <label class="cookie-consent__option">
+        <input
+          v-model="granularPreferences.marketing"
+          data-testid="cookie-marketing"
+          type="checkbox"
+        >
+        <span>
+          <strong>Marketing</strong>
+          <small>Campanhas, atribuição e comunicação personalizada.</small>
+        </span>
+      </label>
+    </div>
+
+    <div class="cookie-consent__actions">
+      <button
+        data-testid="cookie-reject-optional"
+        type="button"
+        class="cookie-consent__button cookie-consent__button--ghost"
+        @click="rejectOptional"
+      >
+        Rejeitar opcionais
+      </button>
+      <button
+        v-if="!isConfiguring"
+        data-testid="cookie-configure"
+        type="button"
+        class="cookie-consent__button cookie-consent__button--secondary"
+        @click="isConfiguring = true"
+      >
+        Configurar
+      </button>
+      <button
+        v-else
+        data-testid="cookie-save-preferences"
+        type="button"
+        class="cookie-consent__button cookie-consent__button--secondary"
+        @click="saveGranularPreferences"
+      >
+        Salvar preferências
+      </button>
+      <button
+        data-testid="cookie-accept-all"
+        type="button"
+        class="cookie-consent__button cookie-consent__button--primary"
+        @click="acceptAll"
+      >
+        Aceitar todos
+      </button>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.cookie-consent {
+  position: fixed;
+  right: clamp(16px, 3vw, 32px);
+  bottom: clamp(16px, 3vw, 32px);
+  z-index: 80;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 20px;
+  width: min(920px, calc(100vw - 32px));
+  padding: 22px;
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(145deg, rgba(18, 26, 42, 0.98), rgba(10, 16, 28, 0.98));
+  box-shadow: var(--shadow-lg);
+}
+
+.cookie-consent__content {
+  min-width: 0;
+}
+
+.cookie-consent__eyebrow {
+  margin: 0 0 8px;
+  color: var(--color-brand-400);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.cookie-consent__title {
+  margin: 0;
+  font-size: var(--font-size-2xl);
+  line-height: 1.2;
+}
+
+.cookie-consent__text {
+  max-width: 620px;
+  margin: 8px 0 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-body-md);
+}
+
+.cookie-consent__policy {
+  display: inline-flex;
+  margin-top: 10px;
+  color: var(--color-brand-400);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.cookie-consent__preferences {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.cookie-consent__option {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid var(--color-outline-subtle);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--color-text-primary);
+}
+
+.cookie-consent__option input {
+  width: 18px;
+  height: 18px;
+  margin-top: 2px;
+  accent-color: var(--color-brand-500);
+}
+
+.cookie-consent__option strong,
+.cookie-consent__option small {
+  display: block;
+}
+
+.cookie-consent__option strong {
+  font-size: var(--font-size-sm);
+}
+
+.cookie-consent__option small {
+  margin-top: 4px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+}
+
+.cookie-consent__option--disabled {
+  opacity: 0.75;
+}
+
+.cookie-consent__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+}
+
+.cookie-consent__button {
+  min-height: 42px;
+  padding: 0 16px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  font-weight: var(--font-weight-bold);
+  transition: background var(--motion-fast), border-color var(--motion-fast), color var(--motion-fast);
+}
+
+.cookie-consent__button--ghost {
+  border-color: var(--color-outline-subtle);
+  background: transparent;
+  color: var(--color-text-secondary);
+}
+
+.cookie-consent__button--secondary {
+  border-color: var(--color-outline-soft);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--color-text-primary);
+}
+
+.cookie-consent__button--primary {
+  background: var(--color-brand-500);
+  color: #03131c;
+}
+
+.cookie-consent__button:hover {
+  border-color: var(--color-brand-400);
+}
+
+@media (max-width: 760px) {
+  .cookie-consent {
+    grid-template-columns: 1fr;
+    padding: 18px;
+  }
+
+  .cookie-consent__preferences {
+    grid-template-columns: 1fr;
+  }
+
+  .cookie-consent__actions {
+    justify-content: stretch;
+  }
+
+  .cookie-consent__button {
+    flex: 1 1 100%;
+  }
+}
+</style>

--- a/app/plugins/posthog.client.spec.ts
+++ b/app/plugins/posthog.client.spec.ts
@@ -1,0 +1,93 @@
+/* eslint-disable jsdoc/require-jsdoc */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const posthogMock = vi.hoisted(() => ({
+  capture: vi.fn(),
+  identify: vi.fn(),
+  init: vi.fn(),
+  opt_in_capturing: vi.fn(),
+  opt_out_capturing: vi.fn(),
+  reset: vi.fn(),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: posthogMock,
+}));
+
+// eslint-disable-next-line import/first
+import { createConsentAwareAnalyticsClient } from "./posthog.client";
+
+interface TestAnalyticsConsentGateway {
+  canUseAnalytics(): boolean;
+  onChange(listener: (nextAllowed: boolean) => void): () => void;
+  setAllowed(nextAllowed: boolean): void;
+}
+
+const createGateway = (initialAllowed: boolean): TestAnalyticsConsentGateway => {
+  let allowed = initialAllowed;
+  const listeners: Array<(allowed: boolean) => void> = [];
+
+  return {
+    canUseAnalytics: () => allowed,
+    onChange: (listener: (nextAllowed: boolean) => void): (() => void) => {
+      listeners.push(listener);
+      return () => {
+        const index = listeners.indexOf(listener);
+        if (index >= 0) {
+          listeners.splice(index, 1);
+        }
+      };
+    },
+    setAllowed: (nextAllowed: boolean): void => {
+      allowed = nextAllowed;
+      listeners.forEach((listener) => listener(nextAllowed));
+    },
+  };
+};
+
+describe("PostHog consent gateway", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not initialize or capture events before analytics consent", () => {
+    const gateway = createGateway(false);
+    const client = createConsentAwareAnalyticsClient("ph_test", "https://eu.i.posthog.com", gateway);
+
+    client.capture("dashboard_viewed");
+    client.identify("user-123");
+    client.capturePageView();
+
+    expect(posthogMock.init).not.toHaveBeenCalled();
+    expect(posthogMock.capture).not.toHaveBeenCalled();
+    expect(posthogMock.identify).not.toHaveBeenCalled();
+  });
+
+  it("initializes once and captures after analytics consent is granted", () => {
+    const gateway = createGateway(false);
+    const client = createConsentAwareAnalyticsClient("ph_test", "https://eu.i.posthog.com", gateway);
+
+    gateway.setAllowed(true);
+    client.capture("dashboard_viewed", { source: "test" });
+    client.identify("user-123");
+    client.capturePageView();
+
+    expect(posthogMock.init).toHaveBeenCalledTimes(1);
+    expect(posthogMock.capture).toHaveBeenCalledWith("dashboard_viewed", { source: "test" });
+    expect(posthogMock.identify).toHaveBeenCalledWith("user-123");
+    expect(posthogMock.capture).toHaveBeenCalledWith("$pageview");
+  });
+
+  it("stops future analytics events when consent is revoked", () => {
+    const gateway = createGateway(true);
+    const client = createConsentAwareAnalyticsClient("ph_test", "https://eu.i.posthog.com", gateway);
+
+    client.capture("dashboard_viewed");
+    gateway.setAllowed(false);
+    client.capture("portfolio_viewed");
+
+    expect(posthogMock.opt_out_capturing).toHaveBeenCalledOnce();
+    expect(posthogMock.reset).toHaveBeenCalledOnce();
+    expect(posthogMock.capture).not.toHaveBeenCalledWith("portfolio_viewed", undefined);
+  });
+});

--- a/app/plugins/posthog.client.ts
+++ b/app/plugins/posthog.client.ts
@@ -1,4 +1,8 @@
 import posthog from "posthog-js";
+import {
+  canUseAnalyticsCookies,
+  subscribeToCookieConsentChanges,
+} from "~/shared/privacy/cookie-consent";
 
 /**
  * Named analytics events emitted throughout the application.
@@ -35,12 +39,45 @@ export interface AnalyticsClient {
   reset(): void;
 }
 
+export interface ConsentAwareAnalyticsClient extends AnalyticsClient {
+  /** Captures the synthetic page-view event emitted after Nuxt navigation. */
+  capturePageView(): void;
+
+  /** Tears down cookie-consent listeners. Used by tests and hot reload. */
+  dispose(): void;
+}
+
+export interface AnalyticsConsentGateway {
+  /** Returns whether analytics cookies are currently allowed. */
+  canUseAnalytics(): boolean;
+
+  /**
+   * Subscribes to analytics consent changes.
+   * @param listener Callback receiving the latest allowed/blocked state.
+   * @returns Unsubscribe callback.
+   */
+  onChange(listener: (allowed: boolean) => void): () => void;
+}
+
 /** No-op client used when PostHog is not configured (dev / missing key). */
 const NOOP_CLIENT: AnalyticsClient = {
   capture: (): void => { /* noop */ },
   identify: (): void => { /* noop */ },
   reset: (): void => { /* noop */ },
 };
+
+/**
+ * Builds the default cookie-consent gateway used by the Nuxt plugin.
+ *
+ * @returns Analytics consent gateway backed by the first-party consent cookie.
+ */
+const createDefaultConsentGateway = (): AnalyticsConsentGateway => ({
+  canUseAnalytics: canUseAnalyticsCookies,
+  onChange: (listener: (allowed: boolean) => void): (() => void) =>
+    subscribeToCookieConsentChanges((preferences) => {
+      listener(canUseAnalyticsCookies(preferences));
+    }),
+});
 
 /**
  * Initializes the PostHog SDK and returns a typed analytics client.
@@ -72,6 +109,76 @@ export function initPostHog(apiKey: string, apiHost: string): AnalyticsClient {
 }
 
 /**
+ * Creates a PostHog client that stays inert until analytics consent is granted.
+ *
+ * @param apiKey PostHog project API key.
+ * @param apiHost PostHog ingest host URL.
+ * @param gateway Consent gateway used to read and observe analytics consent.
+ * @returns Analytics client guarded by cookie consent.
+ */
+export function createConsentAwareAnalyticsClient(
+  apiKey: string,
+  apiHost: string,
+  gateway: AnalyticsConsentGateway = createDefaultConsentGateway(),
+): ConsentAwareAnalyticsClient {
+  let client: AnalyticsClient | null = null;
+  let initialized = false;
+
+  /**
+   * Lazily initializes PostHog only when analytics consent is currently allowed.
+   *
+   * @returns Initialized analytics client or null when consent is missing.
+   */
+  const ensureInitialized = (): AnalyticsClient | null => {
+    if (!gateway.canUseAnalytics()) {
+      return null;
+    }
+
+    if (!initialized) {
+      client = initPostHog(apiKey, apiHost);
+      initialized = true;
+    }
+
+    posthog.opt_in_capturing?.();
+    return client;
+  };
+
+  const unsubscribe = gateway.onChange((allowed) => {
+    if (allowed) {
+      ensureInitialized();
+      return;
+    }
+
+    if (initialized) {
+      posthog.opt_out_capturing?.();
+      posthog.reset();
+    }
+  });
+
+  ensureInitialized();
+
+  return {
+    capture: (event: AuraxisEvent, properties?: Record<string, unknown>): void => {
+      ensureInitialized()?.capture(event, properties);
+    },
+    identify: (userId: string): void => {
+      ensureInitialized()?.identify(userId);
+    },
+    reset: (): void => {
+      if (gateway.canUseAnalytics()) {
+        client?.reset();
+      }
+    },
+    capturePageView: (): void => {
+      if (ensureInitialized()) {
+        posthog.capture("$pageview");
+      }
+    },
+    dispose: unsubscribe,
+  };
+}
+
+/**
  * Nuxt client plugin that initializes PostHog analytics and wires up
  * automatic page-view tracking via the Vue Router.
  *
@@ -88,10 +195,10 @@ export default defineNuxtPlugin((nuxtApp) => {
   }
 
   const apiHost = String(config.public.posthogApiHost ?? "https://eu.i.posthog.com").trim();
-  const client = initPostHog(apiKey, apiHost);
+  const client = createConsentAwareAnalyticsClient(apiKey, apiHost);
 
   nuxtApp.hook("page:finish", (): void => {
-    posthog.capture("$pageview");
+    client.capturePageView();
   });
 
   return { provide: { analytics: client } };

--- a/app/plugins/web-vitals.client.spec.ts
+++ b/app/plugins/web-vitals.client.spec.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Metric } from "web-vitals";
+
+const posthogMock = vi.hoisted(() => ({
+  capture: vi.fn(),
+}));
+
+const sentryMock = vi.hoisted(() => ({
+  setMeasurement: vi.fn(),
+  setTag: vi.fn(),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: posthogMock,
+}));
+
+vi.mock("@sentry/nuxt", () => sentryMock);
+
+// eslint-disable-next-line import/first
+import { emit } from "./web-vitals.client";
+
+const metric: Metric = {
+  name: "LCP",
+  value: 2300.4,
+  rating: "needs-improvement",
+  delta: 2300.4,
+  id: "v3-1",
+  navigationType: "navigate",
+  entries: [],
+};
+
+describe("web-vitals consent gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not send metrics to PostHog or Sentry before analytics consent", () => {
+    emit(metric, false);
+
+    expect(posthogMock.capture).not.toHaveBeenCalled();
+    expect(sentryMock.setMeasurement).not.toHaveBeenCalled();
+    expect(sentryMock.setTag).not.toHaveBeenCalled();
+  });
+
+  it("sends metrics when analytics consent is granted", () => {
+    emit(metric, true);
+
+    expect(posthogMock.capture).toHaveBeenCalledWith("web_vital", expect.objectContaining({
+      name: "LCP",
+      value: 2300,
+    }));
+    expect(sentryMock.setMeasurement).toHaveBeenCalledWith("webvital.lcp", 2300, "millisecond");
+    expect(sentryMock.setTag).toHaveBeenCalledWith("webvital.lcp.rating", "needs-improvement");
+  });
+});

--- a/app/plugins/web-vitals.client.ts
+++ b/app/plugins/web-vitals.client.ts
@@ -1,6 +1,10 @@
 import { onCLS, onFCP, onINP, onLCP, onTTFB, type Metric } from "web-vitals";
 import posthog from "posthog-js";
 import * as Sentry from "@sentry/nuxt";
+import {
+  canUseAnalyticsCookies,
+  subscribeToCookieConsentChanges,
+} from "~/shared/privacy/cookie-consent";
 
 /**
  * Core Web Vitals metric names we track.
@@ -100,11 +104,25 @@ export function reportToSentry(payload: WebVitalPayload): void {
  * Emits the metric to every configured sink. Exported for unit testing.
  *
  * @param metric Metric object from a web-vitals reporter.
+ * @param analyticsAllowed Whether analytics consent is currently granted.
  */
-export function emit(metric: Metric): void {
+export function emit(metric: Metric, analyticsAllowed = canUseAnalyticsCookies()): void {
+  if (!analyticsAllowed) {
+    return;
+  }
+
   const payload = toPayload(metric);
   reportToPostHog(payload);
   reportToSentry(payload);
+}
+
+/** Registers Core Web Vitals reporters with the consent-aware emitter. */
+export function registerWebVitalsReporters(): void {
+  onCLS(emit);
+  onLCP(emit);
+  onINP(emit);
+  onFCP(emit);
+  onTTFB(emit);
 }
 
 /**
@@ -115,10 +133,19 @@ export function emit(metric: Metric): void {
  */
 /* v8 ignore start */
 export default defineNuxtPlugin(() => {
-  onCLS(emit);
-  onLCP(emit);
-  onINP(emit);
-  onFCP(emit);
-  onTTFB(emit);
+  let registered = false;
+
+  /** Registers reporters once analytics consent is available. */
+  const registerWhenAllowed = (): void => {
+    if (registered || !canUseAnalyticsCookies()) {
+      return;
+    }
+
+    registered = true;
+    registerWebVitalsReporters();
+  };
+
+  registerWhenAllowed();
+  subscribeToCookieConsentChanges(registerWhenAllowed);
 });
 /* v8 ignore stop */

--- a/app/shared/privacy/cookie-consent.spec.ts
+++ b/app/shared/privacy/cookie-consent.spec.ts
@@ -1,0 +1,123 @@
+/* eslint-disable jsdoc/require-jsdoc */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  acceptAllCookieConsent,
+  canUseAnalyticsCookies,
+  canUseMarketingCookies,
+  COOKIE_CONSENT_EVENT,
+  COOKIE_CONSENT_KEY,
+  readCookieConsent,
+  rejectOptionalCookieConsent,
+  saveCookieConsent,
+  subscribeToCookieConsentChanges,
+} from "./cookie-consent";
+
+const clearConsentCookie = (): void => {
+  document.cookie = `${COOKIE_CONSENT_KEY}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+};
+
+describe("cookie consent", () => {
+  beforeEach(() => {
+    clearConsentCookie();
+  });
+
+  it("defaults to no optional cookies when the visitor has not chosen yet", () => {
+    expect(readCookieConsent()).toBeNull();
+    expect(canUseAnalyticsCookies()).toBe(false);
+    expect(canUseMarketingCookies()).toBe(false);
+  });
+
+  it("persists all optional categories when the visitor accepts all cookies", () => {
+    const saved = acceptAllCookieConsent(new Date("2026-05-17T10:00:00.000Z"));
+
+    expect(saved).toMatchObject({
+      necessary: true,
+      analytics: true,
+      marketing: true,
+      updatedAt: "2026-05-17T10:00:00.000Z",
+      version: 1,
+    });
+    expect(readCookieConsent()).toEqual(saved);
+    expect(canUseAnalyticsCookies()).toBe(true);
+    expect(canUseMarketingCookies()).toBe(true);
+  });
+
+  it("keeps necessary cookies while rejecting optional categories", () => {
+    const saved = rejectOptionalCookieConsent(new Date("2026-05-17T11:00:00.000Z"));
+
+    expect(saved).toMatchObject({
+      necessary: true,
+      analytics: false,
+      marketing: false,
+      updatedAt: "2026-05-17T11:00:00.000Z",
+    });
+    expect(canUseAnalyticsCookies()).toBe(false);
+    expect(canUseMarketingCookies()).toBe(false);
+  });
+
+  it("normalizes necessary cookies to true when granular preferences are saved", () => {
+    const saved = saveCookieConsent(
+      { necessary: false, analytics: true, marketing: false },
+      new Date("2026-05-17T12:00:00.000Z"),
+    );
+
+    expect(saved.necessary).toBe(true);
+    expect(saved.analytics).toBe(true);
+    expect(saved.marketing).toBe(false);
+  });
+
+  it("ignores malformed or outdated preference cookies", () => {
+    document.cookie = `${COOKIE_CONSENT_KEY}=not-json; path=/`;
+    expect(readCookieConsent()).toBeNull();
+
+    clearConsentCookie();
+    document.cookie = `${COOKIE_CONSENT_KEY}=${encodeURIComponent(JSON.stringify({
+      version: 999,
+      analytics: true,
+      marketing: true,
+    }))}; path=/`;
+
+    expect(readCookieConsent()).toBeNull();
+  });
+
+  it("normalizes legacy saved data with missing updatedAt", () => {
+    document.cookie = `${COOKIE_CONSENT_KEY}=${encodeURIComponent(JSON.stringify({
+      version: 1,
+      analytics: true,
+      marketing: false,
+      updatedAt: null,
+    }))}; path=/`;
+
+    expect(readCookieConsent()).toMatchObject({
+      analytics: true,
+      marketing: false,
+      updatedAt: "",
+    });
+  });
+
+  it("notifies subscribers when preferences change", () => {
+    const subscriber = vi.fn();
+    const unsubscribe = subscribeToCookieConsentChanges(subscriber);
+
+    const saved = saveCookieConsent(
+      { analytics: true, marketing: false },
+      new Date("2026-05-17T13:00:00.000Z"),
+    );
+
+    expect(subscriber).toHaveBeenCalledWith(saved);
+    unsubscribe();
+    rejectOptionalCookieConsent(new Date("2026-05-17T14:00:00.000Z"));
+    expect(subscriber).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores consent events without preference details", () => {
+    const subscriber = vi.fn();
+    const unsubscribe = subscribeToCookieConsentChanges(subscriber);
+
+    window.dispatchEvent(new Event(COOKIE_CONSENT_EVENT));
+
+    expect(subscriber).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+});

--- a/app/shared/privacy/cookie-consent.ts
+++ b/app/shared/privacy/cookie-consent.ts
@@ -1,0 +1,232 @@
+export const COOKIE_CONSENT_KEY = "auraxis_cookie_consent";
+export const COOKIE_CONSENT_VERSION = 1;
+export const COOKIE_CONSENT_EVENT = "auraxis:cookie-consent-changed";
+
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 180;
+
+export interface CookieConsentPreferences {
+  version: typeof COOKIE_CONSENT_VERSION;
+  necessary: true;
+  analytics: boolean;
+  marketing: boolean;
+  updatedAt: string;
+}
+
+export interface CookieConsentInput {
+  necessary?: boolean;
+  analytics?: boolean;
+  marketing?: boolean;
+}
+
+export type CookieConsentSubscriber = (preferences: CookieConsentPreferences) => void;
+
+/** @returns Whether the current runtime exposes browser cookie APIs. */
+const isBrowser = (): boolean => typeof document !== "undefined";
+
+/**
+ * Reads a raw cookie value by key.
+ *
+ * @param key Cookie name to read.
+ * @returns Encoded cookie value or null when absent.
+ */
+const readCookieValue = (key: string): string | null => {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  const prefix = `${key}=`;
+  const entry = document.cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix));
+
+  if (!entry) {
+    return null;
+  }
+
+  return entry.slice(prefix.length);
+};
+
+/**
+ * Checks whether an unknown value can be safely indexed.
+ *
+ * @param value Unknown value to inspect.
+ * @returns True when the value is a non-null object record.
+ */
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+/**
+ * Parses the persisted consent payload.
+ *
+ * @param raw Encoded JSON cookie value.
+ * @returns Normalized consent preferences or null for invalid payloads.
+ */
+const parseCookieConsent = (raw: string): CookieConsentPreferences | null => {
+  try {
+    const parsed: unknown = JSON.parse(decodeURIComponent(raw));
+
+    if (!isRecord(parsed) || parsed.version !== COOKIE_CONSENT_VERSION) {
+      return null;
+    }
+
+    return {
+      version: COOKIE_CONSENT_VERSION,
+      necessary: true,
+      analytics: parsed.analytics === true,
+      marketing: parsed.marketing === true,
+      updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : "",
+    };
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Notifies browser listeners that consent preferences changed.
+ *
+ * @param preferences Latest saved preferences.
+ */
+const dispatchCookieConsentChanged = (preferences: CookieConsentPreferences): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(new CustomEvent<CookieConsentPreferences>(
+    COOKIE_CONSENT_EVENT,
+    { detail: preferences },
+  ));
+};
+
+/**
+ * Persists preferences in a first-party necessary cookie.
+ *
+ * @param preferences Normalized preferences to store.
+ */
+const writeConsentCookie = (preferences: CookieConsentPreferences): void => {
+  if (!isBrowser()) {
+    return;
+  }
+
+  const secure = window.location.protocol === "https:" ? "; Secure" : "";
+  const value = encodeURIComponent(JSON.stringify(preferences));
+  document.cookie = [
+    `${COOKIE_CONSENT_KEY}=${value}`,
+    "path=/",
+    `max-age=${COOKIE_MAX_AGE_SECONDS}`,
+    "SameSite=Lax",
+    secure,
+  ].filter(Boolean).join("; ");
+};
+
+/**
+ * Normalizes partial visitor choices into the versioned cookie payload.
+ *
+ * @param preferences Visitor-selected optional categories.
+ * @param now Timestamp used for auditability.
+ * @returns Versioned cookie consent preferences.
+ */
+export const normalizeCookieConsent = (
+  preferences: CookieConsentInput,
+  now: Date = new Date(),
+): CookieConsentPreferences => ({
+  version: COOKIE_CONSENT_VERSION,
+  necessary: true,
+  analytics: preferences.analytics === true,
+  marketing: preferences.marketing === true,
+  updatedAt: now.toISOString(),
+});
+
+/**
+ * Reads consent preferences from the browser cookie jar.
+ *
+ * @returns Saved preferences or null when no valid choice exists.
+ */
+export const readCookieConsent = (): CookieConsentPreferences | null => {
+  const raw = readCookieValue(COOKIE_CONSENT_KEY);
+  return raw ? parseCookieConsent(raw) : null;
+};
+
+/**
+ * Checks if analytics and performance cookies are allowed.
+ *
+ * @param preferences Optional preferences snapshot. Reads from cookies by default.
+ * @returns Whether analytics cookies may be used.
+ */
+export const canUseAnalyticsCookies = (
+  preferences: CookieConsentPreferences | null = readCookieConsent(),
+): boolean => preferences?.analytics === true;
+
+/**
+ * Checks if marketing cookies are allowed.
+ *
+ * @param preferences Optional preferences snapshot. Reads from cookies by default.
+ * @returns Whether marketing cookies may be used.
+ */
+export const canUseMarketingCookies = (
+  preferences: CookieConsentPreferences | null = readCookieConsent(),
+): boolean => preferences?.marketing === true;
+
+/**
+ * Saves granular consent preferences and emits a browser change event.
+ *
+ * @param preferences Visitor-selected optional categories.
+ * @param now Timestamp used for auditability.
+ * @returns Saved normalized preferences.
+ */
+export const saveCookieConsent = (
+  preferences: CookieConsentInput,
+  now: Date = new Date(),
+): CookieConsentPreferences => {
+  const normalized = normalizeCookieConsent(preferences, now);
+  writeConsentCookie(normalized);
+  dispatchCookieConsentChanged(normalized);
+  return normalized;
+};
+
+/**
+ * Saves consent with every optional category enabled.
+ *
+ * @param now Timestamp used for auditability.
+ * @returns Saved normalized preferences.
+ */
+export const acceptAllCookieConsent = (now: Date = new Date()): CookieConsentPreferences =>
+  saveCookieConsent({ analytics: true, marketing: true }, now);
+
+/**
+ * Saves consent with every optional category disabled.
+ *
+ * @param now Timestamp used for auditability.
+ * @returns Saved normalized preferences.
+ */
+export const rejectOptionalCookieConsent = (now: Date = new Date()): CookieConsentPreferences =>
+  saveCookieConsent({ analytics: false, marketing: false }, now);
+
+/**
+ * Subscribes to browser consent-change events.
+ *
+ * @param subscriber Callback invoked with the latest saved preferences.
+ * @returns Unsubscribe function.
+ */
+export const subscribeToCookieConsentChanges = (
+  subscriber: CookieConsentSubscriber,
+): (() => void) => {
+  if (typeof window === "undefined") {
+    return (): void => { /* noop */ };
+  }
+
+  /**
+   * Forwards valid CustomEvent payloads to the typed subscriber.
+   *
+   * @param event Browser consent-change event.
+   */
+  const listener = (event: Event): void => {
+    const detail = (event as CustomEvent<CookieConsentPreferences>).detail;
+    if (detail) {
+      subscriber(detail);
+    }
+  };
+
+  window.addEventListener(COOKIE_CONSENT_EVENT, listener);
+  return (): void => window.removeEventListener(COOKIE_CONSENT_EVENT, listener);
+};

--- a/e2e/cookie-consent.spec.ts
+++ b/e2e/cookie-consent.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Cookie consent", () => {
+  test("blocks analytics requests before consent and saves granular choices", async ({ page }) => {
+    const analyticsRequests: string[] = [];
+
+    await page.route(/posthog/i, (route) => {
+      analyticsRequests.push(route.request().url());
+      return route.fulfill({ status: 204, body: "" });
+    });
+
+    await page.goto("/");
+
+    const banner = page.getByRole("region", { name: /preferências de cookies/i });
+    await expect(banner).toBeVisible();
+    expect(analyticsRequests).toHaveLength(0);
+
+    await page.getByRole("button", { name: /configurar/i }).click();
+    await page.getByLabel(/analytics e performance/i).uncheck();
+    await page.getByLabel(/marketing/i).check();
+    await page.getByRole("button", { name: /salvar preferências/i }).click();
+
+    await expect(banner).toBeHidden();
+
+    const cookies = await page.evaluate(() => decodeURIComponent(document.cookie));
+    expect(cookies).toContain("\"analytics\":false");
+    expect(cookies).toContain("\"marketing\":true");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a LGPD cookie consent banner with accept, reject, and granular preference flows for analytics and marketing categories.
- Gates PostHog and Web Vitals emission behind explicit analytics consent, including consent-change handling for later opt-in/opt-out.
- Adds unit and E2E coverage proving preferences persist and tracking requests do not fire before consent.

## User impact
Visitors now see a privacy-first cookie flow before non-essential analytics starts. Essential cookies remain enabled, while analytics/marketing are opt-in and can be rejected or configured.

## Acceptance criteria
- [x] PostHog and Web Vitals do not dispatch before analytics consent.
- [x] User can accept all, reject optional cookies, or configure analytics/marketing categories.
- [x] Preferences persist in a first-party versioned consent cookie.
- [x] Cookie policy/privacy link is visible from the banner.
- [x] Desktop and mobile states were visually captured.

## Screenshots
Captured locally against `http://127.0.0.1:3100` with mock/public data.

Desktop preferences expanded:

![Desktop cookie consent](https://github.com/italofelipe/auraxis-web/releases/download/gh-attach-assets/auraxis-cookie-consent-desktop.png)

Mobile initial banner:

![Mobile cookie consent](https://github.com/italofelipe/auraxis-web/releases/download/gh-attach-assets/auraxis-cookie-consent-mobile.png)

## Test plan
- [x] `pnpm quality-check`
- [x] `BASE_URL=http://127.0.0.1:3100 pnpm exec playwright test e2e/cookie-consent.spec.ts --project=chromium`
- [x] `git push` pre-push gate: flags, lint, typecheck, coverage, policy, contracts, build

## Notes
Existing warnings observed during validation:
- i18n PT-only/EN freeze warnings already expected by DEC-186.
- Nuxt chunk-size warning already present in the project build.
- Vitest runner warning for `--localstorage-file` appears in the existing test environment and did not fail the suite.

Closes #846
