### PR TITLE
[WEB] Tema — Naive UI, app shell e componentes base

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,93 +1,103 @@
-import { type Preview, type StoryFn, setup } from "@storybook/vue3";
+import { type Preview, type StoryContext, type StoryFn, setup } from "@storybook/vue3";
 import { darkTheme, NConfigProvider, NMessageProvider, NDialogProvider } from "naive-ui";
 import { defineComponent, h } from "vue";
-import { colors } from "../app/theme/tokens/colors";
+import { buildNaiveThemeOverrides } from "../app/utils/naive-theme";
+import { themePalettes, type ResolvedTheme } from "../app/theme/tokens/semantic";
 import { fonts } from "../app/theme/tokens/typography";
-import { radii } from "../app/theme/tokens/radii";
 
-// Mesmo themeOverrides do useNaiveTheme — mantido em sync
-// (o composable real usa a mesma paleta — este é o provider de story)
-const auraxisOverrides = {
-  common: {
-    primaryColor:        colors.cyan[600],
-    primaryColorHover:   colors.cyan[500],
-    primaryColorPressed: colors.cyan[700],
-    primaryColorSuppl:   colors.cyan[400],
-    bodyColor:           colors.bg.app,
-    cardColor:           colors.bg.surface,
-    modalColor:          colors.bg.surface,
-    popoverColor:        colors.bg.elevated,
-    inputColor:          colors.bg.elevated,
-    borderColor:         colors.border.subtle,
-    dividerColor:        colors.border.subtle,
-    textColorBase:       colors.text.primary,
-    textColor1:          colors.text.primary,
-    textColor2:          colors.text.secondary,
-    textColor3:          colors.text.muted,
-    placeholderColor:    colors.text.subtle,
-    errorColor:          colors.negative.DEFAULT,
-    successColor:        colors.positive.DEFAULT,
-    fontFamily:          fonts.body,
-    borderRadius:        radii.md,
-    borderRadiusSmall:   radii.sm,
-  },
-};
-
-// Registrar providers globais para todas as stories
 setup((app) => {
-  // Registrar componentes Naive UI globalmente nas stories
   app.component("NConfigProvider", NConfigProvider);
   app.component("NMessageProvider", NMessageProvider);
   app.component("NDialogProvider", NDialogProvider);
 });
 
 const preview: Preview = {
+  globalTypes: {
+    themeMode: {
+      name: "Tema",
+      description: "Tema Auraxis usado nas stories",
+      defaultValue: "light",
+      toolbar: {
+        icon: "mirror",
+        items: [
+          { value: "light", title: "Light" },
+          { value: "dark", title: "Dark" },
+        ],
+      },
+    },
+  },
   decorators: [
-    (story: StoryFn): ReturnType<typeof defineComponent> =>
+    (story: StoryFn, context: StoryContext): ReturnType<typeof defineComponent> =>
       defineComponent({
         components: { NConfigProvider, NMessageProvider, NDialogProvider },
         setup(): () => ReturnType<typeof h> {
-          return () =>
-            h(
-              NConfigProvider,
-              { theme: darkTheme, themeOverrides: auraxisOverrides },
-              () =>
-                h(NMessageProvider, {}, () =>
-                  h(NDialogProvider, {}, () => h(story(), {}))
-                )
+          return () => {
+            const themeMode: ResolvedTheme = context.globals.themeMode === "dark" ? "dark" : "light";
+            const palette = themePalettes[themeMode];
+
+            if (typeof document !== "undefined") {
+              document.documentElement.dataset.theme = themeMode;
+              document.documentElement.style.colorScheme = themeMode;
+            }
+
+            return h(
+              "div",
+              {
+                style: {
+                  minHeight: "100vh",
+                  padding: "24px",
+                  background: palette.bg.canvas,
+                  color: palette.text.primary,
+                  fontFamily: fonts.body,
+                },
+              },
+              [
+                h(
+                  NConfigProvider,
+                  {
+                    theme: themeMode === "dark" ? darkTheme : null,
+                    themeOverrides: buildNaiveThemeOverrides(themeMode),
+                  },
+                  () =>
+                    h(NMessageProvider, {}, () =>
+                      h(NDialogProvider, {}, () => h(story(), {})),
+                    ),
+                ),
+              ],
             );
+          };
         },
       }),
   ],
-
   parameters: {
     backgrounds: {
-      default: "auraxis-dark",
+      default: "auraxis-light",
       values: [
-        { name: "auraxis-dark", value: colors.bg.app },
-        { name: "surface", value: colors.bg.surface },
-        { name: "elevated", value: colors.bg.elevated },
+        { name: "auraxis-light", value: themePalettes.light.bg.canvas },
+        { name: "auraxis-dark", value: themePalettes.dark.bg.canvas },
+        { name: "light-surface", value: themePalettes.light.bg.surface },
+        { name: "dark-surface", value: themePalettes.dark.bg.surface },
       ],
     },
     layout: "centered",
     docs: {
       theme: {
-        base: "dark",
+        base: "light",
         brandTitle: "Auraxis Design System",
         brandUrl: "/",
-        colorPrimary: colors.cyan[600],
-        colorSecondary: colors.cyan[500],
-        appBg: colors.bg.app,
-        appContentBg: colors.bg.surface,
-        textColor: colors.text.primary,
-        textMutedColor: colors.text.muted,
-        barBg: colors.bg.elevated,
-        barTextColor: colors.text.secondary,
-        barHoverColor: colors.cyan[500],
-        barSelectedColor: colors.cyan[600],
-        inputBg: colors.bg.elevated,
-        inputBorder: colors.border.subtle,
-        inputTextColor: colors.text.primary,
+        colorPrimary: themePalettes.light.action.primary,
+        colorSecondary: themePalettes.light.chart.investment,
+        appBg: themePalettes.light.bg.canvas,
+        appContentBg: themePalettes.light.bg.surface,
+        textColor: themePalettes.light.text.primary,
+        textMutedColor: themePalettes.light.text.muted,
+        barBg: themePalettes.light.bg.elevated,
+        barTextColor: themePalettes.light.text.secondary,
+        barHoverColor: themePalettes.light.action.primaryHover,
+        barSelectedColor: themePalettes.light.action.primary,
+        inputBg: themePalettes.light.bg.elevated,
+        inputBorder: themePalettes.light.border.subtle,
+        inputTextColor: themePalettes.light.text.primary,
         inputBorderRadius: 8,
         fontBase: fonts.body,
       },

--- a/app/app.spec.ts
+++ b/app/app.spec.ts
@@ -1,15 +1,19 @@
 import { mount } from "@vue/test-utils";
-import { NConfigProvider, type GlobalTheme } from "naive-ui";
-import { computed, ref, type ComputedRef } from "vue";
+import { NConfigProvider, type GlobalTheme, type GlobalThemeOverrides } from "naive-ui";
+import { computed, type ComputedRef } from "vue";
 import { describe, expect, it, vi } from "vitest";
 
 import App from "./app.vue";
 
-vi.mock("~/composables/useTheme", () => ({
-  useTheme: (): { isDark: ReturnType<typeof ref<boolean>>; toggle: () => void; naiveTheme: ComputedRef<GlobalTheme | null> } => ({
-    isDark: ref(true),
-    toggle: vi.fn(),
-    naiveTheme: computed<GlobalTheme | null>(() => null),
+vi.mock("~/composables/useNaiveTheme", () => ({
+  useNaiveTheme: (): {
+    theme: ComputedRef<GlobalTheme | null>;
+    themeOverrides: ComputedRef<GlobalThemeOverrides>;
+  } => ({
+    theme: computed<GlobalTheme | null>(() => null),
+    themeOverrides: computed<GlobalThemeOverrides>(() => ({
+      common: { primaryColor: "#087FA7" },
+    })),
   }),
 }));
 
@@ -39,7 +43,7 @@ describe("App bootstrap", () => {
     expect(wrapper.html()).toContain("nuxt-page-stub");
   });
 
-  it("passa darkTheme e auraxisThemeOverrides para o NConfigProvider", () => {
+  it("passa tema e overrides Auraxis para o NConfigProvider", () => {
     const wrapper = mount(App, {
       global: {
         stubs: {

--- a/app/app.vue
+++ b/app/app.vue
@@ -2,22 +2,20 @@
 import { NConfigProvider, NMessageProvider, NDialogProvider } from "naive-ui";
 import CookieConsentBanner from "~/components/privacy/CookieConsentBanner.vue";
 import { useNaiveTheme } from "~/composables/useNaiveTheme";
-import { useTheme } from "~/composables/useTheme";
 
-const { themeOverrides } = useNaiveTheme();
-const { naiveTheme } = useTheme();
+const { theme, themeOverrides } = useNaiveTheme();
 </script>
 
 <template>
   <!--
     NConfigProvider applies the Auraxis theme globally to all Naive UI components.
-    - naiveTheme: darkTheme or null (light), toggled via useTheme composable
-    - themeOverrides: token overrides from app/composables/useNaiveTheme.ts
+    - theme: darkTheme or null (light), toggled via useTheme composable
+    - themeOverrides: light/dark token overrides from app/composables/useNaiveTheme.ts
     - preflight-style-disabled: prevents Naive UI from injecting a CSS reset
       that would conflict with our own global styles in assets/css/main.css
   -->
   <NConfigProvider
-    :theme="naiveTheme"
+    :theme="theme"
     :theme-overrides="themeOverrides"
     :preflight-style-disabled="true"
   >

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -86,6 +86,19 @@
   --color-warning-bg:   rgba(183, 121, 31, 0.14);
   --color-warning-glow: rgba(183, 121, 31, 0.2);
 
+  /* Interaction surfaces */
+  --color-text-on-brand:      #FFFFFF;
+  --color-overlay-scrim:      rgba(10, 22, 40, 0.42);
+  --color-brand-hover-surface: rgba(8, 127, 167, 0.08);
+  --color-positive-border:    rgba(8, 127, 91, 0.22);
+  --color-positive-hover:     rgba(8, 127, 91, 0.16);
+  --color-negative-border:    rgba(194, 65, 77, 0.22);
+  --color-negative-hover:     rgba(194, 65, 77, 0.16);
+  --color-skeleton-start:     rgba(10, 22, 40, 0.06);
+  --color-skeleton-mid:       rgba(10, 22, 40, 0.12);
+  --color-skeleton-end:       rgba(10, 22, 40, 0.06);
+  --gradient-brand:           linear-gradient(145deg, var(--color-brand-500), var(--color-positive));
+
   /* Borders */
   --color-outline-hard:   rgba(10, 22, 40, 0.2);
   --color-outline-soft:   rgba(10, 22, 40, 0.12);
@@ -191,6 +204,18 @@
   --color-warning-dark: #e89e47;
   --color-warning-bg:   rgba(255, 184, 97, 0.1);
   --color-warning-glow: rgba(255, 184, 97, 0.2);
+
+  /* Interaction surfaces */
+  --color-text-on-brand:      #05070d;
+  --color-overlay-scrim:      rgba(0, 0, 0, 0.62);
+  --color-brand-hover-surface: rgba(255, 255, 255, 0.06);
+  --color-positive-border:    rgba(66, 232, 169, 0.2);
+  --color-positive-hover:     rgba(66, 232, 169, 0.15);
+  --color-negative-border:    rgba(255, 111, 121, 0.2);
+  --color-negative-hover:     rgba(255, 111, 121, 0.15);
+  --color-skeleton-start:     rgba(255, 255, 255, 0.06);
+  --color-skeleton-mid:       rgba(255, 255, 255, 0.12);
+  --color-skeleton-end:       rgba(255, 255, 255, 0.06);
 
   /* Borders */
   --color-outline-hard:   rgba(255, 255, 255, 0.2);

--- a/app/components/ui/BaseSkeleton.vue
+++ b/app/components/ui/BaseSkeleton.vue
@@ -86,9 +86,9 @@ const count = computed<number>((): number => Math.max(1, props.repeat));
   display: block;
   background: linear-gradient(
     90deg,
-    rgba(65, 57, 57, 0.12) 0%,
-    rgba(65, 57, 57, 0.22) 50%,
-    rgba(65, 57, 57, 0.12) 100%
+    var(--color-skeleton-start) 0%,
+    var(--color-skeleton-mid) 50%,
+    var(--color-skeleton-end) 100%
   );
   background-size: 200% 100%;
   animation: base-skeleton-shimmer 1.6s infinite;

--- a/app/components/ui/UiAppShell/UiAppShell.vue
+++ b/app/components/ui/UiAppShell/UiAppShell.vue
@@ -145,14 +145,14 @@ const currentRoute = computed(() => route.path);
 .ui-app-shell__logo-mark {
   width: 32px;
   height: 32px;
-  background: linear-gradient(145deg, var(--color-brand-500), var(--color-accent));
+  background: var(--gradient-brand);
   border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-bg-base);
+  color: var(--color-text-on-brand);
   flex-shrink: 0;
-  box-shadow: 0 0 12px rgba(68, 212, 255, 0.2);
+  box-shadow: var(--shadow-brand-glow-sm);
 }
 
 .ui-app-shell__logo-text {
@@ -174,7 +174,7 @@ const currentRoute = computed(() => route.path);
 .ui-app-shell__overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--color-overlay-scrim);
   z-index: 199;
 }
 

--- a/app/components/ui/UiOptionCardRadio/UiOptionCardRadio.vue
+++ b/app/components/ui/UiOptionCardRadio/UiOptionCardRadio.vue
@@ -67,9 +67,9 @@ const handleKeydown = (event: KeyboardEvent): void => {
   align-items: center;
   gap: var(--space-2, 8px);
   padding: var(--space-3, 12px) var(--space-3, 12px);
-  border: 2px solid var(--color-outline-soft, #e0e0e0);
+  border: 2px solid var(--color-outline-soft);
   border-radius: var(--radius-md, 8px);
-  background: var(--color-bg-surface, #fff);
+  background: var(--color-bg-surface);
   cursor: pointer;
   user-select: none;
   transition:
@@ -79,16 +79,16 @@ const handleKeydown = (event: KeyboardEvent): void => {
 }
 
 .ui-option-card-radio:hover:not(.ui-option-card-radio--disabled) {
-  border-color: var(--color-brand-600, #6366f1);
+  border-color: var(--color-brand-600);
 }
 
 .ui-option-card-radio:focus-visible {
-  box-shadow: 0 0 0 3px var(--color-brand-200, #c7d2fe);
+  box-shadow: 0 0 0 3px var(--color-brand-glow-sm);
 }
 
 .ui-option-card-radio--selected {
-  border-color: var(--color-brand-600, #6366f1);
-  background: var(--color-brand-50, #eef2ff);
+  border-color: var(--color-brand-600);
+  background: var(--color-brand-glow-xs);
 }
 
 .ui-option-card-radio--disabled {
@@ -102,7 +102,7 @@ const handleKeydown = (event: KeyboardEvent): void => {
   height: 18px;
   min-width: 18px;
   border-radius: 50%;
-  border: 2px solid var(--color-outline-soft, #e0e0e0);
+  border: 2px solid var(--color-outline-soft);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -110,14 +110,14 @@ const handleKeydown = (event: KeyboardEvent): void => {
 }
 
 .ui-option-card-radio--selected .ui-option-card-radio__indicator {
-  border-color: var(--color-brand-600, #6366f1);
-  background: var(--color-brand-600, #6366f1);
-  box-shadow: inset 0 0 0 3px var(--color-bg-surface, #fff);
+  border-color: var(--color-brand-600);
+  background: var(--color-brand-600);
+  box-shadow: inset 0 0 0 3px var(--color-bg-surface);
 }
 
 .ui-option-card-radio__text {
   font-size: var(--font-size-sm, 0.875rem);
-  color: var(--color-text-primary, #111);
+  color: var(--color-text-primary);
   line-height: 1.4;
 }
 </style>

--- a/app/components/ui/UiPublicHeader/UiPublicHeader.vue
+++ b/app/components/ui/UiPublicHeader/UiPublicHeader.vue
@@ -256,8 +256,8 @@ const closeMenu = (): void => {
   width: 34px;
   height: 34px;
   border-radius: var(--radius-sm);
-  background: linear-gradient(145deg, #44d4ff, #42e8a9);
-  color: #05070d;
+  background: var(--gradient-brand);
+  color: var(--color-text-on-brand);
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-extrabold);
 }
@@ -285,7 +285,7 @@ const closeMenu = (): void => {
 .ui-public-header__nav-link:hover,
 .ui-public-header__nav-link:focus-visible {
   color: var(--color-text-primary);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--color-brand-hover-surface);
   outline: none;
 }
 
@@ -329,17 +329,17 @@ const closeMenu = (): void => {
 
 .ui-public-header__btn--ghost:hover {
   color: var(--color-text-primary);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--color-brand-hover-surface);
 }
 
 .ui-public-header__btn--primary {
-  background: linear-gradient(140deg, #44d4ff, #42e8a9);
-  color: #05070d;
+  background: var(--gradient-brand);
+  color: var(--color-text-on-brand);
 }
 
 .ui-public-header__btn--primary:hover {
   filter: brightness(1.05);
-  box-shadow: 0 14px 34px rgba(68, 212, 255, 0.18);
+  box-shadow: var(--shadow-brand-glow);
 }
 
 .ui-public-header__btn--full {

--- a/app/components/ui/UiToolsShell/UiToolsShell.vue
+++ b/app/components/ui/UiToolsShell/UiToolsShell.vue
@@ -174,12 +174,12 @@ const currentRoute = computed(() => route.path);
 .ui-tools-shell__logo-mark {
   width: 32px;
   height: 32px;
-  background: var(--color-brand-600);
+  background: var(--gradient-brand);
   border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-bg-base);
+  color: var(--color-text-on-brand);
   flex-shrink: 0;
   box-shadow: var(--shadow-brand-glow-sm);
 }
@@ -232,7 +232,7 @@ const currentRoute = computed(() => route.path);
 .ui-tools-shell__overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--color-overlay-scrim);
   z-index: 199;
 }
 

--- a/app/components/ui/UiTopbar/UiTopbar.vue
+++ b/app/components/ui/UiTopbar/UiTopbar.vue
@@ -124,18 +124,18 @@ const { isDark, toggle: toggleTheme } = useTheme();
 .ui-topbar__action--positive {
   background: var(--color-positive-bg);
   color: var(--color-positive);
-  border-color: rgba(66, 232, 169, 0.2);
+  border-color: var(--color-positive-border);
 }
 .ui-topbar__action--positive:hover {
-  background: rgba(66, 232, 169, 0.15);
+  background: var(--color-positive-hover);
 }
 .ui-topbar__action--negative {
   background: var(--color-negative-bg);
   color: var(--color-negative);
-  border-color: rgba(255, 111, 121, 0.2);
+  border-color: var(--color-negative-border);
 }
 .ui-topbar__action--negative:hover {
-  background: rgba(255, 111, 121, 0.15);
+  background: var(--color-negative-hover);
 }
 .ui-topbar__action--default {
   background: var(--color-bg-elevated);

--- a/app/components/ui/UiWizardProgress/UiWizardProgress.vue
+++ b/app/components/ui/UiWizardProgress/UiWizardProgress.vue
@@ -47,20 +47,20 @@ const label = computed<string>(() => `Pergunta ${props.current} de ${props.total
 .ui-wizard-progress__label {
   font-size: var(--font-size-sm, 0.875rem);
   font-weight: var(--font-weight-semibold, 600);
-  color: var(--color-text-muted, #888);
+  color: var(--color-text-muted);
 }
 
 .ui-wizard-progress__track {
   width: 100%;
   height: 6px;
-  background: var(--color-bg-elevated, #e0e0e0);
+  background: var(--color-bg-elevated);
   border-radius: var(--radius-full, 9999px);
   overflow: hidden;
 }
 
 .ui-wizard-progress__fill {
   height: 100%;
-  background: var(--color-brand-600, #6366f1);
+  background: var(--color-brand-600);
   border-radius: var(--radius-full, 9999px);
   transition: width 0.25s ease;
 }

--- a/app/components/ui/__stories__/TokensShowcase.stories.ts
+++ b/app/components/ui/__stories__/TokensShowcase.stories.ts
@@ -1,34 +1,123 @@
 import type { Meta, StoryObj } from "@storybook/vue3";
-import { defineComponent, h } from "vue";
-import { colors } from "~/theme/tokens/colors";
-import { NCard, NButton } from "naive-ui";
+import { defineComponent, ref } from "vue";
+import { NButton, NCard, NDataTable, NFormItem, NInput, NSelect, NSpace, NSwitch, NTag } from "naive-ui";
+import { themePalettes } from "~/theme/tokens/semantic";
 
-/** Story de validação: verifica que o tema Auraxis está aplicado corretamente no Storybook. */
+const swatches = [
+  ["Ação", "action.primary"],
+  ["Receita", "feedback.positive"],
+  ["Despesa", "feedback.negative"],
+  ["Alerta", "feedback.warning"],
+  ["Investimento", "chart.investment"],
+] as const;
+
+const tableColumns = [
+  { title: "Componente", key: "component" },
+  { title: "Estado", key: "state" },
+  { title: "Token", key: "token" },
+];
+
+const tableData = [
+  { component: "Button", state: "primary", token: "action.primary" },
+  { component: "Input", state: "focus", token: "border.focus" },
+  { component: "Select", state: "active", token: "action.primarySubtle" },
+];
+
+/**
+ * Reads a nested token value from the semantic palette.
+ * @param path Dot-separated token path.
+ * @returns Token color from the light palette for swatch documentation.
+ */
+function getLightToken(path: string): string {
+  return path.split(".").reduce<unknown>((value, key) => {
+    return typeof value === "object" && value !== null && key in value
+      ? (value as Record<string, unknown>)[key]
+      : undefined;
+  }, themePalettes.light) as string;
+}
+
+const swatchRows = swatches.map(([label, path]) => ({
+  label,
+  path,
+  color: getLightToken(path),
+}));
+
 const TokensShowcase = defineComponent({
   name: "TokensShowcase",
-  setup(): () => ReturnType<typeof h> {
-    return () =>
-      h(NCard, { title: "Auraxis Design Tokens", style: { maxWidth: "600px" } }, {
-        default: () => [
-          h("div", { style: "display:flex; gap:8px; flex-wrap:wrap; margin-bottom:16px;" }, [
-            h("div", { style: `width:48px;height:48px;background:${colors.cyan[500]};border-radius:8px;` }),
-            h("div", { style: `width:48px;height:48px;background:${colors.violet[500]};border-radius:8px;` }),
-            h("div", { style: `width:48px;height:48px;background:${colors.lime[500]};border-radius:8px;` }),
-            h("div", { style: `width:48px;height:48px;background:${colors.positive.DEFAULT};border-radius:8px;` }),
-            h("div", { style: `width:48px;height:48px;background:${colors.negative.DEFAULT};border-radius:8px;` }),
-          ]),
-          h("div", { style: "display:flex; gap:8px;" }, [
-            h(NButton, { type: "primary" }, () => "Primary CTA"),
-            h(NButton, { type: "default" }, () => "Default"),
-            h(NButton, { type: "error" }, () => "Error"),
-          ]),
-        ],
-      });
+  components: { NButton, NCard, NDataTable, NFormItem, NInput, NSelect, NSpace, NSwitch, NTag },
+  setup() {
+    const selected = ref("all");
+    const enabled = ref(true);
+
+    return { enabled, selected, swatchRows, tableColumns, tableData };
   },
+  template: `
+    <div style="display:grid;gap:16px;width:min(920px,calc(100vw - 48px));">
+      <NCard title="Auraxis Theme Sandbox" bordered>
+        <p style="margin:0 0 16px;color:var(--color-text-secondary);">
+          Validação visual dos componentes base do Naive UI usando os mesmos overrides do app.
+        </p>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(128px,1fr));gap:12px;">
+          <div
+            v-for="swatch in swatchRows"
+            :key="swatch.path"
+            style="border:1px solid var(--color-outline-soft);border-radius:12px;padding:12px;background:var(--color-bg-elevated);"
+          >
+            <div
+              :style="{ background: swatch.color }"
+              style="height:40px;border-radius:10px;border:1px solid var(--color-outline-soft);margin-bottom:8px;"
+            />
+            <strong style="display:block;color:var(--color-text-primary);">{{ swatch.label }}</strong>
+            <small style="color:var(--color-text-muted);">{{ swatch.path }}</small>
+          </div>
+        </div>
+      </NCard>
+
+      <NCard title="Naive UI controls" bordered>
+        <NSpace vertical :size="16">
+          <NSpace wrap>
+            <NButton type="primary">Primary CTA</NButton>
+            <NButton type="default">Default</NButton>
+            <NButton type="error">Error</NButton>
+            <NButton type="success">Success</NButton>
+          </NSpace>
+
+          <NFormItem label="Campo de busca">
+            <NInput placeholder="Digite para testar foco e placeholder" />
+          </NFormItem>
+
+          <NFormItem label="Filtro">
+            <NSelect
+              v-model:value="selected"
+              :options="[
+                { label: 'Todos', value: 'all' },
+                { label: 'Receitas', value: 'income' },
+                { label: 'Despesas', value: 'expense' },
+              ]"
+            />
+          </NFormItem>
+
+          <NSpace align="center">
+            <NSwitch v-model:value="enabled" />
+            <NTag type="info" bordered>Tokenizado</NTag>
+            <NTag type="success" bordered>Receita</NTag>
+            <NTag type="error" bordered>Despesa</NTag>
+          </NSpace>
+
+          <NDataTable
+            :columns="tableColumns"
+            :data="tableData"
+            :pagination="false"
+            size="small"
+          />
+        </NSpace>
+      </NCard>
+    </div>
+  `,
 });
 
 const meta: Meta = {
-  title: "Design System/Token Showcase",
+  title: "Design System/Theme Sandbox",
   component: TokensShowcase,
   tags: ["autodocs"],
 };

--- a/app/composables/useNaiveTheme/useNaiveTheme.spec.ts
+++ b/app/composables/useNaiveTheme/useNaiveTheme.spec.ts
@@ -1,46 +1,42 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { useNaiveTheme } from "./useNaiveTheme";
+import { buildNaiveThemeOverrides } from "~/utils/naive-theme";
 
 describe("useNaiveTheme", () => {
-  it("returns theme and themeOverrides", () => {
+  it("returns reactive theme and themeOverrides refs", () => {
     const { theme, themeOverrides } = useNaiveTheme();
+
     expect(theme).toBeDefined();
-    expect(themeOverrides).toBeDefined();
+    expect(themeOverrides.value).toBeDefined();
   });
 
-  it("primaryColor maps to cyan-500", () => {
-    const { themeOverrides } = useNaiveTheme();
+  it("builds light overrides from semantic light tokens", () => {
+    const themeOverrides = buildNaiveThemeOverrides("light");
+
+    expect(themeOverrides.common?.primaryColor).toBe("#087FA7");
+    expect(themeOverrides.common?.bodyColor).toBe("#F4F8FB");
+    expect(themeOverrides.common?.cardColor).toBe("#FFFFFF");
+    expect(themeOverrides.Button?.textColorPrimary).toBe("#FFFFFF");
+    expect(themeOverrides.Input?.boxShadowFocus).toContain("rgba(8, 127, 167");
+  });
+
+  it("builds dark overrides from semantic dark tokens", () => {
+    const themeOverrides = buildNaiveThemeOverrides("dark");
+
     expect(themeOverrides.common?.primaryColor).toBe("#44d4ff");
-  });
-
-  it("bodyColor maps to bg-canvas", () => {
-    const { themeOverrides } = useNaiveTheme();
     expect(themeOverrides.common?.bodyColor).toBe("#05070d");
-  });
-
-  it("cardColor maps to bg-surface", () => {
-    const { themeOverrides } = useNaiveTheme();
     expect(themeOverrides.common?.cardColor).toBe("#121a2a");
-  });
-
-  it("errorColor maps to negative token", () => {
-    const { themeOverrides } = useNaiveTheme();
-    expect(themeOverrides.common?.errorColor).toBe("#ff6f79");
-  });
-
-  it("successColor maps to positive token", () => {
-    const { themeOverrides } = useNaiveTheme();
-    expect(themeOverrides.common?.successColor).toBe("#42e8a9");
-  });
-
-  it("Button component overrides exist", () => {
-    const { themeOverrides } = useNaiveTheme();
-    expect(themeOverrides.Button?.colorPrimary).toBe("#44d4ff");
     expect(themeOverrides.Button?.textColorPrimary).toBe("#05070d");
+    expect(themeOverrides.Input?.boxShadowFocus).toContain("rgba(68, 212, 255");
   });
 
-  it("Input component overrides include focus glow", () => {
-    const { themeOverrides } = useNaiveTheme();
-    expect(themeOverrides.Input?.boxShadowFocus).toContain("rgba(68, 212, 255");
+  it("keeps overlay components mapped to the active palette", () => {
+    const light = buildNaiveThemeOverrides("light");
+    const dark = buildNaiveThemeOverrides("dark");
+
+    expect(light.Select?.peers?.InternalSelectMenu?.color).toBe("#F8FBFF");
+    expect(dark.Select?.peers?.InternalSelectMenu?.color).toBe("#0e1523");
+    expect(light.DataTable?.thColor).toBe("#F8FBFF");
+    expect(dark.DataTable?.thColor).toBe("#0e1523");
   });
 });

--- a/app/composables/useNaiveTheme/useNaiveTheme.ts
+++ b/app/composables/useNaiveTheme/useNaiveTheme.ts
@@ -1,161 +1,30 @@
-import { darkTheme, type GlobalThemeOverrides } from "naive-ui";
-import { colors } from "~/theme/tokens/colors";
-import { fonts } from "~/theme/tokens/typography";
-import { radii } from "~/theme/tokens/radii";
+import type { GlobalTheme, GlobalThemeOverrides } from "naive-ui";
+import { computed, type ComputedRef } from "vue";
+import { useTheme } from "~/composables/useTheme";
+import { buildNaiveThemeOverrides } from "~/utils/naive-theme";
 
 export interface NaiveThemeResult {
-  theme: typeof darkTheme;
-  themeOverrides: GlobalThemeOverrides;
-}
-
-/** @returns GlobalThemeOverrides.common mapped from Auraxis DS v3 tokens. */
-function buildCommonOverrides(): GlobalThemeOverrides["common"] {
-  return {
-    primaryColor:             colors.cyan[500],
-    primaryColorHover:        colors.cyan[400],
-    primaryColorPressed:      colors.cyan[600],
-    primaryColorSuppl:        colors.violet[500],
-    bodyColor:                colors.bg.canvas,
-    cardColor:                colors.bg.surface,
-    modalColor:               colors.bg.surface,
-    popoverColor:             colors.bg.elevated,
-    tableColor:               colors.bg.surface,
-    inputColor:               colors.bg.elevated,
-    inputColorDisabled:       colors.bg.surface,
-    borderColor:              colors.border.subtle,
-    dividerColor:             colors.border.subtle,
-    textColorBase:            colors.text.primary,
-    textColor1:               colors.text.primary,
-    textColor2:               colors.text.secondary,
-    textColor3:               colors.text.muted,
-    placeholderColor:         colors.text.subtle,
-    placeholderColorDisabled: colors.text.subtle,
-    errorColor:               colors.negative.DEFAULT,
-    errorColorHover:          colors.negative.dark,
-    successColor:             colors.positive.DEFAULT,
-    successColorHover:        colors.positive.dark,
-    warningColor:             colors.orange[500],
-    fontFamily:               fonts.body,
-    fontFamilyMono:           fonts.mono,
-    borderRadius:             radii.md,
-    borderRadiusSmall:        radii.sm,
-  };
-}
-
-/** @returns Component-level GlobalThemeOverrides for form and interactive elements. */
-function buildComponentOverrides(): Omit<GlobalThemeOverrides, "common"> {
-  return {
-    Button: {
-      colorPrimary:             colors.cyan[500],
-      colorHoverPrimary:        colors.cyan[400],
-      colorPressedPrimary:      colors.cyan[600],
-      colorFocusPrimary:        colors.cyan[400],
-      colorDisabledPrimary:     colors.bg.elevated,
-      textColorPrimary:         colors.bg.canvas,
-      textColorHoverPrimary:    colors.bg.canvas,
-      textColorPressedPrimary:  colors.bg.canvas,
-      textColorDisabledPrimary: colors.text.muted,
-      borderRadiusPrimary:      radii.md,
-    },
-    Input: {
-      color:            colors.bg.elevated,
-      colorFocus:       colors.bg.elevated,
-      colorDisabled:    colors.bg.surface,
-      textColor:        colors.text.primary,
-      placeholderColor: colors.text.subtle,
-      border:           `1px solid ${colors.border.subtle}`,
-      borderFocus:      `1px solid ${colors.cyan[500]}`,
-      borderHover:      `1px solid ${colors.cyan[400]}`,
-      borderRadius:     radii.md,
-      boxShadowFocus:   "0 0 0 2px rgba(68, 212, 255, 0.18)",
-    },
-    Card: {
-      color:          colors.bg.surface,
-      colorModal:     colors.bg.surface,
-      borderColor:    colors.border.subtle,
-      borderRadius:   radii.lg,
-      titleTextColor: colors.text.primary,
-      textColor:      colors.text.secondary,
-    },
-    Form: {
-      labelTextColor:         colors.text.secondary,
-      feedbackTextColorError: colors.negative.DEFAULT,
-    },
-  };
-}
-
-/** @returns Component-level GlobalThemeOverrides for overlay and display elements. */
-function buildOverlayOverrides(): Omit<GlobalThemeOverrides, "common"> {
-  return {
-    Select: {
-      menuColor:             colors.bg.elevated,
-      optionColorActive:     "rgba(68, 212, 255, 0.1)",
-      optionColorPending:    "rgba(68, 212, 255, 0.05)",
-      optionTextColorActive: colors.cyan[400],
-      optionCheckColor:      colors.cyan[500],
-      peers: {
-        InternalSelectMenu: {
-          color: colors.bg.elevated,
-        },
-      },
-    },
-    Modal: {
-      color:        colors.bg.surface,
-      textColor:    colors.text.primary,
-      borderRadius: radii.lg,
-    },
-    Drawer: {
-      color:     colors.bg.surface,
-      textColor: colors.text.primary,
-    },
-    Tag: {
-      colorBordered:  "transparent",
-      textColor:      colors.text.secondary,
-      borderColor:    colors.border.subtle,
-      closeIconColor: colors.text.muted,
-    },
-    Tabs: {
-      tabTextColorLine:       colors.text.muted,
-      tabTextColorHoverLine:  colors.text.secondary,
-      tabTextColorActiveLine: colors.cyan[500],
-      barColor:               colors.cyan[500],
-      tabFontWeightActive:    "600",
-    },
-    DataTable: {
-      thColor:     colors.bg.elevated,
-      thTextColor: colors.text.muted,
-      tdColor:     colors.bg.surface,
-      tdColorHover: colors.bg.elevated,
-      borderColor: colors.border.subtle,
-    },
-    Skeleton: {
-      color:    colors.bg.elevated,
-      colorEnd: colors.bg.surface,
-    },
-    Tooltip: {
-      color:        colors.bg.elevated,
-      textColor:    colors.text.primary,
-      borderRadius: radii.sm,
-    },
-  };
+  theme: ComputedRef<GlobalTheme | null>;
+  themeOverrides: ComputedRef<GlobalThemeOverrides>;
 }
 
 /**
  * Composable canônico de tema do Auraxis para o Naive UI.
+ *
  * Use com NConfigProvider em app.vue:
  *   `<NConfigProvider :theme="theme" :theme-overrides="themeOverrides">`
  *
- * @returns Naive UI theme object and GlobalThemeOverrides derived from Auraxis DS v3 tokens.
+ * @returns Naive UI theme object and GlobalThemeOverrides derived from the active Auraxis theme.
  */
 export function useNaiveTheme(): NaiveThemeResult {
-  const themeOverrides: GlobalThemeOverrides = {
-    common: buildCommonOverrides(),
-    ...buildComponentOverrides(),
-    ...buildOverlayOverrides(),
-  };
+  const { naiveTheme, resolvedTheme } = useTheme();
+
+  const themeOverrides = computed<GlobalThemeOverrides>(() =>
+    buildNaiveThemeOverrides(resolvedTheme.value),
+  );
 
   return {
-    theme: darkTheme,
+    theme: naiveTheme,
     themeOverrides,
   };
 }

--- a/app/layouts/LayoutBase.vue
+++ b/app/layouts/LayoutBase.vue
@@ -30,8 +30,8 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--space-3);
-  border-bottom: 1px solid rgba(38, 33, 33, 0.08);
-  background: rgba(255, 255, 255, 0.9);
+  border-bottom: 1px solid var(--color-outline-soft);
+  background: var(--color-bg-glass);
   backdrop-filter: blur(8px);
   z-index: 10;
 }
@@ -41,14 +41,14 @@
   font-size: var(--font-size-heading-lg);
   line-height: var(--line-height-heading-lg);
   font-weight: var(--font-weight-bold);
-  color: var(--color-neutral-900);
+  color: var(--color-text-primary);
 }
 
 .layout-nav {
   display: flex;
   gap: var(--space-4);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-neutral-700);
+  color: var(--color-text-secondary);
 }
 
 .nav-link {
@@ -63,13 +63,13 @@
 .nav-link:focus {
   outline: none;
   color: var(--color-brand-600);
-  background-color: var(--color-brand-400);
+  background-color: var(--color-brand-hover-surface);
 }
 
 .nav-link.active {
-  color: var(--color-brand-600);
+  color: var(--color-text-on-brand);
   font-weight: var(--font-weight-bold);
-  background-color: var(--color-brand-500);
+  background-color: var(--color-brand-600);
 }
 
 .layout-main {

--- a/app/test-utils/renderWithProviders.ts
+++ b/app/test-utils/renderWithProviders.ts
@@ -64,7 +64,7 @@ export function renderWithProviders(
   const Wrapper = defineComponent({
     setup(): () => ReturnType<typeof h> {
       return (): ReturnType<typeof h> =>
-        h(NConfigProvider, { theme, themeOverrides }, (): ReturnType<typeof h> =>
+        h(NConfigProvider, { theme: theme.value, themeOverrides: themeOverrides.value }, (): ReturnType<typeof h> =>
           h(NMessageProvider, {}, (): ReturnType<typeof h> =>
             h(NDialogProvider, {}, (): ReturnType<typeof h> =>
               h(component, (mountOptions.props ?? {}) as AnyRecord)

--- a/app/utils/naive-theme.ts
+++ b/app/utils/naive-theme.ts
@@ -1,116 +1,286 @@
 /**
  * Auraxis design tokens mapped to Naive UI's GlobalThemeOverrides.
  *
- * Source of truth: DS v3 "Market Pulse"
- * - `docs/wiki/MVP-1-Web-Design-System-v3-Market-Pulse.md`
- * - `designs/web/revamp/tokens/auraxis-ds-v3.tokens.css`
+ * The design-system tokens live in `app/theme/tokens`; this module is the
+ * bridge that lets Naive UI controls follow the active light/dark theme.
  */
 import type { GlobalThemeOverrides } from "naive-ui";
+import { themePalettes, type ResolvedTheme } from "~/theme/tokens/semantic";
+import { fonts } from "~/theme/tokens/typography";
+import { radii } from "~/theme/tokens/radii";
+
+const darkPalette = themePalettes.dark;
 
 /**
- * Core Auraxis token palette — DS v3 "Market Pulse".
- * Exported so wrappers and composables can reference tokens without duplicating values.
+ * Legacy token export used by chart helpers. Keep this shape stable while the
+ * chart layer is migrated to `themePalettes`.
  */
 export const tokens = {
   surface: {
-    base: "#121a2a",
-    deep: "#05070d",
-    card: "#0e1523",
-    cardActive: "#172338",
+    base: darkPalette.bg.surface,
+    deep: darkPalette.bg.canvas,
+    card: darkPalette.bg.elevated,
+    cardActive: darkPalette.bg.muted,
   },
   brand: {
-    primary: "#44d4ff",
-    secondary: "#8b7dff",
-    highlight: "#42e8a9",
-    primaryPressed: "#24beea",
+    primary: darkPalette.action.primary,
+    secondary: darkPalette.chart.investment,
+    highlight: darkPalette.feedback.positive,
+    primaryPressed: darkPalette.action.primaryPressed,
   },
   text: {
-    default: "#f1f5ff",
-    muted: "#d2dcf3",
-    disabled: "#6e7f9f",
+    default: darkPalette.text.primary,
+    muted: darkPalette.text.muted,
+    disabled: darkPalette.text.subtle,
   },
   status: {
-    success: "#42e8a9",
+    success: darkPalette.feedback.positive,
     successSoft: "#86f7cc",
-    danger: "#ff6f79",
+    danger: darkPalette.feedback.negative,
     dangerSoft: "#ff9099",
-    warning: "#ffb861",
-    info: "#44d4ff",
+    warning: darkPalette.feedback.warning,
+    info: darkPalette.feedback.info,
   },
-  border: "rgba(255, 255, 255, 0.1)",
+  border: darkPalette.border.subtle,
 } as const;
 
-/**
- * Naive UI GlobalThemeOverrides applying the Auraxis DS v3 visual identity.
- *
- * Passed to `<NConfigProvider :theme-overrides="auraxisThemeOverrides">` in app.vue.
- * All product components inherit these values automatically — no per-component theming needed.
- */
-export const auraxisThemeOverrides: GlobalThemeOverrides = {
-  common: {
-    // Brand
-    primaryColor: tokens.brand.primary,
-    primaryColorHover: tokens.brand.secondary,
-    primaryColorPressed: tokens.brand.primaryPressed,
-    primaryColorSuppl: tokens.brand.highlight,
-    // Surfaces
-    baseColor: tokens.surface.deep,
-    bodyColor: tokens.surface.deep,
-    cardColor: tokens.surface.card,
-    modalColor: tokens.surface.card,
-    popoverColor: tokens.surface.cardActive,
-    // Text
-    textColorBase: tokens.text.default,
-    textColor1: tokens.text.default,
-    textColor2: tokens.text.muted,
-    textColor3: tokens.text.disabled,
-    placeholderColor: tokens.text.disabled,
-    // Borders
-    borderColor: tokens.border,
-    dividerColor: tokens.border,
-    // Status
-    successColor: tokens.status.success,
-    warningColor: tokens.status.warning,
-    errorColor: tokens.status.danger,
-    infoColor: tokens.status.info,
-    // Typography — Inter + IBM Plex Mono (DS v3)
-    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif",
-    fontFamilyMono: "\"IBM Plex Mono\", \"SF Mono\", ui-monospace, Menlo, monospace",
-    fontSize: "14px",
-    fontSizeMini: "12px",
-    fontSizeSmall: "13px",
-    fontSizeMedium: "14px",
-    fontSizeLarge: "16px",
-    fontSizeHuge: "20px",
-    // Radius — DS v3 scale
-    borderRadius: "10px",
-    borderRadiusSmall: "6px",
-  },
-  Button: {
-    textColor: tokens.surface.deep,
-    fontWeightStrong: "600",
-  },
-  Input: {
-    color: tokens.surface.card,
-    colorFocus: tokens.surface.cardActive,
-    borderColor: tokens.border,
-    borderFocusColor: tokens.brand.primary,
-    borderHoverColor: tokens.brand.secondary,
-    caretColor: tokens.brand.primary,
-  },
-  Card: {
-    color: tokens.surface.card,
-    borderColor: tokens.border,
-  },
-  Layout: {
-    color: tokens.surface.deep,
-    siderColor: tokens.surface.base,
-    headerColor: tokens.surface.base,
-  },
-  DataTable: {
-    thColor: tokens.surface.card,
-    tdColor: tokens.surface.base,
-    tdColorHover: tokens.surface.cardActive,
-    borderColor: tokens.border,
-  },
+const focusShadowByTheme: Record<ResolvedTheme, string> = {
+  light: "0 0 0 2px rgba(8, 127, 167, 0.18)",
+  dark: "0 0 0 2px rgba(68, 212, 255, 0.18)",
 };
+
+const pendingOptionByTheme: Record<ResolvedTheme, string> = {
+  light: "rgba(8, 127, 167, 0.08)",
+  dark: "rgba(68, 212, 255, 0.08)",
+};
+
+type ThemePalette = (typeof themePalettes)[ResolvedTheme];
+
+/**
+ * Builds common Naive UI theme tokens for the active palette.
+ * @param palette Active semantic palette.
+ * @returns Common Naive UI theme tokens.
+ */
+function buildCommonOverrides(palette: ThemePalette): GlobalThemeOverrides["common"] {
+  return {
+    primaryColor:             palette.action.primary,
+    primaryColorHover:        palette.action.primaryHover,
+    primaryColorPressed:      palette.action.primaryPressed,
+    primaryColorSuppl:        palette.chart.investment,
+    baseColor:                palette.bg.canvas,
+    bodyColor:                palette.bg.canvas,
+    cardColor:                palette.bg.surface,
+    modalColor:               palette.bg.surface,
+    popoverColor:             palette.bg.elevated,
+    tableColor:               palette.bg.surface,
+    inputColor:               palette.bg.elevated,
+    inputColorDisabled:       palette.bg.muted,
+    borderColor:              palette.border.subtle,
+    dividerColor:             palette.border.subtle,
+    textColorBase:            palette.text.primary,
+    textColor1:               palette.text.primary,
+    textColor2:               palette.text.secondary,
+    textColor3:               palette.text.muted,
+    placeholderColor:         palette.text.subtle,
+    placeholderColorDisabled: palette.text.subtle,
+    errorColor:               palette.feedback.negative,
+    errorColorHover:          palette.feedback.negative,
+    successColor:             palette.feedback.positive,
+    successColorHover:        palette.feedback.positive,
+    warningColor:             palette.feedback.warning,
+    warningColorHover:        palette.feedback.warning,
+    infoColor:                palette.feedback.info,
+    infoColorHover:           palette.feedback.info,
+    fontFamily:               fonts.body,
+    fontFamilyMono:           fonts.mono,
+    fontSize:                 "14px",
+    fontSizeSmall:            "13px",
+    fontSizeMedium:           "14px",
+    fontSizeLarge:            "16px",
+    borderRadius:             radii.md,
+    borderRadiusSmall:        radii.sm,
+  };
+}
+
+/**
+ * Builds form and card overrides for the active palette.
+ * @param theme Resolved light/dark theme.
+ * @param palette Active semantic palette.
+ * @returns Form and card component overrides.
+ */
+function buildControlOverrides(
+  theme: ResolvedTheme,
+  palette: ThemePalette,
+): Omit<GlobalThemeOverrides, "common"> {
+  return {
+    Button: {
+      colorPrimary:             palette.action.primary,
+      colorHoverPrimary:        palette.action.primaryHover,
+      colorPressedPrimary:      palette.action.primaryPressed,
+      colorFocusPrimary:        palette.action.primaryHover,
+      colorDisabledPrimary:     palette.bg.muted,
+      textColorPrimary:         palette.text.inverse,
+      textColorHoverPrimary:    palette.text.inverse,
+      textColorPressedPrimary:  palette.text.inverse,
+      textColorDisabledPrimary: palette.text.subtle,
+      borderRadiusPrimary:      radii.md,
+      fontWeightStrong:         "600",
+    },
+    Input: {
+      color:            palette.bg.elevated,
+      colorFocus:       palette.bg.elevated,
+      colorDisabled:    palette.bg.muted,
+      textColor:        palette.text.primary,
+      placeholderColor: palette.text.subtle,
+      border:           `1px solid ${palette.border.subtle}`,
+      borderFocus:      `1px solid ${palette.border.focus}`,
+      borderHover:      `1px solid ${palette.action.primaryHover}`,
+      borderRadius:     radii.md,
+      boxShadowFocus:   focusShadowByTheme[theme],
+      caretColor:       palette.action.primary,
+    },
+    Card: {
+      color:          palette.bg.surface,
+      colorModal:     palette.bg.surface,
+      borderColor:    palette.border.subtle,
+      borderRadius:   radii.lg,
+      titleTextColor: palette.text.primary,
+      textColor:      palette.text.secondary,
+    },
+    Layout: {
+      color:       palette.bg.canvas,
+      headerColor: palette.bg.surface,
+      siderColor:  palette.bg.surface,
+    },
+    Form: {
+      labelTextColor:         palette.text.secondary,
+      feedbackTextColorError: palette.feedback.negative,
+    },
+  };
+}
+
+/**
+ * Builds overlay and menu overrides for the active palette.
+ * @param theme Resolved light/dark theme.
+ * @param palette Active semantic palette.
+ * @returns Overlay and menu component overrides.
+ */
+function buildOverlayOverrides(
+  theme: ResolvedTheme,
+  palette: ThemePalette,
+): Omit<GlobalThemeOverrides, "common"> {
+  return {
+    Select: {
+      menuColor:             palette.bg.elevated,
+      optionColorActive:     palette.action.primarySubtle,
+      optionColorPending:    pendingOptionByTheme[theme],
+      optionTextColorActive: palette.action.primary,
+      optionCheckColor:      palette.action.primary,
+      peers: {
+        InternalSelectMenu: {
+          color: palette.bg.elevated,
+        },
+      },
+    },
+    Dropdown: {
+      color:                palette.bg.elevated,
+      optionTextColor:      palette.text.secondary,
+      optionColorHover:     pendingOptionByTheme[theme],
+      optionTextColorHover: palette.text.primary,
+    },
+    Modal: {
+      color:        palette.bg.surface,
+      textColor:    palette.text.primary,
+      borderRadius: radii.lg,
+    },
+    Dialog: {
+      color:        palette.bg.surface,
+      textColor:    palette.text.primary,
+      borderRadius: radii.lg,
+    },
+    Drawer: {
+      color:     palette.bg.surface,
+      textColor: palette.text.primary,
+    },
+  };
+}
+
+/**
+ * Builds display component overrides for tables, tabs, tags and feedback.
+ * @param theme Resolved light/dark theme.
+ * @param palette Active semantic palette.
+ * @returns Display component overrides.
+ */
+function buildDisplayOverrides(
+  theme: ResolvedTheme,
+  palette: ThemePalette,
+): Omit<GlobalThemeOverrides, "common"> {
+  return {
+    Tag: {
+      colorBordered:  "transparent",
+      textColor:      palette.text.secondary,
+      borderColor:    palette.border.subtle,
+      closeIconColor: palette.text.muted,
+    },
+    Tabs: {
+      tabTextColorLine:       palette.text.muted,
+      tabTextColorHoverLine:  palette.text.secondary,
+      tabTextColorActiveLine: palette.action.primary,
+      barColor:               palette.action.primary,
+      tabFontWeightActive:    "600",
+    },
+    DataTable: {
+      thColor:      palette.bg.elevated,
+      thTextColor:  palette.text.muted,
+      tdColor:      palette.bg.surface,
+      tdColorHover: palette.bg.elevated,
+      borderColor:  palette.border.subtle,
+    },
+    Pagination: {
+      itemColorActive:      palette.action.primarySubtle,
+      itemTextColorActive:  palette.action.primary,
+      itemBorderActive:     `1px solid ${palette.border.focus}`,
+      itemBorderHover:      `1px solid ${palette.action.primaryHover}`,
+      itemTextColorHover:   palette.action.primary,
+      buttonColorHover:     pendingOptionByTheme[theme],
+      buttonIconColorHover: palette.action.primary,
+      buttonIconColor:      palette.text.muted,
+    },
+    Skeleton: {
+      color:    palette.bg.elevated,
+      colorEnd: palette.bg.muted,
+    },
+    Tooltip: {
+      color:        palette.bg.elevated,
+      textColor:    palette.text.primary,
+      borderRadius: radii.sm,
+    },
+    Popover: {
+      color:        palette.bg.elevated,
+      textColor:    palette.text.primary,
+      borderRadius: radii.md,
+    },
+    Message: {
+      color:     palette.bg.elevated,
+      textColor: palette.text.primary,
+    },
+  };
+}
+
+/**
+ * Builds Naive UI theme overrides for the active Auraxis theme.
+ * @param theme Resolved light/dark theme.
+ * @returns Naive UI GlobalThemeOverrides aligned to semantic tokens.
+ */
+export function buildNaiveThemeOverrides(theme: ResolvedTheme): GlobalThemeOverrides {
+  const palette = themePalettes[theme];
+
+  return {
+    common: buildCommonOverrides(palette),
+    ...buildControlOverrides(theme, palette),
+    ...buildOverlayOverrides(theme, palette),
+    ...buildDisplayOverrides(theme, palette),
+  };
+}
+
+export const auraxisThemeOverrides: GlobalThemeOverrides = buildNaiveThemeOverrides("dark");


### PR DESCRIPTION
## Resumo

Closes #886

Este PR conecta a base de tema claro/escuro recém-criada ao Naive UI, ao app shell e aos componentes base que dão sustentação visual para as próximas telas core.

## O que mudou

- `NConfigProvider` agora recebe tema e overrides reativos via `useNaiveTheme`, usando `darkTheme` somente no modo escuro e `null` no modo claro.
- `buildNaiveThemeOverrides(theme)` centraliza os overrides do Naive UI para light/dark com tokens semânticos do Auraxis.
- Storybook ganhou seletor global de tema (`Light`/`Dark`) e o `Theme Sandbox` passou a exercitar botões, inputs, selects, switches, tags e tabela em ambos os temas.
- Componentes base e shell (`UiAppShell`, `UiTopbar`, `UiToolsShell`, `LayoutBase`, `BaseSkeleton`, `UiWizardProgress`, `UiOptionCardRadio`, `UiPublicHeader`) passaram a usar variáveis semânticas em vez de cores fixas.
- CSS global recebeu variáveis de interação/skeleton/overlay necessárias para os dois temas.
- Testes de app/provider e `useNaiveTheme` foram atualizados para o novo contrato reativo.

## Fora deste PR

- A equalização visual completa das telas core em light/dark fica para a próxima tarefa (`#887`). Durante a validação, telas como auth/dashboard ainda mostram estilos específicos legados em alguns trechos, então usei o Theme Sandbox como evidência visual desta camada de base.

## Screenshots

Capturados localmente via Storybook Theme Sandbox com componentes e dados mockados:

- Light: `/tmp/auraxis-pr-886-screenshots/theme-sandbox-light.png`
- Dark: `/tmp/auraxis-pr-886-screenshots/theme-sandbox-dark.png`

## Como validei

- `pnpm exec vitest run --coverage.enabled=false app/composables/useNaiveTheme/useNaiveTheme.spec.ts app/composables/useTheme/__tests__/useTheme.spec.ts app/app.spec.ts app/components/ui/UiAppShell/__tests__/UiAppShell.spec.ts app/components/ui/UiTopbar/__tests__/UiTopbar.spec.ts app/components/ui/BaseSkeleton.spec.ts app/assets/css/__tests__/main-theme-vars.spec.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build-storybook`
- `pnpm build`
- `BASE_URL=http://127.0.0.1:3011 pnpm exec playwright test e2e/a11y.spec.ts --project=chromium`
- `BASE_URL=http://127.0.0.1:3011 pnpm exec playwright test e2e/a11y.spec.ts --project=mobile-chrome`
- Pre-push parity gate completo: flags, lint, typecheck, unit + coverage, policy e build.

## Observações

- Não alterei `app/i18n/locales/en.json`.
- O build mantém warnings antigos de i18n/chunk size já existentes, sem falha no gate.
