### PR TITLE
feat(dashboard): WeeklySnapshotCard + preferências de notificação (UX-02-1)

### DIFF
--- a/app/features/notifications/components/NotificationPreferencesPanel.spec.ts
+++ b/app/features/notifications/components/NotificationPreferencesPanel.spec.ts
@@ -1,0 +1,99 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import NotificationPreferencesPanel from "./NotificationPreferencesPanel.vue";
+import type { NotificationPreference } from "~/features/notifications/model/notification-preferences";
+
+const mockData = ref<NotificationPreference[]>([]);
+const mockIsLoading = ref(false);
+const mockIsPending = ref(false);
+const mockMutateAsync = vi.fn().mockResolvedValue([]);
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock("vue-i18n", () => ({
+  useI18n: (): { t: (k: string) => string } => ({ t: (k: string) => k }),
+}));
+vi.mock("#imports", () => ({
+  useI18n: (): { t: (k: string) => string } => ({ t: (k: string) => k }),
+}));
+
+vi.mock("~/composables/useToast", () => ({
+  useToast: (): { success: typeof mockToastSuccess; error: typeof mockToastError } => ({
+    success: mockToastSuccess,
+    error: mockToastError,
+  }),
+}));
+vi.mock("~/features/notifications/queries/use-notification-preferences-query", () => ({
+  useNotificationPreferencesQuery: (): { data: typeof mockData; isLoading: typeof mockIsLoading } => ({
+    data: mockData,
+    isLoading: mockIsLoading,
+  }),
+}));
+vi.mock("~/features/notifications/queries/use-update-notification-preferences-mutation", () => ({
+  useUpdateNotificationPreferencesMutation: (): {
+    mutateAsync: typeof mockMutateAsync;
+    isPending: typeof mockIsPending;
+  } => ({ mutateAsync: mockMutateAsync, isPending: mockIsPending }),
+}));
+
+vi.mock("naive-ui", () => ({
+  NCard: { template: "<section><slot /></section>" },
+  NSpin: { template: "<span class='n-spin' />" },
+  NSwitch: {
+    props: ["value", "disabled"],
+    emits: ["update:value"],
+    template: "<button :disabled='disabled' @click='$emit(\"update:value\", !value)'>toggle</button>",
+  },
+}));
+
+/**
+ * @returns Mounted panel wrapper.
+ */
+function mountPanel(): ReturnType<typeof mount> {
+  return mount(NotificationPreferencesPanel);
+}
+
+describe("NotificationPreferencesPanel", () => {
+  beforeEach(() => {
+    mockData.value = [];
+    mockIsLoading.value = false;
+    mockIsPending.value = false;
+    mockMutateAsync.mockClear().mockResolvedValue([]);
+    mockToastSuccess.mockClear();
+    mockToastError.mockClear();
+  });
+
+  it("renders a toggle for every category with enabled defaults", () => {
+    const w = mountPanel();
+    expect(w.find("[data-testid='pref-due_soon']").exists()).toBe(true);
+    expect(w.find("[data-testid='pref-goals']").exists()).toBe(true);
+    expect(w.find("[data-testid='pref-subscription']").exists()).toBe(true);
+  });
+
+  it("persists a single category toggle", async () => {
+    const w = mountPanel();
+    await w.find("[data-testid='pref-due_soon']").trigger("click");
+    expect(mockMutateAsync).toHaveBeenCalledWith([
+      { category: "due_soon", enabled: false, globalOptOut: false },
+    ]);
+    expect(mockToastSuccess).toHaveBeenCalled();
+  });
+
+  it("pauses all categories via the global opt-out", async () => {
+    const w = mountPanel();
+    await w.find("[data-testid='global-opt-out']").trigger("click");
+    const arg = mockMutateAsync.mock.calls[0]?.[0] as NotificationPreference[];
+    expect(arg).toHaveLength(5);
+    expect(arg.every((p) => p.globalOptOut === true)).toBe(true);
+  });
+
+  it("surfaces an error toast when the mutation fails", async () => {
+    mockMutateAsync.mockRejectedValueOnce(new Error("boom"));
+    const w = mountPanel();
+    await w.find("[data-testid='pref-goals']").trigger("click");
+    await Promise.resolve();
+    expect(mockToastError).toHaveBeenCalled();
+  });
+});

