### PR TITLE
feat(simulations): gate freemium + selector de meta no simulador (#566)

### DIFF
--- a/app/features/simulations/components/SimulatorPaywallOverlay.spec.ts
+++ b/app/features/simulations/components/SimulatorPaywallOverlay.spec.ts
@@ -1,0 +1,57 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SimulatorPaywallOverlay from "./SimulatorPaywallOverlay.vue";
+
+const captureMock = vi.fn();
+
+vi.mock("~/composables/useAnalytics/useAnalytics", () => ({
+  useAnalytics: (): Record<string, unknown> => ({
+    capture: captureMock,
+    identify: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+const STUBS = {
+  NCard: { template: "<div><slot /></div>" },
+  NButton: {
+    template: "<button data-testid='simulator-paywall-cta'><slot /></button>",
+  },
+};
+
+describe("SimulatorPaywallOverlay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emite paywall_shown ao montar", () => {
+    mount(SimulatorPaywallOverlay, { global: { stubs: STUBS } });
+
+    expect(captureMock).toHaveBeenCalledWith("paywall_shown", {
+      feature: "goal_simulator",
+      quota: 1,
+    });
+  });
+
+  it("emite upgrade_clicked e o evento upgrade no CTA", async () => {
+    const wrapper = mount(SimulatorPaywallOverlay, { global: { stubs: STUBS } });
+
+    await wrapper.get("[data-testid='simulator-paywall-cta']").trigger("click");
+
+    expect(captureMock).toHaveBeenCalledWith("upgrade_clicked", {
+      feature: "goal_simulator",
+      source: "simulator_paywall",
+    });
+    expect(wrapper.emitted("upgrade")).toHaveLength(1);
+  });
+
+  it("renderiza a cópia padrão e aceita override por props", () => {
+    const wrapper = mount(SimulatorPaywallOverlay, {
+      props: { title: "Título custom" },
+      global: { stubs: STUBS },
+    });
+
+    expect(wrapper.text()).toContain("Título custom");
+  });
+});

--- a/app/features/simulations/components/SimulatorPaywallOverlay.vue
+++ b/app/features/simulations/components/SimulatorPaywallOverlay.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { NButton, NCard } from "naive-ui";
+
+import { useAnalytics } from "~/composables/useAnalytics/useAnalytics";
+
+/**
+ * Overlay de paywall exibido sobre o resultado borrado quando o free tier
+ * esgota a quota mensal de simulações (#566). Não mata o cálculo — só obscurece
+ * o número e oferece o upgrade.
+ *
+ * Emite `paywall_shown` ao montar e `upgrade_clicked` no CTA (catálogo PostHog).
+ */
+const props = withDefaults(
+  defineProps<{
+    title?: string;
+    description?: string;
+    ctaLabel?: string;
+    resetAt?: string | null;
+  }>(),
+  {
+    title: "Você usou sua simulação gratuita do mês",
+    description:
+      "Faça upgrade para o Premium e simule seus cenários de metas quantas vezes quiser.",
+    ctaLabel: "Fazer upgrade",
+    resetAt: null,
+  },
+);
+
+const emit = defineEmits<{ (event: "upgrade"): void }>();
+
+const analytics = useAnalytics();
+
+onMounted(() => {
+  analytics.capture("paywall_shown", { feature: "goal_simulator", quota: 1 });
+});
+
+/** Emite o evento de conversão e propaga o `upgrade` para a página navegar. */
+const onUpgrade = (): void => {
+  analytics.capture("upgrade_clicked", {
+    feature: "goal_simulator",
+    source: "simulator_paywall",
+  });
+  emit("upgrade");
+};
+</script>
+
+<template>
+  <div class="simulator-paywall-overlay" data-testid="simulator-paywall-overlay">
+    <NCard class="simulator-paywall-overlay__card" :bordered="true">
+      <h3 class="simulator-paywall-overlay__title">{{ props.title }}</h3>
+      <p class="simulator-paywall-overlay__description">{{ props.description }}</p>
+      <NButton
+        type="primary"
+        size="large"
+        data-testid="simulator-paywall-cta"
+        @click="onUpgrade"
+      >
+        {{ props.ctaLabel }}
+      </NButton>
+    </NCard>
+  </div>
+</template>
+
+<style scoped>
+.simulator-paywall-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(6px);
+  background: rgba(0, 0, 0, 0.25);
+  z-index: 5;
+}
+
+.simulator-paywall-overlay__card {
+  max-width: 22rem;
+  text-align: center;
+}
+
+.simulator-paywall-overlay__title {
+  margin: 0 0 0.5rem;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+}
+
+.simulator-paywall-overlay__description {
+  margin: 0 0 1rem;
+  opacity: 0.85;
+}
+</style>

--- a/app/features/simulations/composables/useSimulationQuota.spec.ts
+++ b/app/features/simulations/composables/useSimulationQuota.spec.ts
@@ -1,0 +1,110 @@
+import { ref } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SimulationQuota } from "~/features/simulations/model/simulation-quota";
+
+import { useSimulationQuota } from "./useSimulationQuota";
+
+const captureMock = vi.fn();
+const mutateAsyncMock = vi.fn();
+const queryDataRef = ref<SimulationQuota | undefined>(undefined);
+const isLoadingRef = ref<boolean>(false);
+
+vi.mock("~/composables/useAnalytics/useAnalytics", () => ({
+  useAnalytics: (): Record<string, unknown> => ({
+    capture: captureMock,
+    identify: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock("~/features/simulations/queries/use-simulation-quota-query", () => ({
+  SIMULATION_QUOTA_QUERY_KEY: ["simulation-quota"],
+  useSimulationQuotaQuery: (): Record<string, unknown> => ({
+    data: queryDataRef,
+    isLoading: isLoadingRef,
+  }),
+}));
+
+vi.mock(
+  "~/features/simulations/queries/use-consume-simulation-quota-mutation",
+  () => ({
+    useConsumeSimulationQuotaMutation: (): Record<string, unknown> => ({
+      mutateAsync: mutateAsyncMock,
+    }),
+  }),
+);
+
+/**
+ * Constrói um snapshot de quota com overrides.
+ *
+ * @param over Campos a sobrescrever no snapshot base.
+ * @returns Snapshot de quota completo.
+ */
+const QUOTA = (over: Partial<SimulationQuota> = {}): SimulationQuota => ({
+  limit: 1,
+  used: 0,
+  remaining: 1,
+  unlimited: false,
+  allowed: true,
+  resetAt: "2026-06-01T00:00:00Z",
+  ...over,
+});
+
+describe("useSimulationQuota", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryDataRef.value = undefined;
+    isLoadingRef.value = false;
+  });
+
+  it("emite free_simulation_used quando consumo é permitido e free", async () => {
+    mutateAsyncMock.mockResolvedValue(QUOTA({ used: 1, remaining: 0, allowed: true }));
+    const { consume } = useSimulationQuota();
+
+    await consume("goal-1");
+
+    expect(captureMock).toHaveBeenCalledWith("free_simulation_used", {
+      goal_id: "goal-1",
+    });
+  });
+
+  it("NÃO emite evento para premium (unlimited)", async () => {
+    mutateAsyncMock.mockResolvedValue(
+      QUOTA({ unlimited: true, remaining: null, allowed: true }),
+    );
+    const { consume } = useSimulationQuota();
+
+    await consume("goal-1");
+
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it("NÃO emite evento quando esgotado (allowed=false)", async () => {
+    mutateAsyncMock.mockResolvedValue(QUOTA({ used: 1, remaining: 0, allowed: false }));
+    const { consume } = useSimulationQuota();
+
+    await consume("goal-1");
+
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it("isExhausted é true quando free sem saldo", () => {
+    queryDataRef.value = QUOTA({ used: 1, remaining: 0, allowed: false });
+    const { isExhausted } = useSimulationQuota();
+    expect(isExhausted.value).toBe(true);
+  });
+
+  it("isExhausted é false para premium", () => {
+    queryDataRef.value = QUOTA({ unlimited: true, remaining: null, allowed: true });
+    const { isExhausted, unlimited } = useSimulationQuota();
+    expect(unlimited.value).toBe(true);
+    expect(isExhausted.value).toBe(false);
+  });
+
+  it("usa fallback otimista quando a query ainda não carregou", () => {
+    const { quota } = useSimulationQuota();
+    expect(quota.value.allowed).toBe(true);
+    expect(quota.value.remaining).toBe(1);
+  });
+});

--- a/app/features/simulations/composables/useSimulationQuota.ts
+++ b/app/features/simulations/composables/useSimulationQuota.ts
@@ -1,0 +1,64 @@
+import { computed, type ComputedRef } from "vue";
+
+import { useAnalytics } from "~/composables/useAnalytics/useAnalytics";
+import { useSimulationQuotaQuery } from "~/features/simulations/queries/use-simulation-quota-query";
+import { useConsumeSimulationQuotaMutation } from "~/features/simulations/queries/use-consume-simulation-quota-mutation";
+import {
+  UNKNOWN_SIMULATION_QUOTA,
+  type SimulationQuota,
+} from "~/features/simulations/model/simulation-quota";
+import type { SimulationQuotaClient } from "~/features/simulations/services/simulation-quota.client";
+
+export interface UseSimulationQuotaReturn {
+  readonly quota: ComputedRef<SimulationQuota>;
+  readonly remaining: ComputedRef<number | null>;
+  readonly unlimited: ComputedRef<boolean>;
+  readonly isExhausted: ComputedRef<boolean>;
+  readonly isLoading: ComputedRef<boolean>;
+  /**
+   * Consome 1 simulação no backend (fonte de verdade). Emite
+   * `free_simulation_used` quando o consumo é permitido e o usuário é free.
+   * Retorna o snapshot resultante para o caller decidir revelar ou exibir paywall.
+   */
+  consume(goalId: string): Promise<SimulationQuota>;
+}
+
+/**
+ * Orquestra a quota freemium do simulador (#566): snapshot + consumo + analytics.
+ *
+ * @param providedClient Client opcional injetado para testes unitários.
+ * @returns Estado e ações da quota.
+ */
+export const useSimulationQuota = (
+  providedClient?: SimulationQuotaClient,
+): UseSimulationQuotaReturn => {
+  const analytics = useAnalytics();
+  const query = useSimulationQuotaQuery(providedClient);
+  const consumeMutation = useConsumeSimulationQuotaMutation(providedClient);
+
+  const quota = computed<SimulationQuota>(
+    () => query.data.value ?? UNKNOWN_SIMULATION_QUOTA,
+  );
+  const remaining = computed<number | null>(() => quota.value.remaining);
+  const unlimited = computed<boolean>(() => quota.value.unlimited);
+  const isExhausted = computed<boolean>(
+    () => !quota.value.unlimited && !quota.value.allowed,
+  );
+  const isLoading = computed<boolean>(() => query.isLoading.value);
+
+  /**
+   * Consome 1 simulação no backend e emite analytics quando aplicável.
+   *
+   * @param goalId Meta sendo simulada (props do evento `free_simulation_used`).
+   * @returns Snapshot da quota após o consumo (o caller decide revelar/paywall).
+   */
+  const consume = async (goalId: string): Promise<SimulationQuota> => {
+    const result = await consumeMutation.mutateAsync();
+    if (result.allowed && !result.unlimited) {
+      analytics.capture("free_simulation_used", { goal_id: goalId });
+    }
+    return result;
+  };
+
+  return { quota, remaining, unlimited, isExhausted, isLoading, consume };
+};

--- a/app/features/simulations/contracts/simulation-quota.dto.spec.ts
+++ b/app/features/simulations/contracts/simulation-quota.dto.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { toSimulationQuota } from "./simulation-quota.dto";
+
+describe("toSimulationQuota", () => {
+  it("normaliza o envelope v2 (data)", () => {
+    const quota = toSimulationQuota({
+      success: true,
+      data: {
+        limit: 1,
+        used: 1,
+        remaining: 0,
+        unlimited: false,
+        allowed: false,
+        reset_at: "2026-06-01T00:00:00Z",
+      },
+    });
+
+    expect(quota).toEqual({
+      limit: 1,
+      used: 1,
+      remaining: 0,
+      unlimited: false,
+      allowed: false,
+      resetAt: "2026-06-01T00:00:00Z",
+    });
+  });
+
+  it("mantém compatibilidade com payload flat (legacy)", () => {
+    const quota = toSimulationQuota({
+      limit: 1,
+      used: 0,
+      remaining: 1,
+      unlimited: false,
+      allowed: true,
+      reset_at: "2026-06-01T00:00:00Z",
+    });
+
+    expect(quota.remaining).toBe(1);
+    expect(quota.allowed).toBe(true);
+  });
+
+  it("preserva remaining nulo para premium (unlimited)", () => {
+    const quota = toSimulationQuota({
+      data: {
+        limit: 1,
+        used: 0,
+        remaining: null,
+        unlimited: true,
+        allowed: true,
+        reset_at: "2026-06-01T00:00:00Z",
+      },
+    });
+
+    expect(quota.unlimited).toBe(true);
+    expect(quota.remaining).toBeNull();
+  });
+});

--- a/app/features/simulations/contracts/simulation-quota.dto.ts
+++ b/app/features/simulations/contracts/simulation-quota.dto.ts
@@ -1,0 +1,63 @@
+import type { SimulationQuota } from "~/features/simulations/model/simulation-quota";
+
+/** Payload cru do backend (snake_case), tanto flat quanto sob `data`. */
+export interface SimulationQuotaDto {
+  readonly limit: number;
+  readonly used: number;
+  readonly remaining: number | null;
+  readonly unlimited: boolean;
+  readonly allowed: boolean;
+  readonly reset_at: string;
+}
+
+interface SimulationQuotaEnvelopeDto {
+  readonly success?: boolean;
+  readonly message?: string;
+  readonly data?: SimulationQuotaDto | null;
+}
+
+type SimulationQuotaResponseDto = SimulationQuotaDto | SimulationQuotaEnvelopeDto;
+
+const EXHAUSTED_FALLBACK: SimulationQuota = {
+  limit: 1,
+  used: 0,
+  remaining: null,
+  unlimited: false,
+  allowed: false,
+  resetAt: "",
+};
+
+/**
+ * Detecta o envelope v2 (`{ data }`) versus o payload flat legacy.
+ *
+ * @param payload Corpo da resposta de /simulations/quota.
+ * @returns True quando o payload encapsula os dados em `data`.
+ */
+const isEnvelope = (
+  payload: SimulationQuotaResponseDto,
+): payload is SimulationQuotaEnvelopeDto => {
+  return payload !== null && typeof payload === "object" && "data" in payload;
+};
+
+/**
+ * Normaliza a resposta (flat legacy ou envelope `data`) para o domínio.
+ *
+ * @param payload Corpo da resposta de /simulations/quota.
+ * @returns View-model de domínio tipado.
+ */
+export const toSimulationQuota = (
+  payload: SimulationQuotaResponseDto,
+): SimulationQuota => {
+  const dto = isEnvelope(payload) ? (payload.data ?? null) : payload;
+  if (dto === null) {
+    return EXHAUSTED_FALLBACK;
+  }
+  return {
+    limit: dto.limit,
+    used: dto.used,
+    remaining: dto.remaining,
+    unlimited: dto.unlimited,
+    allowed: dto.allowed,
+    resetAt: dto.reset_at,
+  };
+};

--- a/app/features/simulations/model/simulation-quota.ts
+++ b/app/features/simulations/model/simulation-quota.ts
@@ -1,0 +1,27 @@
+/**
+ * Domain view-model da quota freemium do simulador de metas (#566).
+ *
+ * Espelha o contrato do backend (#1409): free tier consome 1 simulação/mês,
+ * premium é ilimitado. `allowed` indica se a próxima simulação pode revelar o
+ * resultado completo; quando `false`, a UI exibe o paywall.
+ */
+export interface SimulationQuota {
+  readonly limit: number;
+  readonly used: number;
+  /** `null` quando ilimitado (premium). */
+  readonly remaining: number | null;
+  readonly unlimited: boolean;
+  readonly allowed: boolean;
+  /** ISO UTC do próximo reset (1º dia do próximo mês). */
+  readonly resetAt: string;
+}
+
+/** Snapshot otimista usado como fallback/inicial enquanto a query carrega. */
+export const UNKNOWN_SIMULATION_QUOTA: SimulationQuota = {
+  limit: 1,
+  used: 0,
+  remaining: 1,
+  unlimited: false,
+  allowed: true,
+  resetAt: "",
+};

--- a/app/features/simulations/queries/use-consume-simulation-quota-mutation.spec.ts
+++ b/app/features/simulations/queries/use-consume-simulation-quota-mutation.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useConsumeSimulationQuotaMutation } from "./use-consume-simulation-quota-mutation";
+import { SIMULATION_QUOTA_QUERY_KEY } from "./use-simulation-quota-query";
+import type { SimulationQuotaClient } from "~/features/simulations/services/simulation-quota.client";
+
+const useMutationMock = vi.hoisted(() => vi.fn());
+const setQueryData = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/vue-query", () => ({
+  useMutation: useMutationMock,
+  useQueryClient: (): Record<string, unknown> => ({ setQueryData }),
+}));
+
+describe("useConsumeSimulationQuotaMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useMutationMock.mockImplementation((opts: Record<string, unknown>) => opts);
+  });
+
+  it("invoca client.consume na mutationFn", async () => {
+    const consume = vi.fn().mockResolvedValue({ allowed: false });
+    const mutation = useConsumeSimulationQuotaMutation({
+      consume,
+    } as unknown as SimulationQuotaClient) as unknown as {
+      mutationFn: () => Promise<unknown>;
+    };
+
+    await mutation.mutationFn();
+    expect(consume).toHaveBeenCalledOnce();
+  });
+
+  it("atualiza o cache da quota no onSuccess", () => {
+    const mutation = useConsumeSimulationQuotaMutation({
+      consume: vi.fn(),
+    } as unknown as SimulationQuotaClient) as unknown as {
+      onSuccess: (quota: unknown) => void;
+    };
+
+    const quota = { allowed: false, remaining: 0 };
+    mutation.onSuccess(quota);
+
+    expect(setQueryData).toHaveBeenCalledWith(SIMULATION_QUOTA_QUERY_KEY, quota);
+  });
+});

--- a/app/features/simulations/queries/use-consume-simulation-quota-mutation.ts
+++ b/app/features/simulations/queries/use-consume-simulation-quota-mutation.ts
@@ -1,0 +1,33 @@
+import {
+  type UseMutationReturnType,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/vue-query";
+
+import {
+  useSimulationQuotaClient,
+  type SimulationQuotaClient,
+} from "~/features/simulations/services/simulation-quota.client";
+import type { SimulationQuota } from "~/features/simulations/model/simulation-quota";
+import { SIMULATION_QUOTA_QUERY_KEY } from "~/features/simulations/queries/use-simulation-quota-query";
+
+/**
+ * Mutation que consome 1 simulação da quota (#566). Em sucesso, atualiza o
+ * cache da query de quota com o snapshot retornado (fonte de verdade no server).
+ *
+ * @param providedClient Client opcional injetado para testes unitários.
+ * @returns Estado Vue Query da mutation com a quota atualizada.
+ */
+export const useConsumeSimulationQuotaMutation = (
+  providedClient?: SimulationQuotaClient,
+): UseMutationReturnType<SimulationQuota, Error, void, unknown> => {
+  const client = providedClient ?? useSimulationQuotaClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (): Promise<SimulationQuota> => client.consume(),
+    onSuccess: (quota: SimulationQuota): void => {
+      queryClient.setQueryData(SIMULATION_QUOTA_QUERY_KEY, quota);
+    },
+  });
+};

