### PR TITLE
feat(scripts): lighthouse:budget + bundle:budget local convenience (R2/2.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "policy:check": "node scripts/check-frontend-governance.cjs",
     "audit:critical": "pnpm audit --audit-level=critical",
     "audit:high": "pnpm audit --audit-level=high",
+    "bundle:budget": "ANALYZE=true pnpm build && node scripts/analyze-bundle.cjs",
+    "lighthouse:budget": "pnpm dlx @lhci/cli@0.15.x autorun --config=.lighthouserc.yml",
     "codegen": "graphql-codegen --config codegen.ts",
     "codegen:check": "graphql-codegen --config codegen.ts && git diff --exit-code app/shared/types/generated/graphql.ts",
     "quality-check": "pnpm flags:check && pnpm i18n:check && pnpm lint && pnpm typecheck && pnpm test:coverage && pnpm policy:check && pnpm contracts:check && pnpm codegen:check && pnpm build",


### PR DESCRIPTION
## Summary

Fase 2.3 do plano Housekeeping Round 2. Auditoria inicial assumiu que web não tinha lighthouse/bundle budgets enforced — **estava errado**:

- **Bundle**: `.github/workflows/ci.yml > bundle-analysis` job já roda \`node scripts/analyze-bundle.cjs\` com **hard limits 3MB total JS / 400KB largest chunk**
- **Lighthouse**: `.lighthouserc.yml` já configura 3-run avg com **Performance ≥ 90, A11y ≥ 95, Best Practices ≥ 90, SEO ≥ 90** (`error` severity — bloqueia PR). LCP/TBT/CLS warn-level já presentes.

O que faltava era **convenience local** — devs hoje precisam saber rodar `pnpm dlx @lhci/cli autorun` ou `ANALYZE=true pnpm build && node scripts/analyze-bundle.cjs`.

## Mudanças

Apenas adiciona 2 npm scripts em `package.json`:

- `pnpm bundle:budget` → `ANALYZE=true pnpm build && node scripts/analyze-bundle.cjs`
- `pnpm lighthouse:budget` → `pnpm dlx @lhci/cli@0.15.x autorun --config=.lighthouserc.yml`

Sem novos deps. `pnpm dlx` cacheia o lhci/cli localmente.

## Integração

Estes scripts são **consumidos pelo platform `make ship-deep`** (Fase 2.1 já preparado — `ship-deep-local.sh` detecta via grep no package.json).

## Test plan

- [x] `pnpm bundle:budget` produz mesmo report que CI bundle-analysis job
- [x] `pnpm lighthouse:budget` consulta `.lighthouserc.yml` correto

## Closes

Closes #925