### PR TITLE
feat(ai-insights): forecast panel, feedback UI, monthly limits & viewed-month (#958)

### DIFF
--- a/app/features/ai-insights/api/ai-insights-api.spec.ts
+++ b/app/features/ai-insights/api/ai-insights-api.spec.ts
@@ -199,3 +199,104 @@ describe("AIInsightsApiClient", () => {
     expect(http.get).toHaveBeenCalledWith("/me/consents");
   });
 });
+
+describe("AIInsightsApiClient — forecast metadata & feedback", () => {
+  it("parses the monthly remaining-calls header and the forecast flag", async () => {
+    const http = {
+      post: vi.fn().mockResolvedValue({
+        data: {
+          data: {
+            id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            summary: "Previsão de junho",
+            items: [],
+            period_type: "monthly",
+            period_label: "2026-06",
+            period_start: "2026-06-01",
+            period_end: "2026-06-30",
+            tokens_used: 120,
+            cost_usd: 0.00002,
+            model: "gpt-4o",
+            cached: false,
+            forecast: true,
+          },
+        },
+        headers: {
+          "x-ai-calls-remaining": "0",
+          "x-ai-calls-remaining-month": "27",
+        },
+      }),
+    };
+    const client = new AIInsightsApiClient(http as never);
+
+    const result = await client.generateInsight({
+      periodType: "monthly",
+      anchorDate: "2026-06-01",
+    });
+
+    expect(result.callsRemaining).toBe(0);
+    expect(result.callsRemainingMonth).toBe(27);
+    expect(result.forecast).toBe(true);
+    expect(result.id).toBe("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+  });
+
+  it("defaults monthly remaining calls to null when the header is absent", async () => {
+    const http = {
+      post: vi.fn().mockResolvedValue({
+        data: {
+          data: {
+            summary: "Resumo",
+            items: [],
+            period_type: "daily",
+            period_label: "2026-05-18",
+            period_start: "2026-05-18",
+            period_end: "2026-05-18",
+            tokens_used: 80,
+            cost_usd: 0.00001,
+            model: "gpt-4o",
+            cached: false,
+          },
+        },
+        headers: { "x-ai-calls-remaining": "0" },
+      }),
+    };
+    const client = new AIInsightsApiClient(http as never);
+
+    const result = await client.generateInsight({ periodType: "daily" });
+
+    expect(result.callsRemainingMonth).toBeNull();
+  });
+
+  it("submits insight feedback to the per-insight endpoint", async () => {
+    const feedback = {
+      relevance: 5,
+      truthfulness: 4,
+      depth: 3,
+      usefulness: 5,
+      comment: "Muito útil.",
+    };
+    const http = {
+      post: vi.fn().mockResolvedValue({
+        data: {
+          data: {
+            id: "fb-1",
+            insight_id: "ins-1",
+            relevance: 5,
+            truthfulness: 4,
+            depth: 3,
+            usefulness: 5,
+            comment: "Muito útil.",
+            created_at: "2026-05-31T12:00:00Z",
+            updated_at: "2026-05-31T12:00:00Z",
+          },
+        },
+      }),
+    };
+    const client = new AIInsightsApiClient(http as never);
+
+    const result = await client.submitInsightFeedback("ins-1", feedback);
+
+    expect(http.post).toHaveBeenCalledWith("/ai/insights/ins-1/feedback", feedback);
+    expect(result.id).toBe("fb-1");
+    expect(result.insight_id).toBe("ins-1");
+  });
+});

--- a/app/features/ai-insights/api/ai-insights-api.ts
+++ b/app/features/ai-insights/api/ai-insights-api.ts
@@ -6,8 +6,10 @@ import type {
   GenerateInsightRequestDTO,
   GenerateInsightResponseDTO,
   GenerateInsightResponseWithMetaDTO,
+  InsightFeedbackDTO,
   InsightPeriodType,
   InsightSourceSurface,
+  SubmitInsightFeedbackRequestDTO,
   V2EnvelopeDTO,
 } from "~/features/ai-insights/contracts/ai-insight";
 
@@ -117,7 +119,30 @@ export class AIInsightsApiClient {
     return {
       ...data,
       callsRemaining: parseCallsRemaining(response.headers["x-ai-calls-remaining"]),
+      callsRemainingMonth: parseCallsRemaining(
+        response.headers["x-ai-calls-remaining-month"],
+      ),
     };
+  }
+
+  /**
+   * Submits the user's rating and optional comment for a persisted insight.
+   *
+   * @param insightId UUID of the AI insight being rated.
+   * @param feedback Ratings (0–5) for relevance, truthfulness, depth and
+   *   usefulness, plus an optional free-text comment.
+   * @returns The persisted (or upserted) feedback record.
+   */
+  async submitInsightFeedback(
+    insightId: string,
+    feedback: SubmitInsightFeedbackRequestDTO,
+  ): Promise<InsightFeedbackDTO> {
+    const response = await this.#http.post<V2EnvelopeDTO<InsightFeedbackDTO>>(
+      `/ai/insights/${insightId}/feedback`,
+      feedback,
+    );
+
+    return unwrap<InsightFeedbackDTO>(response.data);
   }
 
   /**

--- a/app/features/ai-insights/components/AiInsightButton.spec.ts
+++ b/app/features/ai-insights/components/AiInsightButton.spec.ts
@@ -44,6 +44,7 @@ describe("AiInsightButton", () => {
       hasPremium: ref(false),
       isLoading: ref(false),
       callsRemaining: ref(null),
+      callsRemainingMonth: ref(null),
       hasAIConsent: vi.fn().mockResolvedValue(true),
       generate,
     });
@@ -68,6 +69,7 @@ describe("AiInsightButton", () => {
       hasPremium: ref(true),
       isLoading: ref(false),
       callsRemaining: ref(1),
+      callsRemainingMonth: ref(20),
       hasAIConsent: vi.fn().mockResolvedValue(true),
       generate,
     });
@@ -78,7 +80,8 @@ describe("AiInsightButton", () => {
 
     expect(wrapper.find("[data-testid='loading-modal']").exists()).toBe(true);
     expect(generate).toHaveBeenCalledOnce();
-    expect(wrapper.text()).toContain("1 de 2 insights restantes hoje");
+    expect(wrapper.text()).toContain("1 insight restante hoje");
+    expect(wrapper.text()).toContain("20 no mês");
 
     resolveGenerate(null);
     await flushPromises();
@@ -91,6 +94,7 @@ describe("AiInsightButton", () => {
       hasPremium: ref(true),
       isLoading: ref(false),
       callsRemaining: ref(null),
+      callsRemainingMonth: ref(null),
       hasAIConsent: vi.fn().mockResolvedValue(true),
       generate,
     });
@@ -106,6 +110,32 @@ describe("AiInsightButton", () => {
     expect(generate).toHaveBeenCalledWith({
       periodType: "daily",
       sourceSurface: "transactions",
+    });
+  });
+
+  it("forwards the viewed-month anchor date to insight generation", async () => {
+    const generate = vi.fn().mockResolvedValue(null);
+    useAIInsightsMock.mockReturnValue({
+      hasPremium: ref(true),
+      isLoading: ref(false),
+      callsRemaining: ref(null),
+      callsRemainingMonth: ref(null),
+      hasAIConsent: vi.fn().mockResolvedValue(true),
+      generate,
+    });
+
+    const wrapper = mount(AiInsightButton, {
+      props: { sourceSurface: "transactions", anchorDate: "2026-06-01" },
+      global: { stubs },
+    });
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    expect(generate).toHaveBeenCalledWith({
+      periodType: "daily",
+      sourceSurface: "transactions",
+      anchorDate: "2026-06-01",
     });
   });
 

--- a/app/features/ai-insights/components/AiInsightButton.vue
+++ b/app/features/ai-insights/components/AiInsightButton.vue
@@ -10,8 +10,10 @@ import type { InsightSourceSurface } from "~/features/ai-insights/contracts/ai-i
 
 const props = withDefaults(defineProps<{
   sourceSurface?: InsightSourceSurface;
+  anchorDate?: string;
 }>(), {
   sourceSurface: "dashboard",
+  anchorDate: undefined,
 });
 
 const {
@@ -22,6 +24,7 @@ const {
   isLoading,
   isGrantingAIConsent,
   callsRemaining,
+  callsRemainingMonth,
 } = useAIInsights();
 
 const showLoadingModal = ref(false);
@@ -49,6 +52,7 @@ const generateWithLoading = async (): Promise<void> => {
     await generate({
       periodType: "daily",
       sourceSurface: props.sourceSurface,
+      ...(props.anchorDate ? { anchorDate: props.anchorDate } : {}),
     });
   } finally {
     showLoadingModal.value = false;
@@ -118,7 +122,13 @@ const handleConsentAccept = async (): Promise<void> => {
     </NButton>
 
     <p v-if="callsRemaining !== null" class="ai-insight-button__remaining">
-      {{ callsRemaining }} de 2 insights restantes hoje
+      <span v-if="callsRemaining > 0">
+        {{ callsRemaining }} {{ callsRemaining === 1 ? "insight restante" : "insights restantes" }} hoje
+      </span>
+      <span v-else>Limite diário atingido</span>
+      <span v-if="callsRemainingMonth !== null">
+        · {{ callsRemainingMonth }} no mês
+      </span>
     </p>
 
     <AiInsightLoadingModal v-model="showLoadingModal" />

--- a/app/features/ai-insights/components/AiInsightFeedback.spec.ts
+++ b/app/features/ai-insights/components/AiInsightFeedback.spec.ts
@@ -1,0 +1,115 @@
+import { ref } from "vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AiInsightFeedback from "./AiInsightFeedback.vue";
+
+const useSubmitInsightFeedbackMock = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
+
+vi.mock("~/features/ai-insights/queries/use-submit-insight-feedback", () => ({
+  useSubmitInsightFeedback: useSubmitInsightFeedbackMock,
+}));
+
+interface ToastMock {
+  success: typeof toastSuccess;
+  error: typeof toastError;
+  warning: () => void;
+  info: () => void;
+}
+
+vi.mock("~/composables/useToast", () => ({
+  useToast: (): ToastMock => ({
+    success: toastSuccess,
+    error: toastError,
+    warning: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+/**
+ * Sets every rating to 5 by clicking the last item of each NRate group.
+ *
+ * @param wrapper Mounted component wrapper.
+ */
+const rateAllFive = async (wrapper: ReturnType<typeof mount>): Promise<void> => {
+  const groups = wrapper.findAll(".n-rate");
+  for (const group of groups) {
+    const items = group.findAll(".n-rate__item");
+    await items[items.length - 1]?.trigger("click");
+  }
+  await flushPromises();
+};
+
+describe("AiInsightFeedback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps submit disabled until all four dimensions are rated", async () => {
+    useSubmitInsightFeedbackMock.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: ref(false),
+    });
+
+    const wrapper = mount(AiInsightFeedback, { props: { insightId: "ins-1" } });
+
+    const submit = wrapper.get("[data-testid='feedback-submit']");
+    expect((submit.element as HTMLButtonElement).disabled).toBe(true);
+
+    await rateAllFive(wrapper);
+
+    expect((submit.element as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("submits ratings and trimmed comment, then shows the thank-you state", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({ id: "fb-1", insight_id: "ins-1" });
+    useSubmitInsightFeedbackMock.mockReturnValue({ mutateAsync, isPending: ref(false) });
+
+    const wrapper = mount(AiInsightFeedback, { props: { insightId: "ins-1" } });
+
+    await rateAllFive(wrapper);
+    await wrapper.find("textarea").setValue("  ótimo  ");
+    await wrapper.get("[data-testid='feedback-submit']").trigger("click");
+    await flushPromises();
+
+    expect(mutateAsync).toHaveBeenCalledWith({
+      insightId: "ins-1",
+      feedback: { relevance: 5, truthfulness: 5, depth: 5, usefulness: 5, comment: "ótimo" },
+    });
+    expect(toastSuccess).toHaveBeenCalled();
+    expect(wrapper.emitted("submitted")).toBeTruthy();
+    expect(wrapper.find("[data-testid='feedback-done']").exists()).toBe(true);
+  });
+
+  it("omits an empty comment from the payload", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({ id: "fb-1", insight_id: "ins-1" });
+    useSubmitInsightFeedbackMock.mockReturnValue({ mutateAsync, isPending: ref(false) });
+
+    const wrapper = mount(AiInsightFeedback, { props: { insightId: "ins-1" } });
+
+    await rateAllFive(wrapper);
+    await wrapper.get("[data-testid='feedback-submit']").trigger("click");
+    await flushPromises();
+
+    expect(mutateAsync).toHaveBeenCalledWith({
+      insightId: "ins-1",
+      feedback: { relevance: 5, truthfulness: 5, depth: 5, usefulness: 5 },
+    });
+  });
+
+  it("shows an error toast and stays in the form when submission fails", async () => {
+    const mutateAsync = vi.fn().mockRejectedValue(new Error("boom"));
+    useSubmitInsightFeedbackMock.mockReturnValue({ mutateAsync, isPending: ref(false) });
+
+    const wrapper = mount(AiInsightFeedback, { props: { insightId: "ins-1" } });
+
+    await rateAllFive(wrapper);
+    await wrapper.get("[data-testid='feedback-submit']").trigger("click");
+    await flushPromises();
+
+    expect(toastError).toHaveBeenCalled();
+    expect(wrapper.find("[data-testid='feedback-done']").exists()).toBe(false);
+  });
+});

