### PR TITLE
[WEB] Admin — usuários, assinaturas e entitlements

### DIFF
--- a/app/features/admin/users/model/admin-user.ts
+++ b/app/features/admin/users/model/admin-user.ts
@@ -1,0 +1,102 @@
+export type AdminUserStatus = "active" | "blocked" | "pending" | "deleted";
+
+export type AdminSubscriptionStatus =
+  | "active"
+  | "free"
+  | "trialing"
+  | "past_due"
+  | "canceled"
+  | "inactive";
+
+export interface AdminUserSummary {
+  readonly id: string;
+  readonly name: string;
+  readonly email: string;
+  readonly status: AdminUserStatus;
+  readonly createdAt: string | null;
+  readonly lastSeenAt: string | null;
+  readonly subscriptionPlan: string;
+  readonly subscriptionStatus: AdminSubscriptionStatus;
+  readonly entitlementCount: number;
+}
+
+export interface AdminUserList {
+  readonly users: AdminUserSummary[];
+  readonly page: number;
+  readonly perPage: number;
+  readonly total: number;
+}
+
+export interface AdminUserSubscription {
+  readonly planCode: string;
+  readonly status: AdminSubscriptionStatus;
+  readonly billingCycle: string | null;
+  readonly currentPeriodEnd: string | null;
+}
+
+export interface AdminUserEntitlement {
+  readonly id: string;
+  readonly featureKey: string;
+  readonly label: string;
+  readonly active: boolean;
+  readonly grantedAt: string | null;
+  readonly expiresAt: string | null;
+}
+
+export interface AdminAuditEvent {
+  readonly id: string;
+  readonly action: string;
+  readonly reason: string | null;
+  readonly createdAt: string | null;
+}
+
+export interface AdminUserDetail extends AdminUserSummary {
+  readonly subscription: AdminUserSubscription | null;
+  readonly entitlements: AdminUserEntitlement[];
+  readonly auditEvents: AdminAuditEvent[];
+}
+
+export interface AdminUsersFilters {
+  readonly search?: string;
+  readonly page?: number;
+  readonly perPage?: number;
+}
+
+export interface GrantAdminEntitlementInput {
+  readonly userId: string;
+  readonly featureKey: string;
+  readonly reason: string;
+}
+
+export interface RevokeAdminEntitlementInput {
+  readonly entitlementId: string;
+  readonly reason: string;
+}
+
+export interface AdminEntitlementMutationResult {
+  readonly auditId: string | null;
+  readonly entitlement?: AdminUserEntitlement;
+}
+
+export const ADMIN_ENTITLEMENT_OPTIONS = [
+  {
+    label: "Insights com IA",
+    value: "ai_insights",
+    description: "Permite geração e histórico de análises financeiras com IA.",
+  },
+  {
+    label: "Simulações avançadas",
+    value: "advanced_simulations",
+    description: "Libera calculadoras e cenários premium.",
+  },
+  {
+    label: "Market Pulse",
+    value: "market_pulse",
+    description: "Habilita painéis e sinais de mercado na carteira.",
+  },
+  {
+    label: "Recursos premium",
+    value: "premium_features",
+    description: "Atalho operacional para recursos premium gerais.",
+  },
+] as const;

