### PR TITLE
fix(ai-insights): restrict contextual surfaces by dimension

### DIFF
--- a/app/features/ai-insights/components/AiInsightSection.spec.ts
+++ b/app/features/ai-insights/components/AiInsightSection.spec.ts
@@ -52,7 +52,7 @@ describe("AiInsightSection", () => {
     expect(wrapper.text()).toContain("podem estar desatualizados");
   });
 
-  it("renders only general and requested dimension items", () => {
+  it("renders only requested dimension items", () => {
     const wrapper = mount(AiInsightSection, {
       props: {
         insight: [
@@ -85,7 +85,7 @@ describe("AiInsightSection", () => {
       global: { stubs },
     });
 
-    expect(wrapper.text()).toContain("Visão geral");
+    expect(wrapper.text()).not.toContain("Visão geral");
     expect(wrapper.text()).toContain("Transações em atenção");
     expect(wrapper.text()).not.toContain("Meta em atenção");
   });

--- a/app/features/ai-insights/components/AiInsightSurface.spec.ts
+++ b/app/features/ai-insights/components/AiInsightSurface.spec.ts
@@ -1,0 +1,52 @@
+import { ref } from "vue";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AiInsightSurface from "./AiInsightSurface.vue";
+
+const useAIInsightsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/features/ai-insights/composables/useAIInsights", () => ({
+  useAIInsights: useAIInsightsMock,
+}));
+
+const stubs = {
+  AiInsightButton: { template: "<button>Gerar insight com IA</button>" },
+  AiInsightSection: {
+    props: ["insight"],
+    template: "<section data-testid='insight-section'>{{ insight.map((item) => item.title).join(', ') }}</section>",
+  },
+};
+
+describe("AiInsightSurface", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows an empty contextual state when the generated insight has no item for the surface", () => {
+    useAIInsightsMock.mockReturnValue({
+      currentInsight: ref([
+        {
+          type: "saude_financeira",
+          dimension: "general",
+          title: "Visão geral",
+          message: "Resumo do período.",
+        },
+      ]),
+      insightPeriodLabel: ref("2026-05"),
+      isStale: ref(false),
+      insightModel: ref("gpt-4o-mini"),
+      tokensUsed: ref(120),
+      costUsd: ref(0.00001),
+    });
+
+    const wrapper = mount(AiInsightSurface, {
+      props: { dimension: "transactions" },
+      global: { stubs },
+    });
+
+    expect(wrapper.find("[data-testid='insight-section']").exists()).toBe(false);
+    expect(wrapper.text()).toContain("Nenhum insight específico para esta área");
+    expect(wrapper.text()).toContain("A visão completa continua disponível em Insights");
+  });
+});

--- a/app/features/ai-insights/components/AiInsightSurface.vue
+++ b/app/features/ai-insights/components/AiInsightSurface.vue
@@ -20,6 +20,11 @@ const visibleInsight = computed<InsightItem[] | null>(() => {
 
   return props.dimension ? filterInsightItemsByDimension(items, props.dimension) : items;
 });
+
+const hasGeneratedInsight = computed(() => Boolean(aiInsights.currentInsight.value?.length));
+const shouldShowContextualEmptyState = computed(() =>
+  Boolean(props.dimension && hasGeneratedInsight.value && !visibleInsight.value?.length),
+);
 </script>
 
 <template>
