### PR TITLE
feat(goals): comparação de 3 cenários + salvar rascunho no simulador (#536)

### DIFF
--- a/app/features/goals/utils/simulation-scenarios.spec.ts
+++ b/app/features/goals/utils/simulation-scenarios.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_PINNED_SCENARIOS,
+  addPinnedScenario,
+  canPinScenario,
+  removePinnedScenario,
+  type PinnedScenario,
+} from "./simulation-scenarios";
+
+/**
+ * Constrói um cenário fixado de teste.
+ *
+ * @param id Id do cenário.
+ * @returns Cenário fixado.
+ */
+const scenario = (id: string): PinnedScenario => ({
+  id,
+  label: `Cenário ${id}`,
+  monthlyContribution: 200,
+  annualRatePct: 8,
+  horizonMonths: 24,
+  points: [1, 2, 3],
+});
+
+describe("simulation-scenarios", () => {
+  it("adiciona cenários até o teto", () => {
+    let list: PinnedScenario[] = [];
+    for (let i = 0; i < MAX_PINNED_SCENARIOS; i += 1) {
+      list = addPinnedScenario(list, scenario(String(i)));
+    }
+    expect(list).toHaveLength(MAX_PINNED_SCENARIOS);
+  });
+
+  it("não ultrapassa o teto de cenários", () => {
+    let list: PinnedScenario[] = [];
+    for (let i = 0; i < MAX_PINNED_SCENARIOS + 2; i += 1) {
+      list = addPinnedScenario(list, scenario(String(i)));
+    }
+    expect(list).toHaveLength(MAX_PINNED_SCENARIOS);
+  });
+
+  it("remove por id", () => {
+    const list = [scenario("a"), scenario("b")];
+    expect(removePinnedScenario(list, "a")).toEqual([scenario("b")]);
+  });
+
+  it("canPinScenario reflete o teto", () => {
+    expect(canPinScenario([])).toBe(true);
+    expect(canPinScenario([scenario("a"), scenario("b"), scenario("c")])).toBe(false);
+  });
+});

--- a/app/features/goals/utils/simulation-scenarios.ts
+++ b/app/features/goals/utils/simulation-scenarios.ts
@@ -1,0 +1,57 @@
+/**
+ * Gestão dos cenários fixados para comparação no simulador de metas (PROD-02 / #536).
+ *
+ * O usuário pode fixar até {@link MAX_PINNED_SCENARIOS} cenários "E se?" para
+ * comparar lado a lado no gráfico (cada um vira uma série; o ECharts atribui
+ * cores distintas automaticamente).
+ */
+
+export const MAX_PINNED_SCENARIOS = 3;
+
+export interface PinnedScenario {
+  readonly id: string;
+  readonly label: string;
+  readonly monthlyContribution: number;
+  readonly annualRatePct: number;
+  readonly horizonMonths: number;
+  /** Saldo projetado por mês (já arredondado para 2 casas). */
+  readonly points: readonly number[];
+}
+
+/**
+ * Adiciona um cenário à lista de comparação, respeitando o teto.
+ *
+ * @param list Lista atual de cenários fixados.
+ * @param scenario Cenário a adicionar.
+ * @returns Nova lista (inalterada quando o teto foi atingido).
+ */
+export const addPinnedScenario = (
+  list: readonly PinnedScenario[],
+  scenario: PinnedScenario,
+): PinnedScenario[] => {
+  if (list.length >= MAX_PINNED_SCENARIOS) {
+    return [...list];
+  }
+  return [...list, scenario];
+};
+
+/**
+ * Remove um cenário fixado por id.
+ *
+ * @param list Lista atual.
+ * @param id Id do cenário a remover.
+ * @returns Nova lista sem o cenário.
+ */
+export const removePinnedScenario = (
+  list: readonly PinnedScenario[],
+  id: string,
+): PinnedScenario[] => list.filter((scenario) => scenario.id !== id);
+
+/**
+ * Indica se ainda é possível fixar mais um cenário.
+ *
+ * @param list Lista atual.
+ * @returns True quando abaixo do teto.
+ */
+export const canPinScenario = (list: readonly PinnedScenario[]): boolean =>
+  list.length < MAX_PINNED_SCENARIOS;