--- a/app/features/admin/users/queries/use-admin-entitlement-mutations.ts
+++ b/app/features/admin/users/queries/use-admin-entitlement-mutations.ts
@@ -1,0 +1,90 @@
+import {
+  type UseMutationReturnType,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/vue-query";
+
+import type {
+  AdminEntitlementMutationResult,
+  GrantAdminEntitlementInput,
+  RevokeAdminEntitlementInput,
+} from "~/features/admin/users/model/admin-user";
+import {
+  type AdminUsersClient,
+  useAdminUsersClient,
+} from "~/features/admin/users/services/admin-users.client";
+
+/**
+ * Invalidates admin user caches touched by entitlement mutations.
+ *
+ * @param queryClient Vue Query client instance.
+ * @param userId Optional user detail id to refresh.
+ */
+const invalidateAdminUsers = async (
+  queryClient: ReturnType<typeof useQueryClient>,
+  userId?: string,
+): Promise<void> => {
+  await queryClient.invalidateQueries({ queryKey: ["admin", "users"] });
+
+  if (userId) {
+    await queryClient.invalidateQueries({ queryKey: ["admin", "users", "detail", userId] });
+  }
+};
+
+/**
+ * Creates the mutation used to grant an entitlement from the admin console.
+ *
+ * @param providedClient Optional client for unit tests.
+ * @returns Vue Query mutation for entitlement grants.
+ */
+export const useGrantAdminEntitlementMutation = (
+  providedClient?: AdminUsersClient,
+): UseMutationReturnType<
+  AdminEntitlementMutationResult,
+  Error,
+  GrantAdminEntitlementInput,
+  unknown
+> => {
+  const client = providedClient ?? useAdminUsersClient();
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    AdminEntitlementMutationResult,
+    Error,
+    GrantAdminEntitlementInput
+  >({
+    mutationFn: (input) => client.grantEntitlement(input),
+    onSuccess: async (_data, input): Promise<void> => {
+      await invalidateAdminUsers(queryClient, input.userId);
+    },
+  });
+};
+
+/**
+ * Creates the mutation used to revoke an entitlement from the admin console.
+ *
+ * @param providedClient Optional client for unit tests.
+ * @returns Vue Query mutation for entitlement revokes.
+ */
+export const useRevokeAdminEntitlementMutation = (
+  providedClient?: AdminUsersClient,
+): UseMutationReturnType<
+  AdminEntitlementMutationResult,
+  Error,
+  RevokeAdminEntitlementInput,
+  unknown
+> => {
+  const client = providedClient ?? useAdminUsersClient();
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    AdminEntitlementMutationResult,
+    Error,
+    RevokeAdminEntitlementInput
+  >({
+    mutationFn: (input) => client.revokeEntitlement(input),
+    onSuccess: async (): Promise<void> => {
+      await invalidateAdminUsers(queryClient);
+    },
+  });
+};

--- a/app/features/admin/users/queries/use-admin-user-query.ts
+++ b/app/features/admin/users/queries/use-admin-user-query.ts
@@ -1,0 +1,41 @@
+import { computed, type MaybeRefOrGetter, toValue } from "vue";
+import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+
+import { STALE_TIME } from "~/core/query/stale-time";
+import type { AdminUserDetail } from "~/features/admin/users/model/admin-user";
+import {
+  type AdminUsersClient,
+  useAdminUsersClient,
+} from "~/features/admin/users/services/admin-users.client";
+
+/**
+ * Builds the cache key for one admin user detail query.
+ *
+ * @param userId Selected user id.
+ * @returns Stable Vue Query key.
+ */
+export const adminUserDetailQueryKey = (
+  userId: string | null | undefined,
+): readonly unknown[] => ["admin", "users", "detail", userId ?? ""];
+
+/**
+ * Queries one user's admin detail when an id is selected.
+ *
+ * @param userId Reactive user id.
+ * @param providedClient Optional client for tests.
+ * @returns Vue Query state for the selected user detail.
+ */
+export const useAdminUserQuery = (
+  userId: MaybeRefOrGetter<string | null | undefined>,
+  providedClient?: AdminUsersClient,
+): UseQueryReturnType<AdminUserDetail, Error> => {
+  const client = providedClient ?? useAdminUsersClient();
+  const selectedUserId = computed(() => toValue(userId));
+
+  return useQuery({
+    queryKey: computed(() => adminUserDetailQueryKey(selectedUserId.value)),
+    queryFn: () => client.getUser(selectedUserId.value ?? ""),
+    enabled: computed(() => Boolean(selectedUserId.value)),
+    staleTime: STALE_TIME.ACTIVE,
+  });
+};

--- a/app/features/admin/users/queries/use-admin-users-query.ts
+++ b/app/features/admin/users/queries/use-admin-users-query.ts
@@ -1,0 +1,54 @@
+import { computed, type MaybeRefOrGetter, toValue } from "vue";
+import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+
+import { STALE_TIME } from "~/core/query/stale-time";
+import type {
+  AdminUserList,
+  AdminUsersFilters,
+} from "~/features/admin/users/model/admin-user";
+import {
+  type AdminUsersClient,
+  useAdminUsersClient,
+} from "~/features/admin/users/services/admin-users.client";
+
+/** Root cache key for admin user data. */
+export const ADMIN_USERS_QUERY_KEY = ["admin", "users"] as const;
+
+/**
+ * Builds the cache key for the admin users list.
+ *
+ * @param filters Search and pagination filters.
+ * @returns Stable Vue Query key.
+ */
+export const adminUsersListQueryKey = (
+  filters: AdminUsersFilters,
+): readonly unknown[] => [
+  ...ADMIN_USERS_QUERY_KEY,
+  "list",
+  {
+    search: filters.search ?? "",
+    page: filters.page ?? 1,
+    perPage: filters.perPage ?? 20,
+  },
+];
+
+/**
+ * Queries admin users using reactive search and pagination filters.
+ *
+ * @param filters Reactive filters for the list endpoint.
+ * @param providedClient Optional client for tests.
+ * @returns Vue Query state for the user list.
+ */
+export const useAdminUsersQuery = (
+  filters: MaybeRefOrGetter<AdminUsersFilters>,
+  providedClient?: AdminUsersClient,
+): UseQueryReturnType<AdminUserList, Error> => {
+  const client = providedClient ?? useAdminUsersClient();
+  const normalizedFilters = computed(() => toValue(filters));
+
+  return useQuery({
+    queryKey: computed(() => adminUsersListQueryKey(normalizedFilters.value)),
+    queryFn: () => client.listUsers(normalizedFilters.value),
+    staleTime: STALE_TIME.ACTIVE,
+  });
+};

--- a/app/features/admin/users/services/admin-users.client.spec.ts
+++ b/app/features/admin/users/services/admin-users.client.spec.ts
@@ -1,0 +1,199 @@
+import type { AxiosInstance } from "axios";
+import { describe, expect, it, vi } from "vitest";
+
+import { AdminUsersClient } from "./admin-users.client";
+
+/**
+ * Builds the admin users client with mocked Axios methods.
+ *
+ * @returns Client and spies for HTTP methods.
+ */
+const makeClient = (): {
+  readonly client: AdminUsersClient;
+  readonly get: ReturnType<typeof vi.fn>;
+  readonly post: ReturnType<typeof vi.fn>;
+  readonly deleteRequest: ReturnType<typeof vi.fn>;
+} => {
+  const get = vi.fn();
+  const post = vi.fn();
+  const deleteRequest = vi.fn();
+  const http = { get, post, delete: deleteRequest } as unknown as AxiosInstance;
+
+  return {
+    client: new AdminUsersClient(http),
+    get,
+    post,
+    deleteRequest,
+  };
+};
+
+describe("AdminUsersClient", () => {
+  it("lists users with the expected admin query params and maps the v2 envelope", async () => {
+    const { client, get } = makeClient();
+    get.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          users: [
+            {
+              id: "user-1",
+              name: "Ana Premium",
+              email: "ana@auraxis.com",
+              status: "active",
+              created_at: "2026-05-01T10:00:00Z",
+              last_seen_at: "2026-05-19T12:00:00Z",
+              subscription: { plan_code: "premium", status: "active" },
+              entitlements_count: 3,
+            },
+          ],
+          page: 2,
+          per_page: 25,
+          total: 42,
+        },
+      },
+    });
+
+    const result = await client.listUsers({ search: "ana", page: 2, perPage: 25 });
+
+    expect(get).toHaveBeenCalledWith("/admin/users", {
+      params: { q: "ana", page: 2, per_page: 25 },
+    });
+    expect(result).toEqual({
+      users: [
+        {
+          id: "user-1",
+          name: "Ana Premium",
+          email: "ana@auraxis.com",
+          status: "active",
+          createdAt: "2026-05-01T10:00:00Z",
+          lastSeenAt: "2026-05-19T12:00:00Z",
+          subscriptionPlan: "premium",
+          subscriptionStatus: "active",
+          entitlementCount: 3,
+        },
+      ],
+      page: 2,
+      perPage: 25,
+      total: 42,
+    });
+  });
+
+  it("loads user detail with subscription, entitlements and audit events", async () => {
+    const { client, get } = makeClient();
+    get.mockResolvedValue({
+      data: {
+        data: {
+          user: {
+            id: "user-1",
+            name: "Ana Premium",
+            email: "ana@auraxis.com",
+            status: "active",
+            created_at: "2026-05-01T10:00:00Z",
+            subscription: {
+              plan_code: "premium",
+              status: "active",
+              billing_cycle: "annual",
+              current_period_end: "2036-05-16T17:08:02Z",
+            },
+            entitlements: [
+              {
+                id: "ent-1",
+                feature_key: "ai_insights",
+                label: "Insights com IA",
+                active: true,
+                granted_at: "2026-05-16T17:08:02Z",
+                expires_at: null,
+              },
+            ],
+            audit_events: [
+              {
+                id: "audit-1",
+                action: "entitlement.granted",
+                reason: "Suporte ao teste premium",
+                created_at: "2026-05-16T17:09:00Z",
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    await expect(client.getUser("user-1")).resolves.toMatchObject({
+      id: "user-1",
+      subscription: {
+        planCode: "premium",
+        status: "active",
+        billingCycle: "annual",
+      },
+      entitlements: [
+        {
+          id: "ent-1",
+          featureKey: "ai_insights",
+          label: "Insights com IA",
+          active: true,
+        },
+      ],
+      auditEvents: [
+        {
+          id: "audit-1",
+          action: "entitlement.granted",
+          reason: "Suporte ao teste premium",
+        },
+      ],
+    });
+    expect(get).toHaveBeenCalledWith("/admin/users/user-1");
+  });
+
+  it("grants an entitlement with user id, feature key and reason", async () => {
+    const { client, post } = makeClient();
+    post.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          audit_id: "audit-123",
+          entitlement: {
+            id: "ent-123",
+            feature_key: "ai_insights",
+            label: "Insights com IA",
+            active: true,
+            granted_at: "2026-05-19T10:00:00Z",
+          },
+        },
+      },
+    });
+
+    const result = await client.grantEntitlement({
+      userId: "user-1",
+      featureKey: "ai_insights",
+      reason: "Liberar teste de suporte",
+    });
+
+    expect(post).toHaveBeenCalledWith("/entitlements/admin", {
+      user_id: "user-1",
+      feature_key: "ai_insights",
+      reason: "Liberar teste de suporte",
+    });
+    expect(result.auditId).toBe("audit-123");
+    expect(result.entitlement?.id).toBe("ent-123");
+  });
+
+  it("revokes an entitlement with a reason in the delete body", async () => {
+    const { client, deleteRequest } = makeClient();
+    deleteRequest.mockResolvedValue({
+      data: {
+        success: true,
+        data: { audit_id: "audit-456" },
+      },
+    });
+
+    const result = await client.revokeEntitlement({
+      entitlementId: "ent-123",
+      reason: "Acesso temporário encerrado",
+    });
+
+    expect(deleteRequest).toHaveBeenCalledWith("/entitlements/admin/ent-123", {
+      data: { reason: "Acesso temporário encerrado" },
+    });
+    expect(result.auditId).toBe("audit-456");
+  });
+});

--- a/app/features/admin/users/services/admin-users.client.ts
+++ b/app/features/admin/users/services/admin-users.client.ts
@@ -1,0 +1,367 @@
+import type { AxiosInstance } from "axios";
+
+import { useHttp } from "~/composables/useHttp";
+import type {
+  AdminAuditEvent,
+  AdminEntitlementMutationResult,
+  AdminSubscriptionStatus,
+  AdminUserDetail,
+  AdminUserEntitlement,
+  AdminUserList,
+  AdminUsersFilters,
+  AdminUserStatus,
+  AdminUserSummary,
+  GrantAdminEntitlementInput,
+  RevokeAdminEntitlementInput,
+} from "~/features/admin/users/model/admin-user";
+
+interface AdminSubscriptionDto {
+  readonly plan_code?: string | null;
+  readonly status?: AdminSubscriptionStatus | string | null;
+  readonly billing_cycle?: string | null;
+  readonly current_period_end?: string | null;
+}
+
+interface AdminUserDto {
+  readonly id: string;
+  readonly name?: string | null;
+  readonly email?: string | null;
+  readonly status?: AdminUserStatus | string | null;
+  readonly created_at?: string | null;
+  readonly last_seen_at?: string | null;
+  readonly subscription?: AdminSubscriptionDto | null;
+  readonly entitlements_count?: number | null;
+  readonly entitlements?: AdminEntitlementDto[] | null;
+  readonly audit_events?: AdminAuditEventDto[] | null;
+}
+
+interface AdminEntitlementDto {
+  readonly id: string;
+  readonly feature_key?: string | null;
+  readonly label?: string | null;
+  readonly active?: boolean | null;
+  readonly granted_at?: string | null;
+  readonly expires_at?: string | null;
+}
+
+interface AdminAuditEventDto {
+  readonly id: string;
+  readonly action?: string | null;
+  readonly reason?: string | null;
+  readonly created_at?: string | null;
+}
+
+interface V2EnvelopeDto<T> {
+  readonly data?: T | null;
+}
+
+interface AdminUsersListPayloadDto {
+  readonly users?: AdminUserDto[] | null;
+  readonly page?: number | null;
+  readonly per_page?: number | null;
+  readonly total?: number | null;
+}
+
+interface AdminUserDetailPayloadDto {
+  readonly user?: AdminUserDto | null;
+}
+
+interface AdminEntitlementMutationPayloadDto {
+  readonly audit_id?: string | null;
+  readonly entitlement?: AdminEntitlementDto | null;
+}
+
+type AdminUsersListResponseDto =
+  | AdminUsersListPayloadDto
+  | V2EnvelopeDto<AdminUsersListPayloadDto>;
+
+type AdminUserDetailResponseDto =
+  | AdminUserDto
+  | AdminUserDetailPayloadDto
+  | V2EnvelopeDto<AdminUserDto | AdminUserDetailPayloadDto>;
+
+type AdminEntitlementMutationResponseDto =
+  | AdminEntitlementMutationPayloadDto
+  | V2EnvelopeDto<AdminEntitlementMutationPayloadDto>;
+
+const DEFAULT_USER_STATUS: AdminUserStatus = "pending";
+const DEFAULT_SUBSCRIPTION_STATUS: AdminSubscriptionStatus = "inactive";
+
+/**
+ * Checks whether an unknown payload can be inspected as an object.
+ *
+ * @param value Candidate value.
+ * @returns True for non-null object records.
+ */
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object";
+
+/**
+ * Unwraps the standard API v2 data envelope while accepting flat payloads.
+ *
+ * @param payload Raw response body.
+ * @returns Response data payload.
+ */
+const unwrapData = <T>(payload: T | V2EnvelopeDto<T>): T => {
+  if (isRecord(payload) && "data" in payload && payload.data !== undefined && payload.data !== null) {
+    return payload.data as T;
+  }
+
+  return payload as T;
+};
+
+/**
+ * Normalizes unknown subscription statuses into the admin UI vocabulary.
+ *
+ * @param value Raw status value.
+ * @returns Safe subscription status.
+ */
+const toSubscriptionStatus = (
+  value: string | null | undefined,
+): AdminSubscriptionStatus => {
+  switch (value) {
+    case "active":
+    case "free":
+    case "trialing":
+    case "past_due":
+    case "canceled":
+    case "inactive":
+      return value;
+    default:
+      return DEFAULT_SUBSCRIPTION_STATUS;
+  }
+};
+
+/**
+ * Normalizes unknown user statuses into the admin UI vocabulary.
+ *
+ * @param value Raw status value.
+ * @returns Safe user status.
+ */
+const toUserStatus = (value: string | null | undefined): AdminUserStatus => {
+  switch (value) {
+    case "active":
+    case "blocked":
+    case "pending":
+    case "deleted":
+      return value;
+    default:
+      return DEFAULT_USER_STATUS;
+  }
+};
+
+/**
+ * Maps the backend subscription snapshot to the admin detail model.
+ *
+ * @param subscription Raw subscription DTO.
+ * @returns Admin subscription view model or null.
+ */
+const mapSubscription = (
+  subscription: AdminSubscriptionDto | null | undefined,
+): AdminUserDetail["subscription"] => {
+  if (!subscription) {
+    return null;
+  }
+
+  return {
+    planCode: subscription.plan_code ?? "free",
+    status: toSubscriptionStatus(subscription.status),
+    billingCycle: subscription.billing_cycle ?? null,
+    currentPeriodEnd: subscription.current_period_end ?? null,
+  };
+};
+
+/**
+ * Maps a raw entitlement row to the admin entitlement view model.
+ *
+ * @param entitlement Raw entitlement DTO.
+ * @returns Admin entitlement view model.
+ */
+const mapEntitlement = (entitlement: AdminEntitlementDto): AdminUserEntitlement => ({
+  id: entitlement.id,
+  featureKey: entitlement.feature_key ?? "unknown",
+  label: entitlement.label ?? entitlement.feature_key ?? "Entitlement",
+  active: entitlement.active === true,
+  grantedAt: entitlement.granted_at ?? null,
+  expiresAt: entitlement.expires_at ?? null,
+});
+
+/**
+ * Maps an audit event returned by admin endpoints.
+ *
+ * @param event Raw audit event DTO.
+ * @returns Admin audit event view model.
+ */
+const mapAuditEvent = (event: AdminAuditEventDto): AdminAuditEvent => ({
+  id: event.id,
+  action: event.action ?? "admin.action",
+  reason: event.reason ?? null,
+  createdAt: event.created_at ?? null,
+});
+
+/**
+ * Maps a raw user row to the list summary model.
+ *
+ * @param user Raw user DTO.
+ * @returns Admin user summary.
+ */
+const mapSummary = (user: AdminUserDto): AdminUserSummary => ({
+  id: user.id,
+  name: user.name ?? "Usuário sem nome",
+  email: user.email ?? "sem-email@auraxis.local",
+  status: toUserStatus(user.status),
+  createdAt: user.created_at ?? null,
+  lastSeenAt: user.last_seen_at ?? null,
+  subscriptionPlan: user.subscription?.plan_code ?? "free",
+  subscriptionStatus: toSubscriptionStatus(user.subscription?.status),
+  entitlementCount: user.entitlements_count ?? user.entitlements?.length ?? 0,
+});
+
+/**
+ * Maps a raw user detail payload to the detail view model.
+ *
+ * @param user Raw user DTO with detail fields.
+ * @returns Admin user detail.
+ */
+const mapDetail = (user: AdminUserDto): AdminUserDetail => ({
+  ...mapSummary(user),
+  subscription: mapSubscription(user.subscription),
+  entitlements: (user.entitlements ?? []).map(mapEntitlement),
+  auditEvents: (user.audit_events ?? []).map(mapAuditEvent),
+});
+
+/**
+ * Extracts the list payload from flat or enveloped responses.
+ *
+ * @param payload Raw list response body.
+ * @returns User list payload.
+ */
+const unwrapList = (payload: AdminUsersListResponseDto): AdminUsersListPayloadDto =>
+  unwrapData(payload);
+
+/**
+ * Extracts the user detail object from supported response shapes.
+ *
+ * @param payload Raw detail response body.
+ * @returns User DTO.
+ */
+const unwrapDetail = (payload: AdminUserDetailResponseDto): AdminUserDto => {
+  const data = unwrapData(payload);
+
+  if (isRecord(data) && "user" in data && isRecord(data.user)) {
+    return data.user as unknown as AdminUserDto;
+  }
+
+  return data as AdminUserDto;
+};
+
+/**
+ * Extracts entitlement mutation metadata from response bodies.
+ *
+ * @param payload Raw mutation response body.
+ * @returns Audit metadata and optional entitlement.
+ */
+const unwrapMutation = (
+  payload: AdminEntitlementMutationResponseDto,
+): AdminEntitlementMutationPayloadDto => unwrapData(payload);
+
+export class AdminUsersClient {
+  readonly #http: AxiosInstance;
+
+  /**
+   * @param http Axios instance configured for the Auraxis API.
+   */
+  constructor(http: AxiosInstance) {
+    this.#http = http;
+  }
+
+  /**
+   * Lists users for the admin console.
+   *
+   * @param filters Search and pagination filters.
+   * @returns Paginated user summaries.
+   */
+  async listUsers(filters: AdminUsersFilters = {}): Promise<AdminUserList> {
+    const response = await this.#http.get<AdminUsersListResponseDto>("/admin/users", {
+      params: {
+        q: filters.search,
+        page: filters.page ?? 1,
+        per_page: filters.perPage ?? 20,
+      },
+    });
+    const payload = unwrapList(response.data);
+
+    return {
+      users: (payload.users ?? []).map(mapSummary),
+      page: payload.page ?? filters.page ?? 1,
+      perPage: payload.per_page ?? filters.perPage ?? 20,
+      total: payload.total ?? payload.users?.length ?? 0,
+    };
+  }
+
+  /**
+   * Loads one user's operational detail.
+   *
+   * @param userId User UUID.
+   * @returns User detail with subscription, entitlements and audit events.
+   */
+  async getUser(userId: string): Promise<AdminUserDetail> {
+    const response = await this.#http.get<AdminUserDetailResponseDto>(`/admin/users/${userId}`);
+    return mapDetail(unwrapDetail(response.data));
+  }
+
+  /**
+   * Grants an entitlement through the admin endpoint.
+   *
+   * @param input User, feature and audit reason.
+   * @returns Audit metadata from the backend.
+   */
+  async grantEntitlement(
+    input: GrantAdminEntitlementInput,
+  ): Promise<AdminEntitlementMutationResult> {
+    const response = await this.#http.post<AdminEntitlementMutationResponseDto>(
+      "/entitlements/admin",
+      {
+        user_id: input.userId,
+        feature_key: input.featureKey,
+        reason: input.reason,
+      },
+    );
+    const payload = unwrapMutation(response.data);
+
+    return {
+      auditId: payload.audit_id ?? null,
+      entitlement: payload.entitlement ? mapEntitlement(payload.entitlement) : undefined,
+    };
+  }
+
+  /**
+   * Revokes an entitlement through the admin endpoint.
+   *
+   * @param input Entitlement id and audit reason.
+   * @returns Audit metadata from the backend.
+   */
+  async revokeEntitlement(
+    input: RevokeAdminEntitlementInput,
+  ): Promise<AdminEntitlementMutationResult> {
+    const response = await this.#http.delete<AdminEntitlementMutationResponseDto>(
+      `/entitlements/admin/${input.entitlementId}`,
+      { data: { reason: input.reason } },
+    );
+    const payload = unwrapMutation(response.data);
+
+    return {
+      auditId: payload.audit_id ?? null,
+      entitlement: payload.entitlement ? mapEntitlement(payload.entitlement) : undefined,
+    };
+  }
+}
+
+/**
+ * Resolves the admin users client with the shared HTTP adapter.
+ *
+ * @returns AdminUsersClient instance.
+ */
+export const useAdminUsersClient = (): AdminUsersClient => {
+  return new AdminUsersClient(useHttp());
+};

