### PR TITLE
feat(observability): structured logger + x-request-id propagation (R2/3.2a)

### DIFF
--- a/__tests__/core/observability/logger.spec.ts
+++ b/__tests__/core/observability/logger.spec.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createLogger, logger } from "~/core/observability/logger";
+
+describe("logger — structured output", () => {
+  const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    consoleLogSpy.mockClear();
+    consoleErrorSpy.mockClear();
+    process.env.NODE_ENV = "production"; // JSON output for assertions
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = "test"; // Restore between specs
+  });
+
+  it("emits a single-line JSON entry in production mode", () => {
+    logger.info("auth.login.attempt", { user_id: "abc" });
+
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+    const raw = consoleLogSpy.mock.calls[0]![0] as string;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    expect(parsed.level).toBe("info");
+    expect(parsed.msg).toBe("auth.login.attempt");
+    expect(parsed.user_id).toBe("abc");
+    expect(typeof parsed.ts).toBe("string");
+  });
+
+  it("routes warn/error to console.error, debug/info to console.log", () => {
+    logger.debug("debug");
+    logger.info("info");
+    logger.warn("warn");
+    logger.error("error");
+
+    expect(consoleLogSpy).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not include request_id when none is set", () => {
+    logger.info("no-correlation");
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0]![0] as string) as Record<string, unknown>;
+    expect(parsed.request_id).toBeUndefined();
+  });
+
+  it("withRequestId returns a child logger that emits the correlation id", () => {
+    const correlated = logger.withRequestId("req-abc-123");
+    correlated.info("with-id");
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0]![0] as string) as Record<string, unknown>;
+    expect(parsed.request_id).toBe("req-abc-123");
+  });
+
+  it("withRequestId ignores empty / whitespace ids", () => {
+    const a = logger.withRequestId("");
+    const b = logger.withRequestId("   ");
+    const c = logger.withRequestId(undefined);
+
+    a.info("empty");
+    b.info("ws");
+    c.info("undef");
+
+    const allParsed = consoleLogSpy.mock.calls.map(
+      (c) => JSON.parse(c[0] as string) as Record<string, unknown>,
+    );
+    expect(allParsed.every((p) => p.request_id === undefined)).toBe(true);
+  });
+
+  it("createLogger bakes baseline context into every entry", () => {
+    const scoped = createLogger({ feature: "wallet" });
+    scoped.info("opened");
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0]![0] as string) as Record<string, unknown>;
+    expect(parsed.feature).toBe("wallet");
+    expect(parsed.msg).toBe("opened");
+  });
+
+  it("does not throw when console itself throws", () => {
+    consoleLogSpy.mockImplementationOnce(() => {
+      throw new Error("console exploded");
+    });
+    expect(() => logger.info("safe")).not.toThrow();
+  });
+});
+
+describe("logger — pretty mode (dev)", () => {
+  const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    consoleLogSpy.mockClear();
+    process.env.NODE_ENV = "development";
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = "test";
+  });
+
+  it("uses pretty output when NODE_ENV !== production", () => {
+    logger.info("hello", { ctx: 1 });
+    const raw = consoleLogSpy.mock.calls[0]![0] as string;
+    // Pretty form: "[level] msg {ctx}" — not parseable as JSON object
+    expect(raw.startsWith("[info]")).toBe(true);
+    expect(raw).toContain("hello");
+    expect(raw).toContain("\"ctx\":1");
+  });
+
+  it("pretty mode includes request_id prefix when present", () => {
+    const correlated = logger.withRequestId("abcdef1234567890");
+    correlated.info("with-id");
+    const raw = consoleLogSpy.mock.calls[0]![0] as string;
+    // Short prefix (first 8 chars) shown in brackets
+    expect(raw).toContain("[abcdef12]");
+  });
+});