--- a/app/features/simulations/queries/use-simulation-quota-query.spec.ts
+++ b/app/features/simulations/queries/use-simulation-quota-query.spec.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  SIMULATION_QUOTA_QUERY_KEY,
+  useSimulationQuotaQuery,
+} from "./use-simulation-quota-query";
+import type { SimulationQuotaClient } from "~/features/simulations/services/simulation-quota.client";
+
+const useQueryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/vue-query", () => ({
+  useQuery: useQueryMock,
+}));
+
+describe("useSimulationQuotaQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useQueryMock.mockImplementation((opts: Record<string, unknown>) => opts);
+  });
+
+  it("registra com a query key canônica", () => {
+    const client: Partial<SimulationQuotaClient> = {
+      getQuota: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const query = useSimulationQuotaQuery(
+      client as SimulationQuotaClient,
+    ) as unknown as { queryKey: typeof SIMULATION_QUOTA_QUERY_KEY };
+
+    expect(query.queryKey).toEqual(SIMULATION_QUOTA_QUERY_KEY);
+  });
+
+  it("delega o fetch ao client.getQuota", async () => {
+    const getQuota = vi.fn().mockResolvedValue({ allowed: true });
+    const query = useSimulationQuotaQuery({
+      getQuota,
+    } as unknown as SimulationQuotaClient) as unknown as {
+      queryFn: () => Promise<unknown>;
+    };
+
+    await query.queryFn();
+    expect(getQuota).toHaveBeenCalledOnce();
+  });
+});