--- a/app/layouts/admin.vue
+++ b/app/layouts/admin.vue
@@ -25,7 +25,7 @@ useUserProfileQuery();
 
 const navItems = [
   { key: "overview", label: "Visão geral", to: "/admin", icon: Activity, disabled: false },
-  { key: "users", label: "Usuários", to: "/admin/users", icon: Users, disabled: true },
+  { key: "users", label: "Usuários", to: "/admin/users", icon: Users, disabled: false },
   { key: "insights", label: "Insights IA", to: "/admin/insights", icon: Sparkles, disabled: true },
   { key: "flags", label: "Feature flags", to: "/admin/flags", icon: Flag, disabled: true },
   { key: "audit", label: "Auditoria", to: "/admin/audit", icon: ClipboardList, disabled: true },
@@ -117,11 +117,21 @@ const onLogout = (): void => {
 
 <style scoped>
 .admin-layout {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100vw;
   min-height: 100vh;
   display: grid;
   grid-template-columns: 280px minmax(0, 1fr);
+  overflow-x: hidden;
   background: var(--color-bg-base);
   color: var(--color-text-primary);
+}
+
+.admin-layout *,
+.admin-layout *::before,
+.admin-layout *::after {
+  box-sizing: border-box;
 }
 
 .admin-layout__sidebar {
@@ -220,11 +230,14 @@ const onLogout = (): void => {
 
 .admin-layout__main {
   min-width: 0;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
 }
 
 .admin-layout__topbar {
+  min-width: 0;
+  max-width: 100%;
   min-height: 96px;
   display: flex;
   align-items: center;
@@ -236,6 +249,7 @@ const onLogout = (): void => {
 }
 
 .admin-layout__title-block {
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -256,14 +270,18 @@ const onLogout = (): void => {
   margin: 0;
   font-family: var(--font-heading);
   font-size: var(--font-size-2xl);
+  overflow-wrap: anywhere;
 }
 
 .admin-layout__title-block p {
   margin: 0;
   color: var(--color-text-muted);
+  overflow-wrap: anywhere;
 }
 
 .admin-layout__actions {
+  min-width: 0;
+  max-width: 100%;
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -290,10 +308,13 @@ const onLogout = (): void => {
 
 .admin-layout__identity {
   min-width: 160px;
+  max-width: 100%;
 }
 
 .admin-layout__content {
   flex: 1;
+  min-width: 0;
+  max-width: 100%;
   padding: var(--space-5);
   overflow: auto;
 }
@@ -301,6 +322,12 @@ const onLogout = (): void => {
 @media (max-width: 920px) {
   .admin-layout {
     grid-template-columns: 1fr;
+  }
+
+  .admin-layout__main {
+    width: 100vw;
+    max-width: 100vw;
+    overflow-x: hidden;
   }
 
   .admin-layout__sidebar {
@@ -324,17 +351,33 @@ const onLogout = (): void => {
   }
 
   .admin-layout__topbar {
+    width: 100%;
+    max-width: 100%;
     align-items: flex-start;
     flex-direction: column;
     padding: var(--space-3);
+    overflow-x: hidden;
   }
 
   .admin-layout__actions {
+    width: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
     justify-content: flex-start;
   }
 
+  .admin-layout__search,
+  .admin-layout__logout,
+  .admin-layout__identity {
+    width: 100%;
+    min-width: 0;
+  }
+
   .admin-layout__content {
+    width: 100%;
+    max-width: 100%;
     padding: var(--space-3);
+    overflow-x: hidden;
   }
 }
 </style>

--- a/app/pages/admin/users/index.vue
+++ b/app/pages/admin/users/index.vue
@@ -1,0 +1,1066 @@
+<script setup lang="ts">
+import {
+  Ban,
+  CheckCircle2,
+  Clock3,
+  Crown,
+  History,
+  KeyRound,
+  RefreshCw,
+  Search,
+  ShieldCheck,
+  UserCheck,
+  Users,
+  XCircle,
+} from "lucide-vue-next";
+import { NAlert, NButton, NInput, NModal, NPagination, NSelect, NSpin } from "naive-ui";
+
+import { useToast } from "~/composables/useToast/useToast";
+import { useAdminAccess } from "~/features/admin/model/admin-access";
+import {
+  ADMIN_ENTITLEMENT_OPTIONS,
+  type AdminUserEntitlement,
+} from "~/features/admin/users/model/admin-user";
+import {
+  useGrantAdminEntitlementMutation,
+  useRevokeAdminEntitlementMutation,
+} from "~/features/admin/users/queries/use-admin-entitlement-mutations";
+import { useAdminUserQuery } from "~/features/admin/users/queries/use-admin-user-query";
+import { useAdminUsersQuery } from "~/features/admin/users/queries/use-admin-users-query";
+import { useFeatureFlag } from "~/shared/feature-flags/use-feature-flag";
+
+definePageMeta({
+  layout: "admin",
+  middleware: ["admin"],
+  pageTitle: "Usuários, assinaturas e entitlements",
+  pageSubtitle: "Busca operacional, detalhe de assinatura e ações auditáveis.",
+});
+
+useHead({ title: "Admin Usuários | Auraxis" });
+
+type EntitlementActionKind = "grant" | "revoke";
+
+interface PendingEntitlementAction {
+  readonly kind: EntitlementActionKind;
+  readonly featureKey?: string;
+  readonly entitlementId?: string;
+  readonly label: string;
+}
+
+const toast = useToast();
+const { isAdmin } = useAdminAccess();
+const mutationsEnabled = useFeatureFlag("web.admin.entitlement-mutations");
+
+const searchDraft = ref("");
+const submittedSearch = ref("");
+const page = ref(1);
+const perPage = ref(20);
+const selectedUserId = ref<string | null>(null);
+const selectedFeatureKey = ref<string | null>(null);
+const pendingAction = ref<PendingEntitlementAction | null>(null);
+const actionReason = ref("");
+const actionError = ref("");
+const lastAuditId = ref<string | null>(null);
+
+const usersQuery = useAdminUsersQuery(() => ({
+  search: submittedSearch.value,
+  page: page.value,
+  perPage: perPage.value,
+}));
+const selectedUserQuery = useAdminUserQuery(selectedUserId);
+const grantMutation = useGrantAdminEntitlementMutation();
+const revokeMutation = useRevokeAdminEntitlementMutation();
+
+const users = computed(() => usersQuery.data.value?.users ?? []);
+const selectedUser = computed(() => selectedUserQuery.data.value ?? null);
+const activeEntitlements = computed(() =>
+  selectedUser.value?.entitlements.filter((entitlement) => entitlement.active) ?? [],
+);
+const isMutating = computed(() => grantMutation.isPending.value || revokeMutation.isPending.value);
+const canMutate = computed(() => isAdmin.value && mutationsEnabled.value);
+const userCountLabel = computed(() => {
+  const total = usersQuery.data.value?.total ?? users.value.length;
+  return `${total} ${total === 1 ? "usuário" : "usuários"}`;
+});
+const premiumCount = computed(() =>
+  users.value.filter((user) => user.subscriptionPlan !== "free").length,
+);
+const entitlementCount = computed(() =>
+  users.value.reduce((total, user) => total + user.entitlementCount, 0),
+);
+const grantOptions = computed(() => {
+  const activeKeys = new Set(activeEntitlements.value.map((entitlement) => entitlement.featureKey));
+
+  return ADMIN_ENTITLEMENT_OPTIONS.map((option) => ({
+    label: option.label,
+    value: option.value,
+    disabled: activeKeys.has(option.value),
+  }));
+});
+
+watch(
+  users,
+  (currentUsers) => {
+    if (currentUsers.length === 0) {
+      selectedUserId.value = null;
+      return;
+    }
+
+    if (!selectedUserId.value || !currentUsers.some((user) => user.id === selectedUserId.value)) {
+      selectedUserId.value = currentUsers[0]?.id ?? null;
+    }
+  },
+  { immediate: true },
+);
+
+watch(selectedUserId, () => {
+  selectedFeatureKey.value = null;
+  lastAuditId.value = null;
+});
+
+/**
+ * Applies the typed search term to the admin users query.
+ */
+const submitSearch = (): void => {
+  submittedSearch.value = searchDraft.value.trim();
+  page.value = 1;
+};
+
+/**
+ * Clears search state and returns to the first page.
+ */
+const clearSearch = (): void => {
+  searchDraft.value = "";
+  submittedSearch.value = "";
+  page.value = 1;
+};
+
+/**
+ * Selects a user row and loads its detail panel.
+ *
+ * @param userId User UUID.
+ */
+const selectUser = (userId: string): void => {
+  selectedUserId.value = userId;
+};
+
+/**
+ * Starts the grant flow for the selected entitlement option.
+ */
+const openGrantModal = (): void => {
+  if (!selectedFeatureKey.value) {
+    actionError.value = "Selecione um entitlement antes de continuar.";
+    return;
+  }
+
+  const option = ADMIN_ENTITLEMENT_OPTIONS.find((item) => item.value === selectedFeatureKey.value);
+  pendingAction.value = {
+    kind: "grant",
+    featureKey: selectedFeatureKey.value,
+    label: option?.label ?? selectedFeatureKey.value,
+  };
+  actionReason.value = "";
+  actionError.value = "";
+};
+
+/**
+ * Starts the revoke flow for one active entitlement.
+ *
+ * @param entitlement Entitlement selected for revocation.
+ */
+const openRevokeModal = (entitlement: AdminUserEntitlement): void => {
+  pendingAction.value = {
+    kind: "revoke",
+    entitlementId: entitlement.id,
+    label: entitlement.label,
+  };
+  actionReason.value = "";
+  actionError.value = "";
+};
+
+/**
+ * Closes the action modal when no mutation is pending.
+ */
+const closeActionModal = (): void => {
+  if (isMutating.value) {
+    return;
+  }
+
+  pendingAction.value = null;
+  actionReason.value = "";
+  actionError.value = "";
+};
+
+/**
+ * Validates the required audit reason before mutation.
+ *
+ * @returns True when the reason is long enough.
+ */
+const validateReason = (): boolean => {
+  if (actionReason.value.trim().length < 8) {
+    actionError.value = "Informe um motivo claro com pelo menos 8 caracteres.";
+    return false;
+  }
+
+  actionError.value = "";
+  return true;
+};
+
+/**
+ * Executes the pending grant or revoke action.
+ */
+const confirmAction = async (): Promise<void> => {
+  if (!pendingAction.value || !selectedUserId.value || !validateReason()) {
+    return;
+  }
+
+  const reason = actionReason.value.trim();
+
+  try {
+    const result = pendingAction.value.kind === "grant"
+      ? await grantMutation.mutateAsync({
+        userId: selectedUserId.value,
+        featureKey: pendingAction.value.featureKey ?? "",
+        reason,
+      })
+      : await revokeMutation.mutateAsync({
+        entitlementId: pendingAction.value.entitlementId ?? "",
+        reason,
+      });
+
+    lastAuditId.value = result.auditId;
+    toast.success(
+      pendingAction.value.kind === "grant"
+        ? "Entitlement concedido com registro de auditoria."
+        : "Entitlement revogado com registro de auditoria.",
+    );
+    closeActionModal();
+  } catch {
+    toast.error("Não foi possível concluir a ação administrativa. Tente novamente.");
+  }
+};
+
+/**
+ * Refreshes list and selected detail queries.
+ */
+const refreshUsers = (): void => {
+  void usersQuery.refetch();
+
+  if (selectedUserId.value) {
+    void selectedUserQuery.refetch();
+  }
+};
+
+/**
+ * Formats an ISO datetime for operational display.
+ *
+ * @param value ISO datetime or null.
+ * @returns Localized date-time label.
+ */
+const formatDateTime = (value: string | null): string => {
+  if (!value) {
+    return "—";
+  }
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+};
+
+/**
+ * Converts backend status codes into Portuguese labels.
+ *
+ * @param status Raw status code.
+ * @returns Human-readable status label.
+ */
+const statusLabel = (status: string): string => {
+  const labels: Record<string, string> = {
+    active: "Ativo",
+    blocked: "Bloqueado",
+    pending: "Pendente",
+    deleted: "Removido",
+    free: "Free",
+    trialing: "Trial",
+    past_due: "Pagamento pendente",
+    canceled: "Cancelado",
+    inactive: "Inativo",
+  };
+
+  return labels[status] ?? status;
+};
+</script>
+
+<template>
+  <section class="admin-users" aria-labelledby="admin-users-title">
+    <div class="admin-users__hero">
+      <div>
+        <p class="admin-users__eyebrow">Operação de contas</p>
+        <h2 id="admin-users-title">Usuários, assinaturas e acessos premium</h2>
+        <p>
+          Consulte usuários, valide o estado da assinatura e faça ajustes pontuais
+          em entitlements com motivo obrigatório e rastreio de auditoria.
+        </p>
+      </div>
+      <NButton secondary round :loading="usersQuery.isFetching.value" @click="refreshUsers">
+        <template #icon>
+          <RefreshCw :size="16" aria-hidden="true" />
+        </template>
+        Atualizar
+      </NButton>
+    </div>
+
+    <div class="admin-users__metrics" aria-label="Resumo de usuários">
+      <article class="admin-users__metric">
+        <Users :size="20" aria-hidden="true" />
+        <span>Base filtrada</span>
+        <strong>{{ userCountLabel }}</strong>
+      </article>
+      <article class="admin-users__metric">
+        <Crown :size="20" aria-hidden="true" />
+        <span>Premium na busca</span>
+        <strong>{{ premiumCount }}</strong>
+      </article>
+      <article class="admin-users__metric">
+        <KeyRound :size="20" aria-hidden="true" />
+        <span>Entitlements ativos</span>
+        <strong>{{ entitlementCount }}</strong>
+      </article>
+    </div>
+
+    <NAlert v-if="!canMutate" type="warning" class="admin-users__alert">
+      As ações de grant/revoke estão em modo somente leitura para esta sessão.
+      É necessário ter permissão admin e a flag <strong>web.admin.entitlement-mutations</strong> ativa.
+    </NAlert>
+
+    <div class="admin-users__workspace">
+      <section class="admin-users__panel admin-users__panel--list" aria-label="Lista de usuários">
+        <form class="admin-users__search" @submit.prevent="submitSearch">
+          <NInput
+            v-model:value="searchDraft"
+            clearable
+            placeholder="Buscar por email, nome ou ID"
+            aria-label="Buscar usuário por email, nome ou ID"
+          >
+            <template #prefix>
+              <Search :size="16" aria-hidden="true" />
+            </template>
+          </NInput>
+          <NButton type="primary" attr-type="submit">Buscar</NButton>
+          <NButton secondary :disabled="!submittedSearch && !searchDraft" @click="clearSearch">
+            Limpar
+          </NButton>
+        </form>
+
+        <div v-if="usersQuery.isLoading.value" class="admin-users__loading">
+          <NSpin size="small" />
+          Carregando usuários...
+        </div>
+
+        <NAlert v-else-if="usersQuery.isError.value" type="error">
+          Não foi possível carregar usuários. Verifique sua conexão ou permissões admin.
+        </NAlert>
+
+        <div v-else-if="users.length === 0" class="admin-users__empty">
+          <UserCheck :size="24" aria-hidden="true" />
+          <strong>Nenhum usuário encontrado</strong>
+          <span>Revise o termo de busca ou limpe os filtros.</span>
+        </div>
+
+        <div v-else class="admin-users__list">
+          <button
+            v-for="user in users"
+            :key="user.id"
+            type="button"
+            class="admin-users__row"
+            :class="{ 'admin-users__row--active': user.id === selectedUserId }"
+            @click="selectUser(user.id)"
+          >
+            <span class="admin-users__avatar" aria-hidden="true">
+              {{ user.name.slice(0, 1).toUpperCase() }}
+            </span>
+            <span class="admin-users__row-main">
+              <strong>{{ user.name }}</strong>
+              <small>{{ user.email }}</small>
+            </span>
+            <span class="admin-users__row-side">
+              <span class="admin-users__pill" :data-status="user.subscriptionStatus">
+                {{ user.subscriptionPlan }}
+              </span>
+              <small>{{ user.entitlementCount }} acessos</small>
+            </span>
+          </button>
+        </div>
+
+        <NPagination
+          v-if="(usersQuery.data.value?.total ?? 0) > perPage"
+          v-model:page="page"
+          v-model:page-size="perPage"
+          class="admin-users__pagination"
+          :item-count="usersQuery.data.value?.total ?? 0"
+          :page-sizes="[10, 20, 50]"
+          show-size-picker
+        />
+      </section>
+
+      <section class="admin-users__panel admin-users__panel--detail" aria-label="Detalhe do usuário">
+        <div v-if="!selectedUserId" class="admin-users__empty admin-users__empty--detail">
+          <ShieldCheck :size="26" aria-hidden="true" />
+          <strong>Selecione um usuário</strong>
+          <span>O detalhe de assinatura e entitlements aparecerá aqui.</span>
+        </div>
+
+        <div v-else-if="selectedUserQuery.isLoading.value" class="admin-users__loading">
+          <NSpin size="small" />
+          Carregando detalhe...
+        </div>
+
+        <NAlert v-else-if="selectedUserQuery.isError.value" type="error">
+          Não foi possível carregar o detalhe deste usuário.
+        </NAlert>
+
+        <div v-else-if="selectedUser" class="admin-users__detail">
+          <header class="admin-users__detail-header">
+            <span class="admin-users__avatar admin-users__avatar--large" aria-hidden="true">
+              {{ selectedUser.name.slice(0, 1).toUpperCase() }}
+            </span>
+            <div>
+              <h3>{{ selectedUser.name }}</h3>
+              <p>{{ selectedUser.email }}</p>
+              <span class="admin-users__status">
+                <CheckCircle2 v-if="selectedUser.status === 'active'" :size="14" aria-hidden="true" />
+                <Ban v-else :size="14" aria-hidden="true" />
+                {{ statusLabel(selectedUser.status) }}
+              </span>
+            </div>
+          </header>
+
+          <div class="admin-users__detail-grid">
+            <article>
+              <span>Cadastro</span>
+              <strong>{{ formatDateTime(selectedUser.createdAt) }}</strong>
+            </article>
+            <article>
+              <span>Último acesso</span>
+              <strong>{{ formatDateTime(selectedUser.lastSeenAt) }}</strong>
+            </article>
+            <article>
+              <span>Plano</span>
+              <strong>{{ selectedUser.subscription?.planCode ?? selectedUser.subscriptionPlan }}</strong>
+            </article>
+            <article>
+              <span>Status assinatura</span>
+              <strong>{{ statusLabel(selectedUser.subscription?.status ?? selectedUser.subscriptionStatus) }}</strong>
+            </article>
+          </div>
+
+          <section class="admin-users__section" aria-labelledby="admin-entitlements-title">
+            <div class="admin-users__section-header">
+              <div>
+                <h4 id="admin-entitlements-title">Entitlements</h4>
+                <p>Concessões ativas vinculadas ao usuário selecionado.</p>
+              </div>
+              <span class="admin-users__count">{{ activeEntitlements.length }}</span>
+            </div>
+
+            <div class="admin-users__grant">
+              <NSelect
+                v-model:value="selectedFeatureKey"
+                :options="grantOptions"
+                :disabled="!canMutate || isMutating"
+                placeholder="Selecionar entitlement para conceder"
+                aria-label="Selecionar entitlement para conceder"
+              />
+              <NButton
+                type="primary"
+                :disabled="!canMutate || !selectedFeatureKey"
+                @click="openGrantModal"
+              >
+                <template #icon>
+                  <KeyRound :size="16" aria-hidden="true" />
+                </template>
+                Conceder
+              </NButton>
+            </div>
+
+            <div v-if="activeEntitlements.length === 0" class="admin-users__empty admin-users__empty--compact">
+              <KeyRound :size="22" aria-hidden="true" />
+              <span>Nenhum entitlement ativo.</span>
+            </div>
+
+            <ul v-else class="admin-users__entitlements">
+              <li v-for="entitlement in activeEntitlements" :key="entitlement.id">
+                <div>
+                  <strong>{{ entitlement.label }}</strong>
+                  <small>
+                    {{ entitlement.featureKey }} · concedido em {{ formatDateTime(entitlement.grantedAt) }}
+                  </small>
+                </div>
+                <NButton
+                  size="small"
+                  tertiary
+                  type="error"
+                  :disabled="!canMutate || isMutating"
+                  :aria-label="`Revogar ${entitlement.label}`"
+                  @click="openRevokeModal(entitlement)"
+                >
+                  <template #icon>
+                    <XCircle :size="15" aria-hidden="true" />
+                  </template>
+                  Revogar
+                </NButton>
+              </li>
+            </ul>
+          </section>
+
+          <section class="admin-users__section" aria-labelledby="admin-audit-title">
+            <div class="admin-users__section-header">
+              <div>
+                <h4 id="admin-audit-title">Histórico resumido</h4>
+                <p>Eventos recentes retornados pela API admin.</p>
+              </div>
+              <History :size="18" aria-hidden="true" />
+            </div>
+
+            <p v-if="lastAuditId" class="admin-users__audit-success" aria-live="polite">
+              Último audit id: <strong>{{ lastAuditId }}</strong>
+            </p>
+
+            <ul v-if="selectedUser.auditEvents.length > 0" class="admin-users__audit-list">
+              <li v-for="event in selectedUser.auditEvents" :key="event.id">
+                <Clock3 :size="15" aria-hidden="true" />
+                <span>
+                  <strong>{{ event.action }}</strong>
+                  <small>{{ event.reason ?? "Sem motivo informado" }} · {{ formatDateTime(event.createdAt) }}</small>
+                </span>
+              </li>
+            </ul>
+            <p v-else class="admin-users__muted">Nenhum evento recente retornado.</p>
+          </section>
+        </div>
+      </section>
+    </div>
+
+    <NModal
+      :show="Boolean(pendingAction)"
+      :mask-closable="false"
+      preset="card"
+      class="admin-users-action-modal"
+      @update:show="!$event && closeActionModal()"
+    >
+      <section v-if="pendingAction" class="admin-users-action">
+        <header>
+          <span class="admin-users-action__icon" aria-hidden="true">
+            <KeyRound :size="20" />
+          </span>
+          <div>
+            <h3>
+              {{ pendingAction.kind === "grant" ? "Conceder entitlement" : "Revogar entitlement" }}
+            </h3>
+            <p>{{ pendingAction.label }}</p>
+          </div>
+        </header>
+
+        <p>
+          Esta ação altera o acesso do usuário e precisa de um motivo operacional.
+          O motivo será enviado para auditoria junto da mutação.
+        </p>
+
+        <label class="admin-users-action__field">
+          <span>Motivo da ação</span>
+          <NInput
+            v-model:value="actionReason"
+            type="textarea"
+            placeholder="Ex: ajuste solicitado pelo suporte após validação do pagamento"
+            :autosize="{ minRows: 3, maxRows: 5 }"
+            :disabled="isMutating"
+            @update:value="actionError = ''"
+          />
+        </label>
+
+        <p v-if="actionError" class="admin-users-action__error" role="alert">
+          {{ actionError }}
+        </p>
+
+        <footer>
+          <NButton :disabled="isMutating" @click="closeActionModal">Cancelar</NButton>
+          <NButton
+            type="primary"
+            :loading="isMutating"
+            data-testid="admin-entitlement-confirm"
+            @click="confirmAction"
+          >
+            Confirmar
+          </NButton>
+        </footer>
+      </section>
+    </NModal>
+  </section>
+</template>
+
+<style scoped>
+.admin-users {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+.admin-users *,
+.admin-users *::before,
+.admin-users *::after {
+  box-sizing: border-box;
+}
+
+.admin-users__hero,
+.admin-users__panel,
+.admin-users__metric {
+  border: 1px solid var(--color-outline-soft);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-card);
+}
+
+.admin-users__hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-5);
+  border-radius: var(--radius-lg);
+}
+
+.admin-users__eyebrow {
+  margin: 0 0 var(--space-1);
+  color: var(--color-brand-700);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+}
+
+.admin-users__hero h2,
+.admin-users__detail h3,
+.admin-users__section h4,
+.admin-users-action h3 {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-family: var(--font-heading);
+}
+
+.admin-users__hero h2 {
+  font-size: clamp(1.75rem, 3vw, 2.35rem);
+}
+
+.admin-users__hero p,
+.admin-users__section p,
+.admin-users__detail-header p,
+.admin-users__muted,
+.admin-users-action p {
+  color: var(--color-text-muted);
+}
+
+.admin-users__hero p {
+  max-width: 760px;
+  margin: var(--space-2) 0 0;
+  font-size: var(--font-size-md);
+  line-height: 1.55;
+}
+
+.admin-users__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.admin-users__metric {
+  display: grid;
+  gap: 4px;
+  padding: var(--space-3);
+  border-radius: var(--radius-lg);
+}
+
+.admin-users__metric svg {
+  color: var(--color-brand-700);
+}
+
+.admin-users__metric span {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.admin-users__metric strong {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-xl);
+}
+
+.admin-users__alert {
+  border-radius: var(--radius-lg);
+}
+
+.admin-users__workspace {
+  display: grid;
+  grid-template-columns: minmax(360px, 0.9fr) minmax(0, 1.25fr);
+  gap: var(--space-4);
+  align-items: start;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.admin-users__panel {
+  position: relative;
+  min-width: 0;
+  max-width: 100%;
+  border-radius: var(--radius-lg);
+  padding: var(--space-3);
+}
+
+.admin-users__panel--detail {
+  z-index: 1;
+}
+
+.admin-users__search {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.admin-users__loading,
+.admin-users__empty {
+  display: grid;
+  place-items: center;
+  gap: var(--space-1);
+  min-height: 180px;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.admin-users__empty strong {
+  color: var(--color-text-primary);
+}
+
+.admin-users__empty--compact {
+  min-height: 96px;
+  border: 1px dashed var(--color-outline-soft);
+  border-radius: var(--radius-md);
+}
+
+.admin-users__list,
+.admin-users__detail {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.admin-users__row {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--space-2);
+  align-items: center;
+  padding: var(--space-2);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.admin-users__row--active {
+  border-color: var(--color-brand-400);
+  box-shadow: 0 0 0 3px var(--color-brand-glow-xs);
+}
+
+.admin-users__avatar {
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+  background: var(--gradient-brand);
+  color: var(--color-text-on-brand);
+  font-weight: var(--font-weight-bold);
+}
+
+.admin-users__avatar--large {
+  width: 56px;
+  height: 56px;
+  font-size: var(--font-size-xl);
+}
+
+.admin-users__row-main,
+.admin-users__row-side {
+  display: grid;
+  gap: 2px;
+}
+
+.admin-users__row-main {
+  min-width: 0;
+}
+
+.admin-users__row-main strong,
+.admin-users__row-main small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-users__row-main small,
+.admin-users__row-side small,
+.admin-users__entitlements small,
+.admin-users__audit-list small {
+  color: var(--color-text-muted);
+}
+
+.admin-users__row-side {
+  justify-items: end;
+}
+
+.admin-users__pill,
+.admin-users__status,
+.admin-users__count {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+}
+
+.admin-users__pill {
+  padding: 4px 8px;
+  color: var(--color-brand-700);
+  background: var(--color-brand-glow-xs);
+}
+
+.admin-users__pill[data-status="active"] {
+  color: var(--color-positive-dark);
+  background: var(--color-positive-glow);
+}
+
+.admin-users__pagination {
+  margin-top: var(--space-3);
+  justify-content: flex-end;
+}
+
+.admin-users__detail-header {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  min-width: 0;
+}
+
+.admin-users__detail-header p {
+  margin: 4px 0 var(--space-1);
+  overflow-wrap: anywhere;
+}
+
+.admin-users__status {
+  padding: 4px 8px;
+  color: var(--color-positive-dark);
+  background: var(--color-positive-glow);
+}
+
+.admin-users__detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.admin-users__detail-grid article {
+  display: grid;
+  gap: 4px;
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+}
+
+.admin-users__detail-grid span {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.admin-users__section {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  gap: var(--space-2);
+  min-width: 0;
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-outline-soft);
+}
+
+.admin-users__section-header,
+.admin-users__grant,
+.admin-users__entitlements li,
+.admin-users__audit-list li,
+.admin-users-action header,
+.admin-users-action footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.admin-users__section-header {
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.admin-users__section-header p {
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.admin-users__section-header > div {
+  min-width: 0;
+}
+
+.admin-users__count {
+  padding: 6px 10px;
+  color: var(--color-text-primary);
+  background: var(--color-bg-elevated);
+}
+
+.admin-users__grant {
+  align-items: stretch;
+  min-width: 0;
+}
+
+.admin-users__grant :deep(.n-select) {
+  min-width: 0;
+  max-width: 100%;
+  flex: 1;
+}
+
+.admin-users__entitlements,
+.admin-users__audit-list {
+  display: grid;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.admin-users__entitlements li {
+  justify-content: space-between;
+  min-width: 0;
+  padding: var(--space-2);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+}
+
+.admin-users__entitlements li > div {
+  min-width: 0;
+}
+
+.admin-users__entitlements strong,
+.admin-users__entitlements small,
+.admin-users__audit-list strong,
+.admin-users__audit-list small {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.admin-users__audit-success {
+  margin: 0;
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  color: var(--color-positive-dark);
+  background: var(--color-positive-glow);
+}
+
+.admin-users__audit-list li {
+  align-items: flex-start;
+  color: var(--color-text-muted);
+}
+
+.admin-users__muted {
+  margin: 0;
+}
+
+.admin-users-action {
+  display: grid;
+  gap: var(--space-3);
+  width: min(100%, 560px);
+}
+
+.admin-users-action h3,
+.admin-users-action p {
+  margin: 0;
+}
+
+.admin-users-action__icon {
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  color: var(--color-text-on-brand);
+  background: var(--gradient-brand);
+}
+
+.admin-users-action__field {
+  display: grid;
+  gap: var(--space-1);
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
+}
+
+.admin-users-action__error {
+  color: var(--color-danger);
+  font-weight: var(--font-weight-semibold);
+}
+
+.admin-users-action footer {
+  justify-content: flex-end;
+}
+
+@media (max-width: 1080px) {
+  .admin-users__metrics,
+  .admin-users__detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-users__workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .admin-users__panel {
+    width: auto;
+  }
+}
+
+@media (max-width: 680px) {
+  .admin-users__hero {
+    flex-direction: column;
+    padding: var(--space-3);
+  }
+
+  .admin-users__search,
+  .admin-users__row {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-users__row-side {
+    justify-items: start;
+  }
+
+  .admin-users__grant,
+  .admin-users__entitlements li {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .admin-users__grant :deep(.n-select),
+  .admin-users__grant :deep(.n-button) {
+    width: 100%;
+  }
+}
+</style>

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -441,6 +441,16 @@
       "repositories": ["auraxis-web"]
     },
     {
+      "key": "web.admin.entitlement-mutations",
+      "owner": "platform",
+      "createdAt": "2026-05-19",
+      "removeBy": "2027-12-31",
+      "type": "release",
+      "status": "enabled-prod",
+      "description": "Permite grant/revoke de entitlements pelo painel administrativo.",
+      "repositories": ["auraxis-web"]
+    },
+    {
       "key": "web.dashboard.new-layout",
       "owner": "growth",
       "createdAt": "2026-04-21",

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -4,6 +4,75 @@ import { fillLoginForm, seedCookieConsent, waitForHydration } from "./helpers/au
 const VALID_EMAIL = "test@auraxis.com";
 const VALID_PASSWORD = "ValidPassword1!";
 
+interface MockAdminEntitlement {
+  id: string;
+  feature_key: string;
+  label: string;
+  active: boolean;
+  granted_at: string;
+  expires_at: string | null;
+}
+
+interface MockAdminAuditEvent {
+  id: string;
+  action: string;
+  reason: string;
+  created_at: string;
+}
+
+const initialAdminEntitlements: MockAdminEntitlement[] = [
+  {
+    id: "ent-ai",
+    feature_key: "ai_insights",
+    label: "Insights com IA",
+    active: true,
+    granted_at: "2026-05-16T17:08:02Z",
+    expires_at: null,
+  },
+];
+
+const initialAdminAuditEvents: MockAdminAuditEvent[] = [
+  {
+    id: "audit-seed",
+    action: "entitlement.granted",
+    reason: "Seed de usuário premium",
+    created_at: "2026-05-16T17:09:00Z",
+  },
+];
+
+const adminUsers = [
+  {
+    id: "admin-user-1",
+    name: "Ana Premium",
+    email: "ana@auraxis.com",
+    status: "active",
+    created_at: "2026-05-01T10:00:00Z",
+    last_seen_at: "2026-05-19T12:00:00Z",
+    subscription: {
+      plan_code: "premium",
+      status: "active",
+      billing_cycle: "annual",
+      current_period_end: "2036-05-16T17:08:02Z",
+    },
+    entitlements_count: 1,
+  },
+  {
+    id: "admin-user-2",
+    name: "Bruno Free",
+    email: "bruno@auraxis.com",
+    status: "active",
+    created_at: "2026-04-20T10:00:00Z",
+    last_seen_at: null,
+    subscription: {
+      plan_code: "free",
+      status: "free",
+      billing_cycle: null,
+      current_period_end: null,
+    },
+    entitlements_count: 0,
+  },
+];
+
 /**
  * Builds an unsigned JWT-like token so the frontend can read mocked claims.
  *
@@ -29,6 +98,8 @@ const mockAdminSession = async (
 ): Promise<void> => {
   const token = tokenWithPayload({ roles: options.isAdmin ? ["admin"] : ["user"] });
   let sessionEstablished = false;
+  const adminEntitlements = initialAdminEntitlements.map((entitlement) => ({ ...entitlement }));
+  const adminAuditEvents = initialAdminAuditEvents.map((event) => ({ ...event }));
 
   await page.addInitScript(() => {
     const completedState = JSON.stringify({
@@ -156,6 +227,141 @@ const mockAdminSession = async (
   await page.route("**/transactions/due-range**", (route) => {
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ transactions: [], total: 0 }) });
   });
+
+  await page.route("**/admin/users**", async (route) => {
+    if (route.request().resourceType() === "document") {
+      await route.fallback();
+      return;
+    }
+
+    const url = new URL(route.request().url());
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    const userId = pathParts.length > 2 ? pathParts.at(-1) : null;
+
+    if (userId && userId !== "users") {
+      const user = adminUsers.find((item) => item.id === userId);
+      route.fulfill({
+        status: user ? 200 : 404,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: Boolean(user),
+          data: user
+            ? {
+              user: {
+                ...user,
+                entitlements: adminEntitlements,
+                audit_events: adminAuditEvents,
+              },
+            }
+            : null,
+        }),
+      });
+      return;
+    }
+
+    const query = url.searchParams.get("q")?.toLowerCase() ?? "";
+    const filteredUsers = adminUsers
+      .map((user) => ({
+        ...user,
+        entitlements_count: user.id === "admin-user-1"
+          ? adminEntitlements.filter((entitlement) => entitlement.active).length
+          : user.entitlements_count,
+      }))
+      .filter((user) => {
+        if (!query) {
+          return true;
+        }
+
+        return [user.id, user.name, user.email]
+          .some((value) => value.toLowerCase().includes(query));
+      });
+
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: {
+          users: filteredUsers,
+          page: 1,
+          per_page: 20,
+          total: filteredUsers.length,
+        },
+      }),
+    });
+  });
+
+  await page.route("**/entitlements/admin", async (route) => {
+    const body = JSON.parse(route.request().postData() ?? "{}") as Record<string, string>;
+
+    if (!body.reason || body.reason.length < 8 || !body.user_id || !body.feature_key) {
+      route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ success: false, message: "Invalid entitlement grant" }),
+      });
+      return;
+    }
+
+    adminEntitlements.push({
+      id: "ent-market",
+      feature_key: body.feature_key,
+      label: "Market Pulse",
+      active: true,
+      granted_at: "2026-05-19T12:30:00Z",
+      expires_at: null,
+    });
+    adminAuditEvents.unshift({
+      id: "audit-grant-1",
+      action: "entitlement.granted",
+      reason: body.reason,
+      created_at: "2026-05-19T12:31:00Z",
+    });
+
+    route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: {
+          audit_id: "audit-grant-1",
+          entitlement: adminEntitlements.at(-1),
+        },
+      }),
+    });
+  });
+
+  await page.route("**/entitlements/admin/*", async (route) => {
+    const body = JSON.parse(route.request().postData() ?? "{}") as Record<string, string>;
+    const entitlementId = route.request().url().split("/").at(-1);
+    const entitlement = adminEntitlements.find((item) => item.id === entitlementId);
+
+    if (!entitlement || !body.reason || body.reason.length < 8) {
+      route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ success: false, message: "Invalid entitlement revoke" }),
+      });
+      return;
+    }
+
+    entitlement.active = false;
+    adminAuditEvents.unshift({
+      id: "audit-revoke-1",
+      action: "entitlement.revoked",
+      reason: body.reason,
+      created_at: "2026-05-19T12:40:00Z",
+    });
+
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: { audit_id: "audit-revoke-1" },
+      }),
+    });
+  });
 };
 
 /**
@@ -198,5 +404,52 @@ test.describe("Admin — shell and guard", () => {
     const adminNavigation = page.getByRole("navigation", { name: "Navegação administrativa" });
     await expect(adminNavigation).toBeVisible();
     await expect(adminNavigation.getByRole("link", { name: /Insights IA/ })).toBeVisible();
+  });
+
+  test("shows users, subscription detail and active entitlements", async ({ page }) => {
+    await mockAdminSession(page, { isAdmin: true });
+    await login(page);
+
+    await page.goto("/admin/users");
+
+    await expect(
+      page.getByRole("heading", { name: "Usuários, assinaturas e acessos premium" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: /Ana Premium/ })).toBeVisible();
+    await expect(page.locator(".admin-users__detail").getByRole("heading", { name: "Ana Premium" })).toBeVisible();
+    await expect(
+      page.locator(".admin-users__detail-grid article")
+        .filter({ hasText: "Plano" })
+        .getByText("premium", { exact: true }),
+    ).toBeVisible();
+    await expect(page.locator(".admin-users__entitlements").getByText("Insights com IA")).toBeVisible();
+  });
+
+  test("grants an entitlement with a required audit reason", async ({ page }) => {
+    await mockAdminSession(page, { isAdmin: true });
+    await login(page);
+    await page.goto("/admin/users");
+
+    await page.locator(".admin-users__grant .n-base-selection").click();
+    await page.getByText("Market Pulse", { exact: true }).click();
+    await page.getByRole("button", { name: /Conceder/ }).click();
+    await page.getByPlaceholder(/ajuste solicitado/i).fill("Liberar teste premium solicitado pelo suporte");
+    await page.getByTestId("admin-entitlement-confirm").click();
+
+    await expect(page.getByText(/Último audit id:/)).toContainText("audit-grant-1");
+    await expect(page.locator(".admin-users__entitlements").getByText("Market Pulse")).toBeVisible();
+  });
+
+  test("revokes an entitlement with a required audit reason", async ({ page }) => {
+    await mockAdminSession(page, { isAdmin: true });
+    await login(page);
+    await page.goto("/admin/users");
+
+    await page.getByRole("button", { name: /Revogar Insights com IA/ }).click();
+    await page.getByPlaceholder(/ajuste solicitado/i).fill("Encerrar acesso temporário depois da validação");
+    await page.getByTestId("admin-entitlement-confirm").click();
+
+    await expect(page.getByText(/Último audit id:/)).toContainText("audit-revoke-1");
+    await expect(page.locator(".admin-users__entitlements").getByText("Insights com IA")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Closes #889

## Summary
- Adiciona o console `/admin/users` para busca/listagem de usuários, detalhe de assinatura, entitlements ativos e histórico resumido de auditoria.
- Implementa client/query/mutations tipados para `/admin/users`, grant/revoke em `/entitlements/admin`, invalidação de cache e feedback com `useToast`.
- Habilita o item `Usuários` no shell admin, adiciona feature flag `web.admin.entitlement-mutations` e ajusta o layout admin para mobile sem overflow horizontal.
- Cobre fluxos admin com unit tests e E2E desktop/mobile para acesso, detalhe, concessão e revogação de entitlement com motivo obrigatório.

## Screenshots
Screenshots gerados localmente para revisão/anexo:

- Desktop: `/tmp/auraxis-admin-users-screenshots/admin-users-desktop.png`
- Mobile: `/tmp/auraxis-admin-users-screenshots/admin-users-mobile.png`

Observação: tentei publicar os PNGs via `gh gist create`, mas o GitHub CLI rejeitou upload binário para gist nesta sessão.

## Test Plan
- [x] `pnpm quality-check`
- [x] `pnpm exec playwright test e2e/admin.spec.ts --project=chromium --project=mobile-chrome`
- [x] Pre-push parity gate do repositório