--- a/__tests__/core/observability/request-id-context.spec.ts
+++ b/__tests__/core/observability/request-id-context.spec.ts
@@ -1,0 +1,87 @@
+import type { AxiosResponse } from "axios";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  captureRequestIdInterceptor,
+  currentRequestId,
+  resetRequestIdForTests,
+  setRequestId,
+} from "~/core/observability/request-id-context";
+
+/**
+ * Build a minimal AxiosResponse for tests.
+ *
+ * @param headers Headers object to use in the response.
+ * @returns Constructed AxiosResponse.
+ */
+const makeResponse = (headers: Record<string, unknown>): AxiosResponse => ({
+  data: {},
+  status: 200,
+  statusText: "OK",
+  headers,
+  config: {} as AxiosResponse["config"],
+});
+
+describe("request-id context", () => {
+  beforeEach(() => {
+    resetRequestIdForTests();
+  });
+
+  afterEach(() => {
+    resetRequestIdForTests();
+  });
+
+  it("starts with no captured id", () => {
+    expect(currentRequestId()).toBeUndefined();
+  });
+
+  it("setRequestId stores a valid id", () => {
+    setRequestId("req-abc-123");
+    expect(currentRequestId()).toBe("req-abc-123");
+  });
+
+  it("setRequestId ignores empty / whitespace / undefined", () => {
+    setRequestId("");
+    expect(currentRequestId()).toBeUndefined();
+    setRequestId("   ");
+    expect(currentRequestId()).toBeUndefined();
+    setRequestId(undefined);
+    expect(currentRequestId()).toBeUndefined();
+  });
+});
+
+describe("captureRequestIdInterceptor", () => {
+  beforeEach(() => resetRequestIdForTests());
+  afterEach(() => resetRequestIdForTests());
+
+  it("captures x-request-id from response headers", () => {
+    const response = makeResponse({ "x-request-id": "req-xyz-789" });
+    const returned = captureRequestIdInterceptor(response);
+    expect(returned).toBe(response);
+    expect(currentRequestId()).toBe("req-xyz-789");
+  });
+
+  it("does not capture when x-request-id is missing", () => {
+    const response = makeResponse({ "content-type": "application/json" });
+    captureRequestIdInterceptor(response);
+    expect(currentRequestId()).toBeUndefined();
+  });
+
+  it("ignores non-string x-request-id values defensively", () => {
+    const response = makeResponse({ "x-request-id": 42 });
+    captureRequestIdInterceptor(response);
+    expect(currentRequestId()).toBeUndefined();
+  });
+
+  it("does not throw when headers is missing", () => {
+    const response = {
+      data: {},
+      status: 200,
+      statusText: "OK",
+      headers: undefined,
+      config: {} as AxiosResponse["config"],
+    } as unknown as AxiosResponse;
+    expect(() => captureRequestIdInterceptor(response)).not.toThrow();
+    expect(currentRequestId()).toBeUndefined();
+  });
+});

--- a/app/composables/useHttp/useHttp.spec.ts
+++ b/app/composables/useHttp/useHttp.spec.ts
@@ -93,8 +93,8 @@ describe("useHttp helpers", () => {
       }
     ).handlers;
 
-    // axios-retry registers its own response interceptor — expect 1 (retry only)
-    expect(responseHandlers.filter(Boolean)).toHaveLength(1);
+    // captureRequestIdInterceptor (1) + axios-retry (1) = 2
+    expect(responseHandlers.filter(Boolean)).toHaveLength(2);
   });
 
   it("registra interceptor de resposta quando interceptorOptions é fornecido", () => {
@@ -113,8 +113,8 @@ describe("useHttp helpers", () => {
       }
     ).handlers;
 
-    // axios-retry (1) + registerResponseInterceptors (1) = 2
-    expect(responseHandlers.filter(Boolean)).toHaveLength(2);
+    // captureRequestIdInterceptor (1) + axios-retry (1) + registerResponseInterceptors (1) = 3
+    expect(responseHandlers.filter(Boolean)).toHaveLength(3);
   });
 });
 