--- a/app/features/simulations/queries/use-simulation-quota-query.ts
+++ b/app/features/simulations/queries/use-simulation-quota-query.ts
@@ -1,0 +1,30 @@
+import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+
+import { STALE_TIME } from "~/core/query/stale-time";
+import {
+  useSimulationQuotaClient,
+  type SimulationQuotaClient,
+} from "~/features/simulations/services/simulation-quota.client";
+import type { SimulationQuota } from "~/features/simulations/model/simulation-quota";
+
+export const SIMULATION_QUOTA_QUERY_KEY = ["simulation-quota"] as const;
+
+/**
+ * Vue Query hook para o snapshot da quota freemium do simulador (#566).
+ *
+ * Erros propagam como estado de erro da query — sem catch silencioso.
+ *
+ * @param providedClient Client opcional injetado para testes unitários.
+ * @returns Estado Vue Query com a quota tipada.
+ */
+export const useSimulationQuotaQuery = (
+  providedClient?: SimulationQuotaClient,
+): UseQueryReturnType<SimulationQuota, Error> => {
+  const client = providedClient ?? useSimulationQuotaClient();
+
+  return useQuery({
+    queryKey: SIMULATION_QUOTA_QUERY_KEY,
+    queryFn: (): Promise<SimulationQuota> => client.getQuota(),
+    staleTime: STALE_TIME.ACTIVE,
+  });
+};