--- a/app/features/notifications/components/NotificationPreferencesPanel.vue
+++ b/app/features/notifications/components/NotificationPreferencesPanel.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { NCard, NSpin, NSwitch } from "naive-ui";
+
+import { useToast } from "~/composables/useToast";
+import { useNotificationPreferencesQuery } from "~/features/notifications/queries/use-notification-preferences-query";
+import { useUpdateNotificationPreferencesMutation } from "~/features/notifications/queries/use-update-notification-preferences-mutation";
+import {
+  withDefaultCategories,
+  type NotificationCategory,
+  type NotificationPreference,
+} from "~/features/notifications/model/notification-preferences";
+
+const { t } = useI18n();
+const toast = useToast();
+
+const query = useNotificationPreferencesQuery();
+const mutation = useUpdateNotificationPreferencesMutation();
+
+const preferences = computed<NotificationPreference[]>(() =>
+  withDefaultCategories(query.data.value ?? []),
+);
+
+const isGloballyPaused = computed<boolean>(() =>
+  preferences.value.some((p) => p.globalOptOut),
+);
+
+const isBusy = computed<boolean>(() => query.isLoading.value || mutation.isPending.value);
+
+/**
+ * Persists a batch of preferences, surfacing success/error via toast.
+ *
+ * @param next Preferences to upsert.
+ */
+async function persist(next: NotificationPreference[]): Promise<void> {
+  try {
+    await mutation.mutateAsync(next);
+    toast.success(t("notificationPreferences.saved"));
+  } catch {
+    toast.error(t("notificationPreferences.error"));
+  }
+}
+
+/**
+ * Toggles a single category's enabled flag.
+ *
+ * @param category Category to update.
+ * @param enabled Desired enabled state.
+ */
+async function onToggleCategory(
+  category: NotificationCategory,
+  enabled: boolean,
+): Promise<void> {
+  await persist([{ category, enabled, globalOptOut: isGloballyPaused.value }]);
+}
+
+/**
+ * Toggles the global opt-out across every category.
+ *
+ * @param paused Whether all notifications should be paused.
+ */
+async function onToggleGlobal(paused: boolean): Promise<void> {
+  await persist(
+    preferences.value.map((p) => ({ ...p, globalOptOut: paused })),
+  );
+}
+</script>
+
+<template>
+  <NCard :bordered="true" class="notification-preferences" data-testid="notification-preferences">
+    <div class="notification-preferences__head">
+      <h3>{{ t("notificationPreferences.title") }}</h3>
+      <p>{{ t("notificationPreferences.description") }}</p>
+    </div>
+
+    <div class="notification-preferences__global">
+      <span>{{ t("notificationPreferences.globalOptOut") }}</span>
+      <NSpin v-if="isBusy" :size="16" />
+      <NSwitch
+        v-else
+        :value="isGloballyPaused"
+        data-testid="global-opt-out"
+        @update:value="onToggleGlobal"
+      />
+    </div>
+
+    <ul class="notification-preferences__list">
+      <li
+        v-for="pref in preferences"
+        :key="pref.category"
+        class="notification-preferences__item"
+      >
+        <span>{{ t(`notificationPreferences.categories.${pref.category}`) }}</span>
+        <NSwitch
+          :value="pref.enabled"
+          :disabled="isGloballyPaused || isBusy"
+          :data-testid="`pref-${pref.category}`"
+          @update:value="(v: boolean) => onToggleCategory(pref.category, v)"
+        />
+      </li>
+    </ul>
+  </NCard>
+</template>
+
+<style scoped>
+.notification-preferences {
+  border-radius: var(--radius-xl);
+}
+
+.notification-preferences__head h3 {
+  margin: 0 0 var(--space-1);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.notification-preferences__head p {
+  margin: 0 0 var(--space-3);
+  color: var(--color-text-secondary);
+}
+
+.notification-preferences__global {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-block: var(--space-2);
+  border-top: 1px solid var(--color-outline-soft);
+  border-bottom: 1px solid var(--color-outline-soft);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.notification-preferences__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.notification-preferences__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-block: var(--space-2);
+  color: var(--color-text-secondary);
+}
+
+.notification-preferences__item + .notification-preferences__item {
+  border-top: 1px solid var(--color-outline-soft);
+}
+</style>

--- a/app/features/notifications/contracts/notification-preferences.dto.ts
+++ b/app/features/notifications/contracts/notification-preferences.dto.ts
@@ -1,0 +1,13 @@
+/**
+ * DTOs for the `/user/notification-preferences` endpoint (#836).
+ */
+
+export interface NotificationPreferenceDto {
+  readonly category: string;
+  readonly enabled: boolean;
+  readonly global_opt_out: boolean;
+}
+
+export interface NotificationPreferencesResponseDto {
+  readonly preferences: readonly NotificationPreferenceDto[];
+}

--- a/app/features/notifications/model/notification-preferences.spec.ts
+++ b/app/features/notifications/model/notification-preferences.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NOTIFICATION_CATEGORIES,
+  isNotificationCategory,
+  mapPreferencesResponse,
+  toPreferencePayload,
+  withDefaultCategories,
+} from "./notification-preferences";
+
+describe("notification-preferences model", () => {
+  it("recognizes valid categories", () => {
+    expect(isNotificationCategory("due_soon")).toBe(true);
+    expect(isNotificationCategory("unknown")).toBe(false);
+  });
+
+  it("maps the list response, dropping unknown categories", () => {
+    const prefs = mapPreferencesResponse({
+      preferences: [
+        { category: "due_soon", enabled: false, global_opt_out: false },
+        { category: "legacy_unknown", enabled: true, global_opt_out: false },
+      ],
+    });
+    expect(prefs).toHaveLength(1);
+    expect(prefs[0]).toEqual({ category: "due_soon", enabled: false, globalOptOut: false });
+  });
+
+  it("fills missing categories with enabled defaults", () => {
+    const full = withDefaultCategories([
+      { category: "due_soon", enabled: false, globalOptOut: false },
+    ]);
+    expect(full).toHaveLength(NOTIFICATION_CATEGORIES.length);
+    expect(full.find((p) => p.category === "due_soon")?.enabled).toBe(false);
+    expect(full.find((p) => p.category === "goals")?.enabled).toBe(true);
+  });
+
+  it("serializes a preference into the PATCH payload shape", () => {
+    expect(
+      toPreferencePayload({ category: "wallet", enabled: true, globalOptOut: false }),
+    ).toEqual({ category: "wallet", enabled: true, global_opt_out: false });
+  });
+});

--- a/app/features/notifications/model/notification-preferences.ts
+++ b/app/features/notifications/model/notification-preferences.ts
@@ -1,0 +1,97 @@
+/**
+ * Domain model for user notification preferences (UX-02-1, #561).
+ *
+ * Mirrors the Flask backend `/user/notification-preferences` contract (#836):
+ * per-category opt-in/opt-out plus a per-record global opt-out flag.
+ */
+
+import type {
+  NotificationPreferenceDto,
+  NotificationPreferencesResponseDto,
+} from "~/features/notifications/contracts/notification-preferences.dto";
+
+/** Canonical notification categories accepted by the backend. */
+export const NOTIFICATION_CATEGORIES = [
+  "due_soon",
+  "wallet",
+  "goals",
+  "transactions",
+  "subscription",
+] as const;
+
+export type NotificationCategory = (typeof NOTIFICATION_CATEGORIES)[number];
+
+export interface NotificationPreference {
+  category: NotificationCategory;
+  enabled: boolean;
+  globalOptOut: boolean;
+}
+
+/**
+ * @param value Candidate category string.
+ * @returns Whether the value is a known notification category.
+ */
+export function isNotificationCategory(value: string): value is NotificationCategory {
+  return (NOTIFICATION_CATEGORIES as readonly string[]).includes(value);
+}
+
+/**
+ * Maps a single preference DTO to the domain model.
+ *
+ * @param dto Backend preference record.
+ * @returns Domain preference.
+ */
+export function mapPreferenceDto(dto: NotificationPreferenceDto): NotificationPreference {
+  return {
+    category: dto.category as NotificationCategory,
+    enabled: dto.enabled,
+    globalOptOut: dto.global_opt_out,
+  };
+}
+
+/**
+ * Maps the list response into domain preferences, keeping only known categories.
+ *
+ * @param dto Backend list response.
+ * @returns Domain preferences.
+ */
+export function mapPreferencesResponse(
+  dto: NotificationPreferencesResponseDto,
+): NotificationPreference[] {
+  return dto.preferences
+    .filter((p) => isNotificationCategory(p.category))
+    .map(mapPreferenceDto);
+}
+
+/**
+ * Builds a complete preference list for the UI, defaulting any category the
+ * backend has not persisted yet to enabled (opt-out model).
+ *
+ * @param preferences Persisted domain preferences.
+ * @returns One entry per known category.
+ */
+export function withDefaultCategories(
+  preferences: readonly NotificationPreference[],
+): NotificationPreference[] {
+  const byCategory = new Map(preferences.map((p) => [p.category, p]));
+  return NOTIFICATION_CATEGORIES.map(
+    (category) =>
+      byCategory.get(category) ?? { category, enabled: true, globalOptOut: false },
+  );
+}
+
+/**
+ * Serializes a domain preference into the PATCH payload shape.
+ *
+ * @param preference Domain preference.
+ * @returns DTO accepted by the backend upsert.
+ */
+export function toPreferencePayload(
+  preference: NotificationPreference,
+): NotificationPreferenceDto {
+  return {
+    category: preference.category,
+    enabled: preference.enabled,
+    global_opt_out: preference.globalOptOut,
+  };
+}

