### PR TITLE
feat(sentry): env-aware tracesSampleRate + dev setup guidance (R2/3.1a)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,18 @@
 NUXT_PUBLIC_API_BASE=http://localhost:5000
 
 # Sentry — error tracking (opt-in: deixe em branco para desabilitar)
+#
+# Para DEV LOCAL: crie um Sentry project SEPARADO ("auraxis-web-dev") e use
+# o DSN dele aqui. Em desenvolvimento o sampling sobe para 1.0 (captura
+# tudo) — não use o DSN de produção para não poluir o quota nem confundir
+# alertas reais com bugs locais.
+#
+# Setup:
+#   1. https://sentry.io → New Project → Vue → "auraxis-web-dev"
+#   2. Copie o DSN público (formato: https://<key>@<orgid>.ingest.sentry.io/<projid>)
+#   3. Cole em NUXT_PUBLIC_SENTRY_DSN abaixo
+#   4. Rode `pnpm dev`, force um erro (window.crash()), confirme que aparece
+#      no Sentry project dev
 NUXT_PUBLIC_SENTRY_DSN=
 SENTRY_AUTH_TOKEN=
 NUXT_PUBLIC_APP_ENV=development

--- a/__tests__/plugins/sentry.client.spec.ts
+++ b/__tests__/plugins/sentry.client.spec.ts
@@ -67,6 +67,46 @@ describe("initSentry", () => {
   });
 });
 
+describe("tracesSampleRateFor", () => {
+  it("retorna 1.0 em development para capturar todos os erros locais", async () => {
+    const { tracesSampleRateFor } = await import("../../app/plugins/sentry.client");
+    expect(tracesSampleRateFor("development")).toBe(1.0);
+  });
+
+  it("retorna 0.5 em staging ou preview", async () => {
+    const { tracesSampleRateFor } = await import("../../app/plugins/sentry.client");
+    expect(tracesSampleRateFor("staging")).toBe(0.5);
+    expect(tracesSampleRateFor("preview")).toBe(0.5);
+  });
+
+  it("retorna 0.1 em production (default para qualquer env desconhecido)", async () => {
+    const { tracesSampleRateFor } = await import("../../app/plugins/sentry.client");
+    expect(tracesSampleRateFor("production")).toBe(0.1);
+    expect(tracesSampleRateFor("unknown")).toBe(0.1);
+  });
+});
+
+describe("initSentry com tracesSampleRate env-aware", () => {
+  beforeEach(() => {
+    mockSentryInit.mockClear();
+    vi.resetModules();
+  });
+
+  it("usa 1.0 em development", async () => {
+    const { initSentry } = await import("../../app/plugins/sentry.client");
+    initSentry("https://x@sentry.io/1", "development");
+    const args = mockSentryInit.mock.calls[0]![0] as Record<string, unknown>;
+    expect(args.tracesSampleRate).toBe(1.0);
+  });
+
+  it("usa 0.5 em staging", async () => {
+    const { initSentry } = await import("../../app/plugins/sentry.client");
+    initSentry("https://x@sentry.io/1", "staging");
+    const args = mockSentryInit.mock.calls[0]![0] as Record<string, unknown>;
+    expect(args.tracesSampleRate).toBe(0.5);
+  });
+});
+
 describe("scrubPiiFromEvent — request body redaction", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/app/plugins/sentry.client.ts
+++ b/app/plugins/sentry.client.ts
@@ -150,6 +150,28 @@ export function scrubPiiFromEvent(event: ErrorEvent, _hint: EventHint): ErrorEve
 }
 
 /**
+ * Picks the right `tracesSampleRate` for the active environment.
+ *
+ * - **development**: 1.0 — capture everything so local errors don't get lost
+ *   in sampling. Use a separate dev DSN to keep prod quotas clean.
+ * - **staging / preview**: 0.5 — enough to debug pre-prod bugs without
+ *   flooding the project quota.
+ * - **production**: 0.1 — sampling that scales to real user traffic.
+ *
+ * @param environment - Active environment name.
+ * @returns Sample rate in [0, 1].
+ */
+export function tracesSampleRateFor(environment: string): number {
+  if (environment === "development") {
+    return 1.0;
+  }
+  if (environment === "staging" || environment === "preview") {
+    return 0.5;
+  }
+  return 0.1;
+}
+
+/**
  * Initializes Sentry with the DSN and environment.
  * Exported separately to simplify unit testing.
  *
@@ -161,7 +183,7 @@ export function initSentry(dsn: string, environment: string): void {
     dsn,
     environment,
     enabled: true,
-    tracesSampleRate: 0.1,
+    tracesSampleRate: tracesSampleRateFor(environment),
     sendDefaultPii: false,
     beforeSend: scrubPiiFromEvent,
   });


### PR DESCRIPTION
## Summary

Fase 3.1a (parte web) do plano Housekeeping Round 2. Sentry no web já é robusto (PII scrubbing, opt-in via DSN). Faltava:

1. **tracesSampleRate env-aware** — 1.0 em dev (capturar tudo), 0.5 em staging, 0.1 em prod
2. **`.env.example`** com setup explícito de project Sentry separado para dev

Nova função pura `tracesSampleRateFor(env)` testável. `initSentry` delega.

## Test plan

- [x] 17/17 sentry tests passam (3 novos para `tracesSampleRateFor` + 2 para `initSentry` env-aware)
- [x] DSN vazio continua mantendo plugin inerte (opt-in preservado)

## Out of scope

- Api side: issue separada no auraxis-api (Codex está numa feature backend agora)
- App side: PR sibling no auraxis-app

## Closes

Closes #927