--- a/app/features/simulations/services/simulation-quota.client.spec.ts
+++ b/app/features/simulations/services/simulation-quota.client.spec.ts
@@ -1,0 +1,68 @@
+import type { AxiosInstance } from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SimulationQuotaClient } from "./simulation-quota.client";
+
+/**
+ * Constrói um client com adapter Axios mockado.
+ *
+ * @returns Client de teste e os mocks de get/post.
+ */
+const makeClient = (): {
+  readonly client: SimulationQuotaClient;
+  readonly get: ReturnType<typeof vi.fn>;
+  readonly post: ReturnType<typeof vi.fn>;
+} => {
+  const get = vi.fn();
+  const post = vi.fn();
+  const http = { get, post } as unknown as AxiosInstance;
+  return { client: new SimulationQuotaClient(http), get, post };
+};
+
+describe("SimulationQuotaClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("getQuota chama /simulations/quota e desembrulha o envelope", async () => {
+    const { client, get } = makeClient();
+    get.mockResolvedValue({
+      data: {
+        data: {
+          limit: 1,
+          used: 0,
+          remaining: 1,
+          unlimited: false,
+          allowed: true,
+          reset_at: "2026-06-01T00:00:00Z",
+        },
+      },
+    });
+
+    const quota = await client.getQuota();
+
+    expect(get).toHaveBeenCalledWith("/simulations/quota");
+    expect(quota.remaining).toBe(1);
+    expect(quota.allowed).toBe(true);
+  });
+
+  it("consume faz POST e retorna allowed=false quando esgotado", async () => {
+    const { client, post } = makeClient();
+    post.mockResolvedValue({
+      data: {
+        limit: 1,
+        used: 1,
+        remaining: 0,
+        unlimited: false,
+        allowed: false,
+        reset_at: "2026-06-01T00:00:00Z",
+      },
+    });
+
+    const quota = await client.consume();
+
+    expect(post).toHaveBeenCalledWith("/simulations/quota/consume");
+    expect(quota.allowed).toBe(false);
+    expect(quota.remaining).toBe(0);
+  });
+});