--- a/app/features/notifications/queries/use-notification-preferences-query.ts
+++ b/app/features/notifications/queries/use-notification-preferences-query.ts
@@ -1,0 +1,29 @@
+import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+
+import { STALE_TIME } from "~/core/query/stale-time";
+import {
+  useNotificationPreferencesApiClient,
+  type NotificationPreferencesApiClient,
+} from "~/features/notifications/services/notification-preferences.client";
+import type { NotificationPreference } from "~/features/notifications/model/notification-preferences";
+
+/** Shared query key for the notification preferences resource. */
+export const NOTIFICATION_PREFERENCES_QUERY_KEY = ["notifications", "preferences"] as const;
+
+/**
+ * Vue Query hook for the authenticated user's notification preferences.
+ *
+ * @param providedClient Optional injected client for unit tests.
+ * @returns Vue Query state with the domain preferences list.
+ */
+export const useNotificationPreferencesQuery = (
+  providedClient?: NotificationPreferencesApiClient,
+): UseQueryReturnType<NotificationPreference[], Error> => {
+  const client = providedClient ?? useNotificationPreferencesApiClient();
+
+  return useQuery({
+    queryKey: NOTIFICATION_PREFERENCES_QUERY_KEY,
+    queryFn: (): Promise<NotificationPreference[]> => client.getPreferences(),
+    staleTime: STALE_TIME.STATIC,
+  });
+};

--- a/app/features/notifications/queries/use-update-notification-preferences-mutation.ts
+++ b/app/features/notifications/queries/use-update-notification-preferences-mutation.ts
@@ -1,0 +1,32 @@
+import { type UseMutationReturnType, useMutation, useQueryClient } from "@tanstack/vue-query";
+
+import {
+  useNotificationPreferencesApiClient,
+  type NotificationPreferencesApiClient,
+} from "~/features/notifications/services/notification-preferences.client";
+import type { NotificationPreference } from "~/features/notifications/model/notification-preferences";
+import { NOTIFICATION_PREFERENCES_QUERY_KEY } from "~/features/notifications/queries/use-notification-preferences-query";
+
+/**
+ * Vue Query mutation to upsert notification preferences.
+ *
+ * Invalidates the preferences query on success so server state is refetched
+ * rather than synced by hand.
+ *
+ * @param providedClient Optional injected client for unit tests.
+ * @returns Vue Query mutation for batch preference updates.
+ */
+export const useUpdateNotificationPreferencesMutation = (
+  providedClient?: NotificationPreferencesApiClient,
+): UseMutationReturnType<NotificationPreference[], Error, NotificationPreference[], unknown> => {
+  const client = providedClient ?? useNotificationPreferencesApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (preferences: NotificationPreference[]): Promise<NotificationPreference[]> =>
+      client.updatePreferences(preferences),
+    onSuccess: (): void => {
+      void queryClient.invalidateQueries({ queryKey: NOTIFICATION_PREFERENCES_QUERY_KEY });
+    },
+  });
+};

--- a/app/features/notifications/services/notification-preferences.client.spec.ts
+++ b/app/features/notifications/services/notification-preferences.client.spec.ts
@@ -1,0 +1,40 @@
+import type { AxiosInstance } from "axios";
+import { describe, expect, it, vi } from "vitest";
+
+import { NotificationPreferencesApiClient } from "./notification-preferences.client";
+
+const RESPONSE = {
+  preferences: [
+    { category: "due_soon", enabled: false, global_opt_out: false },
+    { category: "goals", enabled: true, global_opt_out: false },
+  ],
+};
+
+describe("NotificationPreferencesApiClient", () => {
+  it("maps the enveloped GET response", async () => {
+    const get = vi.fn().mockResolvedValue({ data: { success: true, data: RESPONSE }, headers: {} });
+    const http = { get } as unknown as AxiosInstance;
+    const client = new NotificationPreferencesApiClient(http);
+
+    const prefs = await client.getPreferences();
+
+    expect(get).toHaveBeenCalledWith("/user/notification-preferences");
+    expect(prefs).toHaveLength(2);
+    expect(prefs[0]).toEqual({ category: "due_soon", enabled: false, globalOptOut: false });
+  });
+
+  it("sends the PATCH payload and maps the response", async () => {
+    const patch = vi.fn().mockResolvedValue({ data: RESPONSE, headers: {} });
+    const http = { patch } as unknown as AxiosInstance;
+    const client = new NotificationPreferencesApiClient(http);
+
+    const result = await client.updatePreferences([
+      { category: "wallet", enabled: true, globalOptOut: false },
+    ]);
+
+    expect(patch).toHaveBeenCalledWith("/user/notification-preferences", {
+      preferences: [{ category: "wallet", enabled: true, global_opt_out: false }],
+    });
+    expect(result).toHaveLength(2);
+  });
+});