@@ -34,6 +39,10 @@ const visibleInsight = computed<InsightItem[] | null>(() => {
       :tokens-used="aiInsights.tokensUsed.value"
       :cost-usd="aiInsights.costUsd.value"
     />
+    <p v-else-if="shouldShowContextualEmptyState" class="ai-insight-surface__empty">
+      Nenhum insight específico para esta área no período atual. A visão completa continua
+      disponível em Insights.
+    </p>
   </section>
 </template>
 
@@ -42,5 +51,14 @@ const visibleInsight = computed<InsightItem[] | null>(() => {
   display: grid;
   gap: var(--space-3);
   align-items: start;
+}
+
+.ai-insight-surface__empty {
+  margin: 0;
+  padding: var(--space-3);
+  border: 1px dashed var(--color-outline-soft);
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  background: color-mix(in srgb, var(--color-bg-elevated) 86%, transparent);
 }
 </style>

--- a/app/features/ai-insights/composables/use-insights-by-dimension.spec.ts
+++ b/app/features/ai-insights/composables/use-insights-by-dimension.spec.ts
@@ -30,23 +30,18 @@ const items: InsightItem[] = [
 ];
 
 describe("useInsightsByDimension", () => {
-  it("includes general items with the requested contextual dimension", () => {
-    expect(filterInsightItemsByDimension(items, "transactions")).toEqual([
-      items[0],
-      items[1],
-    ]);
+  it("returns only items from the requested contextual dimension", () => {
+    expect(filterInsightItemsByDimension(items, "transactions")).toEqual([items[1]]);
   });
 
-  it("treats legacy items without a dimension as general", () => {
+  it("does not leak legacy general items into contextual surfaces", () => {
     const legacyItem = {
       type: "padrao_gasto",
       title: "Assinatura recorrente",
       message: "Revise sua assinatura.",
     } as InsightItem;
 
-    expect(filterInsightItemsByDimension([legacyItem], "budgets")).toEqual([
-      { ...legacyItem, dimension: "general" },
-    ]);
+    expect(filterInsightItemsByDimension([legacyItem], "budgets")).toEqual([]);
   });
 
   it("returns computed filtered items for reactive consumers", () => {
@@ -56,14 +51,12 @@ describe("useInsightsByDimension", () => {
     const result = useInsightsByDimension(computed(() => source.value), dimension);
 
     expect(result.items.value.map((item) => item.title)).toEqual([
-      "Saldo do período",
       "Despesa fora do padrão",
     ]);
 
     dimension.value = "goals";
 
     expect(result.items.value.map((item) => item.title)).toEqual([
-      "Saldo do período",
       "Meta em atenção",
     ]);
   });

--- a/app/features/ai-insights/composables/use-insights-by-dimension.ts
+++ b/app/features/ai-insights/composables/use-insights-by-dimension.ts
@@ -48,8 +48,8 @@ export const getInsightDimensionLabel = (dimension: InsightDimension): string =>
 };
 
 /**
- * Filters insight items for a contextual surface. General insights are shown on
- * every surface so global recommendations are not hidden.
+ * Filters insight items for a contextual surface. Global/general insights stay
+ * available on dashboard and hub, but do not leak into feature-specific pages.
  *
  * @param items Source insight items.
  * @param dimension Contextual surface dimension.
@@ -61,7 +61,7 @@ export const filterInsightItemsByDimension = (
 ): InsightItem[] => {
   return items
     .map(normalizeDimension)
-    .filter((item) => item.dimension === "general" || item.dimension === dimension);
+    .filter((item) => item.dimension === dimension);
 };
 
 /**


### PR DESCRIPTION
## Summary
- Restore the #876 refinement that missed `main` after #875 was merged.
- Restrict contextual AI insight surfaces to their own `dimension` only, keeping global/general insights on dashboard and the full `/insights` hub.
- Add a contextual empty state when a surface has no specific insight and cover the filter/render behavior with focused tests.

## Screenshots
- N/A for this PR: the change is a contextual filtering fix plus a small empty-state copy path, covered by component tests. No new page/layout state was introduced.

## Tests
- `pnpm vitest run --coverage=false app/features/ai-insights/composables/use-insights-by-dimension.spec.ts app/features/ai-insights/components/AiInsightSection.spec.ts app/features/ai-insights/components/AiInsightSurface.spec.ts`
- `git push` pre-push parity gate: flags, lint, typecheck, unit coverage, governance/contracts, build, codegen

Closes #876