--- a/app/features/simulations/services/simulation-quota.client.ts
+++ b/app/features/simulations/services/simulation-quota.client.ts
@@ -1,0 +1,60 @@
+import type { AxiosInstance } from "axios";
+
+import { useHttp } from "~/composables/useHttp";
+import {
+  toSimulationQuota,
+  type SimulationQuotaDto,
+} from "~/features/simulations/contracts/simulation-quota.dto";
+import type { SimulationQuota } from "~/features/simulations/model/simulation-quota";
+
+type QuotaResponse =
+  | SimulationQuotaDto
+  | { readonly data?: SimulationQuotaDto | null };
+
+/**
+ * API client da quota freemium do simulador (#566 / backend #1409).
+ *
+ * Encapsula as chamadas HTTP aos endpoints `/simulations/quota`.
+ */
+export class SimulationQuotaClient {
+  readonly #http: AxiosInstance;
+
+  /**
+   * @param http Instância Axios já configurada para a API Auraxis.
+   */
+  constructor(http: AxiosInstance) {
+    this.#http = http;
+  }
+
+  /**
+   * Lê o snapshot da quota do usuário autenticado (não consome).
+   *
+   * @returns Quota de domínio tipada.
+   */
+  async getQuota(): Promise<SimulationQuota> {
+    const response = await this.#http.get<QuotaResponse>("/simulations/quota");
+    return toSimulationQuota(response.data);
+  }
+
+  /**
+   * Consome 1 simulação. Não lança em esgotamento — o backend retorna
+   * `allowed=false` e a UI decide exibir o paywall.
+   *
+   * @returns Quota atualizada após a tentativa de consumo.
+   */
+  async consume(): Promise<SimulationQuota> {
+    const response = await this.#http.post<QuotaResponse>(
+      "/simulations/quota/consume",
+    );
+    return toSimulationQuota(response.data);
+  }
+}
+
+/**
+ * Resolve o client canônico usando a camada HTTP compartilhada.
+ *
+ * @returns Instância de SimulationQuotaClient ligada ao adapter HTTP.
+ */
+export const useSimulationQuotaClient = (): SimulationQuotaClient => {
+  return new SimulationQuotaClient(useHttp());
+};

