### PR TITLE
[WEB] /confirm-email magic-link login (layout auth + sign-in transparente)

### DIFF
--- a/app/features/auth/queries/use-confirm-email-mutation.spec.ts
+++ b/app/features/auth/queries/use-confirm-email-mutation.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { useConfirmEmailMutation } from "./use-confirm-email-mutation";
+import type { ConfirmEmailResult } from "~/features/auth/services/auth-email.client";
 
 const createApiMutationMock = vi.hoisted(() => vi.fn());
 
@@ -8,11 +9,27 @@ vi.mock("~/core/query/use-api-mutation", () => ({
   createApiMutation: createApiMutationMock,
 }));
 
+const sampleResult: ConfirmEmailResult = {
+  token: "jwt-abc.payload.sig",
+  user: {
+    identity: { id: "u-1", name: "Smoke", email: "smoke@auraxis.com.br" },
+    email_verification: {
+      verified: true,
+      deadline_at: null,
+      required_now: false,
+      days_remaining: null,
+    },
+  },
+};
+
 describe("useConfirmEmailMutation", () => {
   it("registers a mutation with the api mutation factory", () => {
-    const client = { confirmEmail: vi.fn().mockResolvedValue(undefined) };
+    const client = { confirmEmail: vi.fn().mockResolvedValue(sampleResult) };
     createApiMutationMock.mockImplementation(
-      (fn: (token: string) => Promise<undefined>, opts: unknown) => ({ fn, opts }),
+      (fn: (token: string) => Promise<ConfirmEmailResult>, opts: unknown) => ({
+        fn,
+        opts,
+      }),
     );
 
     useConfirmEmailMutation(client as never);
@@ -21,13 +38,15 @@ describe("useConfirmEmailMutation", () => {
   });
 
   it("calls client.confirmEmail with the provided token", async () => {
-    const client = { confirmEmail: vi.fn().mockResolvedValue(undefined) };
+    const client = { confirmEmail: vi.fn().mockResolvedValue(sampleResult) };
     createApiMutationMock.mockImplementation(
-      (fn: (token: string) => Promise<undefined>) => ({ mutationFn: fn }),
+      (fn: (token: string) => Promise<ConfirmEmailResult>) => ({
+        mutationFn: fn,
+      }),
     );
 
     const mutation = useConfirmEmailMutation(client as never) as unknown as {
-      mutationFn: (token: string) => Promise<undefined>;
+      mutationFn: (token: string) => Promise<ConfirmEmailResult>;
     };
 
     await mutation.mutationFn("abc123");
@@ -35,19 +54,23 @@ describe("useConfirmEmailMutation", () => {
     expect(client.confirmEmail).toHaveBeenCalledWith("abc123");
   });
 
-  it("returns undefined on success", async () => {
-    const client = { confirmEmail: vi.fn().mockResolvedValue(undefined) };
+  it("returns the token + user payload on success (magic-link login)", async () => {
+    const client = { confirmEmail: vi.fn().mockResolvedValue(sampleResult) };
     createApiMutationMock.mockImplementation(
-      (fn: (token: string) => Promise<undefined>) => ({ mutationFn: fn }),
+      (fn: (token: string) => Promise<ConfirmEmailResult>) => ({
+        mutationFn: fn,
+      }),
     );
 
     const mutation = useConfirmEmailMutation(client as never) as unknown as {
-      mutationFn: (token: string) => Promise<undefined>;
+      mutationFn: (token: string) => Promise<ConfirmEmailResult>;
     };
 
     const result = await mutation.mutationFn("token-xyz");
 
-    expect(result).toBeUndefined();
+    expect(result).toEqual(sampleResult);
+    expect(result.token).toBe("jwt-abc.payload.sig");
+    expect(result.user.email_verification.verified).toBe(true);
   });
 
   it("propagates error from client.confirmEmail", async () => {
@@ -55,20 +78,24 @@ describe("useConfirmEmailMutation", () => {
       confirmEmail: vi.fn().mockRejectedValue(new Error("invalid token")),
     };
     createApiMutationMock.mockImplementation(
-      (fn: (token: string) => Promise<undefined>) => ({ mutationFn: fn }),
+      (fn: (token: string) => Promise<ConfirmEmailResult>) => ({
+        mutationFn: fn,
+      }),
     );
 
     const mutation = useConfirmEmailMutation(client as never) as unknown as {
-      mutationFn: (token: string) => Promise<undefined>;
+      mutationFn: (token: string) => Promise<ConfirmEmailResult>;
     };
 
     await expect(mutation.mutationFn("bad-token")).rejects.toThrow("invalid token");
   });
 
   it("passes invalidates option to the factory with subscription key", () => {
-    const client = { confirmEmail: vi.fn().mockResolvedValue(undefined) };
+    const client = { confirmEmail: vi.fn().mockResolvedValue(sampleResult) };
     createApiMutationMock.mockImplementation(
-      (_fn: unknown, opts: { invalidates: readonly (readonly string[])[] }) => ({ opts }),
+      (_fn: unknown, opts: { invalidates: readonly (readonly string[])[] }) => ({
+        opts,
+      }),
     );
 
     const mutation = useConfirmEmailMutation(client as never) as unknown as {

--- a/app/features/auth/queries/use-confirm-email-mutation.ts
+++ b/app/features/auth/queries/use-confirm-email-mutation.ts
@@ -3,24 +3,31 @@ import type { ApiError } from "~/core/errors";
 import { createApiMutation } from "~/core/query/use-api-mutation";
 import {
   type AuthEmailClient,
+  type ConfirmEmailResult,
   useAuthEmailClient,
 } from "~/features/auth/services/auth-email.client";
 
 /**
- * Vue Query mutation hook for confirming an email address.
+ * Vue Query mutation for confirming an email address (magic-link login).
  *
- * Accepts the confirmation token from the URL and sends it to the backend.
- * On success, invalidates the session so the UI reflects the confirmed state.
+ * Sends the HMAC token from the URL to the backend; on success the backend
+ * (a) marks the email as verified, (b) emits a fresh access JWT, and (c) sets
+ * a refresh cookie. The mutation returns `{ token, user }` so the caller can
+ * hydrate the session store and route the user into the app without ever
+ * showing a login form (#1338).
+ *
+ * Invalidates the subscription query because the verified flag participates
+ * in plan-level gating elsewhere in the UI.
  *
  * @param providedClient Optional injected client for unit tests.
- * @returns Vue Query mutation state: `mutate`, `isPending`, `isError`, etc.
+ * @returns Vue Query mutation state: `mutate`, `isPending`, `data`, etc.
  */
 export const useConfirmEmailMutation = (
   providedClient?: AuthEmailClient,
-): UseMutationReturnType<undefined, ApiError, string, unknown> => {
+): UseMutationReturnType<ConfirmEmailResult, ApiError, string, unknown> => {
   const client = providedClient ?? useAuthEmailClient();
-  return createApiMutation<undefined, string>(
-    async (token) => { await client.confirmEmail(token); return undefined; },
+  return createApiMutation<ConfirmEmailResult, string>(
+    async (token) => client.confirmEmail(token),
     {
       invalidates: [["subscription", "me"]],
     },

--- a/app/features/auth/services/__tests__/auth-email.client.spec.ts
+++ b/app/features/auth/services/__tests__/auth-email.client.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AxiosInstance } from "axios";
+
+import { ApiError } from "~/core/errors";
 import { AuthEmailClient } from "../auth-email.client";
 
 const mockHttp = {
@@ -7,26 +9,96 @@ const mockHttp = {
   post: vi.fn(),
 } as unknown as AxiosInstance;
 
-describe("AuthEmailClient", () => {
-  const client = new AuthEmailClient(mockHttp);
+const mockAnonymous = {
+  get: vi.fn(),
+  post: vi.fn(),
+} as unknown as AxiosInstance;
 
-  it("calls POST /auth/email/confirm with the token in the JSON body", async () => {
-    vi.mocked(mockHttp.post).mockResolvedValueOnce({ data: { success: true } });
-    await client.confirmEmail("abc123");
-    expect(mockHttp.post).toHaveBeenCalledWith("/auth/email/confirm", {
-      token: "abc123",
+describe("AuthEmailClient", () => {
+  const client = new AuthEmailClient(mockHttp, mockAnonymous);
+
+  it("calls POST /auth/email/confirm via the anonymous client", async () => {
+    vi.mocked(mockAnonymous.post).mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: "ok",
+        data: {
+          token: "jwt-abc.payload.sig",
+          user: {
+            identity: { id: "u-1", name: "Smoke", email: "u@a.com" },
+            email_verification: {
+              verified: true,
+              deadline_at: null,
+              required_now: false,
+              days_remaining: null,
+            },
+          },
+        },
+      },
     });
+
+    const result = await client.confirmEmail("abc123");
+
+    expect(mockAnonymous.post).toHaveBeenCalledWith(
+      "/auth/email/confirm",
+      { token: "abc123" },
+      expect.objectContaining({
+        headers: expect.objectContaining({ "X-API-Contract": "v2" }),
+        withCredentials: true,
+      }),
+    );
+    expect(result.token).toBe("jwt-abc.payload.sig");
+    expect(result.user.identity.email).toBe("u@a.com");
   });
 
-  it("calls POST /auth/email/resend", async () => {
-    vi.mocked(mockHttp.post).mockResolvedValueOnce({ data: { success: true } });
+  it("does NOT use the authenticated http client for confirmEmail", async () => {
+    vi.mocked(mockAnonymous.post).mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: "ok",
+        data: {
+          token: "t",
+          user: {
+            identity: { id: "u", name: "n", email: "e" },
+            email_verification: {
+              verified: true,
+              deadline_at: null,
+              required_now: false,
+              days_remaining: null,
+            },
+          },
+        },
+      },
+    });
+
+    await client.confirmEmail("abc");
+
+    expect(mockHttp.post).not.toHaveBeenCalled();
+  });
+
+  it("throws ApiError when the envelope is missing token or user", async () => {
+    vi.mocked(mockAnonymous.post).mockResolvedValueOnce({
+      data: { success: true, message: "ok", data: {} },
+    });
+
+    await expect(client.confirmEmail("abc")).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("propagates errors from the anonymous client", async () => {
+    vi.mocked(mockAnonymous.post).mockRejectedValueOnce(
+      new Error("Network error"),
+    );
+    await expect(client.confirmEmail("bad-token")).rejects.toThrow(
+      "Network error",
+    );
+  });
+
+  it("calls POST /auth/email/resend via the authenticated http client", async () => {
+    vi.mocked(mockHttp.post).mockResolvedValueOnce({
+      data: { success: true },
+    });
     await client.resendConfirmation();
     expect(mockHttp.post).toHaveBeenCalledWith("/auth/email/resend");
-  });
-
-  it("propagates errors from confirmEmail", async () => {
-    vi.mocked(mockHttp.post).mockRejectedValueOnce(new Error("Network error"));
-    await expect(client.confirmEmail("bad-token")).rejects.toThrow("Network error");
   });
 
   it("propagates errors from resendConfirmation", async () => {

--- a/app/features/auth/services/auth-email.client.ts
+++ b/app/features/auth/services/auth-email.client.ts
@@ -1,8 +1,13 @@
-import type { AxiosInstance } from "axios";
+import axios, { type AxiosInstance } from "axios";
+
+import { ApiError } from "~/core/errors";
 import { useHttp } from "~/composables/useHttp";
 
+const DEFAULT_API_BASE = "http://localhost:5000";
+
 /**
- * Backend envelope for email-related auth operations.
+ * Backend envelope for email-related auth operations that do NOT issue a
+ * session (e.g. resend confirmation).
  */
 interface AuthEmailResponse {
   readonly success: boolean;
@@ -10,29 +15,102 @@ interface AuthEmailResponse {
 }
 
 /**
+ * Canonical v3 user payload returned by /user/me and by the magic-link
+ * confirmation endpoint. Mirrored from
+ * `auraxis-api/app/services/authenticated_user_payloads.py`.
+ */
+export interface ConfirmEmailUserPayload {
+  readonly identity: {
+    readonly id: string;
+    readonly name: string;
+    readonly email: string;
+  };
+  readonly email_verification: {
+    readonly verified: boolean;
+    readonly deadline_at: string | null;
+    readonly required_now: boolean;
+    readonly days_remaining: number | null;
+  };
+  // Other v3 blocks (profile, financial_profile, etc.) are present but
+  // unused by the confirm-email login flow; the dashboard will refetch
+  // them from /user/me as needed.
+}
+
+/**
+ * Backend envelope for /auth/email/confirm — magic-link login response.
+ *
+ * Mirrors `auraxis-api/app/controllers/auth/confirm_email_resource.py`. When
+ * the HMAC token is valid, the backend mints an access JWT + sets a refresh
+ * cookie, so the frontend can sign the user in transparently (#1338).
+ */
+interface ConfirmEmailEnvelope {
+  readonly success: boolean;
+  readonly message: string;
+  readonly data: {
+    readonly token: string;
+    readonly user: ConfirmEmailUserPayload;
+    readonly refresh_token?: string | null;
+  };
+}
+
+/**
+ * Normalised confirmation result consumed by the page + session store.
+ *
+ * Decoupled from the backend wire shape so the page never sees the snake_case
+ * keys directly.
+ */
+export interface ConfirmEmailResult {
+  readonly token: string;
+  readonly user: ConfirmEmailUserPayload;
+}
+
+/**
  * API client for email-confirmation auth flows.
  *
- * Handles token-based email confirmation and resend-confirmation requests.
+ * The `confirmEmail` call uses an anonymous Axios instance (no Bearer header,
+ * no shared interceptors) because the HMAC token in the URL is the credential
+ * — leaking a stale or expired session JWT into that request would (a) be
+ * pointless and (b) cause the global `Sessão expirada` modal to hijack the UI
+ * during a flow that is supposed to be authentication-agnostic.
  */
 export class AuthEmailClient {
   readonly #http: AxiosInstance;
+  readonly #anonymous: AxiosInstance;
 
   /**
-   * @param http Axios instance already configured for the Auraxis API.
+   * @param http Axios instance already configured for the Auraxis API
+   *   (Bearer + interceptors). Used by `resendConfirmation`.
+   * @param anonymous Axios instance with no Bearer / no interceptors.
+   *   Used by `confirmEmail` so the magic-link flow stays untouched by the
+   *   global session error handling.
    */
-  constructor(http: AxiosInstance) {
+  constructor(http: AxiosInstance, anonymous: AxiosInstance) {
     this.#http = http;
+    this.#anonymous = anonymous;
   }
 
   /**
-   * Confirms the user's email address using the one-time token sent by email.
+   * Confirms the user's email and (when the token is valid) opens a session.
    *
    * Backend: POST /auth/email/confirm — expects `{ token }` as JSON body.
+   * Returns the access JWT + canonical user payload; the refresh cookie is
+   * set server-side via `Set-Cookie` (httpOnly).
    *
    * @param token Confirmation token extracted from the URL query param.
+   * @returns Access token + canonical user payload for `signIn()`.
+   * @throws ApiError when the token is missing, expired or invalid.
    */
-  async confirmEmail(token: string): Promise<void> {
-    await this.#http.post<AuthEmailResponse>("/auth/email/confirm", { token });
+  async confirmEmail(token: string): Promise<ConfirmEmailResult> {
+    const response = await this.#anonymous.post<ConfirmEmailEnvelope>(
+      "/auth/email/confirm",
+      { token },
+      { headers: { "X-API-Contract": "v2" }, withCredentials: true },
+    );
+    const data = response.data?.data;
+    if (data?.token === undefined || data?.user === undefined) {
+      throw new ApiError(500, "Resposta inválida do servidor.");
+    }
+    return { token: data.token, user: data.user };
   }
 
   /**
@@ -46,9 +124,25 @@ export class AuthEmailClient {
 }
 
 /**
- * Resolves the canonical auth-email client using the shared HTTP layer.
+ * Builds the anonymous Axios instance used by `confirmEmail`.
  *
- * @returns AuthEmailClient instance bound to the application HTTP adapter.
+ * Reads the API base URL from the Nuxt runtime config so the client points at
+ * the right backend in every environment.
+ *
+ * @returns Axios instance scoped to the Auraxis API base URL, with no
+ *   interceptors and no Bearer header injection.
+ */
+const buildAnonymousClient = (): AxiosInstance => {
+  const runtimeConfig = useRuntimeConfig();
+  const apiBase = String(runtimeConfig.public.apiBase ?? DEFAULT_API_BASE);
+  return axios.create({ baseURL: apiBase, withCredentials: true });
+};
+
+/**
+ * Resolves the canonical auth-email client using the shared HTTP layer for
+ * authenticated calls and a fresh anonymous client for `confirmEmail`.
+ *
+ * @returns AuthEmailClient instance.
  */
 export const useAuthEmailClient = (): AuthEmailClient =>
-  new AuthEmailClient(useHttp());
+  new AuthEmailClient(useHttp(), buildAnonymousClient());

--- a/app/pages/confirm-email.vue
+++ b/app/pages/confirm-email.vue
@@ -1,27 +1,88 @@
 <script setup lang="ts">
+/**
+ * Magic-link login page (#1338).
+ *
+ * Mounted on `/confirm-email?token=HMAC`. Sends the HMAC token to the
+ * backend; on success the backend mints an access JWT + refresh cookie and
+ * we sign the user in transparently. Failure cases (expired/invalid token)
+ * render an error state with a "resend" CTA — no automatic redirect.
+ *
+ * Page meta:
+ * - `layout: 'auth'` — no sidebar, no default-layout colateral queries that
+ *   could trigger the global Sessão expirada modal.
+ * - `middleware: []` — must be accessible without an existing session, since
+ *   the click can come from a device where the user is not logged in.
+ */
 import { CheckCircle2, XCircle } from "lucide-vue-next";
 import { NButton, NSpin } from "naive-ui";
+import { computed, onMounted } from "vue";
+
 import { useConfirmEmailMutation } from "~/features/auth/queries/use-confirm-email-mutation";
+import type { ConfirmEmailResult } from "~/features/auth/services/auth-email.client";
+import { useSessionStore } from "~/stores/session";
+
+definePageMeta({
+  layout: "auth",
+  // Public route: must work regardless of whether the user already has a
+  // session. Existing sessions are gracefully replaced by the magic-link.
+  middleware: [],
+});
 
 const { t } = useI18n();
 const route = useRoute();
+const router = useRouter();
+const sessionStore = useSessionStore();
 
 useSeoMeta({
   title: t("pages.confirmEmail.meta.title"),
   description: t("pages.confirmEmail.meta.description"),
+  robots: "noindex, nofollow",
 });
 
 const mutation = useConfirmEmailMutation();
 
 const token = computed(() => {
   const raw = route.query.token;
-  return typeof raw === "string" ? raw : null;
+  return typeof raw === "string" && raw.length > 0 ? raw : null;
 });
 
-// Auto-confirm on mount if a token is present in the URL.
-onMounted(() => {
-  if (token.value) {
-    mutation.mutate(token.value);
+/**
+ * Hydrates the session store with the canonical v3 user from the response
+ * and triggers the soft redirect into the app.
+ *
+ * @param result Response payload from `useConfirmEmailMutation`.
+ */
+const completeSignIn = (result: ConfirmEmailResult): void => {
+  const verification = result.user.email_verification;
+  sessionStore.signIn({
+    accessToken: result.token,
+    userEmail: result.user.identity.email,
+    emailVerified: verification.verified,
+    emailVerificationDeadlineAt: verification.deadline_at,
+    emailVerificationRequiredNow: verification.required_now,
+    daysUntilEmailRequired: verification.days_remaining,
+    // Legacy mirrors keep older components in sync until v3 migration is done.
+    emailConfirmed: verification.verified,
+    emailConfirmationDeadlineAt: verification.deadline_at,
+    emailConfirmationBlocked: verification.required_now,
+  });
+};
+
+onMounted(async () => {
+  if (!token.value) {
+    return;
+  }
+  try {
+    const result = await mutation.mutateAsync(token.value);
+    completeSignIn(result);
+    // Tiny micro-celebration before bouncing into the app. 800ms is enough
+    // for the user to register that something happened ("Email confirmado!")
+    // without feeling like a delay.
+    setTimeout(() => {
+      void router.push("/dashboard");
+    }, 800);
+  } catch {
+    // mutation.isError flips automatically; UI below renders the error state.
   }
 });
 
@@ -43,27 +104,24 @@ const status = computed((): "idle" | "pending" | "success" | "error" => {
         <p>{{ $t('pages.confirmEmail.wait') }}</p>
       </template>
 
-      <!-- Success -->
+      <!-- Success (800ms before auto-redirect) -->
       <template v-else-if="status === 'success'">
         <CheckCircle2 class="confirm-email__icon confirm-email__icon--success" :size="64" />
         <h1>{{ $t('pages.confirmEmail.successTitle') }}</h1>
         <p>{{ $t('pages.confirmEmail.successDescription') }}</p>
-        <NButton type="primary" tag="a" href="/dashboard">
-          {{ $t('pages.confirmEmail.cta') }}
-        </NButton>
       </template>
 
-      <!-- Error -->
+      <!-- Error: expired / invalid / reused token -->
       <template v-else-if="status === 'error'">
         <XCircle class="confirm-email__icon confirm-email__icon--error" :size="64" />
         <h1>{{ $t('pages.confirmEmail.errorTitle') }}</h1>
         <p>{{ $t('pages.confirmEmail.errorDescription') }}</p>
-        <NButton type="default" tag="a" href="/resend-confirmation">
+        <NButton type="primary" tag="a" href="/resend-confirmation">
           {{ $t('pages.confirmEmail.resendCta') }}
         </NButton>
       </template>
 
-      <!-- No token -->
+      <!-- No token in URL -->
       <template v-else>
         <XCircle class="confirm-email__icon confirm-email__icon--muted" :size="64" />
         <h1>{{ $t('pages.confirmEmail.noTokenTitle') }}</h1>


### PR DESCRIPTION
## Summary

Smoke E2E em prod 2026-05-21 mostrou usuários logados sendo cuspidos pra `/login` ao clicar no link de confirmação — modal "Sessão expirada" hijack hostile no fluxo. Italo + Claude debateram (2026-05-21) e aprovaram: o token HMAC do email **é credencial** → o `/confirm-email` vira passwordless login (padrão magic-link).

Spec completa: `auraxis-platform/.context/feature_specs/email-confirm-passwordless-login.md`
Backend complementar: italofelipe/auraxis-api#1339

Closes #916

## Changes

### Page (`app/pages/confirm-email.vue`)
- `definePageMeta({ layout: 'auth', middleware: [] })` — fora do layout default (sem sidebar) e sem authenticated guard
- Auto-confirma o token no mount; ao sucesso, hidrata `sessionStore.signIn()` com o canonical v3 + JWT
- **Micro-celebração 800ms** (ícone verde) antes do `router.push('/dashboard')` automático
- Erro (token expirado/inválido/reusado) renderiza estado com CTA "Reenviar link"

### Client (`app/features/auth/services/auth-email.client.ts`)
- `confirmEmail()` usa um **Axios anônimo** (sem Bearer, sem interceptores) — fluxo magic-link nunca é interceptado pelo handler global de 401. Root cause do "Sessão expirada" do smoke.
- `resendConfirmation()` segue usando `useHttp` (precisa JWT)
- Novo `type ConfirmEmailResult` / `ConfirmEmailUserPayload`

### Mutation (`app/features/auth/queries/use-confirm-email-mutation.ts`)
- Retorna `ConfirmEmailResult` (não mais `undefined`)

### Tests
- `auth-email.client.spec.ts`: confirmEmail usa anonymous client; NÃO toca o http autenticado; ApiError em envelope inválido (6 cenários)
- `use-confirm-email-mutation.spec.ts`: response shape + propagação

## Test plan

- [x] `pnpm quality-check` verde local (lint + typecheck + vitest + policy + contracts + codegen + build)
- [x] Pre-commit + pre-push hooks verdes
- [ ] CI verde
- [ ] Smoke E2E pós-deploy:
  - Cadastra conta nova → recebe email → click → /confirm-email
  - Esperado: ícone verde 800ms → /dashboard sem login form
  - Sem modal "Sessão expirada" em nenhum ponto

## Acceptance criteria

- [x] Click com sessão válida: confirma + atualiza sessão + dashboard
- [x] Click sem sessão: confirma + cria sessão automática + dashboard
- [x] Token expirado/inválido: estado de erro + CTA reenvio, **sem** redirect
- [x] Sem modal "Sessão expirada" no fluxo (cliente anônimo)
- [x] Layout sem sidebar (`auth.vue`)

## Out of scope

- Mobile (auraxis-app) — leva separada
- Flag `auth_method` no JWT (pode vir depois)