--- a/app/core/http/http-client.ts
+++ b/app/core/http/http-client.ts
@@ -5,6 +5,7 @@ import axios, {
 
 import { registerResponseInterceptors } from "~/core/api/interceptors";
 import type { ResponseInterceptorOptions } from "~/core/api/types";
+import { captureRequestIdInterceptor } from "~/core/observability/request-id-context";
 import { axiosRetry, DEFAULT_RETRY_CONFIG } from "./retry-config";
 
 /**
@@ -75,6 +76,7 @@ export const createHttpClient = (
   });
 
   client.interceptors.request.use(createAuthInterceptor(getAccessToken));
+  client.interceptors.response.use(captureRequestIdInterceptor);
   axiosRetry(client, DEFAULT_RETRY_CONFIG);
 
   if (interceptorOptions !== undefined) {

--- a/app/core/observability/logger.ts
+++ b/app/core/observability/logger.ts
@@ -1,0 +1,186 @@
+/* eslint-disable no-console -- this is THE observability module; routing
+ * log levels to console is its entire purpose. Business code must not use
+ * console.* directly — use this logger. */
+
+/**
+ * Structured JSON logger with request_id correlation.
+ *
+ * Pairs with the future `x-request-id` header propagated by `auraxis-api`'s
+ * RequestIDMiddleware — once the api side echoes the header in every
+ * response, the http interceptor will feed it into `logger.withRequestId(id)`
+ * so every client-side log can be correlated with the corresponding
+ * backend request.
+ *
+ * Until the api side lands, `withRequestId` accepts any string and the
+ * logger output gracefully includes `request_id: undefined` when no id is
+ * set. Logging is JSON in production (consumed by CloudFront / log
+ * forwarder) and pretty-printed in dev.
+ *
+ * Usage:
+ *   import { logger } from "~/core/observability/logger";
+ *   logger.info("auth.login.attempt", { email_hash: "..." });
+ *   const reqLogger = logger.withRequestId(response.headers["x-request-id"]);
+ *   reqLogger.error("payment.failed", { code: "CARD_DECLINED" });
+ *
+ * Tests cover all branches in __tests__/core/observability/logger.spec.ts.
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface LogContext {
+  [key: string]: unknown;
+}
+
+export interface LogEntry extends LogContext {
+  ts: string;
+  level: LogLevel;
+  msg: string;
+  request_id?: string;
+}
+
+export interface Logger {
+  debug(msg: string, ctx?: LogContext): void;
+  info(msg: string, ctx?: LogContext): void;
+  warn(msg: string, ctx?: LogContext): void;
+  error(msg: string, ctx?: LogContext): void;
+  /**
+   * Returns a child logger that includes `request_id` in every emitted entry.
+   * Empty / whitespace-only ids are ignored (returns a plain child clone).
+   *
+   * @param requestId Candidate correlation id.
+   * @returns Child logger.
+   */
+  withRequestId(requestId: string | undefined): Logger;
+}
+
+/**
+ * Returns true in non-production environments. Affects output formatting:
+ * dev prints pretty (level + msg + JSON ctx), prod prints single-line JSON.
+ *
+ * @returns Whether the active env is non-production.
+ */
+const isDevEnv = (): boolean => {
+  return (
+    typeof process !== "undefined" &&
+    process.env.NODE_ENV !== "production"
+  );
+};
+
+/**
+ * Formats a log entry for human consumption (used in dev only).
+ *
+ * @param entry Structured log entry.
+ * @returns Pretty-printed line.
+ */
+const formatPretty = (entry: LogEntry): string => {
+  const reqIdSuffix = entry.request_id ? ` [${entry.request_id.slice(0, 8)}]` : "";
+  const ctxEntries = Object.entries(entry).filter(
+    ([key]) => !["ts", "level", "msg", "request_id"].includes(key),
+  );
+  const ctxSerialized = ctxEntries.length > 0
+    ? " " + JSON.stringify(Object.fromEntries(ctxEntries))
+    : "";
+  return `[${entry.level}]${reqIdSuffix} ${entry.msg}${ctxSerialized}`;
+};
+
+/**
+ * Writes a log entry. JSON in prod, pretty in dev. Never throws — logging
+ * failures must not break business code.
+ *
+ * @param entry Structured log entry.
+ */
+const writeEntry = (entry: LogEntry): void => {
+  try {
+    const output = isDevEnv() ? formatPretty(entry) : JSON.stringify(entry);
+    const fn = entry.level === "error" || entry.level === "warn"
+      ? console.error.bind(console)
+      : console.log.bind(console);
+    fn(output);
+  } catch {
+    /* observability must never throw */
+  }
+};
+
+/**
+ * Internal logger factory — bakes a baseline context (e.g., request_id) into
+ * every emitted entry. Exposed via {@link createLogger}.
+ *
+ * @param baseCtx Context merged into every log entry.
+ * @returns Logger instance.
+ */
+const buildLogger = (baseCtx: LogContext): Logger => {
+  /**
+   * Emit a structured log entry merging the baseline context with the
+   * per-call context.
+   *
+   * @param level Log level.
+   * @param msg Message.
+   * @param ctx Optional per-call context.
+   */
+  const emit = (level: LogLevel, msg: string, ctx?: LogContext): void => {
+    const entry: LogEntry = {
+      ts: new Date().toISOString(),
+      level,
+      msg,
+      ...baseCtx,
+      ...(ctx ?? {}),
+    };
+    writeEntry(entry);
+  };
+
+  /**
+   * Type guard for non-empty request_id strings.
+   *
+   * @param id Candidate id.
+   * @returns Whether the id is usable.
+   */
+  const isUsableRequestId = (id: string | undefined): id is string => {
+    return typeof id === "string" && id.trim().length > 0;
+  };
+
+  return {
+    debug(msg: string, ctx?: LogContext): void {
+      emit("debug", msg, ctx);
+    },
+    info(msg: string, ctx?: LogContext): void {
+      emit("info", msg, ctx);
+    },
+    warn(msg: string, ctx?: LogContext): void {
+      emit("warn", msg, ctx);
+    },
+    error(msg: string, ctx?: LogContext): void {
+      emit("error", msg, ctx);
+    },
+    withRequestId(requestId: string | undefined): Logger {
+      if (!isUsableRequestId(requestId)) {
+        return buildLogger({ ...baseCtx });
+      }
+      return buildLogger({ ...baseCtx, request_id: requestId });
+    },
+  };
+};
+
+/**
+ * Creates a new logger with an optional baseline context.
+ * Each call returns an independent instance — useful for scoping by feature.
+ *
+ * @param baseCtx Optional context merged into every log entry.
+ * @returns Logger instance.
+ */
+export const createLogger = (baseCtx: LogContext = {}): Logger => {
+  return buildLogger(baseCtx);
+};
+
+/**
+ * Default singleton logger. Most call sites should use this.
+ * Use {@link createLogger} only when scoping by feature is meaningful.
+ */
+export const logger: Logger = createLogger();
+
+/**
+ * Test helpers — exposed for unit tests, not for production use.
+ */
+export const __internals = {
+  formatPretty,
+  isDevEnv,
+};

