### PR TITLE
feat(tools): calculadora de custo de vida regional (PROD-09 growth loop)

### DIFF
--- a/app/data/tools.ts
+++ b/app/data/tools.ts
@@ -18,6 +18,7 @@ export const TOOL_SLUGS: readonly string[] = [
   "cet",
   "clt-vs-pj",
   "conversor-moeda",
+  "custo-de-vida-regional",
   "custo-estilo-vida",
   "desconto-markup",
   "dividir-conta",

--- a/app/features/tools/model/custo-de-vida-regional.spec.ts
+++ b/app/features/tools/model/custo-de-vida-regional.spec.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CUSTO_VIDA_REGIONAL_PUBLIC_PATH,
+  EXPENSE_CATEGORY_KEYS,
+  calculateRegionalCost,
+  createDefaultRegionalCostFormState,
+  decodeQueryToForm,
+  encodeFormToQuery,
+  validateRegionalCostForm,
+  type RegionalCostFormState,
+} from "./custo-de-vida-regional";
+
+/**
+ * Builds a valid form state with sensible defaults for tests.
+ *
+ * @param overrides Partial overrides merged onto the baseline.
+ * @returns A complete form state.
+ */
+function makeForm(overrides: Partial<RegionalCostFormState> = {}): RegionalCostFormState {
+  return {
+    uf: "SP",
+    monthlyIncome: 10000,
+    housing: 2500,
+    transport: 800,
+    food: 1500,
+    leisure: 700,
+    other: 500,
+    ...overrides,
+  };
+}
+
+describe("custo-de-vida-regional model", () => {
+  it("exposes the public path", () => {
+    expect(CUSTO_VIDA_REGIONAL_PUBLIC_PATH).toBe("/tools/custo-de-vida-regional");
+  });
+
+  it("creates a default form state with a valid UF and zeroed expenses", () => {
+    const form = createDefaultRegionalCostFormState();
+    expect(form.uf).toHaveLength(2);
+    expect(form.monthlyIncome).toBe(0);
+    for (const key of EXPENSE_CATEGORY_KEYS) {
+      expect(form[key]).toBe(0);
+    }
+  });
+
+  describe("validation", () => {
+    it("requires a positive income", () => {
+      const errors = validateRegionalCostForm(makeForm({ monthlyIncome: 0 }));
+      expect(errors.some((e) => e.field === "monthlyIncome")).toBe(true);
+    });
+
+    it("requires at least one expense", () => {
+      const errors = validateRegionalCostForm(
+        makeForm({ housing: 0, transport: 0, food: 0, leisure: 0, other: 0 }),
+      );
+      expect(errors.some((e) => e.field === "expenses")).toBe(true);
+    });
+
+    it("rejects an unknown UF", () => {
+      const errors = validateRegionalCostForm(makeForm({ uf: "ZZ" }));
+      expect(errors.some((e) => e.field === "uf")).toBe(true);
+    });
+
+    it("accepts a valid form", () => {
+      expect(validateRegionalCostForm(makeForm())).toHaveLength(0);
+    });
+  });
+
+  describe("calculateRegionalCost", () => {
+    it("sums the monthly cost across categories", () => {
+      const result = calculateRegionalCost(makeForm());
+      expect(result.totalMonthlyCost).toBe(6000);
+      expect(result.totalAnnualCost).toBe(72000);
+    });
+
+    it("computes committed percentage of income", () => {
+      const result = calculateRegionalCost(makeForm({ monthlyIncome: 10000 }));
+      expect(result.committedPct).toBe(60);
+      expect(result.savingsRatePct).toBe(40);
+      expect(result.monthlySavings).toBe(4000);
+    });
+
+    it("returns a per-category breakdown summing to the total", () => {
+      const result = calculateRegionalCost(makeForm());
+      const sum = result.categories.reduce((s, c) => s + c.amount, 0);
+      expect(sum).toBe(result.totalMonthlyCost);
+      const housing = result.categories.find((c) => c.key === "housing");
+      expect(housing?.pctOfIncome).toBe(25);
+    });
+
+    it("computes years to retirement via the 4% rule when saving", () => {
+      const result = calculateRegionalCost(makeForm());
+      // target wealth = annual cost (72000) * 25 = 1,800,000
+      expect(result.targetWealth).toBe(1800000);
+      expect(result.yearsToRetirement).not.toBeNull();
+      expect(result.yearsToRetirement as number).toBeGreaterThan(0);
+    });
+
+    it("returns null years to retirement when there are no savings", () => {
+      const result = calculateRegionalCost(
+        makeForm({ monthlyIncome: 6000 }), // income equals total cost → zero savings
+      );
+      expect(result.monthlySavings).toBe(0);
+      expect(result.yearsToRetirement).toBeNull();
+    });
+
+    it("includes a regional comparison from the dataset", () => {
+      const result = calculateRegionalCost(makeForm());
+      expect(result.regional.uf).toBe("SP");
+      expect(result.regional.avgIncome).toBeGreaterThan(0);
+      expect(result.regional.avgCost).toBeGreaterThan(0);
+      expect(typeof result.regional.costVsRegionalPct).toBe("number");
+    });
+
+    it("produces a sustainability score between 0 and 100", () => {
+      const result = calculateRegionalCost(makeForm());
+      expect(result.sustainabilityScore).toBeGreaterThanOrEqual(0);
+      expect(result.sustainabilityScore).toBeLessThanOrEqual(100);
+    });
+
+    it("scores a heavy spender lower than a frugal saver", () => {
+      const frugal = calculateRegionalCost(makeForm({ monthlyIncome: 10000, housing: 1000, transport: 200, food: 600, leisure: 200, other: 0 }));
+      const heavy = calculateRegionalCost(makeForm({ monthlyIncome: 10000, housing: 4000, transport: 1500, food: 2500, leisure: 1500, other: 400 }));
+      expect(frugal.sustainabilityScore).toBeGreaterThan(heavy.sustainabilityScore);
+    });
+  });
+
+  describe("URL sharing round-trip", () => {
+    it("encodes and decodes a form state", () => {
+      const form = makeForm({ uf: "RJ", monthlyIncome: 8000, leisure: 1200 });
+      const decoded = decodeQueryToForm(encodeFormToQuery(form));
+      expect(decoded).not.toBeNull();
+      expect(decoded?.uf).toBe("RJ");
+      expect(decoded?.monthlyIncome).toBe(8000);
+      expect(decoded?.leisure).toBe(1200);
+    });
+
+    it("returns null for malformed input", () => {
+      expect(decodeQueryToForm("not-base64!!!")).toBeNull();
+    });
+  });
+});

