### PR TITLE
[WEB] Email verification gate (14d) + countdown banner + 403 interceptor

### DIFF
--- a/app/components/auth/EmailConfirmationBanner/EmailConfirmationBanner.vue
+++ b/app/components/auth/EmailConfirmationBanner/EmailConfirmationBanner.vue
@@ -1,28 +1,74 @@
 <script setup lang="ts">
+/**
+ * In-page banner that nudges users to confirm their email during the 14-day
+ * grace period. Three visual states based on `daysUntilEmailRequired`:
+ *
+ *  - **info** (≥ 8 days)   — gentle reminder
+ *  - **urgent** (1–7 days) — warning copy with countdown
+ *  - **expired** (≤ 0)     — read-only mode notice
+ *
+ * The persistent blocking modal is rendered separately by
+ * `EmailVerificationGate` (features/auth) — this banner only hints.
+ */
+import { computed } from "vue";
 import { Mail } from "lucide-vue-next";
 import { NButton } from "naive-ui";
 import { useSessionStore } from "~/stores/session";
 
 const { t } = useI18n();
-
 const sessionStore = useSessionStore();
 
-// Banner is visible when the user is authenticated but has not confirmed email.
-// The `emailConfirmed` field is set on login from the backend response.
 const isVisible = computed(
-  () => sessionStore.isAuthenticated && sessionStore.emailConfirmed === false,
+  () => sessionStore.isAuthenticated && !sessionStore.emailVerified,
 );
+
+const daysRemaining = computed((): number | null => {
+  const raw = sessionStore.daysUntilEmailRequired;
+  return raw === null ? null : Number(raw);
+});
+
+type BannerVariant = "info" | "urgent" | "expired";
+
+const variant = computed((): BannerVariant => {
+  const days = daysRemaining.value;
+  if (days === null) {
+    return "info";
+  }
+  if (days <= 0) {
+    return "expired";
+  }
+  if (days <= 7) {
+    return "urgent";
+  }
+  return "info";
+});
+
+const message = computed((): string => {
+  const days = daysRemaining.value;
+  if (variant.value === "expired") {
+    return t("auth.emailBanner.expired");
+  }
+  if (days === null) {
+    return t("auth.emailBanner.message");
+  }
+  const key = variant.value === "urgent"
+    ? "auth.emailBanner.urgent"
+    : "auth.emailBanner.countdown";
+  return t(key, { count: days }, days);
+});
 </script>
 
 <template>
   <div
     v-if="isVisible"
     class="email-banner"
+    :class="`email-banner--${variant}`"
     role="alert"
+    :data-variant="variant"
     data-testid="email-confirmation-banner"
   >
     <Mail class="email-banner__icon" :size="16" />
-    <p class="email-banner__message">{{ $t('auth.emailBanner.message') }}</p>
+    <p class="email-banner__message">{{ message }}</p>
     <NButton size="small" type="primary" tag="a" href="/resend-confirmation">
       {{ t('auth.emailBanner.cta') }}
     </NButton>
@@ -41,9 +87,27 @@ const isVisible = computed(
   font-size: var(--font-size-xs);
 }
 