--- a/app/pages/goals/[id]/simulate.vue
+++ b/app/pages/goals/[id]/simulate.vue
@@ -9,6 +9,13 @@ import { useUpdateGoalMutation } from "~/features/goals/queries/use-update-goal-
 import { projectGoalScenario, projectedCompletionDate } from "~/features/goals/utils/goal-projection";
 import { useSimulationQuota } from "~/features/simulations/composables/useSimulationQuota";
 import SimulatorPaywallOverlay from "~/features/simulations/components/SimulatorPaywallOverlay.vue";
+import SaveSimulationButton from "~/components/simulation/SaveSimulationButton.vue";
+import {
+  addPinnedScenario,
+  canPinScenario,
+  removePinnedScenario,
+  type PinnedScenario,
+} from "~/features/goals/utils/simulation-scenarios";
 import { formatCurrency } from "~/utils/currency";
 import UiChart from "~/components/ui/UiChart.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
@@ -93,6 +100,52 @@ const adjustedScenario = computed(() => {
   });
 });
 
+// ── Comparação de até 3 cenários (PROD-02 / #536) ────────────────────────
+const comparisons = ref<PinnedScenario[]>([]);
+let scenarioCounter = 0;
+
+const canPin = computed<boolean>(() => canPinScenario(comparisons.value));
+
+/**
+ *
+ */
+const pinCurrentScenario = (): void => {
+  const scenario = adjustedScenario.value;
+  if (!scenario || !canPin.value) { return; }
+  scenarioCounter += 1;
+  comparisons.value = addPinnedScenario(comparisons.value, {
+    id: `s${scenarioCounter}`,
+    label: `${formatCurrency(monthlyContribution.value)}/mês · ${horizonMonths.value}m · ${annualRatePct.value.toFixed(1)}%`,
+    monthlyContribution: monthlyContribution.value,
+    annualRatePct: annualRatePct.value,
+    horizonMonths: horizonMonths.value,
+    points: scenario.points.map((p) => Number(p.balance.toFixed(2))),
+  });
+};
+
+/**
+ *
+ * @param id
+ */
+const removeComparison = (id: string): void => {
+  comparisons.value = removePinnedScenario(comparisons.value, id);
+};
+
+// ── Salvar simulação como rascunho (PROD-02 / #536) ──────────────────────
+const saveInputs = computed<Record<string, unknown>>(() => ({
+  goal_id: goalId.value,
+  monthly_contribution: monthlyContribution.value,
+  annual_rate_pct: annualRatePct.value,
+  horizon_months: horizonMonths.value,
+}));
+
+const saveResult = computed<Record<string, unknown>>(() => ({
+  final_balance: adjustedScenario.value?.finalBalance ?? 0,
+  remaining_gap: adjustedScenario.value?.remainingGap ?? 0,
+  months_to_target: adjustedScenario.value?.monthsToTarget ?? null,
+  projected_completion: adjustedCompletion.value,
+}));
+
 const chartOption = computed<EChartsOption>(() => {
   const baseline = baselineScenario.value;
   const adjusted = adjustedScenario.value;
@@ -131,6 +184,12 @@ const chartOption = computed<EChartsOption>(() => {
         showSymbol: false,
         data: adjusted?.points.map((p) => Number(p.balance.toFixed(2))) ?? [],
       },
+      ...comparisons.value.map((scenario) => ({
+        name: scenario.label,
+        type: "line" as const,
+        showSymbol: false,
+        data: [...scenario.points],
+      })),
     ],
   };
 });
