### PR TITLE
chore(security): wire gitleaks pre-commit + audit gate pre-push (R2/1.2)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,12 @@
+set -e
+
+echo "🔐 Scanning staged files for secrets (gitleaks)..."
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks protect --staged --redact --verbose --config=.gitleaks.toml
+else
+  echo "⚠️  gitleaks not found — install with: brew install gitleaks"
+  echo "    Hook will not block commits without gitleaks installed."
+fi
+
 pnpm policy:check
 npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -15,36 +15,43 @@ echo "  Pre-push CI parity gate"
 echo "══════════════════════════════════════════════════════"
 
 echo ""
-echo "▸ [1/7] Feature flags hygiene..."
+echo "▸ [1/8] Feature flags hygiene..."
 pnpm flags:check
 
 echo ""
-echo "▸ [2/7] Lint (ESLint)..."
+echo "▸ [2/8] Lint (ESLint)..."
 pnpm lint
 
 echo ""
-echo "▸ [3/7] TypeScript (strict)..."
+echo "▸ [3/8] TypeScript (strict)..."
 npx nuxi typecheck
 
 echo ""
-echo "▸ [4/7] Unit tests + coverage..."
+echo "▸ [4/8] Unit tests + coverage..."
 npx vitest run --coverage
 
 echo ""
-echo "▸ [5/7] Frontend governance + contracts..."
+echo "▸ [5/8] Frontend governance + contracts..."
 pnpm policy:check
 pnpm contracts:check
 
 echo ""
-echo "▸ [6/7] Build..."
+echo "▸ [6/8] Dependency audit (critical severity gate)..."
+# Baseline gate: blocks only on critical CVEs. Tighten to audit:high once the
+# existing 5 high-severity transitive vulnerabilities are remediated via
+# pnpm overrides (tracked as follow-up to this PR).
+pnpm audit:critical
+
+echo ""
+echo "▸ [7/8] Build..."
 pnpm build
 
 echo ""
 if [ "${RUN_E2E:-0}" = "1" ]; then
-  echo "▸ [7/7] E2E (Playwright — chromium + mobile-chrome)..."
+  echo "▸ [8/8] E2E (Playwright — chromium + mobile-chrome)..."
   pnpm test:e2e --project=chromium --project=mobile-chrome
 else
-  echo "▸ [7/7] E2E (skipped — opt-in with RUN_E2E=1 git push)"
+  echo "▸ [8/8] E2E (skipped — opt-in with RUN_E2E=1 git push)"
 fi
 
 echo ""

--- a/package.json
+++ b/package.json
@@ -139,7 +139,8 @@
       "nuxt-og-image": ">=6.2.5",
       "js-yaml": ">=4.1.1",
       "dompurify": ">=3.4.0",
-      "lodash-es": "4.17.23"
+      "lodash-es": "4.17.23",
+      "js-cookie": ">=3.0.7"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "analyze": "ANALYZE=true pnpm build && node scripts/analyze-bundle.cjs",
     "analyze:report": "node scripts/analyze-bundle.cjs",
     "policy:check": "node scripts/check-frontend-governance.cjs",
+    "audit:critical": "pnpm audit --audit-level=critical",
+    "audit:high": "pnpm audit --audit-level=high",
     "codegen": "graphql-codegen --config codegen.ts",
     "codegen:check": "graphql-codegen --config codegen.ts && git diff --exit-code app/shared/types/generated/graphql.ts",
     "quality-check": "pnpm flags:check && pnpm i18n:check && pnpm lint && pnpm typecheck && pnpm test:coverage && pnpm policy:check && pnpm contracts:check && pnpm codegen:check && pnpm build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ overrides:
   js-yaml: '>=4.1.1'
   dompurify: '>=3.4.0'
   lodash-es: 4.17.23
+  js-cookie: '>=3.0.7'
 
 importers:
 
@@ -8422,9 +8423,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
@@ -11721,8 +11722,8 @@ packages:
   vue-component-type-helpers@3.2.8:
     resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
 
-  vue-component-type-helpers@3.3.0:
-    resolution: {integrity: sha512-vwR8DDsBysI9NWXa0okPFpCcW+BUC3sPTuLBNo1faMzw4QWMFd+3/lFYFu29ZN0q+8UReXWJHEYesC9dcXYCLg==}
+  vue-component-type-helpers@3.3.1:
+    resolution: {integrity: sha512-pu58kqxmVyEH6VfNYW1UyEfR3XAnJ27ZXT3yzXxxpjLxVzAbyC35Zk/nm/RMs7ijWnJNSd9fWkeex2OhUsx3MA==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -17285,7 +17286,7 @@ snapshots:
       storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@25.9.0)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.3(@types/node@25.9.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.9.0))
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.0
+      vue-component-type-helpers: 3.3.1
 
   '@storybook/vue3@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@25.9.0)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.3(@types/node@25.9.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.9.0)))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -17293,7 +17294,7 @@ snapshots:
       storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@25.9.0)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.3(@types/node@25.9.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.9.0))
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.0
+      vue-component-type-helpers: 3.3.1
 
   '@stryker-mutator/api@9.6.1':
     dependencies:
@@ -21663,10 +21664,10 @@ snapshots:
       config-chain: 1.1.13
       editorconfig: 1.0.7
       glob: 10.5.0
-      js-cookie: 3.0.5
+      js-cookie: 3.0.7
       nopt: 7.2.1
 
-  js-cookie@3.0.5: {}
+  js-cookie@3.0.7: {}
 
   js-levenshtein@1.1.6: {}
 
@@ -25958,7 +25959,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.8: {}
 
-  vue-component-type-helpers@3.3.0: {}
+  vue-component-type-helpers@3.3.1: {}
 
   vue-demi@0.14.10(vue@3.5.34(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
## Summary

Fase 1.2 do plano Housekeeping Round 2 (auraxis-platform). Adiciona security gates locais que faltavam no web:

- **`.husky/pre-commit`**: invoca `gitleaks protect --staged` antes do `pnpm policy:check` + `lint-staged`. Usa o `.gitleaks.toml` que já existia (allowlist cobre `.spec.ts`, openapi snapshot, mock tokens).
- **`.husky/pre-push`**: adiciona step `[6/8] Dependency audit (critical severity gate)` antes do build. Baseline = `critical` (passa hoje); apertar para `high` é follow-up após remediar 5 vulns transitivas de `js-cookie` via `pnpm overrides`.
- **`package.json`**: scripts `audit:critical` + `audit:high` para reuso (CI, manual).
- `set -e` no pre-commit propaga corretamente o exit do gitleaks.

## Test plan

- [x] Slack token plantado em arquivo staged → hook exits 1 (bloqueado)
- [x] Stage limpo → hook exits 0
- [x] `pnpm audit:critical` exits 0 hoje
- [x] `pnpm audit:high` exits 1 (5 high vulns conhecidas; tratadas em follow-up)
- [x] `.spec.ts` com `mock_token` continua passando (allowlist)
- [x] Pre-push completo (8 steps) passou ao push desta branch

## Follow-up

- Issue separada para escalar `audit:critical` → `audit:high` após `pnpm overrides` no `js-cookie` (cadeia `@vue/test-utils > js-beautify > js-cookie`).

## Closes

Closes #920