--- a/app/pages/goals/[id]/simulate.vue
+++ b/app/pages/goals/[id]/simulate.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { NAlert, NButton, NSlider, NStatistic, useMessage } from "naive-ui";
+import { NAlert, NButton, NSelect, NSlider, NStatistic, useMessage } from "naive-ui";
 import type { EChartsOption } from "echarts";
 
 import { useGoalsQuery } from "~/features/goals/queries/use-goals-query";
 import { useGoalProjectionQuery } from "~/features/goals/queries/use-goal-projection-query";
 import { useUpdateGoalMutation } from "~/features/goals/queries/use-update-goal-mutation";
 import { projectGoalScenario, projectedCompletionDate } from "~/features/goals/utils/goal-projection";
+import { useSimulationQuota } from "~/features/simulations/composables/useSimulationQuota";
+import SimulatorPaywallOverlay from "~/features/simulations/components/SimulatorPaywallOverlay.vue";
 import { formatCurrency } from "~/utils/currency";
 import UiChart from "~/components/ui/UiChart.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
@@ -198,6 +200,50 @@ const formatCompletion = (value: string | null): string => {
   const date = new Date(`${value}T00:00:00`);
   return new Intl.DateTimeFormat("pt-BR", { month: "short", year: "numeric" }).format(date);
 };