--- a/app/features/ai-insights/components/AiInsightFeedback.vue
+++ b/app/features/ai-insights/components/AiInsightFeedback.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { computed, reactive, ref } from "vue";
+import { NButton, NInput, NRate } from "naive-ui";
+import { Check, Sparkles } from "lucide-vue-next";
+
+import { useToast } from "~/composables/useToast";
+import { useSubmitInsightFeedback } from "~/features/ai-insights/queries/use-submit-insight-feedback";
+
+const props = defineProps<{
+  insightId: string;
+}>();
+
+const emit = defineEmits<{
+  (event: "submitted"): void;
+}>();
+
+const toast = useToast();
+const mutation = useSubmitInsightFeedback();
+
+const RATING_FIELDS = [
+  { key: "relevance", label: "Relevância" },
+  { key: "truthfulness", label: "Veracidade" },
+  { key: "depth", label: "Profundidade" },
+  { key: "usefulness", label: "Utilidade" },
+] as const;
+
+type RatingKey = (typeof RATING_FIELDS)[number]["key"];
+
+const ratings = reactive<Record<RatingKey, number>>({
+  relevance: 0,
+  truthfulness: 0,
+  depth: 0,
+  usefulness: 0,
+});
+const comment = ref("");
+const submitted = ref(false);
+
+const allRated = computed(() =>
+  RATING_FIELDS.every((field) => ratings[field.key] >= 1),
+);
+const isPending = computed(() => mutation.isPending.value);
+const canSubmit = computed(() => allRated.value && !isPending.value && !submitted.value);
+
+/**
+ * Submits the four ratings plus the optional comment for the current insight.
+ */
+const handleSubmit = async (): Promise<void> => {
+  if (!canSubmit.value) {
+    return;
+  }
+
+  const trimmedComment = comment.value.trim();
+
+  try {
+    await mutation.mutateAsync({
+      insightId: props.insightId,
+      feedback: {
+        relevance: ratings.relevance,
+        truthfulness: ratings.truthfulness,
+        depth: ratings.depth,
+        usefulness: ratings.usefulness,
+        ...(trimmedComment ? { comment: trimmedComment } : {}),
+      },
+    });
+    submitted.value = true;
+    toast.success("Obrigado pelo seu feedback!");
+    emit("submitted");
+  } catch {
+    toast.error("Não foi possível enviar seu feedback. Tente novamente.");
+  }
+};
+</script>
+
+<template>
+  <section class="ai-insight-feedback" aria-label="Feedback do insight">
+    <div v-if="submitted" class="ai-insight-feedback__done" data-testid="feedback-done">
+      <Check :size="18" class="ai-insight-feedback__done-icon" />
+      <p>Obrigado! Seu feedback ajuda a melhorar os próximos insights.</p>
+    </div>
+
+    <template v-else>
+      <header class="ai-insight-feedback__header">
+        <Sparkles :size="16" />
+        <h3 class="ai-insight-feedback__title">O que você achou desse insight?</h3>
+      </header>
+
+      <ul class="ai-insight-feedback__ratings">
+        <li v-for="field in RATING_FIELDS" :key="field.key" class="ai-insight-feedback__row">
+          <span class="ai-insight-feedback__label">{{ field.label }}</span>
+          <NRate
+            v-model:value="ratings[field.key]"
+            :count="5"
+            clearable
+            :aria-label="field.label"
+            :data-testid="`rate-${field.key}`"
+          />
+        </li>
+      </ul>
+
+      <NInput
+        v-model:value="comment"
+        type="textarea"
+        :autosize="{ minRows: 2, maxRows: 5 }"
+        placeholder="Conte o que achou (opcional)"
+        class="ai-insight-feedback__comment"
+        data-testid="feedback-comment"
+      />
+
+      <NButton
+        type="primary"
+        :disabled="!canSubmit"
+        :loading="isPending"
+        data-testid="feedback-submit"
+        @click="handleSubmit"
+      >
+        Enviar feedback
+      </NButton>
+    </template>
+  </section>
+</template>
+
+<style scoped>
+.ai-insight-feedback {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-bg-elevated) 90%, transparent);
+}
+
+.ai-insight-feedback__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-secondary);
+}
+
+.ai-insight-feedback__title {
+  margin: 0;
+  font-size: var(--font-size-body-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.ai-insight-feedback__ratings {
+  display: grid;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ai-insight-feedback__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.ai-insight-feedback__label {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-body-sm);
+}
+
+.ai-insight-feedback__done {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-secondary);
+}
+
+.ai-insight-feedback__done p {
+  margin: 0;
+}
+
+.ai-insight-feedback__done-icon {
+  color: var(--color-success-500, #16a34a);
+}
+</style>

--- a/app/features/ai-insights/components/AiInsightSection.spec.ts
+++ b/app/features/ai-insights/components/AiInsightSection.spec.ts
@@ -36,6 +36,41 @@ describe("AiInsightSection", () => {
     expect(wrapper.text()).toContain("Orçamento pressionado");
   });
 
+  it("shows the forecast banner when the insight is a future-period prediction", () => {
+    const wrapper = mount(AiInsightSection, {
+      props: {
+        insight: [],
+        periodLabel: "2026-06",
+        isStale: false,
+        model: "gpt-4o",
+        tokensUsed: 0,
+        costUsd: 0,
+        forecast: true,
+      },
+      global: { stubs },
+    });
+
+    expect(wrapper.find("[data-testid='forecast-banner']").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Modo previsão");
+  });
+
+  it("hides the forecast banner for present-period insights", () => {
+    const wrapper = mount(AiInsightSection, {
+      props: {
+        insight: [],
+        periodLabel: "2026-05",
+        isStale: false,
+        model: "gpt-4o",
+        tokensUsed: 0,
+        costUsd: 0,
+        forecast: false,
+      },
+      global: { stubs },
+    });
+
+    expect(wrapper.find("[data-testid='forecast-banner']").exists()).toBe(false);
+  });
+
   it("shows stale warning when data comes from a previous month", () => {
     const wrapper = mount(AiInsightSection, {
       props: {

--- a/app/features/ai-insights/components/AiInsightSection.vue
+++ b/app/features/ai-insights/components/AiInsightSection.vue
@@ -24,6 +24,7 @@ const props = defineProps<{
   model: string;
   tokensUsed: number;
   costUsd: number;
+  forecast?: boolean;
 }>();
 
 const formattedPeriodLabel = computed(() => formatInsightPeriod(props.periodLabel));
@@ -70,6 +71,16 @@ const iconForType = (type: string): typeof BarChart2 => {
         {{ model || 'modelo IA' }} · {{ tokensUsed }} tokens · {{ costLabel }}
       </NTag>
     </header>
+
+    <NAlert
+      v-if="forecast"
+      type="info"
+      class="ai-insight-section__alert"
+      data-testid="forecast-banner"
+    >
+      Modo previsão — análise de {{ formattedPeriodLabel }}, um período futuro. Baseada em
+      lançamentos recorrentes e agendados; os valores podem mudar.
+    </NAlert>
 
     <NAlert v-if="isStale" type="warning" class="ai-insight-section__alert">
       Dados de {{ formattedPeriodLabel }} — os insights podem estar desatualizados.

--- a/app/features/ai-insights/components/AiInsightSurface.spec.ts
+++ b/app/features/ai-insights/components/AiInsightSurface.spec.ts
@@ -16,8 +16,12 @@ const stubs = {
     template: "<button data-testid='ai-button'>{{ sourceSurface }}</button>",
   },
   AiInsightSection: {
-    props: ["insight"],
-    template: "<section data-testid='insight-section'>{{ insight.map((item) => item.title).join(', ') }}</section>",
+    props: ["insight", "forecast"],
+    template: "<section data-testid='insight-section' :data-forecast='forecast'>{{ insight.map((item) => item.title).join(', ') }}</section>",
+  },
+  AiInsightFeedback: {
+    props: ["insightId"],
+    template: "<div data-testid='insight-feedback'>{{ insightId }}</div>",
   },
 };
 
@@ -41,6 +45,8 @@ describe("AiInsightSurface", () => {
       insightModel: ref("gpt-4o-mini"),
       tokensUsed: ref(120),
       costUsd: ref(0.00001),
+      forecast: ref(false),
+      currentInsightId: ref(null),
     });
 
     const wrapper = mount(AiInsightSurface, {
@@ -74,6 +80,8 @@ describe("AiInsightSurface", () => {
       insightModel: ref("gpt-4o-mini"),
       tokensUsed: ref(120),
       costUsd: ref(0.00001),
+      forecast: ref(false),
+      currentInsightId: ref(null),
     });
 
     const wrapper = mount(AiInsightSurface, {
@@ -88,5 +96,62 @@ describe("AiInsightSurface", () => {
     expect(wrapper.get("[data-testid='insight-section']").text()).not.toContain(
       "Transações fora do padrão",
     );
+  });
+
+  it("renders the feedback block and forwards forecast when an insight id exists", () => {
+    useAIInsightsMock.mockReturnValue({
+      currentInsight: ref([
+        {
+          type: "saude_financeira",
+          dimension: "transactions",
+          title: "Previsão de junho",
+          message: "Suas contas recorrentes vencem cedo.",
+        },
+      ]),
+      currentInsightId: ref("ins-42"),
+      insightPeriodLabel: ref("2026-06"),
+      isStale: ref(false),
+      insightModel: ref("gpt-4o"),
+      tokensUsed: ref(120),
+      costUsd: ref(0.00001),
+      forecast: ref(true),
+    });
+
+    const wrapper = mount(AiInsightSurface, {
+      props: { dimension: "transactions" },
+      global: { stubs },
+    });
+
+    expect(wrapper.get("[data-testid='insight-feedback']").text()).toContain("ins-42");
+    expect(wrapper.get("[data-testid='insight-section']").attributes("data-forecast")).toBe(
+      "true",
+    );
+  });
+
+  it("hides the feedback block when no insight id is available", () => {
+    useAIInsightsMock.mockReturnValue({
+      currentInsight: ref([
+        {
+          type: "saude_financeira",
+          dimension: "transactions",
+          title: "Visão geral",
+          message: "Resumo do período.",
+        },
+      ]),
+      currentInsightId: ref(null),
+      insightPeriodLabel: ref("2026-05"),
+      isStale: ref(false),
+      insightModel: ref("gpt-4o"),
+      tokensUsed: ref(120),
+      costUsd: ref(0.00001),
+      forecast: ref(false),
+    });
+
+    const wrapper = mount(AiInsightSurface, {
+      props: { dimension: "transactions" },
+      global: { stubs },
+    });
+
+    expect(wrapper.find("[data-testid='insight-feedback']").exists()).toBe(false);
   });
 });

--- a/app/features/ai-insights/components/AiInsightSurface.vue
+++ b/app/features/ai-insights/components/AiInsightSurface.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import { useRoute } from "vue-router";
 
 import AiInsightButton from "./AiInsightButton.vue";
+import AiInsightFeedback from "./AiInsightFeedback.vue";
 import AiInsightSection from "./AiInsightSection.vue";
 import {
   filterInsightItemsByDimension,
@@ -18,6 +19,7 @@ import type {
 const props = defineProps<{
   dimension?: InsightDimension;
   sourceSurface?: InsightSourceSurface;
+  anchorDate?: string;
 }>();
 
 const route = useRoute();
@@ -59,7 +61,7 @@ const shouldShowContextualEmptyState = computed(() =>
 
 <template>
   <section class="ai-insight-surface" aria-label="Insights de IA">
-    <AiInsightButton :source-surface="resolvedSourceSurface" />
+    <AiInsightButton :source-surface="resolvedSourceSurface" :anchor-date="anchorDate" />
     <AiInsightSection
       v-if="visibleInsight?.length"
       :insight="visibleInsight"
@@ -68,6 +70,11 @@ const shouldShowContextualEmptyState = computed(() =>
       :model="aiInsights.insightModel.value"
       :tokens-used="aiInsights.tokensUsed.value"
       :cost-usd="aiInsights.costUsd.value"
+      :forecast="aiInsights.forecast.value"
+    />
+    <AiInsightFeedback
+      v-if="visibleInsight?.length && aiInsights.currentInsightId.value"
+      :insight-id="aiInsights.currentInsightId.value"
     />
     <p v-else-if="shouldShowContextualEmptyState" class="ai-insight-surface__empty">
       Nenhum insight específico para esta área no período atual. A visão completa continua

--- a/app/features/ai-insights/composables/useAIInsights.ts
+++ b/app/features/ai-insights/composables/useAIInsights.ts
@@ -47,6 +47,8 @@ type DerivedAIInsightState = Pick<
   | "isLoading"
   | "isGrantingAIConsent"
   | "currentInsight"
+  | "currentInsightId"
+  | "forecast"
   | "insightPeriodLabel"
   | "insightMonth"
   | "insightModel"
@@ -67,8 +69,11 @@ export interface UseAIInsightsResult {
   readonly generate: (variables?: GenerateAIInsightVariables) => Promise<GeneratedAIInsight | null>;
   readonly isLoading: ComputedRef<boolean>;
   readonly currentInsight: ComputedRef<InsightItem[] | null>;
+  readonly currentInsightId: ComputedRef<string | null>;
   readonly currentResult: Ref<GeneratedAIInsight | null>;
   readonly callsRemaining: Ref<number | null>;
+  readonly callsRemainingMonth: Ref<number | null>;
+  readonly forecast: ComputedRef<boolean>;
   readonly hasPremium: ComputedRef<boolean>;
   readonly entitlementLoading: ComputedRef<boolean>;
   readonly hasAIConsent: () => Promise<boolean>;
@@ -124,6 +129,20 @@ const getCallsRemainingState = (isInjected: boolean): Ref<number | null> => {
 };
 
 /**
+ * Resolves shared monthly-call metadata state.
+ *
+ * @param isInjected Whether dependencies were provided by a test.
+ * @returns Monthly calls remaining state.
+ */
+const getCallsRemainingMonthState = (isInjected: boolean): Ref<number | null> => {
+  if (isInjected) {
+    return ref<number | null>(null);
+  }
+
+  return useState<number | null>("ai-insights:calls-remaining-month", () => null);
+};
+
+/**
  * Resolves the consent mutation for production or injected tests.
  *
  * @param deps Optional injected dependencies.
@@ -174,6 +193,8 @@ const createDerivedState = (args: CreateDerivedStateArgs): DerivedAIInsightState
   isLoading: computed(() => args.mutation.isPending.value),
   isGrantingAIConsent: computed(() => args.consentMutation.isPending.value),
   currentInsight: computed(() => args.currentResult.value?.items ?? null),
+  currentInsightId: computed(() => args.currentResult.value?.id ?? null),
+  forecast: computed(() => args.currentResult.value?.forecast ?? false),
   insightPeriodLabel: computed(() => args.currentResult.value?.periodLabel ?? getCurrentMonth()),
   insightMonth: computed(() => args.currentResult.value?.periodLabel ?? getCurrentMonth()),
   insightModel: computed(() => args.currentResult.value?.model ?? ""),
@@ -197,6 +218,7 @@ export const useAIInsights = (deps?: UseAIInsightsDeps): UseAIInsightsResult => 
   const consentStatus = resolveConsentStatus(deps, apiClient);
   const currentResult = getCurrentResultState(Boolean(deps));
   const callsRemaining = getCallsRemainingState(Boolean(deps));
+  const callsRemainingMonth = getCallsRemainingMonthState(Boolean(deps));
   const state = createDerivedState({ entitlement, mutation, consentMutation, currentResult });
 
   /**
@@ -215,6 +237,7 @@ export const useAIInsights = (deps?: UseAIInsightsDeps): UseAIInsightsResult => 
     const result = mapGeneratedInsight(await mutation.mutateAsync(variables));
     currentResult.value = result;
     callsRemaining.value = result.callsRemaining;
+    callsRemainingMonth.value = result.callsRemainingMonth;
     return result;
   };
 
@@ -236,8 +259,11 @@ export const useAIInsights = (deps?: UseAIInsightsDeps): UseAIInsightsResult => 
     generate,
     isLoading: state.isLoading,
     currentInsight: state.currentInsight,
+    currentInsightId: state.currentInsightId,
+    forecast: state.forecast,
     currentResult,
     callsRemaining,
+    callsRemainingMonth,
     hasPremium: state.hasPremium,
     entitlementLoading: state.entitlementLoading,
     hasAIConsent: hasAIConsentStatus,

--- a/app/features/ai-insights/contracts/ai-insight.ts
+++ b/app/features/ai-insights/contracts/ai-insight.ts
@@ -41,6 +41,7 @@ export interface GenerateInsightRequestDTO {
 }
 
 export interface GenerateInsightResponseDTO {
+  readonly id?: string;
   readonly summary: string;
   readonly items: InsightItem[];
   readonly period_type: InsightPeriodType;
@@ -53,10 +54,32 @@ export interface GenerateInsightResponseDTO {
   readonly cost_usd: number;
   readonly model: string;
   readonly cached: boolean;
+  readonly forecast?: boolean;
 }
 
 export interface GenerateInsightResponseWithMetaDTO extends GenerateInsightResponseDTO {
   readonly callsRemaining: number | null;
+  readonly callsRemainingMonth: number | null;
+}
+
+export interface SubmitInsightFeedbackRequestDTO {
+  readonly relevance: number;
+  readonly truthfulness: number;
+  readonly depth: number;
+  readonly usefulness: number;
+  readonly comment?: string;
+}
+
+export interface InsightFeedbackDTO {
+  readonly id: string;
+  readonly insight_id: string;
+  readonly relevance: number;
+  readonly truthfulness: number;
+  readonly depth: number;
+  readonly usefulness: number;
+  readonly comment: string | null;
+  readonly created_at: string;
+  readonly updated_at: string;
 }
 
 export interface AIInsightHistoryDTO {

--- a/app/features/ai-insights/model/ai-insight.spec.ts
+++ b/app/features/ai-insights/model/ai-insight.spec.ts
@@ -7,6 +7,7 @@ import {
   mapAIInsightDto,
   mapGeneratedInsight,
   parseInsightItems,
+  resolveInsightAnchorDate,
 } from "./ai-insight";
 import type { AIInsightDTO, InsightItem } from "~/features/ai-insights/contracts/ai-insight";
 
@@ -127,6 +128,7 @@ describe("AI insight model", () => {
     ];
 
     const mapped = mapGeneratedInsight({
+      id: "11111111-1111-1111-1111-111111111111",
       summary: "Resumo mensal",
       items,
       period_type: "monthly",
@@ -137,13 +139,46 @@ describe("AI insight model", () => {
       tokens_used: 180,
       cost_usd: 0.00003,
       cached: false,
+      forecast: true,
       callsRemaining: 1,
+      callsRemainingMonth: 12,
     });
 
     expect(mapped.items).toEqual(items);
     expect(mapped.summary).toBe("Resumo mensal");
     expect(mapped.periodType).toBe("monthly");
     expect(mapped.periodLabel).toBe("2026-05");
+    expect(mapped.id).toBe("11111111-1111-1111-1111-111111111111");
+    expect(mapped.forecast).toBe(true);
+    expect(mapped.callsRemainingMonth).toBe(12);
+  });
+
+  it("defaults id to null and forecast to false when the backend omits them", () => {
+    const mapped = mapGeneratedInsight({
+      summary: "Resumo do dia",
+      items: [
+        {
+          type: "saude_financeira",
+          dimension: "general",
+          title: "Tudo certo",
+          message: "Suas contas estão equilibradas.",
+        },
+      ],
+      period_type: "daily",
+      period_label: "2026-05-18",
+      period_start: "2026-05-18",
+      period_end: "2026-05-18",
+      model: "gpt-4o-mini",
+      tokens_used: 60,
+      cost_usd: 0.00001,
+      cached: false,
+      callsRemaining: null,
+      callsRemainingMonth: null,
+    });
+
+    expect(mapped.id).toBeNull();
+    expect(mapped.forecast).toBe(false);
+    expect(mapped.callsRemainingMonth).toBeNull();
   });
 
   it("falls back legacy items without dimension to general", () => {
@@ -203,5 +238,28 @@ describe("AI insight model", () => {
       tone: "neutral",
       label: "Insight",
     });
+  });
+});
+
+describe("resolveInsightAnchorDate", () => {
+  const now = new Date(2026, 4, 15); // 2026-05-15
+
+  it("returns undefined when no period start is selected", () => {
+    expect(resolveInsightAnchorDate(null, now)).toBeUndefined();
+  });
+
+  it("returns undefined for the current month so the backend uses today", () => {
+    const currentMonthStart = new Date(2026, 4, 1).getTime();
+    expect(resolveInsightAnchorDate(currentMonthStart, now)).toBeUndefined();
+  });
+
+  it("anchors to the first day of a future month for forecast mode", () => {
+    const futureMonthStart = new Date(2026, 5, 1).getTime();
+    expect(resolveInsightAnchorDate(futureMonthStart, now)).toBe("2026-06-01");
+  });
+
+  it("anchors to the first day of a past month for history", () => {
+    const pastMonthStart = new Date(2026, 2, 1).getTime();
+    expect(resolveInsightAnchorDate(pastMonthStart, now)).toBe("2026-03-01");
   });
 });

--- a/app/features/ai-insights/model/ai-insight.ts
+++ b/app/features/ai-insights/model/ai-insight.ts
@@ -37,6 +37,7 @@ export interface GenerateAIInsightVariables {
 }
 
 export interface GeneratedAIInsight {
+  readonly id: string | null;
   readonly summary: string;
   readonly items: InsightItem[];
   readonly periodType: InsightPeriodType;
@@ -47,7 +48,9 @@ export interface GeneratedAIInsight {
   readonly tokensUsed: number;
   readonly costUsd: number;
   readonly cached: boolean;
+  readonly forecast: boolean;
   readonly callsRemaining: number | null;
+  readonly callsRemainingMonth: number | null;
 }
 
 export const FALLBACK_INSIGHT_ITEM: InsightItem = {
@@ -273,6 +276,7 @@ export const mapAIInsightDto = (dto: AIInsightDTO): AIInsight => ({
 export const mapGeneratedInsight = (
   dto: GenerateInsightResponseWithMetaDTO,
 ): GeneratedAIInsight => ({
+  id: dto.id ?? null,
   summary: dto.summary,
   items: normalizeStructuredInsightItems(dto.items) ?? [FALLBACK_INSIGHT_ITEM],
   periodType: dto.period_type,
@@ -283,7 +287,9 @@ export const mapGeneratedInsight = (
   tokensUsed: dto.tokens_used,
   costUsd: dto.cost_usd,
   cached: dto.cached,
+  forecast: dto.forecast === true,
   callsRemaining: dto.callsRemaining,
+  callsRemainingMonth: dto.callsRemainingMonth,
 });
 
 /**
@@ -344,6 +350,37 @@ export const formatInsightCreatedAt = (createdAt: string): string => {
     hour: "2-digit",
     minute: "2-digit",
   });
+};
+
+/**
+ * Resolves the anchor date (YYYY-MM-DD) used to generate an insight for the
+ * month currently being viewed on the transactions screen.
+ *
+ * Returns undefined for the current month so the backend keeps its default
+ * "today" daily insight. For any other month it anchors to that month's first
+ * day — a past month yields history, a future month triggers forecast mode
+ * (`forecast: true`) on the backend.
+ *
+ * @param periodStart Timestamp of the viewed month's first day, or null.
+ * @param now Current date override used by tests.
+ * @returns Anchor date string, or undefined to use the backend default.
+ */
+export const resolveInsightAnchorDate = (
+  periodStart: number | null,
+  now: Date = new Date(),
+): string | undefined => {
+  if (periodStart === null) {
+    return undefined;
+  }
+
+  const date = new Date(periodStart);
+  if (date.getFullYear() === now.getFullYear() && date.getMonth() === now.getMonth()) {
+    return undefined;
+  }
+
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
 };
 
 /**

--- a/app/features/ai-insights/queries/use-submit-insight-feedback.spec.ts
+++ b/app/features/ai-insights/queries/use-submit-insight-feedback.spec.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  useSubmitInsightFeedback,
+  type SubmitInsightFeedbackVariables,
+} from "./use-submit-insight-feedback";
+
+const useMutationMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/vue-query", () => ({
+  useMutation: useMutationMock,
+}));
+
+describe("useSubmitInsightFeedback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useMutationMock.mockImplementation((options: unknown) => options);
+  });
+
+  it("registers a mutation that posts feedback for the given insight id", async () => {
+    const client = {
+      submitInsightFeedback: vi.fn().mockResolvedValue({ id: "fb-1", insight_id: "ins-1" }),
+    };
+
+    const mutation = useSubmitInsightFeedback(client as never) as unknown as {
+      mutationFn: (variables: SubmitInsightFeedbackVariables) => Promise<unknown>;
+    };
+
+    await mutation.mutationFn({
+      insightId: "ins-1",
+      feedback: { relevance: 5, truthfulness: 4, depth: 3, usefulness: 5, comment: "ok" },
+    });
+
+    expect(client.submitInsightFeedback).toHaveBeenCalledWith("ins-1", {
+      relevance: 5,
+      truthfulness: 4,
+      depth: 3,
+      usefulness: 5,
+      comment: "ok",
+    });
+  });
+});

--- a/app/features/ai-insights/queries/use-submit-insight-feedback.ts
+++ b/app/features/ai-insights/queries/use-submit-insight-feedback.ts
@@ -1,0 +1,42 @@
+import { type UseMutationReturnType, useMutation } from "@tanstack/vue-query";
+
+import type { ApiError } from "~/core/errors";
+import {
+  type AIInsightsApiClient,
+  useAIInsightsApiClient,
+} from "~/features/ai-insights/api/ai-insights-api";
+import type {
+  InsightFeedbackDTO,
+  SubmitInsightFeedbackRequestDTO,
+} from "~/features/ai-insights/contracts/ai-insight";
+
+export interface SubmitInsightFeedbackVariables {
+  readonly insightId: string;
+  readonly feedback: SubmitInsightFeedbackRequestDTO;
+}
+
+/**
+ * Mutation hook for submitting a rating/comment on a persisted AI insight.
+ *
+ * Mirrors `POST /ai/insights/<insight_id>/feedback`. The insight id comes from
+ * the generation response or a history item — only persisted insights can be
+ * rated.
+ *
+ * @param providedClient Optional injected API client for tests.
+ * @returns Vue Query mutation state.
+ */
+export const useSubmitInsightFeedback = (
+  providedClient?: AIInsightsApiClient,
+): UseMutationReturnType<
+  InsightFeedbackDTO,
+  ApiError,
+  SubmitInsightFeedbackVariables,
+  unknown
+> => {
+  const client = providedClient ?? useAIInsightsApiClient();
+
+  return useMutation<InsightFeedbackDTO, ApiError, SubmitInsightFeedbackVariables>({
+    mutationFn: (variables) =>
+      client.submitInsightFeedback(variables.insightId, variables.feedback),
+  });
+};

--- a/app/pages/transactions/index.vue
+++ b/app/pages/transactions/index.vue
@@ -11,6 +11,7 @@ import TransactionToolbar from "~/features/transactions/components/TransactionTo
 import TransactionExportModal from "~/features/transactions/components/TransactionExportModal.vue";
 import TransactionPaymentModal from "~/features/transactions/components/TransactionPaymentModal.vue";
 import AiInsightSurface from "~/features/ai-insights/components/AiInsightSurface.vue";
+import { resolveInsightAnchorDate } from "~/features/ai-insights/model/ai-insight";
 import { formatCurrency } from "~/utils/currency";
 
 definePageMeta({
@@ -29,6 +30,10 @@ const {
   viewMode, selectedDay, showDayDetail, onDayClick,
   filters, TYPE_OPTIONS, STATUS_OPTIONS, tagOptions, tagMap, tagDetailMap, accountMap, clearFilters,
 } = useTransactionFilters();
+
+// Pass the viewed month to AI insight generation so navigating to a future
+// month yields a forecast; the current month keeps the default "today" insight.
+const insightAnchorDate = computed(() => resolveInsightAnchorDate(filterStartDate.value));
 
 const showCreateTag = ref(false);
 const showExportModal = ref(false);
@@ -209,7 +214,11 @@ const totalBalance = computed(() => totalIncome.value - totalExpense.value);
     <!-- ── Financial calendar ──────────────────────────────────────────────── -->
     <FinancialCalendar v-else-if="viewMode === 'calendar'" class="transactions-page__calendar" @day-click="onDayClick" />
 
-    <AiInsightSurface class="transactions-page__ai-insights" dimension="transactions" />
+    <AiInsightSurface
+      class="transactions-page__ai-insights"
+      dimension="transactions"
+      :anchor-date="insightAnchorDate"
+    />
 
   </div>
 </template>

--- a/app/shared/types/generated/graphql.ts
+++ b/app/shared/types/generated/graphql.ts
@@ -37,6 +37,18 @@ export type Scalars = {
   UUID: { input: string; output: string; }
 };
 
+export type AiInsightFeedbackPayload = {
+  __typename?: 'AIInsightFeedbackPayload';
+  comment?: Maybe<Scalars['String']['output']>;
+  depth?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['String']['output']>;
+  insightId?: Maybe<Scalars['String']['output']>;
+  ok: Scalars['Boolean']['output'];
+  relevance?: Maybe<Scalars['Int']['output']>;
+  truthfulness?: Maybe<Scalars['Int']['output']>;
+  usefulness?: Maybe<Scalars['Int']['output']>;
+};
+
 export type AiInsightHistoryResultType = {
   __typename?: 'AIInsightHistoryResultType';
   items: Array<AiInsightType>;
@@ -466,6 +478,7 @@ export type GenerateAiInsightPayload = {
   cached?: Maybe<Scalars['Boolean']['output']>;
   contextVersion?: Maybe<Scalars['String']['output']>;
   costUsd?: Maybe<Scalars['Float']['output']>;
+  forecast?: Maybe<Scalars['Boolean']['output']>;
   items?: Maybe<Array<Maybe<AiInsightItemType>>>;
   model?: Maybe<Scalars['String']['output']>;
   ok: Scalars['Boolean']['output'];
@@ -803,6 +816,8 @@ export type Mutation = {
   revokeSession?: Maybe<RevokeSessionMutation>;
   saveInstallmentVsCashSimulation?: Maybe<SaveInstallmentVsCashSimulationMutation>;
   simulateGoalPlan?: Maybe<SimulateGoalPlanMutation>;
+  /** GraphQL parity for POST /ai/insights/<id>/feedback (#1387). */
+  submitAiInsightFeedback?: Maybe<AiInsightFeedbackPayload>;
   updateAccount?: Maybe<AccountPayload>;
   /** @deprecated ADR-0002: use PATCH /budgets/{id} */
   updateBudget?: Maybe<UpdateBudgetMutation>;
@@ -1099,6 +1114,16 @@ export type MutationSimulateGoalPlanArgs = {
   monthlyIncome?: InputMaybe<Scalars['String']['input']>;
   targetAmount: Scalars['String']['input'];
   targetDate?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type MutationSubmitAiInsightFeedbackArgs = {
+  comment?: InputMaybe<Scalars['String']['input']>;
+  depth: Scalars['Int']['input'];
+  insightId: Scalars['String']['input'];
+  relevance: Scalars['Int']['input'];
+  truthfulness: Scalars['Int']['input'];
+  usefulness: Scalars['Int']['input'];
 };
 
 


### PR DESCRIPTION
## Summary
Implements WEB #958 (épico #814, frente C — Insights):
- **Modo Previsão**: banner in `AiInsightSection` when the backend returns `forecast=true` (future months).
- **UI de Feedback** (`AiInsightFeedback`): 4 ratings 0–5 (relevância, veracidade, profundidade, utilidade) + comment, via REST `POST /ai/insights/<id>/feedback`, with loading/success/error states.
- **Limites**: daily + monthly remaining read from `X-AI-Calls-Remaining` / `X-AI-Calls-Remaining-Month` headers (removes the hardcoded "2/dia"; cap is now 1/dia).
- **Mês visualizado**: the transactions screen passes the viewed month as the generation anchor (future month → forecast; current month keeps today's daily insight).
- Contract/model: `id` + `forecast` on the generation payload; feedback DTOs; `resolveInsightAnchorDate`. Regenerated `graphql.ts` (picks up `forecast` + `submitAiInsightFeedback` from the backend schema).

Render-by-dimension already existed and is preserved.

## Tests
- TDD across model/api/queries/composable + component specs. Full suite green (3539), coverage above thresholds, lint/typecheck/build clean.

## Refs
Closes #958