--- a/app/core/observability/request-id-context.ts
+++ b/app/core/observability/request-id-context.ts
@@ -1,0 +1,69 @@
+/**
+ * Request-ID propagation context.
+ *
+ * Stores the most recent `x-request-id` returned by `auraxis-api` so that
+ * subsequent client-side logs can be correlated with the corresponding
+ * backend request. Maintained as a module-level singleton — there is only
+ * one client per runtime (see app/core/http/CLAUDE.md) so sharing is safe.
+ *
+ * The api side of this propagation (RequestIDMiddleware echoing the id in
+ * every response) is the responsibility of `auraxis-api`. Until that lands,
+ * `currentRequestId()` returns undefined and the logger gracefully omits
+ * the field.
+ */
+
+import type { AxiosResponse } from "axios";
+
+let _currentRequestId: string | undefined;
+
+/**
+ * Returns the most recently captured request_id, or undefined.
+ *
+ * @returns Current request_id or undefined.
+ */
+export const currentRequestId = (): string | undefined => {
+  return _currentRequestId;
+};
+
+/**
+ * Sets the active request_id. Empty / whitespace-only ids are ignored.
+ *
+ * @param id Candidate request_id (typically from `x-request-id` header).
+ */
+export const setRequestId = (id: string | undefined): void => {
+  if (typeof id !== "string" || id.trim().length === 0) {
+    return;
+  }
+  _currentRequestId = id;
+};
+
+/**
+ * Test utility — resets the captured id between tests.
+ */
+export const resetRequestIdForTests = (): void => {
+  _currentRequestId = undefined;
+};
+
+/**
+ * Axios response interceptor that captures the `x-request-id` header and
+ * makes it available via {@link currentRequestId}. Re-exports the response
+ * unchanged.
+ *
+ * Register on the HTTP client to enable propagation:
+ *   client.interceptors.response.use(captureRequestIdInterceptor);
+ *
+ * @param response Axios response.
+ * @returns The same response (unchanged).
+ */
+export const captureRequestIdInterceptor = (
+  response: AxiosResponse,
+): AxiosResponse => {
+  const headers = response.headers;
+  if (headers && typeof headers === "object") {
+    const id = (headers as Record<string, unknown>)["x-request-id"];
+    if (typeof id === "string") {
+      setRequestId(id);
+    }
+  }
+  return response;
+};


### PR DESCRIPTION
## Summary

Fase 3.2a (parte web) do plano Housekeeping Round 2.

### Mudanças

- **`app/core/observability/logger.ts`** (NOVO): Logger com `debug/info/warn/error` + `withRequestId(id)`. JSON em prod, pretty em dev. Graceful on console throws.
- **`app/core/observability/request-id-context.ts`** (NOVO): module-level singleton (\`currentRequestId\`/\`setRequestId\`/\`resetRequestIdForTests\`) + Axios response interceptor (\`captureRequestIdInterceptor\`).
- **`app/core/http/http-client.ts`**: registra \`captureRequestIdInterceptor\` no client canônico.
- 16 specs cobrindo todos os branches.

## Como funciona

Quando api side de Fase 3.2 fizer `RequestIDMiddleware` echo do header `x-request-id` em toda response, o interceptor já vai capturar automaticamente. Features podem então:

```ts
import { logger } from "~/core/observability/logger";
import { currentRequestId } from "~/core/observability/request-id-context";

logger.withRequestId(currentRequestId()).info("auth.login.attempt", {
  email_hash: hashOf(email),
});
```

E todos os logs do client ficarão correlacionados com a request do backend.

## Test plan

- [x] Logger emite JSON em prod, pretty em dev (16/16 specs)
- [x] `withRequestId` ignora empty/whitespace ids
- [x] Interceptor captura header válido, ignora ausente / não-string
- [x] Não throw quando console explode
- [x] Lint clean

## Out of scope

- Api side: `RequestIDMiddleware` echo do header (Codex está na api agora)
- App side: PR sibling no auraxis-app

## Closes

Closes #929