+.email-banner--urgent {
+  background: color-mix(in srgb, var(--color-warning) 14%, transparent);
+  border-bottom-color: color-mix(in srgb, var(--color-warning) 40%, transparent);
+}
+
+.email-banner--expired {
+  background: color-mix(in srgb, var(--color-negative) 16%, transparent);
+  border-bottom-color: color-mix(in srgb, var(--color-negative) 45%, transparent);
+}
+
 .email-banner__icon {
   flex-shrink: 0;
   color: var(--color-brand-500);
+}
+
+.email-banner--urgent .email-banner__icon {
+  color: var(--color-warning);
+}
+
+.email-banner--expired .email-banner__icon {
+  color: var(--color-negative);
 }
 
 .email-banner__message {

--- a/app/components/auth/EmailConfirmationBanner/__tests__/EmailConfirmationBanner.spec.ts
+++ b/app/components/auth/EmailConfirmationBanner/__tests__/EmailConfirmationBanner.spec.ts
@@ -6,11 +6,38 @@ import EmailConfirmationBanner from "../EmailConfirmationBanner.vue";
 
 const sessionMock = {
   isAuthenticated: false as boolean,
-  emailConfirmed: null as boolean | null,
+  emailVerified: false as boolean,
+  daysUntilEmailRequired: null as number | null,
 };
 
 vi.mock("~/stores/session", () => ({
   useSessionStore: (): typeof sessionMock => sessionMock,
+}));
+
+const tMock = vi.fn(
+  (key: string, params?: Record<string, unknown>, count?: number) => {
+    const days = (params?.count as number | undefined) ?? count ?? 0;
+    if (key === "auth.emailBanner.expired") {
+      return "EXPIRED";
+    }
+    if (key === "auth.emailBanner.urgent") {
+      return `URGENT-${days}`;
+    }
+    if (key === "auth.emailBanner.countdown") {
+      return `COUNTDOWN-${days}`;
+    }
+    if (key === "auth.emailBanner.message") {
+      return "MESSAGE";
+    }
+    if (key === "auth.emailBanner.cta") {
+      return "CTA";
+    }
+    return key;
+  },
+);
+
+vi.mock("vue-i18n", () => ({
+  useI18n: (): { t: typeof tMock } => ({ t: tMock }),
 }));
 
 vi.mock("naive-ui", async (importOriginal) => {
@@ -18,43 +45,97 @@ vi.mock("naive-ui", async (importOriginal) => {
   const actual = await importOriginal<any>();
   return {
     ...actual,
-    NButton: { name: "NButton", template: "<button><slot /></button>", props: ["href", "size", "type", "tag"] },
+    NButton: {
+      name: "NButton",
+      template: "<button><slot /></button>",
+      props: ["href", "size", "type", "tag"],
+    },
   };
 });
 
 describe("EmailConfirmationBanner", () => {
   it("does not render when user is not authenticated", () => {
     sessionMock.isAuthenticated = false;
-    sessionMock.emailConfirmed = false;
+    sessionMock.emailVerified = false;
+    sessionMock.daysUntilEmailRequired = 10;
     const wrapper = mount(EmailConfirmationBanner);
-    expect(wrapper.find("[data-testid='email-confirmation-banner']").exists()).toBe(false);
+    expect(
+      wrapper.find("[data-testid='email-confirmation-banner']").exists(),
+    ).toBe(false);
   });
 
-  it("does not render when email is already confirmed", () => {
+  it("does not render when email is already verified", () => {
     sessionMock.isAuthenticated = true;
-    sessionMock.emailConfirmed = true;
+    sessionMock.emailVerified = true;
+    sessionMock.daysUntilEmailRequired = null;
     const wrapper = mount(EmailConfirmationBanner);
-    expect(wrapper.find("[data-testid='email-confirmation-banner']").exists()).toBe(false);
+    expect(
+      wrapper.find("[data-testid='email-confirmation-banner']").exists(),
+    ).toBe(false);
   });
 
-  it("does not render when emailConfirmed is null (unknown state)", () => {
+  it("renders the info variant for 8+ days remaining", () => {
     sessionMock.isAuthenticated = true;
-    sessionMock.emailConfirmed = null;
+    sessionMock.emailVerified = false;
+    sessionMock.daysUntilEmailRequired = 10;
     const wrapper = mount(EmailConfirmationBanner);
-    expect(wrapper.find("[data-testid='email-confirmation-banner']").exists()).toBe(false);
+    const banner = wrapper.find("[data-testid='email-confirmation-banner']");
+    expect(banner.exists()).toBe(true);
+    expect(banner.attributes("data-variant")).toBe("info");
+    expect(banner.text()).toContain("COUNTDOWN-10");
   });
 
-  it("renders banner when authenticated and email is not confirmed", () => {
+  it("renders the urgent variant for 1–7 days remaining", () => {
     sessionMock.isAuthenticated = true;
-    sessionMock.emailConfirmed = false;
+    sessionMock.emailVerified = false;
+    sessionMock.daysUntilEmailRequired = 3;
     const wrapper = mount(EmailConfirmationBanner);
-    expect(wrapper.find("[data-testid='email-confirmation-banner']").exists()).toBe(true);
+    const banner = wrapper.find("[data-testid='email-confirmation-banner']");
+    expect(banner.attributes("data-variant")).toBe("urgent");
+    expect(banner.text()).toContain("URGENT-3");
   });
 
-  it("has correct role attribute for accessibility", () => {
+  it("renders the expired variant for 0 or negative days", () => {
     sessionMock.isAuthenticated = true;
-    sessionMock.emailConfirmed = false;
+    sessionMock.emailVerified = false;
+    sessionMock.daysUntilEmailRequired = 0;
     const wrapper = mount(EmailConfirmationBanner);
-    expect(wrapper.find("[data-testid='email-confirmation-banner']").attributes("role")).toBe("alert");
+    const banner = wrapper.find("[data-testid='email-confirmation-banner']");
+    expect(banner.attributes("data-variant")).toBe("expired");
+    expect(banner.text()).toContain("EXPIRED");
+  });
+
+  it("renders the expired variant for negative days remaining", () => {
+    sessionMock.isAuthenticated = true;
+    sessionMock.emailVerified = false;
+    sessionMock.daysUntilEmailRequired = -2;
+    const wrapper = mount(EmailConfirmationBanner);
+    expect(
+      wrapper
+        .find("[data-testid='email-confirmation-banner']")
+        .attributes("data-variant"),
+    ).toBe("expired");
+  });
+
+  it("falls back to the legacy message when daysUntilEmailRequired is null", () => {
+    sessionMock.isAuthenticated = true;
+    sessionMock.emailVerified = false;
+    sessionMock.daysUntilEmailRequired = null;
+    const wrapper = mount(EmailConfirmationBanner);
+    const banner = wrapper.find("[data-testid='email-confirmation-banner']");
+    expect(banner.attributes("data-variant")).toBe("info");
+    expect(banner.text()).toContain("MESSAGE");
+  });
+
+  it("has role=alert for accessibility", () => {
+    sessionMock.isAuthenticated = true;
+    sessionMock.emailVerified = false;
+    sessionMock.daysUntilEmailRequired = 5;
+    const wrapper = mount(EmailConfirmationBanner);
+    expect(
+      wrapper
+        .find("[data-testid='email-confirmation-banner']")
+        .attributes("role"),
+    ).toBe("alert");
   });
 });

--- a/app/composables/useHttp/useHttp.ts
+++ b/app/composables/useHttp/useHttp.ts
@@ -3,6 +3,7 @@ import { useDialog, useMessage } from "naive-ui";
 
 import { createHttpClient } from "~/core/http/http-client";
 import { isAdminImpersonationReadOnlyActive } from "~/features/admin/impersonation/composables/use-admin-impersonation-session";
+import { useEmailVerificationGate } from "~/features/auth/composables/use-email-verification-gate";
 import { useSessionStore } from "~/stores/session";
 
 const DEFAULT_API_BASE = "http://localhost:5000";
@@ -149,6 +150,7 @@ export const refreshAccessToken = async (
 export const useHttp = (): AxiosInstance => {
   const runtimeConfig = useRuntimeConfig();
   const sessionStore = useSessionStore();
+  const verificationGate = useEmailVerificationGate();
   const message = useMessage();
   const dialog = useDialog();
   const { t } = useI18n();
@@ -178,6 +180,17 @@ export const useHttp = (): AxiosInstance => {
         }
 
         return newToken;
+      },
+      onEmailVerificationRequired: (body): void => {
+        // Mirror the soft-block state into the session store so any banner
+        // re-renders into "expired" mode without waiting for /user/me to refetch.
+        sessionStore.emailVerificationRequiredNow = true;
+        sessionStore.emailVerified = false;
+        verificationGate.open({
+          message: body.message,
+          deadlinePassedAt: body.deadline_passed_at,
+          resendEndpoint: body.resend_endpoint,
+        });
       },
       onForbidden: (msg: string): void => {
         message.error(msg, { duration: 5_000 });

--- a/app/core/api/__tests__/interceptors.spec.ts
+++ b/app/core/api/__tests__/interceptors.spec.ts
@@ -139,6 +139,56 @@ describe("registerResponseInterceptors", () => {
     expect(onServerError).not.toHaveBeenCalled();
   });
 
+  it("delega para onEmailVerificationRequired em 403 com body EMAIL_VERIFICATION_REQUIRED", async () => {
+    const onEmailVerificationRequired = vi.fn();
+    client = axios.create({ baseURL: "http://localhost" });
+    onForbidden = vi.fn();
+    registerResponseInterceptors(client, {
+      onForbidden,
+      onServerError,
+      onEmailVerificationRequired,
+    });
+    const handler = getRejectedHandler(client);
+
+    const emailVerifyError = Object.assign(new Error("Forbidden"), {
+      isAxiosError: true,
+      response: {
+        status: 403,
+        data: {
+          error: "EMAIL_VERIFICATION_REQUIRED",
+          message: "Confirme seu email para continuar",
+          deadline_passed_at: "2026-05-20T10:00:00Z",
+          resend_endpoint: "/auth/email/resend",
+        },
+      },
+    });
+
+    await expect(handler(emailVerifyError)).rejects.toBeInstanceOf(ApiError);
+    expect(onEmailVerificationRequired).toHaveBeenCalledOnce();
+    expect(onEmailVerificationRequired).toHaveBeenCalledWith({
+      error: "EMAIL_VERIFICATION_REQUIRED",
+      message: "Confirme seu email para continuar",
+      deadline_passed_at: "2026-05-20T10:00:00Z",
+      resend_endpoint: "/auth/email/resend",
+    });
+    // Quando o gate handler atende, onForbidden NÃO deve ser chamado.
+    expect(onForbidden).not.toHaveBeenCalled();
+  });
+
+  it("usa onForbidden quando onEmailVerificationRequired não é fornecido (compat)", async () => {
+    // setup default: só onForbidden + onServerError registrados (sem handler do gate)
+    const handler = getRejectedHandler(client);
+    const emailVerifyError = Object.assign(new Error("Forbidden"), {
+      isAxiosError: true,
+      response: {
+        status: 403,
+        data: { error: "EMAIL_VERIFICATION_REQUIRED", message: "x" },
+      },
+    });
+    await expect(handler(emailVerifyError)).rejects.toBeInstanceOf(ApiError);
+    expect(onForbidden).toHaveBeenCalledOnce();
+  });
+
   it("chama onServerError com mensagem padrão e relança ApiError em 500", async () => {
     const handler = getRejectedHandler(client);
 

--- a/app/core/api/interceptors.ts
+++ b/app/core/api/interceptors.ts
@@ -15,7 +15,30 @@ import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from "axio
 
 import { ApiError } from "~/core/errors";
 
-import type { ResponseInterceptorOptions } from "./types";
+import type {
+  EmailVerificationRequiredBody,
+  ResponseInterceptorOptions,
+} from "./types";
+
+/**
+ * Type guard: true when the body looks like a backend
+ * `EMAIL_VERIFICATION_REQUIRED` response.
+ *
+ * See `auraxis-api/app/decorators/require_email_verified.py` for the
+ * canonical shape.
+ *
+ * @param body Raw response body to inspect.
+ * @returns True when the body has `error === "EMAIL_VERIFICATION_REQUIRED"`.
+ */
+const isEmailVerificationRequiredBody = (
+  body: unknown,
+): body is EmailVerificationRequiredBody => {
+  if (body === null || typeof body !== "object") {
+    return false;
+  }
+  const candidate = body as { error?: unknown };
+  return candidate.error === "EMAIL_VERIFICATION_REQUIRED";
+};
 
 /** User-facing message shown when a 403 Forbidden response is received. */
 const FORBIDDEN_MESSAGE =
@@ -111,6 +134,70 @@ const createSharedRefresh = (
  * @param client Axios instance to attach the interceptor to.
  * @param options Optional side-effect callbacks for 401, 403 and 5xx responses.
  */
+/**
+ * Attempts to recover from a 401 by refreshing the access token and retrying
+ * the original request. Returns the resolved client promise when the retry
+ * succeeds, or null when no refresh handler is available / refresh failed.
+ *
+ * @param client Axios instance bound to the interceptor.
+ * @param error Original Axios error that triggered the interceptor.
+ * @param sharedRefresh Refresh handler shared across concurrent 401s.
+ * @returns Retried response, or null when no retry was performed.
+ */
+const tryRefreshAndRetry = async (
+  client: AxiosInstance,
+  error: unknown,
+  sharedRefresh: () => Promise<string | null>,
+): Promise<unknown> => {
+  const config = axios.isAxiosError(error)
+    ? (error.config as RetryableConfig | undefined)
+    : undefined;
+  if (!config || config._retry) {
+    return null;
+  }
+  config._retry = true;
+  const newToken = await sharedRefresh();
+  if (!newToken) {
+    return null;
+  }
+  config.headers.Authorization = `Bearer ${newToken}`;
+  return client(config);
+};
+
+/**
+ * Routes a 403 response either to the email-verification gate handler (when
+ * the body matches `EMAIL_VERIFICATION_REQUIRED`) or to the generic
+ * `onForbidden` toast handler.
+ *
+ * @param error Original Axios error from the failed request.
+ * @param options Interceptor callbacks.
+ */
+const handleForbidden = (
+  error: unknown,
+  options: ResponseInterceptorOptions,
+): void => {
+  const rawBody = axios.isAxiosError(error)
+    ? error.response?.data
+    : undefined;
+  if (
+    options.onEmailVerificationRequired
+    && isEmailVerificationRequiredBody(rawBody)
+  ) {
+    options.onEmailVerificationRequired(rawBody);
+    return;
+  }
+  options.onForbidden?.(FORBIDDEN_MESSAGE);
+};
+
+/**
+ * Public entry point — wires the cross-cutting response handlers (401 refresh,
+ * 403 email-verification gate / forbidden toast, 5xx server-error toast)
+ * onto the provided Axios instance. See the block doc above
+ * {@link tryRefreshAndRetry} for the per-status behaviour matrix.
+ *
+ * @param client Axios instance to attach the interceptor to.
+ * @param options Optional side-effect callbacks for 401, 403 and 5xx responses.
+ */
 export const registerResponseInterceptors = (
   client: AxiosInstance,
   options: ResponseInterceptorOptions,
@@ -125,23 +212,14 @@ export const registerResponseInterceptors = (
       const apiError = toApiError(error);
 
       if (apiError.status === 401 && sharedRefresh) {
-        const config = axios.isAxiosError(error)
-          ? (error.config as RetryableConfig | undefined)
-          : undefined;
-
-        if (config && !config._retry) {
-          config._retry = true;
-          const newToken = await sharedRefresh();
-
-          if (newToken) {
-            config.headers.Authorization = `Bearer ${newToken}`;
-            return client(config) as Promise<never>;
-          }
+        const retried = await tryRefreshAndRetry(client, error, sharedRefresh);
+        if (retried !== null) {
+          return retried as Promise<never>;
         }
       }
 
       if (apiError.status === 403) {
-        options.onForbidden?.(FORBIDDEN_MESSAGE);
+        handleForbidden(error, options);
         return Promise.reject(apiError);
       }
 

--- a/app/core/api/types.ts
+++ b/app/core/api/types.ts
@@ -47,13 +47,42 @@ export interface PaginatedResponse<T> extends ApiResponse<T[]> {
 }
 
 /**
+ * Backend body shape for a 403 EMAIL_VERIFICATION_REQUIRED response.
+ *
+ * Returned by mutation endpoints (transactions, goals, wallet, etc.) after
+ * the user's 14-day email-verification grace period has expired.
+ * See `auraxis-api/app/decorators/require_email_verified.py`.
+ */
+export interface EmailVerificationRequiredBody {
+  readonly error: "EMAIL_VERIFICATION_REQUIRED";
+  readonly message: string;
+  readonly deadline_passed_at: string | null;
+  readonly resend_endpoint: string;
+}
+
+/**
  * Callbacks injected into the global HTTP response interceptor.
  *
  * All handlers are optional — omitting one disables that automatic behavior.
  */
 export interface ResponseInterceptorOptions {
   /**
-   * Called when a response returns HTTP 403.
+   * Called when a 403 response carries an EMAIL_VERIFICATION_REQUIRED body.
+   * Used to open the global verification gate modal so the user can resend
+   * the confirmation email without bouncing on the generic 403 toast.
+   *
+   * When this handler is provided AND the body matches, `onForbidden` is NOT
+   * called for the same response.
+   *
+   * @param body Backend payload with deadline_passed_at and resend_endpoint.
+   */
+  readonly onEmailVerificationRequired?: (
+    body: EmailVerificationRequiredBody,
+  ) => void;
+
+  /**
+   * Called when a response returns HTTP 403 (other than
+   * EMAIL_VERIFICATION_REQUIRED, which has its own handler above).
    * Typically used to show a "no permission" toast.
    *
    * @param message Localised message to display.

--- a/app/features/auth/components/EmailVerificationGate.vue
+++ b/app/features/auth/components/EmailVerificationGate.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+/**
+ * EmailVerificationGate — modal that blocks the UI when the user tries to
+ * perform a mutation after the 14-day email-verification grace period has
+ * expired (backend returns 403 EMAIL_VERIFICATION_REQUIRED).
+ *
+ * Mounted once at the layout level. Subscribes to the `useEmailVerificationGate`
+ * store; opens automatically when the HTTP interceptor catches the 403.
+ *
+ * UX rules:
+ * - `mask-closable: false` + `closable: false` — user must take an action
+ * - Two CTAs: resend confirmation email + refresh session
+ * - Refresh action probes /auth/refresh; if the backend reports the user is
+ *   now verified, the modal closes automatically.
+ */
+import { Mail, ShieldCheck } from "lucide-vue-next";
+import { NButton, NModal } from "naive-ui";
+import { storeToRefs } from "pinia";
+import { computed, ref } from "vue";
+
+import { useToast } from "~/composables/useToast";
+import { refreshAccessToken } from "~/composables/useHttp/useHttp";
+import { useEmailVerificationGate } from "~/features/auth/composables/use-email-verification-gate";
+import { useResendConfirmationMutation } from "~/features/auth/queries/use-resend-confirmation-mutation";
+import { useSessionStore } from "~/stores/session";
+
+const { t, locale } = useI18n();
+const runtimeConfig = useRuntimeConfig();
+const DEFAULT_API_BASE = "http://localhost:5000";
+
+const gate = useEmailVerificationGate();
+const { isOpen, payload } = storeToRefs(gate);
+
+const sessionStore = useSessionStore();
+const toast = useToast();
+const resendMutation = useResendConfirmationMutation();
+
+const isRefreshing = ref(false);
+
+const deadlineFormatted = computed((): string | null => {
+  const raw = payload.value?.deadlinePassedAt ?? null;
+  if (raw === null) {
+    return null;
+  }
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toLocaleString(locale.value, {
+    dateStyle: "long",
+    timeStyle: "short",
+  });
+});
+
+/**
+ * Triggers the resend confirmation email mutation, surfacing a success or
+ * error toast based on the outcome.
+ */
+const onResend = async (): Promise<void> => {
+  try {
+    await resendMutation.mutateAsync(undefined);
+    toast.success(t("auth.emailGate.resendSuccess"));
+  } catch {
+    toast.error(t("auth.emailGate.resendError"));
+  }
+};
+
+/**
+ * Probes /auth/refresh to re-hydrate the session. If the backend reports
+ * the user is no longer blocked by the grace period, the gate closes.
+ */
+const onRefresh = async (): Promise<void> => {
+  isRefreshing.value = true;
+  try {
+    const apiBase = String(runtimeConfig.public.apiBase ?? DEFAULT_API_BASE);
+    await refreshAccessToken(apiBase, sessionStore);
+    if (!sessionStore.emailVerificationRequiredNow) {
+      gate.close();
+    }
+  } finally {
+    isRefreshing.value = false;
+  }
+};
+</script>
+
+<template>
+  <NModal
+    :show="isOpen"
+    preset="card"
+    :mask-closable="false"
+    :closable="false"
+    :close-on-esc="false"
+    :title="t('auth.emailGate.title')"
+    class="email-verification-gate"
+    style="max-width: 520px"
+    data-testid="email-verification-gate"
+  >
+    <div class="email-verification-gate__body">
+      <div class="email-verification-gate__icon">
+        <Mail :size="40" />
+      </div>
+      <p class="email-verification-gate__copy">
+        {{ payload?.message ?? t('auth.emailGate.body') }}
+      </p>
+      <p
+        v-if="deadlineFormatted"
+        class="email-verification-gate__deadline"
+        data-testid="email-verification-gate-deadline"
+      >
+        <ShieldCheck :size="14" />
+        <span>{{ t('auth.emailGate.deadlinePassed', { date: deadlineFormatted }) }}</span>
+      </p>
+      <p class="email-verification-gate__hint">
+        {{ t('auth.emailGate.refreshHint') }}
+      </p>
+    </div>
+
+    <template #action>
+      <div class="email-verification-gate__actions">
+        <NButton
+          :loading="isRefreshing"
+          :disabled="resendMutation.isPending.value"
+          ghost
+          data-testid="email-verification-gate-refresh"
+          @click="onRefresh"
+        >
+          {{ isRefreshing
+            ? t('auth.emailGate.ctaRefreshing')
+            : t('auth.emailGate.ctaRefresh')
+          }}
+        </NButton>
+        <NButton
+          type="primary"
+          :loading="resendMutation.isPending.value"
+          :disabled="isRefreshing"
+          data-testid="email-verification-gate-resend"
+          @click="onResend"
+        >
+          {{ resendMutation.isPending.value
+            ? t('auth.emailGate.ctaResending')
+            : t('auth.emailGate.ctaResend')
+          }}
+        </NButton>
+      </div>
+    </template>
+  </NModal>
+</template>
+
+<style scoped>
+.email-verification-gate__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  text-align: center;
+  padding: var(--space-2) 0;
+}
+
+.email-verification-gate__icon {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--color-brand-500) 14%, transparent);
+  color: var(--color-brand-500);
+}
+
+.email-verification-gate__copy {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  line-height: 1.5;
+}
+
+.email-verification-gate__deadline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.email-verification-gate__hint {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.email-verification-gate__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  width: 100%;
+}
+</style>

--- a/app/features/auth/composables/use-email-verification-gate.spec.ts
+++ b/app/features/auth/composables/use-email-verification-gate.spec.ts
@@ -1,0 +1,53 @@
+import { setActivePinia, createPinia } from "pinia";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  type EmailVerificationGatePayload,
+  useEmailVerificationGate,
+} from "./use-email-verification-gate";
+
+describe("useEmailVerificationGate", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  const samplePayload: EmailVerificationGatePayload = {
+    message: "Confirme seu email",
+    deadlinePassedAt: "2026-05-20T10:00:00Z",
+    resendEndpoint: "/auth/email/resend",
+  };
+
+  it("starts closed with no payload", () => {
+    const gate = useEmailVerificationGate();
+    expect(gate.isOpen).toBe(false);
+    expect(gate.payload).toBeNull();
+  });
+
+  it("open(payload) flips isOpen and stores the payload", () => {
+    const gate = useEmailVerificationGate();
+    gate.open(samplePayload);
+    expect(gate.isOpen).toBe(true);
+    expect(gate.payload).toEqual(samplePayload);
+  });
+
+  it("close() resets isOpen and payload", () => {
+    const gate = useEmailVerificationGate();
+    gate.open(samplePayload);
+    gate.close();
+    expect(gate.isOpen).toBe(false);
+    expect(gate.payload).toBeNull();
+  });
+
+  it("open() can be called multiple times with new payloads", () => {
+    const gate = useEmailVerificationGate();
+    gate.open(samplePayload);
+    const second: EmailVerificationGatePayload = {
+      message: "Outro motivo",
+      deadlinePassedAt: null,
+      resendEndpoint: "/auth/email/resend",
+    };
+    gate.open(second);
+    expect(gate.payload).toEqual(second);
+    expect(gate.isOpen).toBe(true);
+  });
+});

--- a/app/features/auth/composables/use-email-verification-gate.ts
+++ b/app/features/auth/composables/use-email-verification-gate.ts
@@ -1,0 +1,45 @@
+/**
+ * Global state for the email verification gate modal.
+ *
+ * Opens automatically when the HTTP interceptor catches a 403 response with
+ * body `{ error: "EMAIL_VERIFICATION_REQUIRED", ... }`. The single modal
+ * mounted in the default layout subscribes to this state.
+ *
+ * Closes when the user confirms verification (refresh succeeds) or
+ * explicitly dismisses.
+ */
+
+import { defineStore } from "pinia";
+
+/**
+ * Payload emitted by the backend when the 14-day grace period expires
+ * without email confirmation. Mirrors the canonical body of a 403
+ * `EMAIL_VERIFICATION_REQUIRED` response.
+ */
+export interface EmailVerificationGatePayload {
+  readonly message: string;
+  readonly deadlinePassedAt: string | null;
+  readonly resendEndpoint: string;
+}
+
+interface GateState {
+  isOpen: boolean;
+  payload: EmailVerificationGatePayload | null;
+}
+
+export const useEmailVerificationGate = defineStore("emailVerificationGate", {
+  state: (): GateState => ({
+    isOpen: false,
+    payload: null,
+  }),
+  actions: {
+    open(payload: EmailVerificationGatePayload): void {
+      this.isOpen = true;
+      this.payload = payload;
+    },
+    close(): void {
+      this.isOpen = false;
+      this.payload = null;
+    },
+  },
+});

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -1090,7 +1090,28 @@
     },
     "emailBanner": {
       "message": "Confirme seu e-mail para garantir acesso completo à sua conta.",
-      "cta": "Confirmar e-mail"
+      "cta": "Confirmar e-mail",
+      "countdown": {
+        "one": "Falta {count} dia para confirmar seu e-mail.",
+        "other": "Faltam {count} dias para confirmar seu e-mail."
+      },
+      "urgent": {
+        "one": "Falta {count} dia! Sua conta entrará em modo somente-leitura.",
+        "other": "Faltam {count} dias! Sua conta entrará em modo somente-leitura."
+      },
+      "expired": "Sua conta está em modo somente-leitura. Confirme seu e-mail para continuar."
+    },
+    "emailGate": {
+      "title": "Confirme seu e-mail para continuar",
+      "body": "Sua conta passou pelo período de 14 dias sem confirmação. Para criar novas transações, metas e outras ações, confirme seu e-mail.",
+      "deadlinePassed": "Prazo expirou em {date}.",
+      "ctaResend": "Reenviar e-mail de confirmação",
+      "ctaResending": "Enviando…",
+      "ctaRefresh": "Já confirmei, atualizar",
+      "ctaRefreshing": "Verificando…",
+      "resendSuccess": "Reenviamos o e-mail de confirmação. Confira sua caixa de entrada.",
+      "resendError": "Não foi possível reenviar o e-mail agora. Tente novamente.",
+      "refreshHint": "Após confirmar pelo link no e-mail, clique aqui para atualizar."
     },
     "password": {
       "strength": {

--- a/app/layouts/default.spec.ts
+++ b/app/layouts/default.spec.ts
@@ -102,6 +102,7 @@ const globalStubs = {
   },
   BillingStatusBanner: true,
   EmailConfirmationModal: true,
+  EmailVerificationGate: true,
   AdminImpersonationBanner: true,
 };
 

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -27,6 +27,7 @@ import { isFeatureEnabled } from "~/shared/feature-flags";
 import { useOnboarding } from "~/features/onboarding/composables/useOnboarding";
 import { useAdminAccess } from "~/features/admin/model/admin-access";
 import AdminImpersonationBanner from "~/features/admin/impersonation/components/AdminImpersonationBanner.vue";
+import EmailVerificationGate from "~/features/auth/components/EmailVerificationGate.vue";
 import OnboardingWizard from "~/features/onboarding/components/OnboardingWizard.vue";
 import OnboardingTriggerButton from "~/features/onboarding/components/OnboardingTriggerButton.vue";
 
@@ -144,6 +145,7 @@ function onReplayOnboarding(): void {
 <template>
   <div class="app-root">
     <AdminImpersonationBanner />
+    <EmailVerificationGate />
     <EmailConfirmationModal />
     <BillingStatusBanner />
     <UiAppShell

--- a/app/shared/types/generated/graphql.ts
+++ b/app/shared/types/generated/graphql.ts
@@ -37,6 +37,38 @@ export type Scalars = {
   UUID: { input: string; output: string; }
 };
 
+export type AiInsightHistoryResultType = {
+  __typename?: 'AIInsightHistoryResultType';
+  items: Array<AiInsightType>;
+  page: Scalars['Int']['output'];
+  perPage: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+/** A single LLM-produced insight item, tagged by dimension. */
+export type AiInsightItemType = {
+  __typename?: 'AIInsightItemType';
+  dimension: Scalars['String']['output'];
+  evidence?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  message: Scalars['String']['output'];
+  title: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+};
+
+export type AiInsightType = {
+  __typename?: 'AIInsightType';
+  content: Scalars['String']['output'];
+  costUsd: Scalars['Float']['output'];
+  createdAt: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  insightType: Scalars['String']['output'];
+  model: Scalars['String']['output'];
+  periodEnd: Scalars['String']['output'];
+  periodLabel: Scalars['String']['output'];
+  periodStart: Scalars['String']['output'];
+  tokensUsed: Scalars['Int']['output'];
+};
+
 export type AccountListType = {
   __typename?: 'AccountListType';
   accounts: Array<AccountType>;
@@ -99,6 +131,72 @@ export type AuthPayloadType = {
   message: Scalars['String']['output'];
   token?: Maybe<Scalars['String']['output']>;
   user?: Maybe<UserType>;
+};
+
+export type BankImportConfirmationPayload = {
+  __typename?: 'BankImportConfirmationPayload';
+  bankName?: Maybe<Scalars['String']['output']>;
+  /** Field-level validation errors (empty on success). */
+  errors: Array<ValidationError>;
+  importedCount?: Maybe<Scalars['Int']['output']>;
+  /** Human-readable status message. */
+  message: Scalars['String']['output'];
+  month?: Maybe<Scalars['String']['output']>;
+  /** True when the mutation completed without errors. */
+  ok: Scalars['Boolean']['output'];
+  replacedCount?: Maybe<Scalars['Int']['output']>;
+  skippedDuplicates?: Maybe<Scalars['Int']['output']>;
+  transactions?: Maybe<Array<ImportedTransactionType>>;
+};
+
+export type BankImportPreviewEntryType = {
+  __typename?: 'BankImportPreviewEntryType';
+  amount: Scalars['String']['output'];
+  bankName: Scalars['String']['output'];
+  date: Scalars['String']['output'];
+  description: Scalars['String']['output'];
+  duplicateReason?: Maybe<Scalars['String']['output']>;
+  externalId: Scalars['String']['output'];
+  isDuplicate: Scalars['Boolean']['output'];
+  transactionType: Scalars['String']['output'];
+};
+
+export type BankImportPreviewPayload = {
+  __typename?: 'BankImportPreviewPayload';
+  data?: Maybe<BankImportPreviewType>;
+  /** Field-level validation errors (empty on success). */
+  errors: Array<ValidationError>;
+  /** Human-readable status message. */
+  message: Scalars['String']['output'];
+  /** True when the mutation completed without errors. */
+  ok: Scalars['Boolean']['output'];
+};
+
+export type BankImportPreviewType = {
+  __typename?: 'BankImportPreviewType';
+  bankName: Scalars['String']['output'];
+  duplicateEntries: Scalars['Int']['output'];
+  entries: Array<BankImportPreviewEntryType>;
+  newEntries: Scalars['Int']['output'];
+  totalEntries: Scalars['Int']['output'];
+};
+
+export type BillCycleType = {
+  __typename?: 'BillCycleType';
+  dueDate: Scalars['String']['output'];
+  endDate: Scalars['String']['output'];
+  startDate: Scalars['String']['output'];
+  status: Scalars['String']['output'];
+};
+
+export type BillTransactionType = {
+  __typename?: 'BillTransactionType';
+  amount: Scalars['DecimalScalar']['output'];
+  dueDate?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  status?: Maybe<Scalars['String']['output']>;
+  title: Scalars['String']['output'];
+  type?: Maybe<Scalars['String']['output']>;
 };
 
 /** An enumeration. */
@@ -212,6 +310,47 @@ export type CreateTransactionMutation = {
   message: Scalars['String']['output'];
 };
 
+export type CreditCardBillType = {
+  __typename?: 'CreditCardBillType';
+  cycle: BillCycleType;
+  paidAmount: Scalars['DecimalScalar']['output'];
+  pendingAmount: Scalars['DecimalScalar']['output'];
+  totalAmount: Scalars['DecimalScalar']['output'];
+  transactions?: Maybe<Array<Maybe<BillTransactionType>>>;
+};
+
+export type CreditCardListType = {
+  __typename?: 'CreditCardListType';
+  creditCards?: Maybe<Array<Maybe<CreditCardType>>>;
+  total?: Maybe<Scalars['Int']['output']>;
+};
+
+export type CreditCardType = {
+  __typename?: 'CreditCardType';
+  bank?: Maybe<Scalars['String']['output']>;
+  benefits?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  brand?: Maybe<Scalars['String']['output']>;
+  closingDay?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  dueDay?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['String']['output'];
+  lastFourDigits?: Maybe<Scalars['String']['output']>;
+  limitAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  name: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['String']['output']>;
+  validityDate?: Maybe<Scalars['String']['output']>;
+};
+
+export type CreditCardUtilizationType = {
+  __typename?: 'CreditCardUtilizationType';
+  availableAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  committedAmount: Scalars['DecimalScalar']['output'];
+  cycle: BillCycleType;
+  limitAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  utilizationPct?: Maybe<Scalars['Float']['output']>;
+};
+
 export type DashboardCategoriesType = {
   __typename?: 'DashboardCategoriesType';
   expense: Array<Maybe<DashboardCategoryType>>;
@@ -291,6 +430,53 @@ export type DeleteWalletEntryMutation = {
   ok: Scalars['Boolean']['output'];
 };
 
+export type FiscalDocumentListType = {
+  __typename?: 'FiscalDocumentListType';
+  fiscalDocuments: Array<FiscalDocumentType>;
+  total: Scalars['Int']['output'];
+};
+
+export type FiscalDocumentPayload = {
+  __typename?: 'FiscalDocumentPayload';
+  data?: Maybe<FiscalDocumentType>;
+  /** Field-level validation errors (empty on success). */
+  errors: Array<ValidationError>;
+  /** Human-readable status message. */
+  message: Scalars['String']['output'];
+  /** True when the mutation completed without errors. */
+  ok: Scalars['Boolean']['output'];
+};
+
+export type FiscalDocumentType = {
+  __typename?: 'FiscalDocumentType';
+  counterparty: Scalars['String']['output'];
+  createdAt: Scalars['String']['output'];
+  currency: Scalars['String']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  externalId: Scalars['String']['output'];
+  grossAmount: Scalars['DecimalScalar']['output'];
+  id: Scalars['ID']['output'];
+  issuedAt: Scalars['String']['output'];
+  status: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+};
+
+export type GenerateAiInsightPayload = {
+  __typename?: 'GenerateAiInsightPayload';
+  cached?: Maybe<Scalars['Boolean']['output']>;
+  contextVersion?: Maybe<Scalars['String']['output']>;
+  costUsd?: Maybe<Scalars['Float']['output']>;
+  items?: Maybe<Array<Maybe<AiInsightItemType>>>;
+  model?: Maybe<Scalars['String']['output']>;
+  ok: Scalars['Boolean']['output'];
+  periodEnd?: Maybe<Scalars['String']['output']>;
+  periodLabel?: Maybe<Scalars['String']['output']>;
+  periodStart?: Maybe<Scalars['String']['output']>;
+  periodType?: Maybe<Scalars['String']['output']>;
+  summary?: Maybe<Scalars['String']['output']>;
+  tokensUsed?: Maybe<Scalars['Int']['output']>;
+};
+
 export type GoalListPayloadType = {
   __typename?: 'GoalListPayloadType';
   items: Array<Maybe<GoalTypeObject>>;
@@ -340,6 +526,17 @@ export type GoalTypeObject = {
   targetDate?: Maybe<Scalars['String']['output']>;
   title: Scalars['String']['output'];
   updatedAt?: Maybe<Scalars['String']['output']>;
+};
+
+export type ImportedTransactionType = {
+  __typename?: 'ImportedTransactionType';
+  amount: Scalars['String']['output'];
+  bankName?: Maybe<Scalars['String']['output']>;
+  dueDate: Scalars['String']['output'];
+  externalId?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  title: Scalars['String']['output'];
+  type: Scalars['String']['output'];
 };
 
 export type InstallmentVsCashAssumptionsType = {
@@ -533,18 +730,34 @@ export type Mutation = {
   addTicker?: Maybe<AddTickerPayload>;
   /** @deprecated ADR-0002: use POST /wallet */
   addWalletEntry?: Maybe<AddWalletEntryMutation>;
+  /** @deprecated ADR-0002: use DELETE /fiscal/receivables/{id} */
+  cancelReceivable?: Maybe<ReceivablePayload>;
   /** @deprecated ADR-0004: use POST /subscription/cancel */
   cancelSubscription?: Maybe<CancelSubscriptionMutation>;
+  /**
+   * Persist a subset of bank statement entries as transactions.
+   *
+   * ``mode`` controls how existing data is handled:
+   *
+   * - ``selective``: skip duplicates, import only new entries.
+   * - ``replace_month``: delete all existing bank-imported transactions for
+   *   the given month/bank before importing the selected set.
+   */
+  confirmBankImport?: Maybe<BankImportConfirmationPayload>;
   confirmEmail?: Maybe<AuthPayloadType>;
   createAccount?: Maybe<AccountPayload>;
   /** @deprecated ADR-0002: use POST /budgets */
   createBudget?: Maybe<CreateBudgetMutation>;
   /** @deprecated ADR-0004: use POST /subscription/checkout */
   createCheckoutSession?: Maybe<CreateCheckoutSessionMutation>;
+  /** @deprecated ADR-0002: use POST /fiscal/fiscal-documents */
+  createFiscalDocument?: Maybe<FiscalDocumentPayload>;
   /** @deprecated ADR-0002: use POST /goals */
   createGoal?: Maybe<CreateGoalMutation>;
   createGoalFromInstallmentVsCashSimulation?: Maybe<CreateGoalFromInstallmentVsCashSimulationMutation>;
   createPlannedExpenseFromInstallmentVsCashSimulation?: Maybe<CreatePlannedExpenseFromInstallmentVsCashSimulationMutation>;
+  /** @deprecated ADR-0002: use POST /fiscal/receivables */
+  createReceivable?: Maybe<ReceivablePayload>;
   createTag?: Maybe<TagPayload>;
   /** @deprecated ADR-0002: use POST /transactions */
   createTransaction?: Maybe<CreateTransactionMutation>;
@@ -562,8 +775,25 @@ export type Mutation = {
   /** @deprecated ADR-0002: use DELETE /wallet/{id} */
   deleteWalletEntry?: Maybe<DeleteWalletEntryMutation>;
   forgotPassword?: Maybe<AuthPayloadType>;
+  /**
+   * GraphQL parity for POST /ai/insights/generate.
+   *
+   * Reuses AIAdvisoryService — quota (2x/day Premium), entitlement gate and
+   * LGPD consent are enforced inside the service. GraphQL surface exposes the
+   * same payload shape so the frontend hub can render either path identically.
+   */
+  generateAiInsight?: Maybe<GenerateAiInsightPayload>;
   login?: Maybe<AuthPayloadType>;
   logout?: Maybe<LogoutMutation>;
+  /** @deprecated ADR-0002: use PATCH /fiscal/receivables/{id}/receive */
+  markReceivableReceived?: Maybe<ReceivablePayload>;
+  /**
+   * Parse a bank statement text and return a deduplication preview.
+   *
+   * The client submits the raw text content (CSV for Nubank, OFX for others)
+   * together with a bank identifier.  No data is written to the database.
+   */
+  previewBankStatement?: Maybe<BankImportPreviewPayload>;
   registerUser?: Maybe<AuthPayloadType>;
   resendConfirmationEmail?: Maybe<AuthPayloadType>;
   resetPassword?: Maybe<AuthPayloadType>;
@@ -621,6 +851,19 @@ export type MutationAddWalletEntryArgs = {
 };
 
 
+export type MutationCancelReceivableArgs = {
+  entryId: Scalars['UUID']['input'];
+};
+
+
+export type MutationConfirmBankImportArgs = {
+  bankName: Scalars['String']['input'];
+  mode: Scalars['String']['input'];
+  month: Scalars['String']['input'];
+  selectedEntries: Array<SelectedEntryInput>;
+};
+
+
 export type MutationConfirmEmailArgs = {
   token: Scalars['String']['input'];
 };
@@ -648,6 +891,15 @@ export type MutationCreateBudgetArgs = {
 export type MutationCreateCheckoutSessionArgs = {
   billingCycle?: InputMaybe<BillingCycle>;
   planSlug: Scalars['String']['input'];
+};
+
+
+export type MutationCreateFiscalDocumentArgs = {
+  amount: Scalars['String']['input'];
+  counterpartName?: InputMaybe<Scalars['String']['input']>;
+  externalId?: InputMaybe<Scalars['String']['input']>;
+  issuedAt: Scalars['String']['input'];
+  type: Scalars['String']['input'];
 };
 
 
@@ -692,6 +944,14 @@ export type MutationCreatePlannedExpenseFromInstallmentVsCashSimulationArgs = {
 };
 
 
+export type MutationCreateReceivableArgs = {
+  amount: Scalars['String']['input'];
+  category?: InputMaybe<Scalars['String']['input']>;
+  description: Scalars['String']['input'];
+  expectedDate: Scalars['String']['input'];
+};
+
+
 export type MutationCreateTagArgs = {
   color?: InputMaybe<Scalars['String']['input']>;
   icon?: InputMaybe<Scalars['String']['input']>;
@@ -702,6 +962,7 @@ export type MutationCreateTagArgs = {
 export type MutationCreateTransactionArgs = {
   accountId?: InputMaybe<Scalars['UUID']['input']>;
   amount: Scalars['String']['input'];
+  category?: InputMaybe<Scalars['String']['input']>;
   creditCardId?: InputMaybe<Scalars['UUID']['input']>;
   currency?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
@@ -765,9 +1026,28 @@ export type MutationForgotPasswordArgs = {
 };
 
 
+export type MutationGenerateAiInsightArgs = {
+  anchorDate?: InputMaybe<Scalars['String']['input']>;
+  periodType: Scalars['String']['input'];
+};
+
+
 export type MutationLoginArgs = {
   email: Scalars['String']['input'];
   password: Scalars['String']['input'];
+};
+
+
+export type MutationMarkReceivableReceivedArgs = {
+  entryId: Scalars['UUID']['input'];
+  receivedAmount?: InputMaybe<Scalars['String']['input']>;
+  receivedDate: Scalars['String']['input'];
+};
+
+
+export type MutationPreviewBankStatementArgs = {
+  bankName: Scalars['String']['input'];
+  content: Scalars['String']['input'];
 };
 
 
@@ -882,6 +1162,7 @@ export type MutationUpdateTagArgs = {
 export type MutationUpdateTransactionArgs = {
   accountId?: InputMaybe<Scalars['UUID']['input']>;
   amount?: InputMaybe<Scalars['String']['input']>;
+  category?: InputMaybe<Scalars['String']['input']>;
   creditCardId?: InputMaybe<Scalars['UUID']['input']>;
   currency?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
@@ -1026,11 +1307,16 @@ export type Query = {
   __typename?: 'Query';
   account?: Maybe<AccountType>;
   accounts?: Maybe<AccountListType>;
+  aiInsightHistory?: Maybe<AiInsightHistoryResultType>;
   billingPlans?: Maybe<BillingPlanListPayloadType>;
   budget?: Maybe<BudgetType>;
   budgetSummary?: Maybe<BudgetSummaryType>;
   budgets?: Maybe<BudgetListPayloadType>;
+  creditCardBill?: Maybe<CreditCardBillType>;
+  creditCardUtilization?: Maybe<CreditCardUtilizationType>;
+  creditCards?: Maybe<CreditCardListType>;
   dashboardOverview?: Maybe<TransactionDashboardPayloadType>;
+  fiscalDocuments?: Maybe<FiscalDocumentListType>;
   goal?: Maybe<GoalTypeObject>;
   goalPlan?: Maybe<GoalPlanType>;
   goals?: Maybe<GoalListPayloadType>;
@@ -1045,6 +1331,8 @@ export type Query = {
   notificationPreferences?: Maybe<NotificationPreferencesType>;
   portfolioValuation?: Maybe<PortfolioValuationPayloadType>;
   portfolioValuationHistory?: Maybe<PortfolioHistoryPayloadType>;
+  receivables?: Maybe<ReceivableListType>;
+  receivablesSummary?: Maybe<ReceivableSummaryType>;
   simulation?: Maybe<SimulationType>;
   simulations: SimulationListPayloadType;
   tag?: Maybe<TagType>;
@@ -1067,13 +1355,35 @@ export type QueryAccountArgs = {
 };
 
 
+export type QueryAiInsightHistoryArgs = {
+  page?: InputMaybe<Scalars['Int']['input']>;
+  perPage?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
 export type QueryBudgetArgs = {
   budgetId: Scalars['UUID']['input'];
 };
 
 
+export type QueryCreditCardBillArgs = {
+  cardId: Scalars['UUID']['input'];
+  month: Scalars['String']['input'];
+};
+
+
+export type QueryCreditCardUtilizationArgs = {
+  cardId: Scalars['UUID']['input'];
+};
+
+
 export type QueryDashboardOverviewArgs = {
   month: Scalars['String']['input'];
+};
+
+
+export type QueryFiscalDocumentsArgs = {
+  type?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1140,6 +1450,11 @@ export type QueryInvestmentValuationArgs = {
 export type QueryPortfolioValuationHistoryArgs = {
   finalDate?: InputMaybe<Scalars['String']['input']>;
   startDate?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryReceivablesArgs = {
+  status?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1227,6 +1542,52 @@ export type QueryWeeklySummaryArgs = {
   startDate?: InputMaybe<Scalars['String']['input']>;
 };
 
+/**
+ * IMPORTANT: expected_net_amount is advisory-only. Clients MUST display
+ * the ``disclaimer`` field alongside any monetary value derived from it.
+ */
+export type ReceivableEntryType = {
+  __typename?: 'ReceivableEntryType';
+  createdAt: Scalars['String']['output'];
+  disclaimer: Scalars['String']['output'];
+  expectedNetAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  fiscalDocumentId: Scalars['ID']['output'];
+  id: Scalars['ID']['output'];
+  outstandingAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  receivedAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  receivedAt?: Maybe<Scalars['String']['output']>;
+  reconciliationStatus: Scalars['String']['output'];
+};
+
+export type ReceivableListType = {
+  __typename?: 'ReceivableListType';
+  receivables: Array<ReceivableEntryType>;
+  total: Scalars['Int']['output'];
+};
+
+export type ReceivablePayload = {
+  __typename?: 'ReceivablePayload';
+  data?: Maybe<ReceivableEntryType>;
+  /** Field-level validation errors (empty on success). */
+  errors: Array<ValidationError>;
+  /** Human-readable status message. */
+  message: Scalars['String']['output'];
+  /** True when the mutation completed without errors. */
+  ok: Scalars['Boolean']['output'];
+};
+
+/**
+ * IMPORTANT: all monetary values are advisory-only estimates.
+ * Always display the ``disclaimer`` field.
+ */
+export type ReceivableSummaryType = {
+  __typename?: 'ReceivableSummaryType';
+  disclaimer: Scalars['String']['output'];
+  expectedTotal: Scalars['String']['output'];
+  pendingTotal: Scalars['String']['output'];
+  receivedTotal: Scalars['String']['output'];
+};
+
 /** Revoke all active sessions — global logout (#1028). */
 export type RevokeAllSessionsMutation = {
   __typename?: 'RevokeAllSessionsMutation';
@@ -1246,6 +1607,15 @@ export type SaveInstallmentVsCashSimulationMutation = {
   calculation: InstallmentVsCashCalculationPayloadType;
   message: Scalars['String']['output'];
   simulation: InstallmentVsCashSimulationType;
+};
+
+export type SelectedEntryInput = {
+  amount: Scalars['String']['input'];
+  bankName: Scalars['String']['input'];
+  date: Scalars['String']['input'];
+  description: Scalars['String']['input'];
+  externalId: Scalars['String']['input'];
+  transactionType: Scalars['String']['input'];
 };
 
 export type SimulateGoalPlanMutation = {
@@ -1388,6 +1758,7 @@ export type TransactionTypeObject = {
   accountId?: Maybe<Scalars['String']['output']>;
   amount: Scalars['String']['output'];
   bankName?: Maybe<Scalars['String']['output']>;
+  category?: Maybe<Scalars['String']['output']>;
   createdAt?: Maybe<Scalars['String']['output']>;
   creditCardId?: Maybe<Scalars['String']['output']>;
   currency: Scalars['String']['output'];
@@ -1462,7 +1833,11 @@ export type UserType = {
   __typename?: 'UserType';
   avatarUrl?: Maybe<Scalars['String']['output']>;
   birthDate?: Maybe<Scalars['String']['output']>;
+  daysUntilEmailRequired?: Maybe<Scalars['Int']['output']>;
   email: Scalars['String']['output'];
+  emailVerificationDeadlineAt?: Maybe<Scalars['String']['output']>;
+  emailVerificationRequiredNow?: Maybe<Scalars['Boolean']['output']>;
+  emailVerified?: Maybe<Scalars['Boolean']['output']>;
   financialObjectives?: Maybe<Scalars['String']['output']>;
   gender?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];

--- a/app/shared/types/generated/graphql.ts
+++ b/app/shared/types/generated/graphql.ts
@@ -37,38 +37,6 @@ export type Scalars = {
   UUID: { input: string; output: string; }
 };
 
-export type AiInsightHistoryResultType = {
-  __typename?: 'AIInsightHistoryResultType';
-  items: Array<AiInsightType>;
-  page: Scalars['Int']['output'];
-  perPage: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
-};
-
-/** A single LLM-produced insight item, tagged by dimension. */
-export type AiInsightItemType = {
-  __typename?: 'AIInsightItemType';
-  dimension: Scalars['String']['output'];
-  evidence?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  message: Scalars['String']['output'];
-  title: Scalars['String']['output'];
-  type: Scalars['String']['output'];
-};
-
-export type AiInsightType = {
-  __typename?: 'AIInsightType';
-  content: Scalars['String']['output'];
-  costUsd: Scalars['Float']['output'];
-  createdAt: Scalars['String']['output'];
-  id: Scalars['ID']['output'];
-  insightType: Scalars['String']['output'];
-  model: Scalars['String']['output'];
-  periodEnd: Scalars['String']['output'];
-  periodLabel: Scalars['String']['output'];
-  periodStart: Scalars['String']['output'];
-  tokensUsed: Scalars['Int']['output'];
-};
-
 export type AccountListType = {
   __typename?: 'AccountListType';
   accounts: Array<AccountType>;
@@ -131,72 +99,6 @@ export type AuthPayloadType = {
   message: Scalars['String']['output'];
   token?: Maybe<Scalars['String']['output']>;
   user?: Maybe<UserType>;
-};
-
-export type BankImportConfirmationPayload = {
-  __typename?: 'BankImportConfirmationPayload';
-  bankName?: Maybe<Scalars['String']['output']>;
-  /** Field-level validation errors (empty on success). */
-  errors: Array<ValidationError>;
-  importedCount?: Maybe<Scalars['Int']['output']>;
-  /** Human-readable status message. */
-  message: Scalars['String']['output'];
-  month?: Maybe<Scalars['String']['output']>;
-  /** True when the mutation completed without errors. */
-  ok: Scalars['Boolean']['output'];
-  replacedCount?: Maybe<Scalars['Int']['output']>;
-  skippedDuplicates?: Maybe<Scalars['Int']['output']>;
-  transactions?: Maybe<Array<ImportedTransactionType>>;
-};
-
-export type BankImportPreviewEntryType = {
-  __typename?: 'BankImportPreviewEntryType';
-  amount: Scalars['String']['output'];
-  bankName: Scalars['String']['output'];
-  date: Scalars['String']['output'];
-  description: Scalars['String']['output'];
-  duplicateReason?: Maybe<Scalars['String']['output']>;
-  externalId: Scalars['String']['output'];
-  isDuplicate: Scalars['Boolean']['output'];
-  transactionType: Scalars['String']['output'];
-};
-
-export type BankImportPreviewPayload = {
-  __typename?: 'BankImportPreviewPayload';
-  data?: Maybe<BankImportPreviewType>;
-  /** Field-level validation errors (empty on success). */
-  errors: Array<ValidationError>;
-  /** Human-readable status message. */
-  message: Scalars['String']['output'];
-  /** True when the mutation completed without errors. */
-  ok: Scalars['Boolean']['output'];
-};
-
-export type BankImportPreviewType = {
-  __typename?: 'BankImportPreviewType';
-  bankName: Scalars['String']['output'];
-  duplicateEntries: Scalars['Int']['output'];
-  entries: Array<BankImportPreviewEntryType>;
-  newEntries: Scalars['Int']['output'];
-  totalEntries: Scalars['Int']['output'];
-};
-
-export type BillCycleType = {
-  __typename?: 'BillCycleType';
-  dueDate: Scalars['String']['output'];
-  endDate: Scalars['String']['output'];
-  startDate: Scalars['String']['output'];
-  status: Scalars['String']['output'];
-};
-
-export type BillTransactionType = {
-  __typename?: 'BillTransactionType';
-  amount: Scalars['DecimalScalar']['output'];
-  dueDate?: Maybe<Scalars['String']['output']>;
-  id: Scalars['String']['output'];
-  status?: Maybe<Scalars['String']['output']>;
-  title: Scalars['String']['output'];
-  type?: Maybe<Scalars['String']['output']>;
 };
 
 /** An enumeration. */
@@ -310,47 +212,6 @@ export type CreateTransactionMutation = {
   message: Scalars['String']['output'];
 };
 
-export type CreditCardBillType = {
-  __typename?: 'CreditCardBillType';
-  cycle: BillCycleType;
-  paidAmount: Scalars['DecimalScalar']['output'];
-  pendingAmount: Scalars['DecimalScalar']['output'];
-  totalAmount: Scalars['DecimalScalar']['output'];
-  transactions?: Maybe<Array<Maybe<BillTransactionType>>>;
-};
-
-export type CreditCardListType = {
-  __typename?: 'CreditCardListType';
-  creditCards?: Maybe<Array<Maybe<CreditCardType>>>;
-  total?: Maybe<Scalars['Int']['output']>;
-};
-
-export type CreditCardType = {
-  __typename?: 'CreditCardType';
-  bank?: Maybe<Scalars['String']['output']>;
-  benefits?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  brand?: Maybe<Scalars['String']['output']>;
-  closingDay?: Maybe<Scalars['Int']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  description?: Maybe<Scalars['String']['output']>;
-  dueDay?: Maybe<Scalars['Int']['output']>;
-  id: Scalars['String']['output'];
-  lastFourDigits?: Maybe<Scalars['String']['output']>;
-  limitAmount?: Maybe<Scalars['DecimalScalar']['output']>;
-  name: Scalars['String']['output'];
-  updatedAt?: Maybe<Scalars['String']['output']>;
-  validityDate?: Maybe<Scalars['String']['output']>;
-};
-
-export type CreditCardUtilizationType = {
-  __typename?: 'CreditCardUtilizationType';
-  availableAmount?: Maybe<Scalars['DecimalScalar']['output']>;
-  committedAmount: Scalars['DecimalScalar']['output'];
-  cycle: BillCycleType;
-  limitAmount?: Maybe<Scalars['DecimalScalar']['output']>;
-  utilizationPct?: Maybe<Scalars['Float']['output']>;
-};
-
 export type DashboardCategoriesType = {
   __typename?: 'DashboardCategoriesType';
   expense: Array<Maybe<DashboardCategoryType>>;
@@ -430,53 +291,6 @@ export type DeleteWalletEntryMutation = {
   ok: Scalars['Boolean']['output'];
 };
 
-export type FiscalDocumentListType = {
-  __typename?: 'FiscalDocumentListType';
-  fiscalDocuments: Array<FiscalDocumentType>;
-  total: Scalars['Int']['output'];
-};
-
-export type FiscalDocumentPayload = {
-  __typename?: 'FiscalDocumentPayload';
-  data?: Maybe<FiscalDocumentType>;
-  /** Field-level validation errors (empty on success). */
-  errors: Array<ValidationError>;
-  /** Human-readable status message. */
-  message: Scalars['String']['output'];
-  /** True when the mutation completed without errors. */
-  ok: Scalars['Boolean']['output'];
-};
-
-export type FiscalDocumentType = {
-  __typename?: 'FiscalDocumentType';
-  counterparty: Scalars['String']['output'];
-  createdAt: Scalars['String']['output'];
-  currency: Scalars['String']['output'];
-  description?: Maybe<Scalars['String']['output']>;
-  externalId: Scalars['String']['output'];
-  grossAmount: Scalars['DecimalScalar']['output'];
-  id: Scalars['ID']['output'];
-  issuedAt: Scalars['String']['output'];
-  status: Scalars['String']['output'];
-  type: Scalars['String']['output'];
-};
-
-export type GenerateAiInsightPayload = {
-  __typename?: 'GenerateAiInsightPayload';
-  cached?: Maybe<Scalars['Boolean']['output']>;
-  contextVersion?: Maybe<Scalars['String']['output']>;
-  costUsd?: Maybe<Scalars['Float']['output']>;
-  items?: Maybe<Array<Maybe<AiInsightItemType>>>;
-  model?: Maybe<Scalars['String']['output']>;
-  ok: Scalars['Boolean']['output'];
-  periodEnd?: Maybe<Scalars['String']['output']>;
-  periodLabel?: Maybe<Scalars['String']['output']>;
-  periodStart?: Maybe<Scalars['String']['output']>;
-  periodType?: Maybe<Scalars['String']['output']>;
-  summary?: Maybe<Scalars['String']['output']>;
-  tokensUsed?: Maybe<Scalars['Int']['output']>;
-};
-
 export type GoalListPayloadType = {
   __typename?: 'GoalListPayloadType';
   items: Array<Maybe<GoalTypeObject>>;
@@ -526,17 +340,6 @@ export type GoalTypeObject = {
   targetDate?: Maybe<Scalars['String']['output']>;
   title: Scalars['String']['output'];
   updatedAt?: Maybe<Scalars['String']['output']>;
-};
-
-export type ImportedTransactionType = {
-  __typename?: 'ImportedTransactionType';
-  amount: Scalars['String']['output'];
-  bankName?: Maybe<Scalars['String']['output']>;
-  dueDate: Scalars['String']['output'];
-  externalId?: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
-  title: Scalars['String']['output'];
-  type: Scalars['String']['output'];
 };
 
 export type InstallmentVsCashAssumptionsType = {
@@ -730,34 +533,18 @@ export type Mutation = {
   addTicker?: Maybe<AddTickerPayload>;
   /** @deprecated ADR-0002: use POST /wallet */
   addWalletEntry?: Maybe<AddWalletEntryMutation>;
-  /** @deprecated ADR-0002: use DELETE /fiscal/receivables/{id} */
-  cancelReceivable?: Maybe<ReceivablePayload>;
   /** @deprecated ADR-0004: use POST /subscription/cancel */
   cancelSubscription?: Maybe<CancelSubscriptionMutation>;
-  /**
-   * Persist a subset of bank statement entries as transactions.
-   *
-   * ``mode`` controls how existing data is handled:
-   *
-   * - ``selective``: skip duplicates, import only new entries.
-   * - ``replace_month``: delete all existing bank-imported transactions for
-   *   the given month/bank before importing the selected set.
-   */
-  confirmBankImport?: Maybe<BankImportConfirmationPayload>;
   confirmEmail?: Maybe<AuthPayloadType>;
   createAccount?: Maybe<AccountPayload>;
   /** @deprecated ADR-0002: use POST /budgets */
   createBudget?: Maybe<CreateBudgetMutation>;
   /** @deprecated ADR-0004: use POST /subscription/checkout */
   createCheckoutSession?: Maybe<CreateCheckoutSessionMutation>;
-  /** @deprecated ADR-0002: use POST /fiscal/fiscal-documents */
-  createFiscalDocument?: Maybe<FiscalDocumentPayload>;
   /** @deprecated ADR-0002: use POST /goals */
   createGoal?: Maybe<CreateGoalMutation>;
   createGoalFromInstallmentVsCashSimulation?: Maybe<CreateGoalFromInstallmentVsCashSimulationMutation>;
   createPlannedExpenseFromInstallmentVsCashSimulation?: Maybe<CreatePlannedExpenseFromInstallmentVsCashSimulationMutation>;
-  /** @deprecated ADR-0002: use POST /fiscal/receivables */
-  createReceivable?: Maybe<ReceivablePayload>;
   createTag?: Maybe<TagPayload>;
   /** @deprecated ADR-0002: use POST /transactions */
   createTransaction?: Maybe<CreateTransactionMutation>;
@@ -775,25 +562,8 @@ export type Mutation = {
   /** @deprecated ADR-0002: use DELETE /wallet/{id} */
   deleteWalletEntry?: Maybe<DeleteWalletEntryMutation>;
   forgotPassword?: Maybe<AuthPayloadType>;
-  /**
-   * GraphQL parity for POST /ai/insights/generate.
-   *
-   * Reuses AIAdvisoryService — quota (2x/day Premium), entitlement gate and
-   * LGPD consent are enforced inside the service. GraphQL surface exposes the
-   * same payload shape so the frontend hub can render either path identically.
-   */
-  generateAiInsight?: Maybe<GenerateAiInsightPayload>;
   login?: Maybe<AuthPayloadType>;
   logout?: Maybe<LogoutMutation>;
-  /** @deprecated ADR-0002: use PATCH /fiscal/receivables/{id}/receive */
-  markReceivableReceived?: Maybe<ReceivablePayload>;
-  /**
-   * Parse a bank statement text and return a deduplication preview.
-   *
-   * The client submits the raw text content (CSV for Nubank, OFX for others)
-   * together with a bank identifier.  No data is written to the database.
-   */
-  previewBankStatement?: Maybe<BankImportPreviewPayload>;
   registerUser?: Maybe<AuthPayloadType>;
   resendConfirmationEmail?: Maybe<AuthPayloadType>;
   resetPassword?: Maybe<AuthPayloadType>;
@@ -851,19 +621,6 @@ export type MutationAddWalletEntryArgs = {
 };
 
 
-export type MutationCancelReceivableArgs = {
-  entryId: Scalars['UUID']['input'];
-};
-
-
-export type MutationConfirmBankImportArgs = {
-  bankName: Scalars['String']['input'];
-  mode: Scalars['String']['input'];
-  month: Scalars['String']['input'];
-  selectedEntries: Array<SelectedEntryInput>;
-};
-
-
 export type MutationConfirmEmailArgs = {
   token: Scalars['String']['input'];
 };
@@ -891,15 +648,6 @@ export type MutationCreateBudgetArgs = {
 export type MutationCreateCheckoutSessionArgs = {
   billingCycle?: InputMaybe<BillingCycle>;
   planSlug: Scalars['String']['input'];
-};
-
-
-export type MutationCreateFiscalDocumentArgs = {
-  amount: Scalars['String']['input'];
-  counterpartName?: InputMaybe<Scalars['String']['input']>;
-  externalId?: InputMaybe<Scalars['String']['input']>;
-  issuedAt: Scalars['String']['input'];
-  type: Scalars['String']['input'];
 };
 
 
@@ -944,14 +692,6 @@ export type MutationCreatePlannedExpenseFromInstallmentVsCashSimulationArgs = {
 };
 
 
-export type MutationCreateReceivableArgs = {
-  amount: Scalars['String']['input'];
-  category?: InputMaybe<Scalars['String']['input']>;
-  description: Scalars['String']['input'];
-  expectedDate: Scalars['String']['input'];
-};
-
-
 export type MutationCreateTagArgs = {
   color?: InputMaybe<Scalars['String']['input']>;
   icon?: InputMaybe<Scalars['String']['input']>;
@@ -962,7 +702,6 @@ export type MutationCreateTagArgs = {
 export type MutationCreateTransactionArgs = {
   accountId?: InputMaybe<Scalars['UUID']['input']>;
   amount: Scalars['String']['input'];
-  category?: InputMaybe<Scalars['String']['input']>;
   creditCardId?: InputMaybe<Scalars['UUID']['input']>;
   currency?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
@@ -1026,28 +765,9 @@ export type MutationForgotPasswordArgs = {
 };
 
 
-export type MutationGenerateAiInsightArgs = {
-  anchorDate?: InputMaybe<Scalars['String']['input']>;
-  periodType: Scalars['String']['input'];
-};
-
-
 export type MutationLoginArgs = {
   email: Scalars['String']['input'];
   password: Scalars['String']['input'];
-};
-
-
-export type MutationMarkReceivableReceivedArgs = {
-  entryId: Scalars['UUID']['input'];
-  receivedAmount?: InputMaybe<Scalars['String']['input']>;
-  receivedDate: Scalars['String']['input'];
-};
-
-
-export type MutationPreviewBankStatementArgs = {
-  bankName: Scalars['String']['input'];
-  content: Scalars['String']['input'];
 };
 
 
@@ -1162,7 +882,6 @@ export type MutationUpdateTagArgs = {
 export type MutationUpdateTransactionArgs = {
   accountId?: InputMaybe<Scalars['UUID']['input']>;
   amount?: InputMaybe<Scalars['String']['input']>;
-  category?: InputMaybe<Scalars['String']['input']>;
   creditCardId?: InputMaybe<Scalars['UUID']['input']>;
   currency?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
@@ -1307,16 +1026,11 @@ export type Query = {
   __typename?: 'Query';
   account?: Maybe<AccountType>;
   accounts?: Maybe<AccountListType>;
-  aiInsightHistory?: Maybe<AiInsightHistoryResultType>;
   billingPlans?: Maybe<BillingPlanListPayloadType>;
   budget?: Maybe<BudgetType>;
   budgetSummary?: Maybe<BudgetSummaryType>;
   budgets?: Maybe<BudgetListPayloadType>;
-  creditCardBill?: Maybe<CreditCardBillType>;
-  creditCardUtilization?: Maybe<CreditCardUtilizationType>;
-  creditCards?: Maybe<CreditCardListType>;
   dashboardOverview?: Maybe<TransactionDashboardPayloadType>;
-  fiscalDocuments?: Maybe<FiscalDocumentListType>;
   goal?: Maybe<GoalTypeObject>;
   goalPlan?: Maybe<GoalPlanType>;
   goals?: Maybe<GoalListPayloadType>;
@@ -1331,8 +1045,6 @@ export type Query = {
   notificationPreferences?: Maybe<NotificationPreferencesType>;
   portfolioValuation?: Maybe<PortfolioValuationPayloadType>;
   portfolioValuationHistory?: Maybe<PortfolioHistoryPayloadType>;
-  receivables?: Maybe<ReceivableListType>;
-  receivablesSummary?: Maybe<ReceivableSummaryType>;
   simulation?: Maybe<SimulationType>;
   simulations: SimulationListPayloadType;
   tag?: Maybe<TagType>;
@@ -1355,35 +1067,13 @@ export type QueryAccountArgs = {
 };
 
 
-export type QueryAiInsightHistoryArgs = {
-  page?: InputMaybe<Scalars['Int']['input']>;
-  perPage?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
 export type QueryBudgetArgs = {
   budgetId: Scalars['UUID']['input'];
 };
 
 
-export type QueryCreditCardBillArgs = {
-  cardId: Scalars['UUID']['input'];
-  month: Scalars['String']['input'];
-};
-
-
-export type QueryCreditCardUtilizationArgs = {
-  cardId: Scalars['UUID']['input'];
-};
-
-
 export type QueryDashboardOverviewArgs = {
   month: Scalars['String']['input'];
-};
-
-
-export type QueryFiscalDocumentsArgs = {
-  type?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1450,11 +1140,6 @@ export type QueryInvestmentValuationArgs = {
 export type QueryPortfolioValuationHistoryArgs = {
   finalDate?: InputMaybe<Scalars['String']['input']>;
   startDate?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type QueryReceivablesArgs = {
-  status?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1542,52 +1227,6 @@ export type QueryWeeklySummaryArgs = {
   startDate?: InputMaybe<Scalars['String']['input']>;
 };
 
-/**
- * IMPORTANT: expected_net_amount is advisory-only. Clients MUST display
- * the ``disclaimer`` field alongside any monetary value derived from it.
- */
-export type ReceivableEntryType = {
-  __typename?: 'ReceivableEntryType';
-  createdAt: Scalars['String']['output'];
-  disclaimer: Scalars['String']['output'];
-  expectedNetAmount?: Maybe<Scalars['DecimalScalar']['output']>;
-  fiscalDocumentId: Scalars['ID']['output'];
-  id: Scalars['ID']['output'];
-  outstandingAmount?: Maybe<Scalars['DecimalScalar']['output']>;
-  receivedAmount?: Maybe<Scalars['DecimalScalar']['output']>;
-  receivedAt?: Maybe<Scalars['String']['output']>;
-  reconciliationStatus: Scalars['String']['output'];
-};
-
-export type ReceivableListType = {
-  __typename?: 'ReceivableListType';
-  receivables: Array<ReceivableEntryType>;
-  total: Scalars['Int']['output'];
-};
-
-export type ReceivablePayload = {
-  __typename?: 'ReceivablePayload';
-  data?: Maybe<ReceivableEntryType>;
-  /** Field-level validation errors (empty on success). */
-  errors: Array<ValidationError>;
-  /** Human-readable status message. */
-  message: Scalars['String']['output'];
-  /** True when the mutation completed without errors. */
-  ok: Scalars['Boolean']['output'];
-};
-
-/**
- * IMPORTANT: all monetary values are advisory-only estimates.
- * Always display the ``disclaimer`` field.
- */
-export type ReceivableSummaryType = {
-  __typename?: 'ReceivableSummaryType';
-  disclaimer: Scalars['String']['output'];
-  expectedTotal: Scalars['String']['output'];
-  pendingTotal: Scalars['String']['output'];
-  receivedTotal: Scalars['String']['output'];
-};
-
 /** Revoke all active sessions — global logout (#1028). */
 export type RevokeAllSessionsMutation = {
   __typename?: 'RevokeAllSessionsMutation';
@@ -1607,15 +1246,6 @@ export type SaveInstallmentVsCashSimulationMutation = {
   calculation: InstallmentVsCashCalculationPayloadType;
   message: Scalars['String']['output'];
   simulation: InstallmentVsCashSimulationType;
-};
-
-export type SelectedEntryInput = {
-  amount: Scalars['String']['input'];
-  bankName: Scalars['String']['input'];
-  date: Scalars['String']['input'];
-  description: Scalars['String']['input'];
-  externalId: Scalars['String']['input'];
-  transactionType: Scalars['String']['input'];
 };
 
 export type SimulateGoalPlanMutation = {
@@ -1758,7 +1388,6 @@ export type TransactionTypeObject = {
   accountId?: Maybe<Scalars['String']['output']>;
   amount: Scalars['String']['output'];
   bankName?: Maybe<Scalars['String']['output']>;
-  category?: Maybe<Scalars['String']['output']>;
   createdAt?: Maybe<Scalars['String']['output']>;
   creditCardId?: Maybe<Scalars['String']['output']>;
   currency: Scalars['String']['output'];

--- a/app/stores/session.spec.ts
+++ b/app/stores/session.spec.ts
@@ -112,6 +112,61 @@ describe("session store (split-token, SEC-GAP-01)", () => {
 
       expect(store.isAuthenticated).toBe(true);
     });
+
+    it("mirrors legacy emailConfirmed onto the new emailVerified field", () => {
+      const store = useSessionStore();
+      store.signIn({
+        accessToken: "tok",
+        userEmail: "u@auraxis.com",
+        emailConfirmed: true,
+      });
+      expect(store.emailVerified).toBe(true);
+    });
+
+    it("prefers the v3 emailVerified param over the legacy emailConfirmed", () => {
+      const store = useSessionStore();
+      store.signIn({
+        accessToken: "tok",
+        userEmail: "u@auraxis.com",
+        emailConfirmed: false,
+        emailVerified: true,
+      });
+      expect(store.emailVerified).toBe(true);
+    });
+  });
+
+  // ─── hydrateEmailVerification (v3 /user/me block) ─────────────────────────
+
+  describe("hydrateEmailVerification", () => {
+    it("populates the v3 fields and mirrors them onto the legacy fields", () => {
+      const store = useSessionStore();
+      store.hydrateEmailVerification({
+        verified: false,
+        deadlineAt: "2026-06-04T12:00:00Z",
+        requiredNow: false,
+        daysRemaining: 7,
+      });
+      expect(store.emailVerified).toBe(false);
+      expect(store.emailVerificationDeadlineAt).toBe("2026-06-04T12:00:00Z");
+      expect(store.emailVerificationRequiredNow).toBe(false);
+      expect(store.daysUntilEmailRequired).toBe(7);
+      // Legacy mirrors stay in sync so existing components keep working.
+      expect(store.emailConfirmed).toBe(false);
+      expect(store.emailConfirmationDeadlineAt).toBe("2026-06-04T12:00:00Z");
+      expect(store.emailConfirmationBlocked).toBe(false);
+    });
+
+    it("flips the blocked mirror when requiredNow is true", () => {
+      const store = useSessionStore();
+      store.hydrateEmailVerification({
+        verified: false,
+        deadlineAt: "2026-05-20T10:00:00Z",
+        requiredNow: true,
+        daysRemaining: -2,
+      });
+      expect(store.emailConfirmationBlocked).toBe(true);
+      expect(store.emailVerificationRequiredNow).toBe(true);
+    });
   });
 
   // ─── signOut ──────────────────────────────────────────────────────────────
@@ -134,6 +189,11 @@ describe("session store (split-token, SEC-GAP-01)", () => {
       expect(store.emailConfirmed).toBeNull();
       expect(store.emailConfirmationDeadlineAt).toBeNull();
       expect(store.emailConfirmationBlocked).toBe(false);
+      // v3 fields should also be reset on signOut.
+      expect(store.emailVerified).toBe(false);
+      expect(store.emailVerificationDeadlineAt).toBeNull();
+      expect(store.emailVerificationRequiredNow).toBe(false);
+      expect(store.daysUntilEmailRequired).toBeNull();
     });
 
     it("marks isAuthenticated as false after sign-out", () => {

--- a/app/stores/session.ts
+++ b/app/stores/session.ts
@@ -6,6 +6,12 @@ interface SessionState {
   emailConfirmed: boolean | null;
   emailConfirmationDeadlineAt: string | null;
   emailConfirmationBlocked: boolean;
+  // v3 canonical email_verification block (mirrors /user/me v3 response).
+  // Coexists with the legacy fields above during the migration window.
+  emailVerified: boolean;
+  emailVerificationDeadlineAt: string | null;
+  emailVerificationRequiredNow: boolean;
+  daysUntilEmailRequired: number | null;
 }
 
 /** Parameters for the signIn action. */
@@ -20,12 +26,31 @@ export interface SignInParams {
   readonly emailConfirmationDeadlineAt?: string | null;
   /** True when the backend has blocked access until confirmation. */
   readonly emailConfirmationBlocked?: boolean;
+  /** v3 canonical: whether email_verified_at is set. */
+  readonly emailVerified?: boolean;
+  /** v3 canonical: ISO datetime of the grace-period deadline. */
+  readonly emailVerificationDeadlineAt?: string | null;
+  /** v3 canonical: true when grace period has expired without verification. */
+  readonly emailVerificationRequiredNow?: boolean;
+  /** v3 canonical: countdown in days (can be negative). */
+  readonly daysUntilEmailRequired?: number | null;
   /**
    * @deprecated Ignored since SEC-GAP-01. The refresh token is now managed as
    * an httpOnly cookie set server-side by POST /auth/login and
    * POST /auth/refresh — it is never accessible from JavaScript.
    */
   readonly refreshToken?: string | null;
+}
+
+/**
+ * Shape of the canonical v3 email_verification block returned by /user/me.
+ * Used by `hydrateEmailVerification()` to keep the store in sync.
+ */
+export interface EmailVerificationHydration {
+  readonly verified: boolean;
+  readonly deadlineAt: string | null;
+  readonly requiredNow: boolean;
+  readonly daysRemaining: number | null;
 }
 
 /**
@@ -56,6 +81,10 @@ export const useSessionStore = defineStore("session", {
     emailConfirmed: null,
     emailConfirmationDeadlineAt: null,
     emailConfirmationBlocked: false,
+    emailVerified: false,
+    emailVerificationDeadlineAt: null,
+    emailVerificationRequiredNow: false,
+    daysUntilEmailRequired: null,
   }),
   getters: {
     isAuthenticated: (state): boolean => state.accessToken !== null,
@@ -79,9 +108,36 @@ export const useSessionStore = defineStore("session", {
       this.emailConfirmed = params.emailConfirmed ?? null;
       this.emailConfirmationDeadlineAt = params.emailConfirmationDeadlineAt ?? null;
       this.emailConfirmationBlocked = params.emailConfirmationBlocked ?? false;
+      this.emailVerified = params.emailVerified ?? params.emailConfirmed ?? false;
+      this.emailVerificationDeadlineAt =
+        params.emailVerificationDeadlineAt
+        ?? params.emailConfirmationDeadlineAt
+        ?? null;
+      this.emailVerificationRequiredNow =
+        params.emailVerificationRequiredNow
+        ?? params.emailConfirmationBlocked
+        ?? false;
+      this.daysUntilEmailRequired = params.daysUntilEmailRequired ?? null;
       // SEC-GAP-01 migration: wipe the old non-httpOnly cookie so tokens are
       // no longer stored in JavaScript-readable browser storage.
       clearLegacyCookie();
+    },
+    /**
+     * Hydrates the email_verification fields from the canonical /user/me v3
+     * response block. Called after any successful /user/me fetch (initial
+     * bootstrap, periodic refresh, post-confirmation refetch).
+     *
+     * @param block Canonical v3 email_verification block from /user/me.
+     */
+    hydrateEmailVerification(block: EmailVerificationHydration): void {
+      this.emailVerified = block.verified;
+      this.emailVerificationDeadlineAt = block.deadlineAt;
+      this.emailVerificationRequiredNow = block.requiredNow;
+      this.daysUntilEmailRequired = block.daysRemaining;
+      // Keep legacy mirrors in sync for components that still read them.
+      this.emailConfirmed = block.verified;
+      this.emailConfirmationDeadlineAt = block.deadlineAt;
+      this.emailConfirmationBlocked = block.requiredNow;
     },
     /**
      * Updates the in-memory access token after a successful /auth/refresh
@@ -99,6 +155,10 @@ export const useSessionStore = defineStore("session", {
       this.emailConfirmed = null;
       this.emailConfirmationDeadlineAt = null;
       this.emailConfirmationBlocked = false;
+      this.emailVerified = false;
+      this.emailVerificationDeadlineAt = null;
+      this.emailVerificationRequiredNow = false;
+      this.daysUntilEmailRequired = null;
       clearLegacyCookie();
     },
   },


### PR DESCRIPTION
## Summary

Frontend gate para o **soft-block de email verification** entregue pela Fase 1 backend (auraxis-api PRs #1326, #1328, #1330, #1332, #1335). Implementa:

1. **Countdown banner** — 3 estados visuais conforme `daysUntilEmailRequired` (info / urgent / expired)
2. **Modal de gate** — abre automaticamente quando qualquer mutation retorna `403 EMAIL_VERIFICATION_REQUIRED` do backend
3. **Interceptor HTTP** — detecta o 403 com body canônico e delega para handler dedicado
4. **Session store v3** — 4 novos campos (`emailVerified`, `emailVerificationDeadlineAt`, `emailVerificationRequiredNow`, `daysUntilEmailRequired`) hidratados do `/user/me`

Closes italofelipe/auraxis-web#914

## Test plan

- [x] `pnpm quality-check` verde local antes do push (regra firmada — lint + typecheck + test:coverage + policy + contracts + codegen + build)
- [x] Coverage ≥ 85% mantida
- [x] Pre-commit + pre-push hooks verdes
- [ ] CI verde

### Smoke E2E manual recomendado pós-merge

1. Login com conta nova → `EmailConfirmationBanner` info-mode aparece (info azul, "Faltam 14 dias")
2. Simular grace ≤7d via DB (`UPDATE users SET created_at = NOW() - INTERVAL '8 days'`) → banner urgent (laranja)
3. Simular grace expirado (`INTERVAL '15 days'`) → banner expired (vermelho) + tentar criar transação → modal `EmailVerificationGate` abre
4. Click "Reenviar e-mail" → toast success
5. Confirmar email pelo link real → click "Já confirmei, atualizar" → backend reporta verified=true → modal fecha

## Out of scope

- Middleware Nuxt route guard (modal já cobre — opcional na DoR original)
- Mobile (auraxis-app) — Fase 3 separada pós-TestFlight
- E2E Playwright spec dedicado (mantém só vitest unit/integration)
- Light/dark variants no banner (segue tokens v3 globais)

## Files changed

| Arquivo | Mudança |
|---|---|
| `app/stores/session.ts` (+60) | 4 fields v3 + hydrate action + signOut reset |
| `app/components/auth/EmailConfirmationBanner/*.vue` (+74) | 3 estados (info/urgent/expired) com data-variant |
| `app/features/auth/components/EmailVerificationGate.vue` (+200, novo) | Modal não-dismissable com resend + refresh CTAs |
| `app/features/auth/composables/use-email-verification-gate.ts` (+45, novo) | Pinia store global do gate |
| `app/core/api/types.ts` (+31) | `EmailVerificationRequiredBody` + `onEmailVerificationRequired` callback |
| `app/core/api/interceptors.ts` (+106) | Detecção do body canônico + refactor em helpers para complexity |
| `app/composables/useHttp/useHttp.ts` (+13) | Wire-up: passa callback do gate + mirror local no store |
| `app/layouts/default.vue` (+2) | Monta `<EmailVerificationGate />` |
| `app/layouts/default.spec.ts` (+1) | Stub no globalStubs |
| `app/i18n/locales/pt.json` (+23) | Keys novas em `auth.emailBanner.*` + `auth.emailGate.*` (en.json **não** modificado) |
| `app/shared/types/generated/graphql.ts` | Regen do schema do auraxis-api #1332 (drift bloqueava codegen:check; não relacionado ao gate) |
| `tests/*.spec.ts` (+241 cumulativo) | Cobertura para banner / composable / interceptor / store |