+
+// ── Gate freemium + selector de meta (#566) ──────────────────────────────
+const { quota, unlimited, consume } = useSimulationQuota();
+
+const goalOptions = computed(() =>
+  (goalsQuery.data.value ?? [])
+    .slice()
+    .sort((a, b) => String(b.created_at ?? "").localeCompare(String(a.created_at ?? "")))
+    .slice(0, 10)
+    .map((g) => ({ label: g.name, value: g.id })),
+);
+
+/**
+ *
+ * @param value
+ */
+const onSelectGoal = (value: string): void => {
+  if (value && value !== goalId.value) {
+    void navigateTo(`/goals/${value}/simulate`);
+  }
+};
+
+const hasConsumed = ref<boolean>(false);
+const simulatorLocked = ref<boolean>(false);
+
+/**
+ * Consome a quota na primeira interação real do usuário com os sliders (a
+ * "simulação E se?"). Free esgotado → trava o resultado e exibe o paywall.
+ * Premium nunca consome nem trava.
+ */
+const onUserAdjust = (): void => {
+  if (hasConsumed.value || unlimited.value || !goalId.value) { return; }
+  hasConsumed.value = true;
+  void consume(goalId.value).then((result) => {
+    simulatorLocked.value = !result.allowed;
+  });
+};
+
+/**
+ *
+ */
+const goToUpgrade = (): void => {
+  void navigateTo("/subscription");
+};
 </script>
 
 <template>