--- a/app/features/notifications/services/notification-preferences.client.ts
+++ b/app/features/notifications/services/notification-preferences.client.ts
@@ -1,0 +1,81 @@
+import type { AxiosInstance } from "axios";
+
+import { useHttp } from "~/composables/useHttp";
+import type { V2EnvelopeDTO } from "~/features/ai-insights/contracts/ai-insight";
+import type { NotificationPreferencesResponseDto } from "~/features/notifications/contracts/notification-preferences.dto";
+import {
+  mapPreferencesResponse,
+  toPreferencePayload,
+  type NotificationPreference,
+} from "~/features/notifications/model/notification-preferences";
+
+/**
+ * Unwraps the v2 envelope, tolerating legacy flat payloads.
+ *
+ * @param payload Backend response body.
+ * @returns The inner payload.
+ */
+const unwrap = <T>(payload: V2EnvelopeDTO<T> | T): T => {
+  if (
+    payload !== null &&
+    typeof payload === "object" &&
+    "data" in payload &&
+    (payload as V2EnvelopeDTO<T>).data !== undefined
+  ) {
+    return (payload as V2EnvelopeDTO<T>).data as T;
+  }
+  return payload as T;
+};
+
+const ENDPOINT = "/user/notification-preferences";
+
+/**
+ * HTTP adapter for user notification preferences.
+ */
+export class NotificationPreferencesApiClient {
+  readonly #http: AxiosInstance;
+
+  /**
+   * @param http Axios instance configured with auth and API contract headers.
+   */
+  constructor(http: AxiosInstance) {
+    this.#http = http;
+  }
+
+  /**
+   * Lists the authenticated user's notification preferences.
+   *
+   * @returns Domain preferences.
+   */
+  async getPreferences(): Promise<NotificationPreference[]> {
+    const response = await this.#http.get<V2EnvelopeDTO<NotificationPreferencesResponseDto>>(
+      ENDPOINT,
+    );
+    return mapPreferencesResponse(unwrap<NotificationPreferencesResponseDto>(response.data));
+  }
+
+  /**
+   * Upserts a batch of notification preferences.
+   *
+   * @param preferences Domain preferences to persist.
+   * @returns The persisted domain preferences.
+   */
+  async updatePreferences(
+    preferences: readonly NotificationPreference[],
+  ): Promise<NotificationPreference[]> {
+    const response = await this.#http.patch<V2EnvelopeDTO<NotificationPreferencesResponseDto>>(
+      ENDPOINT,
+      { preferences: preferences.map(toPreferencePayload) },
+    );
+    return mapPreferencesResponse(unwrap<NotificationPreferencesResponseDto>(response.data));
+  }
+}
+
+/**
+ * Factory wiring the preferences client to the default HTTP composable.
+ *
+ * @returns Ready-to-use client instance.
+ */
+export const useNotificationPreferencesApiClient = (): NotificationPreferencesApiClient => {
+  return new NotificationPreferencesApiClient(useHttp());
+};

--- a/app/features/weekly-snapshot/components/WeeklySnapshotCard.spec.ts
+++ b/app/features/weekly-snapshot/components/WeeklySnapshotCard.spec.ts
@@ -1,0 +1,124 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import WeeklySnapshotCard from "./WeeklySnapshotCard.vue";
+import {
+  WEEKLY_SNAPSHOT_SEEN_KEY,
+  type WeeklySnapshot,
+} from "~/features/weekly-snapshot/model/weekly-snapshot";
+
+const mockHasPremium = ref(false);
+const mockData = ref<WeeklySnapshot | null>(null);
+const mockIsLoading = ref(false);
+const mockIsError = ref(false);
+
+vi.mock("vue-i18n", () => ({
+  useI18n: (): { t: (k: string) => string; n: (v: number) => string } => ({
+    t: (k: string) => k,
+    n: (v: number) => String(v),
+  }),
+}));
+vi.mock("#imports", () => ({
+  useI18n: (): { t: (k: string) => string; n: (v: number) => string } => ({
+    t: (k: string) => k,
+    n: (v: number) => String(v),
+  }),
+}));
+
+vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
+  useEntitlementQuery: (): { data: typeof mockHasPremium } => ({ data: mockHasPremium }),
+}));
+vi.mock("~/features/weekly-snapshot/queries/use-weekly-snapshot-query", () => ({
+  useWeeklySnapshotQuery: (): {
+    data: typeof mockData;
+    isLoading: typeof mockIsLoading;
+    isError: typeof mockIsError;
+  } => ({ data: mockData, isLoading: mockIsLoading, isError: mockIsError }),
+}));
+
+vi.mock("lucide-vue-next", () => ({
+  CalendarRange: { template: "<span />" },
+  Lock: { template: "<span />" },
+  Sparkles: { template: "<span />" },
+}));
+
+vi.mock("naive-ui", () => ({
+  NCard: { template: "<section><slot name='header' /><slot /></section>" },
+  NSkeleton: { props: ["text", "repeat"], template: "<div class='n-skeleton' />" },
+  NTag: { template: "<span><slot /></span>" },
+  NButton: { props: ["type", "tag", "href", "size", "quaternary"], template: "<button @click='$emit(\"click\")'><slot /></button>", emits: ["click"] },
+}));
+
+const SNAPSHOT: WeeklySnapshot = {
+  narrative: "Esta semana você gastou R$ 1.200.",
+  weekStart: "2026-06-01",
+  weekEnd: "2026-06-07",
+  currentIncome: 5000,
+  currentExpense: 1200,
+  currentBalance: 3800,
+  transactionCount: 14,
+  expenseDeltaPercent: 10.09,
+  balanceDeltaPercent: -2.81,
+};
+
+const stubs = {
+  UiMetricCard: { props: ["label", "value", "trend"], template: "<div class='ui-metric-card'>{{ label }}: {{ value }}</div>" },
+  UiInlineError: { props: ["message"], template: "<div class='ui-inline-error'>{{ message }}</div>" },
+};
+
+/**
+ * @returns Mounted card wrapper.
+ */
+function mountCard(): ReturnType<typeof mount> {
+  return mount(WeeklySnapshotCard, { global: { stubs } });
+}
+
+describe("WeeklySnapshotCard", () => {
+  beforeEach(() => {
+    mockHasPremium.value = false;
+    mockData.value = null;
+    mockIsLoading.value = false;
+    mockIsError.value = false;
+    window.localStorage.clear();
+  });
+
+  it("shows the premium teaser for free users", () => {
+    const w = mountCard();
+    expect(w.find("[data-testid='weekly-snapshot-locked']").exists()).toBe(true);
+  });
+
+  it("shows a skeleton while premium data loads", () => {
+    mockHasPremium.value = true;
+    mockIsLoading.value = true;
+    const w = mountCard();
+    expect(w.find("[data-testid='weekly-snapshot-loading']").exists()).toBe(true);
+  });
+
+  it("shows an error state when the premium query fails", () => {
+    mockHasPremium.value = true;
+    mockIsError.value = true;
+    const w = mountCard();
+    expect(w.find("[data-testid='weekly-snapshot-error']").exists()).toBe(true);
+  });
+
+  it("renders narrative and metrics for premium users with data", () => {
+    mockHasPremium.value = true;
+    mockData.value = SNAPSHOT;
+    const w = mountCard();
+    expect(w.text()).toContain("Esta semana você gastou");
+    expect(w.findAll(".ui-metric-card").length).toBe(3);
+  });
+
+  it("shows the NOVO badge when unseen and clears it on mark-seen", async () => {
+    mockHasPremium.value = true;
+    mockData.value = SNAPSHOT;
+    const w = mountCard();
+    expect(w.find("[data-testid='weekly-snapshot-new-badge']").exists()).toBe(true);
+
+    await w.find("[data-testid='weekly-snapshot-mark-seen']").trigger("click");
+
+    expect(window.localStorage.getItem(WEEKLY_SNAPSHOT_SEEN_KEY)).toBe("2026-06-01_2026-06-07_1200");
+    expect(w.find("[data-testid='weekly-snapshot-new-badge']").exists()).toBe(false);
+  });
+});