--- a/app/features/tools/model/custo-de-vida-regional.ts
+++ b/app/features/tools/model/custo-de-vida-regional.ts
@@ -1,0 +1,321 @@
+/**
+ * Domain model for the Calculadora de Custo de Vida Regional (PROD-09, #556/#557/#558).
+ *
+ * Public, login-free growth tool. Compares the user's monthly lifestyle cost
+ * against regional averages (IBGE/DIEESE reference data), derives the share of
+ * income committed, a sustainability score (0–100), and the years-to-retirement
+ * estimate via the 4% rule. Supports URL query encoding for viral sharing.
+ *
+ * Distinct from `custo-estilo-vida.ts`, which models opportunity cost of spending.
+ */
+
+import costOfLivingByUf from "../../../shared/data/cost-of-living-by-uf.json";
+
+import { round2 } from "./math-utils";
+
+export const CUSTO_VIDA_REGIONAL_PUBLIC_PATH = "/tools/custo-de-vida-regional";
+
+/** Annual real (inflation-adjusted) return used for the retirement projection. */
+export const DEFAULT_REAL_RETURN_PCT = 4;
+
+/** Safe withdrawal multiplier (4% rule): wealth target = annual cost × 25. */
+export const SAFE_WITHDRAWAL_MULTIPLIER = 25;
+
+// ─── Regional dataset ──────────────────────────────────────────────────────
+
+interface RegionalEntry {
+  name: string;
+  avgIncome: number;
+  avgCost: number;
+}
+
+const REGIONAL_DATA = (costOfLivingByUf as { data: Record<string, RegionalEntry> }).data;
+
+/** Sorted list of valid UF codes from the dataset. */
+export const UF_CODES: readonly string[] = Object.keys(REGIONAL_DATA).sort();
+
+/**
+ * @param uf UF code (e.g. "SP").
+ * @returns The regional entry, or null when the UF is unknown.
+ */
+export function getRegionalEntry(uf: string): RegionalEntry | null {
+  return REGIONAL_DATA[uf] ?? null;
+}
+
+// ─── Expense categories ──────────────────────────────────────────────────────
+
+export const EXPENSE_CATEGORY_KEYS = [
+  "housing",
+  "transport",
+  "food",
+  "leisure",
+  "other",
+] as const;
+
+export type ExpenseCategoryKey = (typeof EXPENSE_CATEGORY_KEYS)[number];
+
+// ─── Form state ──────────────────────────────────────────────────────────────
+
+export interface RegionalCostFormState extends Record<string, unknown> {
+  uf: string;
+  monthlyIncome: number;
+  housing: number;
+  transport: number;
+  food: number;
+  leisure: number;
+  other: number;
+}
+
+/**
+ * @returns Default form state (São Paulo, zeroed income and expenses).
+ */
+export function createDefaultRegionalCostFormState(): RegionalCostFormState {
+  return {
+    uf: "SP",
+    monthlyIncome: 0,
+    housing: 0,
+    transport: 0,
+    food: 0,
+    leisure: 0,
+    other: 0,
+  };
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+export interface RegionalCostValidationError {
+  field: string;
+  messageKey: string;
+}
+
+/**
+ * @param form Current form state.
+ * @returns Validation errors, if any.
+ */
+export function validateRegionalCostForm(
+  form: RegionalCostFormState,
+): RegionalCostValidationError[] {
+  const errors: RegionalCostValidationError[] = [];
+
+  if (!getRegionalEntry(form.uf)) {
+    errors.push({ field: "uf", messageKey: "errors.ufRequired" });
+  }
+
+  if (!Number.isFinite(form.monthlyIncome) || form.monthlyIncome <= 0) {
+    errors.push({ field: "monthlyIncome", messageKey: "errors.incomeRequired" });
+  }
+
+  const totalExpenses = EXPENSE_CATEGORY_KEYS.reduce((sum, key) => sum + (form[key] || 0), 0);
+  if (!Number.isFinite(totalExpenses) || totalExpenses <= 0) {
+    errors.push({ field: "expenses", messageKey: "errors.atLeastOneExpenseRequired" });
+  }
+
+  return errors;
+}
+
+// ─── Result ────────────────────────────────────────────────────────────────
+
+export interface CategoryBreakdown {
+  key: ExpenseCategoryKey;
+  amount: number;
+  pctOfIncome: number;
+  pctOfTotal: number;
+}
+
+export interface RegionalComparison {
+  uf: string;
+  name: string;
+  avgIncome: number;
+  avgCost: number;
+  /** User total cost relative to regional average cost, as a +/- percentage. */
+  costVsRegionalPct: number;
+  /** User income relative to regional average income, as a +/- percentage. */
+  incomeVsRegionalPct: number;
+}
+
+export interface RegionalCostResult {
+  totalMonthlyCost: number;
+  totalAnnualCost: number;
+  committedPct: number;
+  savingsRatePct: number;
+  monthlySavings: number;
+  categories: CategoryBreakdown[];
+  targetWealth: number;
+  yearsToRetirement: number | null;
+  regional: RegionalComparison;
+  sustainabilityScore: number;
+}
+
+/**
+ * Clamps a value into the inclusive [min, max] range.
+ *
+ * @param value Raw value.
+ * @param min Lower bound.
+ * @param max Upper bound.
+ * @returns The clamped value.
+ */
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Estimates years to financial independence using the 4% rule.
+ *
+ * Solves the future-value-of-annuity equation for the number of months needed
+ * to reach `targetWealth` given monthly contributions invested at a real rate.
+ *
+ * @param monthlySavings Amount invested each month (must be > 0).
+ * @param targetWealth Wealth target (annual cost × 25).
+ * @param annualRealReturnPct Annual real return percentage.
+ * @returns Years to retirement, or null when savings are non-positive.
+ */
+export function estimateYearsToRetirement(
+  monthlySavings: number,
+  targetWealth: number,
+  annualRealReturnPct: number = DEFAULT_REAL_RETURN_PCT,
+): number | null {
+  if (monthlySavings <= 0 || targetWealth <= 0) {
+    return null;
+  }
+  const monthlyRate = Math.pow(1 + annualRealReturnPct / 100, 1 / 12) - 1;
+  if (monthlyRate === 0) {
+    return round2(targetWealth / monthlySavings / 12);
+  }
+  const months =
+    Math.log(1 + (targetWealth * monthlyRate) / monthlySavings) / Math.log(1 + monthlyRate);
+  return round2(months / 12);
+}
+
+/**
+ * Computes the full regional cost analysis.
+ *
+ * @param form Validated form state.
+ * @returns Cost breakdown, regional comparison, retirement and sustainability metrics.
+ */
+export function calculateRegionalCost(form: RegionalCostFormState): RegionalCostResult {
+  const income = form.monthlyIncome;
+  const totalMonthlyCost = round2(
+    EXPENSE_CATEGORY_KEYS.reduce((sum, key) => sum + (form[key] || 0), 0),
+  );
+  const totalAnnualCost = round2(totalMonthlyCost * 12);
+  const monthlySavings = round2(income - totalMonthlyCost);
+  const committedPct = income > 0 ? round2((totalMonthlyCost / income) * 100) : 0;
+  const savingsRatePct = income > 0 ? round2((monthlySavings / income) * 100) : 0;
+
+  const categories: CategoryBreakdown[] = EXPENSE_CATEGORY_KEYS.map((key) => {
+    const amount = round2(form[key] || 0);
+    return {
+      key,
+      amount,
+      pctOfIncome: income > 0 ? round2((amount / income) * 100) : 0,
+      pctOfTotal: totalMonthlyCost > 0 ? round2((amount / totalMonthlyCost) * 100) : 0,
+    };
+  });
+
+  const targetWealth = round2(totalAnnualCost * SAFE_WITHDRAWAL_MULTIPLIER);
+  const yearsToRetirement = estimateYearsToRetirement(monthlySavings, targetWealth);
+
+  const entry = getRegionalEntry(form.uf) ?? { name: form.uf, avgIncome: 0, avgCost: 0 };
+  const regional: RegionalComparison = {
+    uf: form.uf,
+    name: entry.name,
+    avgIncome: entry.avgIncome,
+    avgCost: entry.avgCost,
+    costVsRegionalPct:
+      entry.avgCost > 0 ? round2((totalMonthlyCost / entry.avgCost - 1) * 100) : 0,
+    incomeVsRegionalPct: entry.avgIncome > 0 ? round2((income / entry.avgIncome - 1) * 100) : 0,
+  };
+
+  const sustainabilityScore = computeSustainabilityScore({
+    savingsRatePct,
+    totalMonthlyCost,
+    regionalAvgCost: entry.avgCost,
+  });
+
+  return {
+    totalMonthlyCost,
+    totalAnnualCost,
+    committedPct,
+    savingsRatePct,
+    monthlySavings,
+    categories,
+    targetWealth,
+    yearsToRetirement,
+    regional,
+    sustainabilityScore,
+  };
+}
+
+interface SustainabilityInput {
+  savingsRatePct: number;
+  totalMonthlyCost: number;
+  regionalAvgCost: number;
+}
+
+/**
+ * Blends savings discipline (70%) with regional cost efficiency (30%) into a
+ * 0–100 sustainability score. A 20%+ savings rate and spending at or below the
+ * regional average both earn full marks on their respective components.
+ *
+ * @param input Savings rate and regional cost context.
+ * @returns Sustainability score in [0, 100].
+ */
+export function computeSustainabilityScore(input: SustainabilityInput): number {
+  const savingsScore = clamp((input.savingsRatePct / 20) * 100, 0, 100);
+  const ratio = input.regionalAvgCost > 0 ? input.totalMonthlyCost / input.regionalAvgCost : 1;
+  const regionalScore = clamp((2 - ratio) * 100, 0, 100);
+  return Math.round(clamp(0.7 * savingsScore + 0.3 * regionalScore, 0, 100));
+}
+
+// ─── URL sharing ─────────────────────────────────────────────────────────────
+
+/**
+ * @param form Form state to encode.
+ * @returns Base64-encoded compact query payload.
+ */
+export function encodeFormToQuery(form: RegionalCostFormState): string {
+  const data = {
+    u: form.uf,
+    i: form.monthlyIncome,
+    h: form.housing,
+    t: form.transport,
+    f: form.food,
+    l: form.leisure,
+    o: form.other,
+  };
+  return btoa(JSON.stringify(data));
+}
+
+/**
+ * Coerces an unknown value into a finite number, defaulting to zero.
+ *
+ * @param value Raw value from the decoded payload.
+ * @returns The numeric value, or 0 when not a finite number.
+ */
+function coerceNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * @param encoded Base64-encoded payload produced by {@link encodeFormToQuery}.
+ * @returns Decoded form state, or null when the payload is malformed.
+ */
+export function decodeQueryToForm(encoded: string): RegionalCostFormState | null {
+  try {
+    const data = JSON.parse(atob(encoded)) as Record<string, unknown>;
+    if (typeof data.u !== "string") {
+      return null;
+    }
+    return {
+      uf: data.u,
+      monthlyIncome: coerceNumber(data.i),
+      housing: coerceNumber(data.h),
+      transport: coerceNumber(data.t),
+      food: coerceNumber(data.f),
+      leisure: coerceNumber(data.l),
+      other: coerceNumber(data.o),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/app/features/tools/model/custo-de-vida-regional.ts
+++ b/app/features/tools/model/custo-de-vida-regional.ts
@@ -32,7 +32,9 @@ interface RegionalEntry {
 const REGIONAL_DATA = (costOfLivingByUf as { data: Record<string, RegionalEntry> }).data;
 
 /** Sorted list of valid UF codes from the dataset. */
-export const UF_CODES: readonly string[] = Object.keys(REGIONAL_DATA).sort();
+export const UF_CODES: readonly string[] = Object.keys(REGIONAL_DATA).sort((a, b) =>
+  a.localeCompare(b),
+);
 
 /**
  * @param uf UF code (e.g. "SP").

--- a/app/features/tools/model/tools-catalog.ts
+++ b/app/features/tools/model/tools-catalog.ts
@@ -326,6 +326,17 @@ export const TOOLS_CATALOG: readonly Tool[] = [
     saveIntent: "goal",
     category: "planejamento",
   },
+  {
+    id: "custo-de-vida-regional",
+    name: "Custo de Vida Regional",
+    description:
+      "Compare seus gastos com a média do seu estado e descubra seu score de sustentabilidade financeira.",
+    enabled: isFeatureEnabled("web.tools.custo-de-vida-regional"),
+    accessLevel: "public",
+    route: "/tools/custo-de-vida-regional",
+    featureFlag: "web.tools.custo-de-vida-regional",
+    category: "planejamento",
+  },
 ];
 
 /**

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -3953,5 +3953,101 @@
         "unavailable": "Ainda não há histórico suficiente para comparar meses."
       }
     }
+  },
+  "custoVidaRegional": {
+    "seo": {
+      "title": "Calculadora de Custo de Vida por Estado | Auraxis",
+      "description": "Descubra quanto do seu salário o seu estilo de vida consome, compare com a média do seu estado e veja em quantos anos você poderia se aposentar.",
+      "ogTitle": "Quanto Custa o Seu Estilo de Vida? | Auraxis",
+      "ogDescription": "Compare o custo do seu estilo de vida com a média regional e descubra seu score de sustentabilidade financeira."
+    },
+    "hero": {
+      "title": "Custo de Vida Regional",
+      "subtitle": "Compare seus gastos com a média do seu estado e descubra o quão sustentável é o seu estilo de vida."
+    },
+    "form": {
+      "title": "Sua renda e seus gastos mensais",
+      "uf": "Estado (UF)",
+      "ufPlaceholder": "Selecione seu estado",
+      "monthlyIncome": "Renda mensal líquida (R$)",
+      "housing": "Moradia (aluguel, condomínio, contas)",
+      "transport": "Transporte (combustível, app, transporte público)",
+      "food": "Alimentação (mercado, restaurantes)",
+      "leisure": "Lazer (streaming, viagens, hobbies)",
+      "other": "Outros gastos fixos",
+      "calculate": "Calcular",
+      "reset": "Limpar"
+    },
+    "categories": {
+      "housing": "Moradia",
+      "transport": "Transporte",
+      "food": "Alimentação",
+      "leisure": "Lazer",
+      "other": "Outros"
+    },
+    "results": {
+      "totalMonthly": "Custo mensal total",
+      "totalAnnual": "Custo anual total",
+      "committedPct": "Da sua renda comprometida",
+      "savingsRate": "Taxa de poupança",
+      "monthlySavings": "Sobra por mês",
+      "sustainabilityTitle": "Score de sustentabilidade",
+      "sustainabilityHint": "Combina sua taxa de poupança com o quão eficiente é o seu custo frente à média regional.",
+      "retirementTitle": "Anos até a independência financeira",
+      "retirementYears": "{years} anos",
+      "retirementNever": "Com a sobra atual não é possível projetar a aposentadoria. Reduza gastos ou aumente a renda.",
+      "retirementHint": "Estimativa pela regra dos 4%: patrimônio-alvo = gasto anual × 25, com {rate}% de rentabilidade real ao ano.",
+      "targetWealth": "Patrimônio-alvo",
+      "regionalTitle": "Comparação com {uf}",
+      "regionalAvgCost": "Custo médio no estado",
+      "regionalAvgIncome": "Renda média no estado",
+      "costVsRegionalAbove": "Seu custo está {pct}% acima da média do estado",
+      "costVsRegionalBelow": "Seu custo está {pct}% abaixo da média do estado",
+      "costVsRegionalEqual": "Seu custo está na média do estado",
+      "breakdownTitle": "Onde vai o seu dinheiro",
+      "ofIncome": "{pct}% da renda"
+    },
+    "share": {
+      "title": "Compartilhe seu resultado",
+      "whatsapp": "WhatsApp",
+      "twitter": "X / Twitter",
+      "copyLink": "Copiar link",
+      "copied": "Link copiado!",
+      "message": "Meu estilo de vida consome {pct}% da minha renda. Descubra o seu no Auraxis:"
+    },
+    "cta": {
+      "title": "Transforme esse diagnóstico em ação",
+      "description": "Crie sua conta grátis para acompanhar gastos, definir metas e melhorar seu score de sustentabilidade.",
+      "button": "Criar conta grátis"
+    },
+    "errors": {
+      "ufRequired": "Selecione um estado válido.",
+      "incomeRequired": "Informe sua renda mensal.",
+      "atLeastOneExpenseRequired": "Informe pelo menos um gasto."
+    },
+    "disclaimer": {
+      "note": "Valores regionais aproximados (IBGE PNAD/POF e DIEESE), para fins educativos. A projeção de aposentadoria assume rentabilidade real constante e não considera impostos ou imprevistos."
+    },
+    "faq": {
+      "title": "Perguntas frequentes",
+      "items": [
+        {
+          "q": "Como o score de sustentabilidade é calculado?",
+          "a": "Ele combina sua taxa de poupança (peso 70%) com a eficiência do seu custo frente à média do seu estado (peso 30%). Poupar 20% ou mais da renda e gastar no máximo a média regional levam à nota máxima."
+        },
+        {
+          "q": "O que é a regra dos 4%?",
+          "a": "É uma referência de independência financeira: ao acumular um patrimônio equivalente a 25 vezes seu gasto anual, você poderia sacar cerca de 4% ao ano de forma sustentável."
+        },
+        {
+          "q": "De onde vêm os dados regionais?",
+          "a": "São aproximações baseadas em pesquisas do IBGE (PNAD Contínua e POF) e do DIEESE. Servem como referência educativa e não substituem dados oficiais atualizados."
+        },
+        {
+          "q": "Posso compartilhar o resultado?",
+          "a": "Sim. Use os botões de compartilhamento ou copie o link após calcular — ele recria automaticamente sua simulação para quem abrir."
+        }
+      ]
+    }
   }
 }

--- a/app/pages/tools/custo-de-vida-regional.spec.ts
+++ b/app/pages/tools/custo-de-vida-regional.spec.ts
@@ -1,0 +1,173 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref, type App } from "vue";
+
+import CustoVidaRegionalPage from "./custo-de-vida-regional.vue";
+import type { RegionalCostResult } from "~/features/tools/model/custo-de-vida-regional";
+
+const mockValidate = vi.hoisted(() => vi.fn().mockReturnValue([]));
+const mockCalculate = vi.hoisted(() => vi.fn());
+const mockIsAuthenticated = ref(false);
+
+vi.mock("vue-i18n", () => ({
+  useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({
+    t: (key: string) => key,
+    n: (v: number) => String(v),
+  }),
+}));
+vi.mock("#imports", () => ({
+  definePageMeta: vi.fn(),
+  useHead: vi.fn(),
+  useSeoMeta: vi.fn(),
+  useI18n: (): { t: (key: string) => string; n: (v: number) => string } => ({
+    t: (key: string) => key,
+    n: (v: number) => String(v),
+  }),
+}));
+vi.mock("echarts/core", () => ({ use: vi.fn() }));
+vi.mock("vue-echarts", () => ({ default: { props: ["option", "autoresize"], template: "<div class='v-chart'></div>" } }));
+
+vi.mock("naive-ui", () => ({
+  NAlert: { props: ["type"], template: "<div class='n-alert'><slot /></div>" },
+  NButton: { props: ["type", "size", "quaternary", "block", "attrType", "tag", "href", "target", "rel"], template: "<button class='n-button' @click='$emit(\"click\")'><slot /></button>", emits: ["click"] },
+  NForm: { emits: ["submit"], template: "<form @submit.prevent='$emit(\"submit\", $event)'><slot /></form>" },
+  NFormItem: { props: ["label"], template: "<div class='n-form-item'><slot /></div>" },
+  NInputNumber: { props: ["value", "min", "max", "precision", "prefix"], emits: ["update:value"], template: "<input class='n-input-number' />" },
+  NProgress: { props: ["percentage", "status", "type", "showIndicator"], template: "<div class='n-progress'></div>" },
+  NSelect: { props: ["value", "options", "filterable", "placeholder"], emits: ["update:value"], template: "<select class='n-select'></select>" },
+  NSpace: { props: ["vertical", "size"], template: "<div><slot /></div>" },
+  NThing: { props: ["title", "description"], template: "<div class='n-thing'>{{ title }}: {{ description }}</div>" },
+  useMessage: vi.fn(() => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() })),
+}));
+
+vi.mock("~/stores/session", () => ({
+  useSessionStore: (): { isAuthenticated: boolean } => ({
+    get isAuthenticated(): boolean {
+      return mockIsAuthenticated.value;
+    },
+  }),
+}));
+
+vi.mock("~/features/tools/model/custo-de-vida-regional", () => ({
+  EXPENSE_CATEGORY_KEYS: ["housing", "transport", "food", "leisure", "other"],
+  UF_CODES: ["SP", "RJ"],
+  getRegionalEntry: (uf: string): { name: string; avgIncome: number; avgCost: number } => ({ name: uf, avgIncome: 6800, avgCost: 4800 }),
+  createDefaultRegionalCostFormState: (): object => ({ uf: "SP", monthlyIncome: 0, housing: 0, transport: 0, food: 0, leisure: 0, other: 0 }),
+  decodeQueryToForm: vi.fn().mockReturnValue(null),
+  encodeFormToQuery: vi.fn().mockReturnValue("encoded"),
+  validateRegionalCostForm: mockValidate,
+  calculateRegionalCost: mockCalculate,
+}));
+
+const mockResult: RegionalCostResult = {
+  totalMonthlyCost: 6000,
+  totalAnnualCost: 72000,
+  committedPct: 60,
+  savingsRatePct: 40,
+  monthlySavings: 4000,
+  categories: [
+    { key: "housing", amount: 2500, pctOfIncome: 25, pctOfTotal: 41.67 },
+    { key: "food", amount: 1500, pctOfIncome: 15, pctOfTotal: 25 },
+  ],
+  targetWealth: 1800000,
+  yearsToRetirement: 23,
+  regional: { uf: "SP", name: "São Paulo", avgIncome: 6800, avgCost: 4800, costVsRegionalPct: 25, incomeVsRegionalPct: 0 },
+  sustainabilityScore: 80,
+};
+
+const globalStubs = {
+  NuxtLayout: { props: ["name"], template: "<div class='nuxt-layout'><slot /></div>" },
+  UiPageHeader: { props: ["title", "subtitle"], template: "<div class='ui-page-header'><h1>{{ title }}</h1></div>" },
+  UiGlassPanel: { props: ["glow"], template: "<div class='ui-glass-panel'><slot /></div>" },
+  UiSurfaceCard: { template: "<div class='ui-surface-card'><slot /></div>" },
+  UiStickySummaryCard: { template: "<div class='ui-sticky-summary-card'><slot /></div>" },
+  CalculatorFormSection: { props: ["title"], template: "<div class='calculator-form-section'><slot /></div>" },
+  ToolGuestCta: { template: "<div class='tool-guest-cta'>guest-cta</div>" },
+  UiChart: { props: ["option", "height"], template: "<div class='v-chart'></div>" },
+  NuxtLink: { props: ["to"], template: "<a class='nuxt-link'><slot /></a>" },
+};
+
+/**
+ * Installs a minimal Nuxt app context onto the Vue app instance.
+ *
+ * @param app Vue app instance under test.
+ */
+function nuxtContextPlugin(app: App): void {
+  Reflect.set(app, "$nuxt", {
+    _route: { path: "/tools/custo-de-vida-regional", meta: {}, params: {}, query: {} },
+    $router: { push: vi.fn(), replace: vi.fn() },
+    $config: { public: {} },
+    payload: { serverRendered: false },
+    ssrContext: { head: { push: vi.fn(() => ({ patch: vi.fn(), dispose: vi.fn() })) } },
+    static: { data: {} },
+    isHydrating: false,
+    deferHydration: (): void => {},
+    runWithContext: <T>(cb: () => T): T => cb(),
+    hooks: { callHook: vi.fn(), hook: vi.fn() },
+    _asyncDataPromises: {},
+    _asyncData: {},
+  });
+}
+
+/**
+ * @returns Mounted component wrapper.
+ */
+function mountPage(): ReturnType<typeof mount> {
+  return mount(CustoVidaRegionalPage, {
+    global: { plugins: [{ install: nuxtContextPlugin }], stubs: globalStubs },
+  });
+}
+
+/**
+ * Resets shared mock state before each test.
+ */
+function resetState(): void {
+  setActivePinia(createPinia());
+  mockValidate.mockReturnValue([]);
+  mockCalculate.mockReset();
+  mockIsAuthenticated.value = false;
+}
+
+describe("CustoVidaRegionalPage — layout", () => {
+  beforeEach(resetState);
+
+  it("renders NuxtLayout", () => {
+    expect(mountPage().find(".nuxt-layout").exists()).toBe(true);
+  });
+
+  it("shows guest CTA for unauthenticated users", () => {
+    expect(mountPage().find(".tool-guest-cta").exists()).toBe(true);
+  });
+});
+
+describe("CustoVidaRegionalPage — validation", () => {
+  beforeEach(resetState);
+
+  it("shows a validation error and skips calculation when invalid", async () => {
+    mockValidate.mockReturnValue([{ field: "monthlyIncome", messageKey: "errors.incomeRequired" }]);
+    const w = mountPage();
+    await w.find("form").trigger("submit");
+    await flushPromises();
+    expect(w.find(".n-alert").exists()).toBe(true);
+    expect(mockCalculate).not.toHaveBeenCalled();
+  });
+});
+
+describe("CustoVidaRegionalPage — results", () => {
+  beforeEach(resetState);
+
+  it("does not render results before calculation", () => {
+    expect(mountPage().find(".n-progress").exists()).toBe(false);
+  });
+
+  it("renders score and share actions after calculation", async () => {
+    mockCalculate.mockReturnValue(mockResult);
+    const w = mountPage();
+    await w.find("form").trigger("submit");
+    await flushPromises();
+    expect(mockCalculate).toHaveBeenCalled();
+    expect(w.find(".n-progress").exists()).toBe(true);
+    expect(w.find("[data-testid='copy-share-url']").exists()).toBe(true);
+  });
+});

--- a/app/pages/tools/custo-de-vida-regional.vue
+++ b/app/pages/tools/custo-de-vida-regional.vue
@@ -81,10 +81,10 @@ function categoryLabel(key: ExpenseCategoryKey): string {
 }
 
 onMounted(() => {
-  if (typeof window === "undefined") {
+  if (typeof globalThis.window === "undefined") {
     return;
   }
-  const data = new URLSearchParams(window.location.search).get("d");
+  const data = new URLSearchParams(globalThis.location.search).get("d");
   if (!data) {
     return;
   }
@@ -107,8 +107,8 @@ function handleCalculate(): void {
   }
   setValidationError(null);
   result.value = calculateRegionalCost(form.value);
-  if (typeof window !== "undefined") {
-    shareUrl.value = `${window.location.origin}${window.location.pathname}?d=${encodeFormToQuery(form.value)}`;
+  if (typeof globalThis.window !== "undefined") {
+    shareUrl.value = `${globalThis.location.origin}${globalThis.location.pathname}?d=${encodeFormToQuery(form.value)}`;
   }
 }
 

--- a/app/pages/tools/custo-de-vida-regional.vue
+++ b/app/pages/tools/custo-de-vida-regional.vue
@@ -1,0 +1,560 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import type { EChartsOption } from "echarts";
+import {
+  NAlert,
+  NButton,
+  NForm,
+  NFormItem,
+  NInputNumber,
+  NProgress,
+  NSelect,
+  NSpace,
+  NThing,
+  useMessage,
+} from "naive-ui";
+
+import { useSessionStore } from "~/stores/session";
+import {
+  EXPENSE_CATEGORY_KEYS,
+  UF_CODES,
+  calculateRegionalCost,
+  createDefaultRegionalCostFormState,
+  decodeQueryToForm,
+  encodeFormToQuery,
+  getRegionalEntry,
+  validateRegionalCostForm,
+  type ExpenseCategoryKey,
+  type RegionalCostFormState,
+  type RegionalCostResult,
+} from "~/features/tools/model/custo-de-vida-regional";
+import { useCalculatorFormState } from "~/features/tools/composables/use-calculator-form-state";
+import CalculatorFormSection from "~/components/tool/CalculatorFormSection/CalculatorFormSection.vue";
+import ToolGuestCta from "~/components/tool/ToolGuestCta/ToolGuestCta.vue";
+import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
+import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
+import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
+import UiChart from "~/components/ui/UiChart.vue";
+
+definePageMeta({ layout: false });
+
+const { t, n } = useI18n();
+const toast = useMessage();
+const sessionStore = useSessionStore();
+
+useSeoMeta({
+  title: () => t("custoVidaRegional.seo.title"),
+  description: () => t("custoVidaRegional.seo.description"),
+  ogTitle: () => t("custoVidaRegional.seo.ogTitle"),
+  ogDescription: () => t("custoVidaRegional.seo.ogDescription"),
+  twitterCard: "summary_large_image",
+});
+
+const isAuthenticated = computed<boolean>(() => sessionStore.isAuthenticated);
+
+const ufOptions = UF_CODES.map((code) => ({
+  label: `${getRegionalEntry(code)?.name ?? code} (${code})`,
+  value: code,
+}));
+
+const { form, validationError, patch, reset, setValidationError } =
+  useCalculatorFormState<RegionalCostFormState>(createDefaultRegionalCostFormState);
+
+const result = ref<RegionalCostResult | null>(null);
+const shareUrl = ref<string | null>(null);
+
+/**
+ * @param value Numeric amount.
+ * @returns BRL-formatted string.
+ */
+function formatBrl(value: number): string {
+  return n(value, "currency");
+}
+
+/**
+ * @param key Expense category key.
+ * @returns Localized category label.
+ */
+function categoryLabel(key: ExpenseCategoryKey): string {
+  return t(`custoVidaRegional.categories.${key}`);
+}
+
+onMounted(() => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const data = new URLSearchParams(window.location.search).get("d");
+  if (!data) {
+    return;
+  }
+  const decoded = decodeQueryToForm(data);
+  if (decoded) {
+    patch(decoded);
+    handleCalculate();
+  }
+});
+
+/**
+ * Validates and computes the regional cost result.
+ */
+function handleCalculate(): void {
+  const errors = validateRegionalCostForm(form.value);
+  if (errors.length > 0) {
+    const first = errors[0];
+    setValidationError(first ? t(`custoVidaRegional.${first.messageKey}`) : null);
+    return;
+  }
+  setValidationError(null);
+  result.value = calculateRegionalCost(form.value);
+  if (typeof window !== "undefined") {
+    shareUrl.value = `${window.location.origin}${window.location.pathname}?d=${encodeFormToQuery(form.value)}`;
+  }
+}
+
+/**
+ * Resets the form and clears the result.
+ */
+function handleReset(): void {
+  reset();
+  result.value = null;
+  shareUrl.value = null;
+}
+
+/**
+ * @returns Localized share message text.
+ */
+function shareMessage(): string {
+  const pct = result.value ? Math.round(result.value.committedPct) : 0;
+  return t("custoVidaRegional.share.message", { pct });
+}
+
+/**
+ * Copies the share URL to the clipboard.
+ */
+async function handleCopyShareUrl(): Promise<void> {
+  if (!shareUrl.value) {
+    return;
+  }
+  await navigator.clipboard.writeText(shareUrl.value);
+  toast.success(t("custoVidaRegional.share.copied"));
+}
+
+const whatsappShareHref = computed<string>(() => {
+  if (!shareUrl.value) {
+    return "#";
+  }
+  const text = encodeURIComponent(`${shareMessage()} ${shareUrl.value}`);
+  return `https://wa.me/?text=${text}`;
+});
+
+const twitterShareHref = computed<string>(() => {
+  if (!shareUrl.value) {
+    return "#";
+  }
+  const text = encodeURIComponent(shareMessage());
+  const url = encodeURIComponent(shareUrl.value);
+  return `https://twitter.com/intent/tweet?text=${text}&url=${url}`;
+});
+
+const committedProgressStatus = computed<"success" | "warning" | "error">(() => {
+  const pct = result.value?.committedPct ?? 0;
+  if (pct <= 70) {
+    return "success";
+  }
+  if (pct <= 90) {
+    return "warning";
+  }
+  return "error";
+});
+
+const scoreStatus = computed<"success" | "warning" | "error">(() => {
+  const score = result.value?.sustainabilityScore ?? 0;
+  if (score >= 70) {
+    return "success";
+  }
+  if (score >= 40) {
+    return "warning";
+  }
+  return "error";
+});
+
+const summaryMetrics = computed(() => {
+  if (!result.value) {
+    return [];
+  }
+  return [
+    { label: t("custoVidaRegional.results.totalAnnual"), value: formatBrl(result.value.totalAnnualCost) },
+    { label: t("custoVidaRegional.results.monthlySavings"), value: formatBrl(result.value.monthlySavings) },
+    { label: t("custoVidaRegional.results.savingsRate"), value: `${result.value.savingsRatePct}%` },
+  ];
+});
+
+const regionalLabel = computed<string>(() => {
+  if (!result.value) {
+    return "";
+  }
+  const r = result.value.regional;
+  const pct = Math.abs(Math.round(r.costVsRegionalPct));
+  if (r.costVsRegionalPct > 1) {
+    return t("custoVidaRegional.results.costVsRegionalAbove", { pct });
+  }
+  if (r.costVsRegionalPct < -1) {
+    return t("custoVidaRegional.results.costVsRegionalBelow", { pct });
+  }
+  return t("custoVidaRegional.results.costVsRegionalEqual");
+});
+
+const retirementLabel = computed<string>(() => {
+  if (!result.value) {
+    return "";
+  }
+  if (result.value.yearsToRetirement === null) {
+    return t("custoVidaRegional.results.retirementNever");
+  }
+  return t("custoVidaRegional.results.retirementYears", {
+    years: Math.ceil(result.value.yearsToRetirement),
+  });
+});
+
+/** Donut chart of the per-category spending breakdown. */
+const breakdownChartOption = computed<EChartsOption>(() => {
+  if (!result.value) {
+    return {} as EChartsOption;
+  }
+  const data = result.value.categories
+    .filter((c) => c.amount > 0)
+    .map((c) => ({ name: categoryLabel(c.key), value: c.amount }));
+  return {
+    tooltip: {
+      trigger: "item",
+      formatter: (params: unknown): string => {
+        const p = params as { name: string; value: number; percent: number };
+        return `${p.name}: ${formatBrl(p.value)} (${p.percent}%)`;
+      },
+    },
+    legend: { bottom: 0 },
+    series: [
+      {
+        type: "pie",
+        radius: ["45%", "70%"],
+        avoidLabelOverlap: true,
+        label: { show: false },
+        data,
+      },
+    ],
+  } as unknown as EChartsOption;
+});
+</script>
+
+<template>
+  <div class="custo-vida-regional-root">
+    <NuxtLayout :name="isAuthenticated ? 'default' : 'tools-public'">
+      <div class="custo-vida-regional-page">
+        <div class="custo-vida-regional-page__layout">
+          <div class="custo-vida-regional-page__form-col">
+            <UiPageHeader
+              :title="t('custoVidaRegional.hero.title')"
+              :subtitle="t('custoVidaRegional.hero.subtitle')"
+            />
+
+            <UiGlassPanel>
+              <NForm @submit.prevent="handleCalculate">
+                <CalculatorFormSection :title="t('custoVidaRegional.form.title')">
+                  <NFormItem :label="t('custoVidaRegional.form.uf')">
+                    <NSelect
+                      :value="form.uf"
+                      :options="ufOptions"
+                      filterable
+                      :placeholder="t('custoVidaRegional.form.ufPlaceholder')"
+                      @update:value="(v) => patch({ uf: v })"
+                    />
+                  </NFormItem>
+
+                  <NFormItem :label="t('custoVidaRegional.form.monthlyIncome')">
+                    <NInputNumber
+                      :value="form.monthlyIncome"
+                      :min="0"
+                      :precision="2"
+                      prefix="R$"
+                      style="width: 100%"
+                      @update:value="(v) => patch({ monthlyIncome: v ?? 0 })"
+                    />
+                  </NFormItem>
+
+                  <NFormItem
+                    v-for="key in EXPENSE_CATEGORY_KEYS"
+                    :key="key"
+                    :label="t(`custoVidaRegional.form.${key}`)"
+                  >
+                    <NInputNumber
+                      :value="(form[key] as number)"
+                      :min="0"
+                      :precision="2"
+                      prefix="R$"
+                      style="width: 100%"
+                      @update:value="(v) => patch({ [key]: v ?? 0 })"
+                    />
+                  </NFormItem>
+                </CalculatorFormSection>
+
+                <NAlert v-if="validationError" type="error" style="margin-bottom: 16px">
+                  {{ validationError }}
+                </NAlert>
+
+                <NSpace style="margin-top: 16px">
+                  <NButton type="primary" attr-type="submit">
+                    {{ t('custoVidaRegional.form.calculate') }}
+                  </NButton>
+                  <NButton quaternary @click="handleReset">
+                    {{ t('custoVidaRegional.form.reset') }}
+                  </NButton>
+                </NSpace>
+              </NForm>
+            </UiGlassPanel>
+          </div>
+
+          <div v-if="result" class="custo-vida-regional-page__result-col">
+            <!-- Sustainability score + committed % -->
+            <UiStickySummaryCard>
+              <div class="custo-vida-regional-page__score">
+                <p class="custo-vida-regional-page__score-title">
+                  {{ t('custoVidaRegional.results.sustainabilityTitle') }}
+                </p>
+                <NProgress
+                  type="circle"
+                  :percentage="result.sustainabilityScore"
+                  :status="scoreStatus"
+                />
+                <p class="custo-vida-regional-page__score-hint">
+                  {{ t('custoVidaRegional.results.sustainabilityHint') }}
+                </p>
+              </div>
+
+              <div class="custo-vida-regional-page__committed">
+                <span class="custo-vida-regional-page__committed-value">
+                  {{ result.committedPct }}%
+                </span>
+                <span class="custo-vida-regional-page__committed-label">
+                  {{ t('custoVidaRegional.results.committedPct') }}
+                </span>
+                <NProgress
+                  :percentage="Math.min(result.committedPct, 100)"
+                  :status="committedProgressStatus"
+                  :show-indicator="false"
+                />
+              </div>
+
+              <NThing
+                :title="t('custoVidaRegional.results.totalMonthly')"
+                :description="formatBrl(result.totalMonthlyCost)"
+              />
+              <NThing
+                v-for="metric in summaryMetrics"
+                :key="metric.label"
+                :title="metric.label"
+                :description="metric.value"
+              />
+
+              <NSpace v-if="shareUrl" vertical style="margin-top: 16px">
+                <p class="custo-vida-regional-page__share-title">
+                  {{ t('custoVidaRegional.share.title') }}
+                </p>
+                <NSpace>
+                  <NButton tag="a" :href="whatsappShareHref" target="_blank" rel="noopener" size="small">
+                    {{ t('custoVidaRegional.share.whatsapp') }}
+                  </NButton>
+                  <NButton tag="a" :href="twitterShareHref" target="_blank" rel="noopener" size="small">
+                    {{ t('custoVidaRegional.share.twitter') }}
+                  </NButton>
+                  <NButton size="small" quaternary data-testid="copy-share-url" @click="handleCopyShareUrl">
+                    {{ t('custoVidaRegional.share.copyLink') }}
+                  </NButton>
+                </NSpace>
+              </NSpace>
+            </UiStickySummaryCard>
+
+            <!-- Regional comparison -->
+            <UiSurfaceCard>
+              <p class="custo-vida-regional-page__section-title">
+                {{ t('custoVidaRegional.results.regionalTitle', { uf: result.regional.name }) }}
+              </p>
+              <p class="custo-vida-regional-page__regional-headline">{{ regionalLabel }}</p>
+              <NThing
+                :title="t('custoVidaRegional.results.regionalAvgCost')"
+                :description="formatBrl(result.regional.avgCost)"
+              />
+              <NThing
+                :title="t('custoVidaRegional.results.regionalAvgIncome')"
+                :description="formatBrl(result.regional.avgIncome)"
+              />
+            </UiSurfaceCard>
+
+            <!-- Category breakdown -->
+            <UiSurfaceCard>
+              <p class="custo-vida-regional-page__section-title">
+                {{ t('custoVidaRegional.results.breakdownTitle') }}
+              </p>
+              <UiChart :option="breakdownChartOption" height="260px" />
+            </UiSurfaceCard>
+
+            <!-- Retirement projection -->
+            <UiSurfaceCard>
+              <p class="custo-vida-regional-page__section-title">
+                {{ t('custoVidaRegional.results.retirementTitle') }}
+              </p>
+              <p class="custo-vida-regional-page__retirement">{{ retirementLabel }}</p>
+              <NThing
+                :title="t('custoVidaRegional.results.targetWealth')"
+                :description="formatBrl(result.targetWealth)"
+              />
+              <p class="custo-vida-regional-page__hint">
+                {{ t('custoVidaRegional.results.retirementHint', { rate: 4 }) }}
+              </p>
+            </UiSurfaceCard>
+
+            <!-- Register CTA (guests only) -->
+            <UiSurfaceCard v-if="!isAuthenticated" class="custo-vida-regional-page__cta-card">
+              <p class="custo-vida-regional-page__cta-title">{{ t('custoVidaRegional.cta.title') }}</p>
+              <p class="custo-vida-regional-page__cta-desc">{{ t('custoVidaRegional.cta.description') }}</p>
+              <NuxtLink to="/register">
+                <NButton type="primary" block>{{ t('custoVidaRegional.cta.button') }}</NButton>
+              </NuxtLink>
+            </UiSurfaceCard>
+
+            <p class="custo-vida-regional-page__disclaimer">{{ t('custoVidaRegional.disclaimer.note') }}</p>
+          </div>
+        </div>
+
+        <!-- FAQ for SEO -->
+        <section class="custo-vida-regional-page__faq" aria-label="FAQ">
+          <h2>{{ t('custoVidaRegional.faq.title') }}</h2>
+          <details
+            v-for="(item, i) in (t('custoVidaRegional.faq.items', []) as unknown as Array<{ q: string; a: string }>)"
+            :key="i"
+            class="custo-vida-regional-page__faq-item"
+          >
+            <summary>{{ item.q }}</summary>
+            <p>{{ item.a }}</p>
+          </details>
+        </section>
+      </div>
+      <ToolGuestCta v-if="!isAuthenticated" />
+    </NuxtLayout>
+  </div>
+</template>
+
+<style scoped>
+.custo-vida-regional-page {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+  padding: clamp(var(--space-3), 3vw, var(--space-5));
+}
+
+.custo-vida-regional-page__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--space-4);
+  align-items: start;
+}
+
+.custo-vida-regional-page__result-col {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.custo-vida-regional-page__score {
+  display: grid;
+  justify-items: center;
+  gap: var(--space-2);
+  text-align: center;
+  margin-bottom: var(--space-3);
+}
+
+.custo-vida-regional-page__score-title,
+.custo-vida-regional-page__section-title {
+  margin: 0 0 var(--space-2);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.custo-vida-regional-page__score-hint,
+.custo-vida-regional-page__hint {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.custo-vida-regional-page__committed {
+  display: grid;
+  gap: var(--space-1);
+  margin-bottom: var(--space-3);
+}
+
+.custo-vida-regional-page__committed-value {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+}
+
+.custo-vida-regional-page__committed-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.custo-vida-regional-page__regional-headline,
+.custo-vida-regional-page__retirement {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-brand-500);
+}
+
+.custo-vida-regional-page__share-title {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.custo-vida-regional-page__cta-card {
+  background: color-mix(in srgb, var(--color-brand-500) 8%, transparent);
+}
+
+.custo-vida-regional-page__cta-title {
+  margin: 0 0 var(--space-1);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+}
+
+.custo-vida-regional-page__cta-desc {
+  margin: 0 0 var(--space-3);
+  color: var(--color-text-secondary);
+}
+
+.custo-vida-regional-page__disclaimer {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.custo-vida-regional-page__faq {
+  margin-top: var(--space-5);
+  max-width: 820px;
+}
+
+.custo-vida-regional-page__faq-item {
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--color-outline-soft);
+}
+
+.custo-vida-regional-page__faq-item summary {
+  cursor: pointer;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+@media (max-width: 860px) {
+  .custo-vida-regional-page__layout {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/app/shared/data/cost-of-living-by-uf.json
+++ b/app/shared/data/cost-of-living-by-uf.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "source": "Aproximações baseadas em IBGE (PNAD Contínua — rendimento médio mensal domiciliar) e DIEESE (custo de vida / cesta básica). Valores de referência para fins educativos; não substituem dados oficiais.",
+    "currency": "BRL",
+    "period": "monthly",
+    "updatedAt": "2026-06"
+  },
+  "data": {
+    "AC": { "name": "Acre", "avgIncome": 4200, "avgCost": 3100 },
+    "AL": { "name": "Alagoas", "avgIncome": 3900, "avgCost": 2900 },
+    "AP": { "name": "Amapá", "avgIncome": 4300, "avgCost": 3200 },
+    "AM": { "name": "Amazonas", "avgIncome": 4400, "avgCost": 3300 },
+    "BA": { "name": "Bahia", "avgIncome": 4100, "avgCost": 3000 },
+    "CE": { "name": "Ceará", "avgIncome": 4000, "avgCost": 2950 },
+    "DF": { "name": "Distrito Federal", "avgIncome": 8200, "avgCost": 5200 },
+    "ES": { "name": "Espírito Santo", "avgIncome": 5400, "avgCost": 3900 },
+    "GO": { "name": "Goiás", "avgIncome": 5100, "avgCost": 3700 },
+    "MA": { "name": "Maranhão", "avgIncome": 3600, "avgCost": 2700 },
+    "MT": { "name": "Mato Grosso", "avgIncome": 5300, "avgCost": 3800 },
+    "MS": { "name": "Mato Grosso do Sul", "avgIncome": 5200, "avgCost": 3750 },
+    "MG": { "name": "Minas Gerais", "avgIncome": 5000, "avgCost": 3600 },
+    "PA": { "name": "Pará", "avgIncome": 4000, "avgCost": 3000 },
+    "PB": { "name": "Paraíba", "avgIncome": 3950, "avgCost": 2900 },
+    "PR": { "name": "Paraná", "avgIncome": 5600, "avgCost": 4000 },
+    "PE": { "name": "Pernambuco", "avgIncome": 4200, "avgCost": 3100 },
+    "PI": { "name": "Piauí", "avgIncome": 3800, "avgCost": 2850 },
+    "RJ": { "name": "Rio de Janeiro", "avgIncome": 6400, "avgCost": 4600 },
+    "RN": { "name": "Rio Grande do Norte", "avgIncome": 4100, "avgCost": 3050 },
+    "RS": { "name": "Rio Grande do Sul", "avgIncome": 5700, "avgCost": 4100 },
+    "RO": { "name": "Rondônia", "avgIncome": 4600, "avgCost": 3400 },
+    "RR": { "name": "Roraima", "avgIncome": 4500, "avgCost": 3350 },
+    "SC": { "name": "Santa Catarina", "avgIncome": 6000, "avgCost": 4300 },
+    "SP": { "name": "São Paulo", "avgIncome": 6800, "avgCost": 4800 },
+    "SE": { "name": "Sergipe", "avgIncome": 4050, "avgCost": 3000 },
+    "TO": { "name": "Tocantins", "avgIncome": 4400, "avgCost": 3250 }
+  }
+}

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -411,6 +411,16 @@
       "repositories": ["auraxis-web"]
     },
     {
+      "key": "web.tools.custo-de-vida-regional",
+      "owner": "growth",
+      "createdAt": "2026-06-02",
+      "removeBy": "2027-12-31",
+      "type": "release",
+      "status": "enabled-prod",
+      "description": "Calculadora pública de custo de vida regional (PROD-09 growth loop): comparação com média do estado, score de sustentabilidade e anos até aposentadoria.",
+      "repositories": ["auraxis-web"]
+    },
+    {
       "key": "web.premium.paywall-enabled",
       "owner": "growth",
       "createdAt": "2026-04-21",


### PR DESCRIPTION
## Contexto

PROD-09 (#532) — growth loop público. A rota existente `/tools/custo-estilo-vida` implementa uma calculadora de *custo de oportunidade* (divergente do spec PROD-09). Conforme decisão de produto, esta entrega cria uma **rota nova separada** `/tools/custo-de-vida-regional`, preservando a página atual.

## O que entra

- **Nova página SSG pública** `/tools/custo-de-vida-regional` (+ `/en/...` via prerender), layout `tools-public`.
- **Model puro** `custo-de-vida-regional.ts` (TDD, 16 testes): total mensal, % da renda comprometida, score de sustentabilidade (0–100), anos até a aposentadoria (regra dos 4%), comparação regional.
- **Dataset** `shared/data/cost-of-living-by-uf.json` — 27 UFs (aproximações IBGE PNAD/POF + DIEESE, com disclaimer).
- **Resultado + infográfico** (donut ECharts) + **card compartilhável** (WhatsApp / X / copiar link com share URL codificada) + **CTA de registro** + FAQ para SEO.
- **Feature flag** `web.tools.custo-de-vida-regional` + entrada no catálogo de tools (parity check OK).
- i18n **pt** completo; EN via fallback (en.json congelado, DEC-186).

## Critérios de aceite (PROD-09)

- [x] Página indexável (prerender + sitemap via @nuxtjs/seo)
- [x] Cálculo client-side instantâneo (≤ 500ms)
- [x] OG tags dinâmicos (useSeoMeta) + share social
- [x] CTA 'Crie sua conta grátis'

## Quality gates

`pnpm quality-check` PASS (lint + typecheck + coverage 85.77% branches ≥ 85% + flags + contracts + build: 171 páginas prerendered, 0 falhas).

Closes #556
Closes #557
Closes #558
Refs #532