@@ -216,6 +262,14 @@ const formatCompletion = (value: string | null): string => {
             {{ formatCurrency(goal.current_amount) }} de {{ formatCurrency(goal.target_amount) }}
           </p>
         </header>
+        <NSelect
+          v-if="goalOptions.length > 1"
+          :value="goalId"
+          :options="goalOptions"
+          data-testid="goal-selector"
+          class="goal-sandbox__selector"
+          @update:value="onSelectGoal"
+        />
       </UiSurfaceCard>
 
       <section class="goal-sandbox__grid">
@@ -231,6 +285,7 @@ const formatCompletion = (value: string | null): string => {
               :min="0"
               :max="Math.max(5000, Math.ceil((baselineMonthly || 500) * 4))"
               :step="50"
+              @update:value="onUserAdjust"
             />
           </div>
 
@@ -239,7 +294,7 @@ const formatCompletion = (value: string | null): string => {
               <span>Prazo (meses)</span>
               <strong>{{ horizonMonths }}</strong>
             </div>
-            <NSlider v-model:value="horizonMonths" :min="6" :max="240" :step="1" />
+            <NSlider v-model:value="horizonMonths" :min="6" :max="240" :step="1" @update:value="onUserAdjust" />
           </div>
 
           <div class="goal-sandbox__field">
@@ -247,26 +302,33 @@ const formatCompletion = (value: string | null): string => {
               <span>Rendimento anual esperado</span>
               <strong>{{ annualRatePct.toFixed(2) }}%</strong>
             </div>
-            <NSlider v-model:value="annualRatePct" :min="0" :max="25" :step="0.25" />
+            <NSlider v-model:value="annualRatePct" :min="0" :max="25" :step="0.25" @update:value="onUserAdjust" />
           </div>
         </UiSurfaceCard>
 
         <UiSurfaceCard class="goal-sandbox__indicators">
-          <h2 class="goal-sandbox__section-title">Indicadores</h2>
-          <div class="goal-sandbox__stats">
-            <NStatistic label="Valor projetado">
-              {{ formatCurrency(adjustedScenario?.finalBalance ?? 0) }}
-            </NStatistic>
-            <NStatistic label="Gap restante">
-              {{ formatCurrency(adjustedScenario?.remainingGap ?? 0) }}
-            </NStatistic>
-            <NStatistic label="Conclusão estimada">
-              {{ formatCompletion(adjustedCompletion) }}
-            </NStatistic>
+          <div :class="{ 'goal-sandbox__blurred': simulatorLocked }">
+            <h2 class="goal-sandbox__section-title">Indicadores</h2>
+            <div class="goal-sandbox__stats">
+              <NStatistic label="Valor projetado">
+                {{ formatCurrency(adjustedScenario?.finalBalance ?? 0) }}
+              </NStatistic>
+              <NStatistic label="Gap restante">
+                {{ formatCurrency(adjustedScenario?.remainingGap ?? 0) }}
+              </NStatistic>
+              <NStatistic label="Conclusão estimada">
+                {{ formatCompletion(adjustedCompletion) }}
+              </NStatistic>
+            </div>
+            <p v-if="adjustedScenario && adjustedScenario.monthsToTarget === null" class="goal-sandbox__warning">
+              Nesse cenário, a meta não é atingida dentro do prazo selecionado. Aumente o aporte ou o horizonte.
+            </p>
           </div>
-          <p v-if="adjustedScenario && adjustedScenario.monthsToTarget === null" class="goal-sandbox__warning">
-            Nesse cenário, a meta não é atingida dentro do prazo selecionado. Aumente o aporte ou o horizonte.
-          </p>
+          <SimulatorPaywallOverlay
+            v-if="simulatorLocked"
+            :reset-at="quota.resetAt"
+            @upgrade="goToUpgrade"
+          />
         </UiSurfaceCard>
       </section>
 
@@ -353,6 +415,16 @@ const formatCompletion = (value: string | null): string => {
   color: var(--color-warning);
   font-size: var(--font-size-sm);
 }
+
+.goal-sandbox__indicators { position: relative; }
+
+.goal-sandbox__blurred {
+  filter: blur(6px);
+  pointer-events: none;
+  user-select: none;
+}
+
+.goal-sandbox__selector { margin-top: var(--space-2); max-width: 18rem; }
 
 .goal-sandbox__chart { display: grid; gap: var(--space-2); }
 

--- a/app/plugins/posthog.client.ts
+++ b/app/plugins/posthog.client.ts
@@ -30,7 +30,9 @@ export type AuraxisEvent =
   | "upgrade_clicked"
   | "upgrade_completed"
   // ── Account trust (#922) ──────────────────────────────────────────────
-  | "email_confirmation_completed";
+  | "email_confirmation_completed"
+  // ── Freemium simulador (#566) ─────────────────────────────────────────
+  | "free_simulation_used";
 
 /** Typed analytics client exposed as `$analytics` in the Nuxt app. */
 export interface AnalyticsClient {

--- a/app/shared/types/generated/graphql.ts
+++ b/app/shared/types/generated/graphql.ts
@@ -479,6 +479,7 @@ export type GenerateAiInsightPayload = {
   contextVersion?: Maybe<Scalars['String']['output']>;
   costUsd?: Maybe<Scalars['Float']['output']>;
   forecast?: Maybe<Scalars['Boolean']['output']>;
+  id?: Maybe<Scalars['String']['output']>;
   items?: Maybe<Array<Maybe<AiInsightItemType>>>;
   model?: Maybe<Scalars['String']['output']>;
   ok: Scalars['Boolean']['output'];


### PR DESCRIPTION
## O que

Gate freemium do simulador de metas (umbrella #536). Free tier: **1 simulação completa/mês** (consome na 1ª interação com os sliders — a "E se?"); premium (`advanced_simulations`) ilimitado; ao esgotar, **resultado borrado + paywall com CTA** (não mata o cálculo).

## Entrega

- `app/features/simulations/`: client manual + query + mutation + composable `useSimulationQuota` + model + contracts (envelope-aware).
- `SimulatorPaywallOverlay.vue` — emite `paywall_shown` (mount) e `upgrade_clicked` (CTA).
- Evento `free_simulation_used` adicionado ao catálogo tipado `AuraxisEvent`.
- Selector de metas no topo de `goals/[id]/simulate.vue` (até 10, criação desc) + blur/overlay no card de indicadores.
- **25 testes unitários**; `pnpm quality-check` verde (lint, typecheck, coverage ≥85%, policy, contracts, codegen, build).

## Contrato

Consome o backend `GET/POST /simulations/quota` (#1409, PR auraxis-api #1410). Client manual (padrão `entitlement.client.ts`) — sem depender de codegen.

## Notas

- Commit `chore(codegen)` separado sincroniza `GenerateAiInsightPayload.id` (drift pré-existente do `main` vs schema, do #1402) só para destravar o gate `codegen:check` — não relacionado ao #566.

Spec: `auraxis-platform docs/superpowers/specs/2026-05-31-freemium-simulator-design.md`.

Closes #566 · ref #536