--- a/app/features/weekly-snapshot/components/WeeklySnapshotCard.vue
+++ b/app/features/weekly-snapshot/components/WeeklySnapshotCard.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { NButton, NCard, NSkeleton, NTag } from "naive-ui";
+import { CalendarRange, Lock, Sparkles } from "lucide-vue-next";
+
+import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
+import { useWeeklySnapshotQuery } from "~/features/weekly-snapshot/queries/use-weekly-snapshot-query";
+import {
+  WEEKLY_SNAPSHOT_SEEN_KEY,
+  buildSnapshotSignature,
+  isSnapshotUnseen,
+} from "~/features/weekly-snapshot/model/weekly-snapshot";
+import UiMetricCard from "~/components/ui/UiMetricCard/UiMetricCard.vue";
+import UiInlineError from "~/components/ui/UiInlineError/UiInlineError.vue";
+
+const { t, n } = useI18n();
+
+const entitlement = useEntitlementQuery("advanced_simulations");
+const hasPremium = computed<boolean>(() => entitlement.data.value === true);
+
+const snapshotQuery = useWeeklySnapshotQuery(undefined, { enabled: hasPremium });
+const snapshot = computed(() => snapshotQuery.data.value ?? null);
+
+const lastSeen = ref<string | null>(null);
+
+onMounted(() => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  lastSeen.value = window.localStorage.getItem(WEEKLY_SNAPSHOT_SEEN_KEY);
+});
+
+const isUnseen = computed<boolean>(() => {
+  if (!snapshot.value) {
+    return false;
+  }
+  return isSnapshotUnseen(snapshot.value, lastSeen.value);
+});
+
+/**
+ * Persists the current snapshot signature so the "NOVO" badge clears.
+ */
+function markAsSeen(): void {
+  if (typeof window === "undefined" || !snapshot.value) {
+    return;
+  }
+  const signature = buildSnapshotSignature(snapshot.value);
+  window.localStorage.setItem(WEEKLY_SNAPSHOT_SEEN_KEY, signature);
+  lastSeen.value = signature;
+}
+
+/**
+ * @param value Numeric amount.
+ * @returns BRL-formatted string.
+ */
+function formatBrl(value: number): string {
+  return n(value, "currency");
+}
+
+const isLoading = computed<boolean>(() => hasPremium.value && snapshotQuery.isLoading.value);
+const isError = computed<boolean>(() => hasPremium.value && snapshotQuery.isError.value);
+</script>
+
+<template>
+  <NCard :bordered="true" class="weekly-snapshot-card" data-testid="weekly-snapshot-card">
+    <template #header>
+      <span class="weekly-snapshot-card__header">
+        <CalendarRange :size="18" aria-hidden="true" />
+        {{ t("weeklySnapshot.title") }}
+        <NTag v-if="isUnseen" type="success" size="small" round data-testid="weekly-snapshot-new-badge">
+          {{ t("weeklySnapshot.newBadge") }}
+        </NTag>
+      </span>
+    </template>
+
+    <!-- Free users: premium teaser -->
+    <div v-if="!hasPremium" class="weekly-snapshot-card__locked" data-testid="weekly-snapshot-locked">
+      <Lock :size="20" aria-hidden="true" />
+      <p class="weekly-snapshot-card__locked-title">{{ t("weeklySnapshot.locked.title") }}</p>
+      <p class="weekly-snapshot-card__locked-desc">{{ t("weeklySnapshot.locked.description") }}</p>
+      <NButton type="primary" tag="a" href="/subscription" size="small">
+        {{ t("weeklySnapshot.locked.cta") }}
+      </NButton>
+    </div>
+
+    <!-- Premium loading -->
+    <div v-else-if="isLoading" data-testid="weekly-snapshot-loading">
+      <NSkeleton text :repeat="3" />
+    </div>
+
+    <!-- Premium error -->
+    <UiInlineError
+      v-else-if="isError"
+      :message="t('weeklySnapshot.error')"
+      data-testid="weekly-snapshot-error"
+    />
+
+    <!-- Premium data -->
+    <div v-else-if="snapshot" class="weekly-snapshot-card__body">
+      <p class="weekly-snapshot-card__narrative">
+        <Sparkles :size="16" aria-hidden="true" />
+        {{ snapshot.narrative }}
+      </p>
+
+      <div class="weekly-snapshot-card__metrics">
+        <UiMetricCard :label="t('weeklySnapshot.metrics.expense')" :value="formatBrl(snapshot.currentExpense)" :trend="snapshot.expenseDeltaPercent" />
+        <UiMetricCard :label="t('weeklySnapshot.metrics.balance')" :value="formatBrl(snapshot.currentBalance)" :trend="snapshot.balanceDeltaPercent" />
+        <UiMetricCard :label="t('weeklySnapshot.metrics.transactions')" :value="String(snapshot.transactionCount)" />
+      </div>
+
+      <div v-if="isUnseen" class="weekly-snapshot-card__actions">
+        <NButton size="tiny" quaternary data-testid="weekly-snapshot-mark-seen" @click="markAsSeen">
+          {{ t("weeklySnapshot.markSeen") }}
+        </NButton>
+      </div>
+    </div>
+  </NCard>
+</template>
+
+<style scoped>
+.weekly-snapshot-card {
+  border-radius: var(--radius-xl);
+}
+
+.weekly-snapshot-card__header {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.weekly-snapshot-card__locked {
+  display: grid;
+  justify-items: start;
+  gap: var(--space-2);
+  color: var(--color-text-secondary);
+}
+
+.weekly-snapshot-card__locked-title {
+  margin: 0;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.weekly-snapshot-card__locked-desc {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.weekly-snapshot-card__body {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.weekly-snapshot-card__narrative {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  margin: 0;
+  line-height: 1.6;
+  color: var(--color-text-primary);
+}
+
+.weekly-snapshot-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.weekly-snapshot-card__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 640px) {
+  .weekly-snapshot-card__metrics {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/app/features/weekly-snapshot/contracts/weekly-snapshot.dto.ts
+++ b/app/features/weekly-snapshot/contracts/weekly-snapshot.dto.ts
@@ -1,0 +1,39 @@
+/**
+ * DTOs for the AI weekly-summary narrative endpoint (`GET /ai/insights/weekly-summary`).
+ *
+ * The endpoint is premium-gated (entitlement `advanced_simulations`) and wraps
+ * its payload in the v2 envelope. Shapes mirror the Flask backend
+ * (`ai_advisory_service.generate_weekly_summary_narrative`).
+ */
+
+export interface WeeklyPeriodTotalsDto {
+  readonly start: string;
+  readonly end: string;
+  readonly income: number;
+  readonly expense: number;
+  readonly balance: number;
+  readonly transaction_count: number;
+}
+
+export interface WeeklyComparisonDto {
+  readonly income_delta: number;
+  readonly income_delta_percent: number;
+  readonly expense_delta: number;
+  readonly expense_delta_percent: number;
+  readonly balance_delta: number;
+  readonly balance_delta_percent: number;
+}
+
+export interface WeeklySummaryDto {
+  readonly current_week: WeeklyPeriodTotalsDto;
+  readonly previous_week: WeeklyPeriodTotalsDto;
+  readonly comparison: WeeklyComparisonDto;
+}
+
+export interface WeeklySummaryNarrativeDto {
+  readonly narrative: string;
+  readonly tokens_used?: number;
+  readonly cost_usd?: number;
+  readonly model?: string;
+  readonly summary: WeeklySummaryDto;
+}

--- a/app/features/weekly-snapshot/model/weekly-snapshot.spec.ts
+++ b/app/features/weekly-snapshot/model/weekly-snapshot.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSnapshotSignature,
+  isSnapshotUnseen,
+  mapWeeklySnapshotDto,
+} from "./weekly-snapshot";
+import type { WeeklySummaryNarrativeDto } from "../contracts/weekly-snapshot.dto";
+
+const DTO: WeeklySummaryNarrativeDto = {
+  narrative: "Esta semana você gastou R$ 1.200, 10% a mais que na semana passada.",
+  tokens_used: 280,
+  cost_usd: 0.000042,
+  model: "gpt-4o-mini",
+  summary: {
+    current_week: { start: "2026-06-01", end: "2026-06-07", income: 5000, expense: 1200, balance: 3800, transaction_count: 14 },
+    previous_week: { start: "2026-05-25", end: "2026-05-31", income: 5000, expense: 1090, balance: 3910, transaction_count: 11 },
+    comparison: {
+      income_delta: 0,
+      income_delta_percent: 0,
+      expense_delta: 110,
+      expense_delta_percent: 10.09,
+      balance_delta: -110,
+      balance_delta_percent: -2.81,
+    },
+  },
+};
+
+describe("mapWeeklySnapshotDto", () => {
+  it("maps the narrative and current-week totals", () => {
+    const snapshot = mapWeeklySnapshotDto(DTO);
+    expect(snapshot.narrative).toContain("Esta semana");
+    expect(snapshot.currentExpense).toBe(1200);
+    expect(snapshot.currentIncome).toBe(5000);
+    expect(snapshot.currentBalance).toBe(3800);
+    expect(snapshot.transactionCount).toBe(14);
+    expect(snapshot.weekStart).toBe("2026-06-01");
+    expect(snapshot.weekEnd).toBe("2026-06-07");
+  });
+
+  it("maps the week-over-week comparison deltas", () => {
+    const snapshot = mapWeeklySnapshotDto(DTO);
+    expect(snapshot.expenseDeltaPercent).toBe(10.09);
+    expect(snapshot.balanceDeltaPercent).toBe(-2.81);
+  });
+});
+
+describe("buildSnapshotSignature", () => {
+  it("is stable for the same snapshot", () => {
+    const snapshot = mapWeeklySnapshotDto(DTO);
+    expect(buildSnapshotSignature(snapshot)).toBe(buildSnapshotSignature(snapshot));
+  });
+
+  it("changes when the week or expense changes", () => {
+    const a = mapWeeklySnapshotDto(DTO);
+    const b = mapWeeklySnapshotDto({
+      ...DTO,
+      summary: { ...DTO.summary, current_week: { ...DTO.summary.current_week, expense: 1500 } },
+    });
+    expect(buildSnapshotSignature(a)).not.toBe(buildSnapshotSignature(b));
+  });
+});
+
+describe("isSnapshotUnseen", () => {
+  it("is unseen when no signature was stored", () => {
+    const snapshot = mapWeeklySnapshotDto(DTO);
+    expect(isSnapshotUnseen(snapshot, null)).toBe(true);
+  });
+
+  it("is seen when the stored signature matches", () => {
+    const snapshot = mapWeeklySnapshotDto(DTO);
+    expect(isSnapshotUnseen(snapshot, buildSnapshotSignature(snapshot))).toBe(false);
+  });
+
+  it("is unseen when the stored signature differs", () => {
+    const snapshot = mapWeeklySnapshotDto(DTO);
+    expect(isSnapshotUnseen(snapshot, "stale-signature")).toBe(true);
+  });
+});

--- a/app/features/weekly-snapshot/model/weekly-snapshot.ts
+++ b/app/features/weekly-snapshot/model/weekly-snapshot.ts
@@ -1,0 +1,71 @@
+/**
+ * Domain model for the Weekly Snapshot card (UX-02-1, #561).
+ *
+ * Maps the premium AI weekly-summary narrative DTO into a compact view model
+ * and provides pure helpers for the "NOVO" badge (localStorage-backed
+ * seen/unseen detection driven by a stable content signature).
+ */
+
+import type { WeeklySummaryNarrativeDto } from "../contracts/weekly-snapshot.dto";
+
+export interface WeeklySnapshot {
+  narrative: string;
+  weekStart: string;
+  weekEnd: string;
+  currentIncome: number;
+  currentExpense: number;
+  currentBalance: number;
+  transactionCount: number;
+  expenseDeltaPercent: number;
+  balanceDeltaPercent: number;
+}
+
+/** localStorage key holding the last snapshot signature the user has seen. */
+export const WEEKLY_SNAPSHOT_SEEN_KEY = "auraxis.weekly-snapshot.seen";
+
+/**
+ * Maps the backend narrative DTO into the Weekly Snapshot domain model.
+ *
+ * @param dto Premium weekly-summary narrative payload.
+ * @returns Compact view model for the dashboard card.
+ */
+export function mapWeeklySnapshotDto(dto: WeeklySummaryNarrativeDto): WeeklySnapshot {
+  const current = dto.summary.current_week;
+  const comparison = dto.summary.comparison;
+  return {
+    narrative: dto.narrative,
+    weekStart: current.start,
+    weekEnd: current.end,
+    currentIncome: current.income,
+    currentExpense: current.expense,
+    currentBalance: current.balance,
+    transactionCount: current.transaction_count,
+    expenseDeltaPercent: comparison.expense_delta_percent,
+    balanceDeltaPercent: comparison.balance_delta_percent,
+  };
+}
+
+/**
+ * Builds a stable signature for change detection. Two snapshots with the same
+ * week bounds and current-week expense produce the same signature.
+ *
+ * @param snapshot Weekly snapshot view model.
+ * @returns Signature string.
+ */
+export function buildSnapshotSignature(snapshot: WeeklySnapshot): string {
+  return `${snapshot.weekStart}_${snapshot.weekEnd}_${snapshot.currentExpense}`;
+}
+
+/**
+ * Decides whether the snapshot is new relative to the last seen signature.
+ *
+ * @param snapshot Weekly snapshot view model.
+ * @param lastSeenSignature Signature previously persisted, or null.
+ * @returns True when the snapshot has not been seen yet.
+ */
+export function isSnapshotUnseen(
+  snapshot: WeeklySnapshot,
+  lastSeenSignature: string | null,
+): boolean {
+  return buildSnapshotSignature(snapshot) !== lastSeenSignature;
+}

--- a/app/features/weekly-snapshot/queries/use-weekly-snapshot-query.ts
+++ b/app/features/weekly-snapshot/queries/use-weekly-snapshot-query.ts
@@ -1,0 +1,39 @@
+import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+import { type MaybeRefOrGetter, toValue } from "vue";
+
+import { STALE_TIME } from "~/core/query/stale-time";
+import {
+  useWeeklySnapshotApiClient,
+  type WeeklySnapshotApiClient,
+} from "~/features/weekly-snapshot/services/weekly-snapshot.client";
+import type { WeeklySnapshot } from "~/features/weekly-snapshot/model/weekly-snapshot";
+
+interface UseWeeklySnapshotQueryOptions {
+  /** Whether the query may run. Gate on premium entitlement to avoid 403 churn. */
+  enabled?: MaybeRefOrGetter<boolean>;
+}
+
+/**
+ * Vue Query hook for the premium AI weekly-summary narrative.
+ *
+ * Errors propagate as query error state (no silent catch). Callers should pass
+ * `enabled` bound to the premium entitlement so free users never trigger the
+ * backend 403.
+ *
+ * @param providedClient Optional injected client for unit tests.
+ * @param options Query controls (notably `enabled`).
+ * @returns Vue Query state with the weekly snapshot domain model.
+ */
+export const useWeeklySnapshotQuery = (
+  providedClient?: WeeklySnapshotApiClient,
+  options: UseWeeklySnapshotQueryOptions = {},
+): UseQueryReturnType<WeeklySnapshot, Error> => {
+  const client = providedClient ?? useWeeklySnapshotApiClient();
+
+  return useQuery({
+    queryKey: ["weekly-snapshot"] as const,
+    queryFn: (): Promise<WeeklySnapshot> => client.getWeeklySnapshot(),
+    enabled: (): boolean => toValue(options.enabled ?? true),
+    staleTime: STALE_TIME.STATIC,
+  });
+};

--- a/app/features/weekly-snapshot/services/weekly-snapshot.client.spec.ts
+++ b/app/features/weekly-snapshot/services/weekly-snapshot.client.spec.ts
@@ -1,0 +1,38 @@
+import type { AxiosInstance } from "axios";
+import { describe, expect, it, vi } from "vitest";
+
+import { WeeklySnapshotApiClient } from "./weekly-snapshot.client";
+import type { WeeklySummaryNarrativeDto } from "../contracts/weekly-snapshot.dto";
+
+const DTO: WeeklySummaryNarrativeDto = {
+  narrative: "Resumo da semana.",
+  summary: {
+    current_week: { start: "2026-06-01", end: "2026-06-07", income: 5000, expense: 1200, balance: 3800, transaction_count: 14 },
+    previous_week: { start: "2026-05-25", end: "2026-05-31", income: 5000, expense: 1090, balance: 3910, transaction_count: 11 },
+    comparison: { income_delta: 0, income_delta_percent: 0, expense_delta: 110, expense_delta_percent: 10.09, balance_delta: -110, balance_delta_percent: -2.81 },
+  },
+};
+
+/**
+ * @param data Response body to resolve.
+ * @returns A fake Axios instance exposing a stubbed get().
+ */
+function fakeHttp(data: unknown): AxiosInstance {
+  return { get: vi.fn().mockResolvedValue({ data, headers: {} }) } as unknown as AxiosInstance;
+}
+
+describe("WeeklySnapshotApiClient", () => {
+  it("maps an enveloped payload to the domain model", async () => {
+    const client = new WeeklySnapshotApiClient(fakeHttp({ success: true, data: DTO }));
+    const snapshot = await client.getWeeklySnapshot();
+    expect(snapshot.currentExpense).toBe(1200);
+    expect(snapshot.expenseDeltaPercent).toBe(10.09);
+  });
+
+  it("tolerates a flat (legacy) payload", async () => {
+    const client = new WeeklySnapshotApiClient(fakeHttp(DTO));
+    const snapshot = await client.getWeeklySnapshot();
+    expect(snapshot.narrative).toBe("Resumo da semana.");
+    expect(snapshot.transactionCount).toBe(14);
+  });
+});

--- a/app/features/weekly-snapshot/services/weekly-snapshot.client.ts
+++ b/app/features/weekly-snapshot/services/weekly-snapshot.client.ts
@@ -1,0 +1,62 @@
+import type { AxiosInstance } from "axios";
+
+import { useHttp } from "~/composables/useHttp";
+import type { V2EnvelopeDTO } from "~/features/ai-insights/contracts/ai-insight";
+import type { WeeklySummaryNarrativeDto } from "~/features/weekly-snapshot/contracts/weekly-snapshot.dto";
+import {
+  mapWeeklySnapshotDto,
+  type WeeklySnapshot,
+} from "~/features/weekly-snapshot/model/weekly-snapshot";
+
+/**
+ * Unwraps the v2 envelope, tolerating legacy flat payloads.
+ *
+ * @param payload Backend response body.
+ * @returns The inner payload.
+ */
+const unwrap = <T>(payload: V2EnvelopeDTO<T> | T): T => {
+  if (
+    payload !== null &&
+    typeof payload === "object" &&
+    "data" in payload &&
+    (payload as V2EnvelopeDTO<T>).data !== undefined
+  ) {
+    return (payload as V2EnvelopeDTO<T>).data as T;
+  }
+  return payload as T;
+};
+
+/**
+ * HTTP adapter for the premium AI weekly-summary narrative endpoint.
+ */
+export class WeeklySnapshotApiClient {
+  readonly #http: AxiosInstance;
+
+  /**
+   * @param http Axios instance configured with auth and API contract headers.
+   */
+  constructor(http: AxiosInstance) {
+    this.#http = http;
+  }
+
+  /**
+   * Fetches the weekly snapshot narrative for the authenticated premium user.
+   *
+   * @returns Weekly snapshot domain model.
+   */
+  async getWeeklySnapshot(): Promise<WeeklySnapshot> {
+    const response = await this.#http.get<V2EnvelopeDTO<WeeklySummaryNarrativeDto>>(
+      "/ai/insights/weekly-summary",
+    );
+    return mapWeeklySnapshotDto(unwrap<WeeklySummaryNarrativeDto>(response.data));
+  }
+}
+
+/**
+ * Factory wiring the weekly-snapshot client to the default HTTP composable.
+ *
+ * @returns Ready-to-use client instance.
+ */
+export const useWeeklySnapshotApiClient = (): WeeklySnapshotApiClient => {
+  return new WeeklySnapshotApiClient(useHttp());
+};

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -4,6 +4,36 @@
     "light": "Claro",
     "dark": "Escuro"
   },
+  "weeklySnapshot": {
+    "title": "Resumo da semana",
+    "newBadge": "NOVO",
+    "markSeen": "Marcar como visto",
+    "error": "Não foi possível carregar seu resumo semanal agora.",
+    "locked": {
+      "title": "Briefing semanal com IA",
+      "description": "Receba um resumo inteligente dos seus gastos da semana, com comparativo e destaques. Disponível no plano Premium.",
+      "cta": "Conhecer o Premium"
+    },
+    "metrics": {
+      "expense": "Gastos da semana",
+      "balance": "Saldo da semana",
+      "transactions": "Transações"
+    }
+  },
+  "notificationPreferences": {
+    "title": "Categorias de notificação",
+    "description": "Escolha sobre o que você quer ser avisado. Você pode pausar tudo de uma vez com o controle geral.",
+    "globalOptOut": "Pausar todas as notificações",
+    "saved": "Preferências atualizadas",
+    "error": "Não foi possível salvar suas preferências.",
+    "categories": {
+      "due_soon": "Vencimentos próximos",
+      "wallet": "Carteira e investimentos",
+      "goals": "Metas",
+      "transactions": "Transações",
+      "subscription": "Assinatura"
+    }
+  },
   "error": {
     "404": {
       "title": "Página não encontrada",

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import { NButton, NDatePicker } from "naive-ui";
 
 import DashboardControlBar from "~/features/dashboard/components/DashboardControlBar.vue";
+import WeeklySnapshotCard from "~/features/weekly-snapshot/components/WeeklySnapshotCard.vue";
 import DashboardMarketPulseWorkspace from "~/features/dashboard/components/DashboardMarketPulseWorkspace.vue";
 import AiInsightSurface from "~/features/ai-insights/components/AiInsightSurface.vue";
 import OnboardingSkipNudge from "~/features/onboarding/components/OnboardingSkipNudge.vue";
@@ -170,6 +171,8 @@ const closeFirstTransactionForm = (): void => {
         :mode="selectedMode"
         :loading="dashboardQuery.isLoading.value || trendsQuery.isLoading.value"
       />
+
+      <WeeklySnapshotCard class="dashboard-page__weekly-snapshot" />
 
       <AiInsightSurface class="dashboard-page__ai-insights" />
 

--- a/app/pages/settings/notifications.spec.ts
+++ b/app/pages/settings/notifications.spec.ts
@@ -87,6 +87,10 @@ vi.mock("~/features/notifications/composables/usePushSubscription", () => ({
   usePushSubscription: (): typeof pushHarness => pushHarness,
 }));
 
+vi.mock("~/features/notifications/components/NotificationPreferencesPanel.vue", () => ({
+  default: { template: "<div data-testid='notification-preferences-stub' />" },
+}));
+
 vi.mock("lucide-vue-next", () => ({
   Bell: { template: "<span data-testid='bell-icon' />" },
   BellRing: { template: "<span data-testid='bell-ring-icon' />" },

--- a/app/pages/settings/notifications.vue
+++ b/app/pages/settings/notifications.vue
@@ -4,6 +4,7 @@ import { NCard, NSwitch, NAlert, NButton, NSpin, NTag } from "naive-ui";
 import { Bell, BellRing, CalendarClock, MailCheck, ShieldCheck } from "lucide-vue-next";
 
 import { usePushSubscription } from "~/features/notifications/composables/usePushSubscription";
+import NotificationPreferencesPanel from "~/features/notifications/components/NotificationPreferencesPanel.vue";
 
 definePageMeta({
   middleware: ["authenticated"],
@@ -176,6 +177,8 @@ const onToggle = async (value: boolean): Promise<void> => {
         </NButton>
       </div>
     </NCard>
+
+    <NotificationPreferencesPanel class="notifications-page__preferences" />
   </div>
 </template>
 


### PR DESCRIPTION
## Contexto

UX-02-1 (#561, sub de #534). Backend já existe na v1 (`GET /ai/insights/weekly-summary`, `GET/PATCH /user/notification-preferences`). Conforme decisão: card alimentado pela **narrativa de IA** + preferências por categoria. #562 (email/push cron) permanece deferido.

## O que entra

**WeeklySnapshotCard** (dashboard)
- Consome `/ai/insights/weekly-summary` (premium, entitlement `advanced_simulations`).
- Mostra narrativa da semana + gastos, saldo e variação vs semana anterior (UiMetricCard com trend).
- Badge **NOVO** via localStorage (assinatura de conteúdo) + ação 'marcar como visto'.
- **Gate premium**: usuários free veem teaser + CTA de upgrade; estados skeleton/erro tratados.

**Preferências de notificação** (`/settings/notifications`)
- Painel `NotificationPreferencesPanel` consumindo `/user/notification-preferences` (GET + PATCH upsert).
- Toggle por categoria (Vencimentos, Carteira, Metas, Transações, Assinatura) + **opt-out global**.
- Mantém o card de push readiness existente (`usePushSubscription`).

> Nota: o backend modela preferências por **categoria** (+ `global_opt_out`), não por canal push/email/in-app. A UI reflete o contrato real; granularidade de canal de email entra com #562.

## Arquitetura
- features `weekly-snapshot` e `notifications` seguindo a camada canônica (contracts/model/services/queries/components), mappers puros com TDD, clients com testes de envelope, componentes com specs.

## Quality gates
`pnpm quality-check` PASS (lint + typecheck + coverage 85.77% branches ≥ 85% + flags + contracts + build: 169 páginas, 0 falhas). i18n pt; EN via fallback (en.json congelado, DEC-186).

Closes #561
Refs #534