@@ -333,8 +392,22 @@ const goToUpgrade = (): void => {
       </section>
 
       <UiSurfaceCard class="goal-sandbox__chart">
-        <h2 class="goal-sandbox__section-title">Projeção ao longo do tempo</h2>
-        <UiChart :option="chartOption" :update-key="`${horizonMonths}-${monthlyContribution}-${annualRatePct}`" height="340px" />
+        <div class="goal-sandbox__chart-head">
+          <h2 class="goal-sandbox__section-title">Projeção ao longo do tempo</h2>
+          <NButton
+            size="small"
+            :disabled="!canPin || !adjustedScenario"
+            data-testid="pin-scenario"
+            @click="pinCurrentScenario"
+          >
+            Adicionar à comparação
+          </NButton>
+        </div>
+        <UiChart
+          :option="chartOption"
+          :update-key="`${horizonMonths}-${monthlyContribution}-${annualRatePct}-${comparisons.length}`"
+          height="340px"
+        />
         <ul class="goal-sandbox__legend">
           <li>
             <span class="goal-sandbox__legend-dot goal-sandbox__legend-dot--baseline" />
@@ -345,10 +418,27 @@ const goToUpgrade = (): void => {
             Aporte ajustado ({{ formatCurrency(monthlyContribution) }} · {{ formatCompletion(adjustedCompletion) }})
           </li>
         </ul>
+
+        <div v-if="comparisons.length" class="goal-sandbox__comparisons" data-testid="comparisons">
+          <span class="goal-sandbox__comparisons-title">Cenários comparados ({{ comparisons.length }}/3)</span>
+          <ul>
+            <li v-for="scenario in comparisons" :key="scenario.id">
+              <span>{{ scenario.label }}</span>
+              <NButton text size="tiny" :data-testid="`remove-${scenario.id}`" @click="removeComparison(scenario.id)">✕</NButton>
+            </li>
+          </ul>
+        </div>
       </UiSurfaceCard>
 
       <div class="goal-sandbox__actions">
         <NButton secondary @click="navigateTo('/goals')">Cancelar</NButton>
+        <SaveSimulationButton
+          tool-id="goal-simulator"
+          rule-version="2026.06"
+          :inputs="saveInputs"
+          :result="saveResult"
+          label="Salvar como rascunho"
+        />
         <NButton type="primary" :loading="updateMutation.isPending.value" :disabled="!canApply" @click="applyScenario">
           Aplicar este cenário
         </NButton>
@@ -427,6 +517,41 @@ const goToUpgrade = (): void => {
 .goal-sandbox__selector { margin-top: var(--space-2); max-width: 18rem; }
 
 .goal-sandbox__chart { display: grid; gap: var(--space-2); }
+
+.goal-sandbox__chart-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.goal-sandbox__comparisons {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--font-size-xs);
+}
+
+.goal-sandbox__comparisons-title {
+  font-weight: var(--font-weight-medium);
+  opacity: 0.8;
+}
+
+.goal-sandbox__comparisons ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.goal-sandbox__comparisons li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
 
 .goal-sandbox__legend {
   list-style: none;


### PR DESCRIPTION
## O que

Fecha as **2 ACs restantes** do umbrella PROD-02 'Simulador E Se?' (#536). A página, projection, tempo real e o gate freemium (#566) já estavam entregues.

- **Comparar até 3 cenários simultâneos**: botão 'Adicionar à comparação' fixa o cenário ajustado atual (cap 3); cada fixado vira uma série no gráfico (cores distintas automáticas do ECharts) + lista com remover. Lógica pura em `app/features/goals/utils/simulation-scenarios.ts` (add/remove/cap) com 4 testes.
- **Salvar simulação como rascunho**: reusa o `<SaveSimulationButton tool-id="goal-simulator">` existente, persistindo inputs (aporte/taxa/horizonte) + result (saldo/gap/conclusão) do cenário.

Strings hardcoded (consistente com a página, que não usa i18n) → sem ritual de en-freeze. `pnpm quality-check` verde.

Closes #536