### PR TITLE
feat(insights): SpendingInsightCard — radar de gastos compulsivos (PROD-04, #568)

### DIFF
--- a/app/features/spending-patterns/components/SpendingInsightCard.spec.ts
+++ b/app/features/spending-patterns/components/SpendingInsightCard.spec.ts
@@ -1,0 +1,55 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import SpendingInsightCard from "./SpendingInsightCard.vue";
+
+const mockHasPremium = ref(false);
+
+vi.mock("vue-i18n", () => ({
+  useI18n: (): { t: (k: string) => string } => ({ t: (k: string) => k }),
+}));
+vi.mock("#imports", () => ({
+  useI18n: (): { t: (k: string) => string } => ({ t: (k: string) => k }),
+}));
+vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
+  useEntitlementQuery: (): { data: typeof mockHasPremium } => ({ data: mockHasPremium }),
+}));
+vi.mock("lucide-vue-next", () => ({
+  Lock: { template: "<span />" },
+  Radar: { template: "<span />" },
+}));
+vi.mock("naive-ui", () => ({
+  NCard: { template: "<section><slot name='header' /><slot /></section>" },
+  NButton: { props: ["type", "tag", "href", "size"], template: "<button><slot /></button>" },
+}));
+
+const stubs = {
+  SpendingInsightContent: { template: "<div data-testid='spending-insight-content-stub' />" },
+};
+
+/**
+ * @returns Mounted card wrapper.
+ */
+function mountCard(): ReturnType<typeof mount> {
+  return mount(SpendingInsightCard, { global: { stubs } });
+}
+
+describe("SpendingInsightCard", () => {
+  beforeEach(() => {
+    mockHasPremium.value = false;
+  });
+
+  it("shows the premium teaser for free users and no content", () => {
+    const w = mountCard();
+    expect(w.find("[data-testid='spending-insight-locked']").exists()).toBe(true);
+    expect(w.find("[data-testid='spending-insight-content-stub']").exists()).toBe(false);
+  });
+
+  it("mounts the premium content for entitled users", () => {
+    mockHasPremium.value = true;
+    const w = mountCard();
+    expect(w.find("[data-testid='spending-insight-locked']").exists()).toBe(false);
+    expect(w.find("[data-testid='spending-insight-content-stub']").exists()).toBe(true);
+  });
+});

--- a/app/features/spending-patterns/components/SpendingInsightCard.vue
+++ b/app/features/spending-patterns/components/SpendingInsightCard.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { NButton, NCard } from "naive-ui";
+import { Lock, Radar } from "lucide-vue-next";
+
+import { useEntitlementQuery } from "~/features/paywall/queries/use-entitlement-query";
+import SpendingInsightContent from "~/features/spending-patterns/components/SpendingInsightContent.vue";
+
+const { t } = useI18n();
+
+const entitlement = useEntitlementQuery("advanced_simulations");
+const hasPremium = computed<boolean>(() => entitlement.data.value === true);
+</script>
+
+<template>
+  <NCard :bordered="true" class="spending-insight-card" data-testid="spending-insight-card">
+    <template #header>
+      <span class="spending-insight-card__header">
+        <Radar :size="18" aria-hidden="true" />
+        {{ t("spendingPatterns.title") }}
+      </span>
+    </template>
+
+    <!-- Free users: premium teaser. The premium content component (and its
+         transaction/pattern queries) only mounts when the user is premium. -->
+    <div v-if="!hasPremium" class="spending-insight-card__locked" data-testid="spending-insight-locked">
+      <Lock :size="20" aria-hidden="true" />
+      <p class="spending-insight-card__locked-title">{{ t("spendingPatterns.locked.title") }}</p>
+      <p class="spending-insight-card__locked-desc">{{ t("spendingPatterns.locked.description") }}</p>
+      <NButton type="primary" tag="a" href="/subscription" size="small">
+        {{ t("spendingPatterns.locked.cta") }}
+      </NButton>
+    </div>
+
+    <SpendingInsightContent v-else />
+  </NCard>
+</template>
+
+<style scoped>
+.spending-insight-card {
+  border-radius: var(--radius-xl);
+}
+
+.spending-insight-card__header {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.spending-insight-card__locked {
+  display: grid;
+  justify-items: start;
+  gap: var(--space-2);
+  color: var(--color-text-secondary);
+}
+
+.spending-insight-card__locked-title {
+  margin: 0;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.spending-insight-card__locked-desc {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+</style>

--- a/app/features/spending-patterns/components/SpendingInsightContent.spec.ts
+++ b/app/features/spending-patterns/components/SpendingInsightContent.spec.ts
@@ -1,0 +1,95 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import SpendingInsightContent from "./SpendingInsightContent.vue";
+import type { SpendingPattern } from "~/features/spending-patterns/model/spending-patterns";
+
+const mockTxData = ref<unknown[]>([]);
+const mockTxLoading = ref(false);
+const mockPatterns = ref<SpendingPattern[]>([]);
+const mockPatternsLoading = ref(false);
+const mockPatternsError = ref(false);
+
+vi.mock("vue-i18n", () => ({
+  useI18n: (): { t: (k: string) => string; n: (v: number) => string } => ({
+    t: (k: string) => k,
+    n: (v: number) => String(v),
+  }),
+}));
+vi.mock("#imports", () => ({
+  useI18n: (): { t: (k: string) => string; n: (v: number) => string } => ({
+    t: (k: string) => k,
+    n: (v: number) => String(v),
+  }),
+}));
+
+vi.mock("~/features/transactions/queries/use-list-transactions-query", () => ({
+  useListTransactionsQuery: (): { data: typeof mockTxData; isLoading: typeof mockTxLoading } => ({
+    data: mockTxData,
+    isLoading: mockTxLoading,
+  }),
+}));
+vi.mock("~/features/spending-patterns/queries/use-spending-patterns-query", () => ({
+  useSpendingPatternsQuery: (): {
+    data: typeof mockPatterns;
+    isLoading: typeof mockPatternsLoading;
+    isError: typeof mockPatternsError;
+  } => ({ data: mockPatterns, isLoading: mockPatternsLoading, isError: mockPatternsError }),
+}));
+
+vi.mock("naive-ui", () => ({
+  NSkeleton: { props: ["text", "repeat"], template: "<div class='n-skeleton' />" },
+  NTag: { props: ["type", "size", "round"], template: "<span><slot /></span>" },
+  NButton: { props: ["size", "quaternary"], template: "<button><slot /></button>" },
+}));
+
+const stubs = { NuxtLink: { props: ["to"], template: "<a><slot /></a>" } };
+
+const PATTERN: SpendingPattern = {
+  description: "Cafés diários",
+  frequency: "diária",
+  averageValue: 12.5,
+  suggestedAction: "Defina um teto mensal",
+  severity: "high",
+};
+
+/**
+ * @returns Mounted content wrapper.
+ */
+function mountContent(): ReturnType<typeof mount> {
+  return mount(SpendingInsightContent, { global: { stubs } });
+}
+
+describe("SpendingInsightContent", () => {
+  beforeEach(() => {
+    mockTxData.value = [];
+    mockTxLoading.value = false;
+    mockPatterns.value = [];
+    mockPatternsLoading.value = false;
+    mockPatternsError.value = false;
+  });
+
+  it("shows a skeleton while loading", () => {
+    mockPatternsLoading.value = true;
+    expect(mountContent().find("[data-testid='spending-insight-loading']").exists()).toBe(true);
+  });
+
+  it("shows a soft unavailable state on error", () => {
+    mockPatternsError.value = true;
+    expect(mountContent().find("[data-testid='spending-insight-error']").exists()).toBe(true);
+  });
+
+  it("shows the empty state when no patterns", () => {
+    expect(mountContent().find("[data-testid='spending-insight-empty']").exists()).toBe(true);
+  });
+
+  it("renders the pattern list with a create-budget CTA", () => {
+    mockPatterns.value = [PATTERN];
+    const w = mountContent();
+    const list = w.find("[data-testid='spending-insight-list']");
+    expect(list.exists()).toBe(true);
+    expect(w.text()).toContain("Cafés diários");
+    expect(w.find("[data-testid='spending-insight-budget-cta']").exists()).toBe(true);
+  });
+});

--- a/app/features/spending-patterns/components/SpendingInsightContent.vue
+++ b/app/features/spending-patterns/components/SpendingInsightContent.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { NButton, NSkeleton, NTag } from "naive-ui";
+
+import { useListTransactionsQuery } from "~/features/transactions/queries/use-list-transactions-query";
+import { useSpendingPatternsQuery } from "~/features/spending-patterns/queries/use-spending-patterns-query";
+import { buildTransactionInputs } from "~/features/spending-patterns/model/spending-patterns";
+import type { SpendingPatternSeverityDto } from "~/features/spending-patterns/contracts/spending-patterns.dto";
+
+const { t, n } = useI18n();
+
+/**
+ * @param offsetDays Days to subtract from today.
+ * @returns ISO date string (YYYY-MM-DD).
+ */
+function isoDaysAgo(offsetDays: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+const transactionFilters = computed(() => ({
+  type: "expense" as const,
+  start_date: isoDaysAgo(90),
+  end_date: isoDaysAgo(0),
+}));
+
+const transactionsQuery = useListTransactionsQuery(transactionFilters);
+
+const transactionInputs = computed(() =>
+  buildTransactionInputs(transactionsQuery.data.value ?? []),
+);
+
+const patternsQuery = useSpendingPatternsQuery(transactionInputs, {
+  enabled: computed(() => transactionInputs.value.length > 0),
+});
+
+const patterns = computed(() => patternsQuery.data.value ?? []);
+
+const isLoading = computed<boolean>(
+  () => transactionsQuery.isLoading.value || patternsQuery.isLoading.value,
+);
+const isError = computed<boolean>(() => patternsQuery.isError.value);
+const isEmpty = computed<boolean>(
+  () => !isLoading.value && !isError.value && patterns.value.length === 0,
+);
+
+const SEVERITY_TAG: Record<SpendingPatternSeverityDto, "default" | "warning" | "error"> = {
+  low: "default",
+  medium: "warning",
+  high: "error",
+};
+
+/**
+ * @param value Numeric amount.
+ * @returns BRL-formatted string.
+ */
+function formatBrl(value: number): string {
+  return n(value, "currency");
+}
+</script>
+
+<template>
+  <div>
+    <div v-if="isLoading" data-testid="spending-insight-loading">
+      <NSkeleton text :repeat="3" />
+    </div>
+
+    <!-- Soft unavailable state (e.g. backend not yet reachable / 503). -->
+    <p v-else-if="isError" class="spending-insight-content__muted" data-testid="spending-insight-error">
+      {{ t("spendingPatterns.unavailable") }}
+    </p>
+
+    <p v-else-if="isEmpty" class="spending-insight-content__muted" data-testid="spending-insight-empty">
+      {{ t("spendingPatterns.empty") }}
+    </p>
+
+    <ul v-else class="spending-insight-content__list" data-testid="spending-insight-list">
+      <li v-for="(pattern, i) in patterns" :key="i" class="spending-insight-content__item">
+        <div class="spending-insight-content__item-head">
+          <span class="spending-insight-content__item-title">{{ pattern.description }}</span>
+          <NTag :type="SEVERITY_TAG[pattern.severity]" size="small" round>
+            {{ t(`spendingPatterns.severity.${pattern.severity}`) }}
+          </NTag>
+        </div>
+        <p class="spending-insight-content__item-meta">
+          {{ pattern.frequency }} ·
+          {{ t("spendingPatterns.average", { value: formatBrl(pattern.averageValue) }) }}
+        </p>
+        <p class="spending-insight-content__item-action">{{ pattern.suggestedAction }}</p>
+        <NuxtLink to="/budgets">
+          <NButton size="tiny" quaternary data-testid="spending-insight-budget-cta">
+            {{ t("spendingPatterns.createBudget") }}
+          </NButton>
+        </NuxtLink>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.spending-insight-content__muted {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.spending-insight-content__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.spending-insight-content__item + .spending-insight-content__item {
+  border-top: 1px solid var(--color-outline-soft);
+  padding-top: var(--space-3);
+}
+
+.spending-insight-content__item-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.spending-insight-content__item-title {
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.spending-insight-content__item-meta {
+  margin: var(--space-1) 0 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.spending-insight-content__item-action {
+  margin: var(--space-1) 0;
+  color: var(--color-text-secondary);
+}
+</style>

--- a/app/features/spending-patterns/contracts/spending-patterns.dto.ts
+++ b/app/features/spending-patterns/contracts/spending-patterns.dto.ts
@@ -1,0 +1,36 @@
+/**
+ * DTOs for the spending-patterns radar (PROD-04, #568).
+ *
+ * The web POSTs the user's recent expense transactions to
+ * `POST /ai/insights/spending-patterns` (v1 gateway → auraxis-api-v2) and
+ * receives up to three detected compulsive-spending patterns.
+ */
+
+export type SpendingPatternSeverityDto = "low" | "medium" | "high";
+
+export interface SpendingPatternTransactionInputDto {
+  readonly amount: number;
+  readonly occurred_on: string;
+  readonly category?: string;
+  readonly merchant?: string;
+  readonly kind: "expense" | "income";
+}
+
+export interface SpendingPatternsRequestDto {
+  readonly transactions: readonly SpendingPatternTransactionInputDto[];
+  readonly period_days: number;
+}
+
+export interface SpendingPatternDto {
+  readonly description: string;
+  readonly frequency: string;
+  readonly average_value: number;
+  readonly suggested_action: string;
+  readonly severity: SpendingPatternSeverityDto;
+}
+
+export interface SpendingPatternsResponseDto {
+  readonly patterns: readonly SpendingPatternDto[];
+  readonly model: string;
+  readonly generated_count: number;
+}

--- a/app/features/spending-patterns/model/spending-patterns.spec.ts
+++ b/app/features/spending-patterns/model/spending-patterns.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTransactionInputs,
+  mapSpendingPatternsResponse,
+  severityRank,
+} from "./spending-patterns";
+import type { SpendingPatternsResponseDto } from "../contracts/spending-patterns.dto";
+
+describe("spending-patterns model", () => {
+  it("ranks severities high > medium > low", () => {
+    expect(severityRank("high")).toBeGreaterThan(severityRank("medium"));
+    expect(severityRank("medium")).toBeGreaterThan(severityRank("low"));
+  });
+
+  it("maps and sorts patterns by descending severity", () => {
+    const dto: SpendingPatternsResponseDto = {
+      model: "stub",
+      generated_count: 3,
+      patterns: [
+        { description: "A", frequency: "x", average_value: 10, suggested_action: "y", severity: "low" },
+        { description: "B", frequency: "x", average_value: 20, suggested_action: "y", severity: "high" },
+        { description: "C", frequency: "x", average_value: 30, suggested_action: "y", severity: "medium" },
+      ],
+    };
+    const patterns = mapSpendingPatternsResponse(dto);
+    expect(patterns.map((p) => p.severity)).toEqual(["high", "medium", "low"]);
+    expect(patterns[0]?.averageValue).toBe(20);
+  });
+
+  describe("buildTransactionInputs", () => {
+    const txs = [
+      { amount: "12.50", type: "expense" as const, due_date: "2026-05-01", title: "Café" },
+      { amount: "3000.00", type: "income" as const, due_date: "2026-05-05", title: "Salário" },
+      { amount: "0", type: "expense" as const, due_date: "2026-05-02", title: "Zero" },
+      { amount: "abc", type: "expense" as const, due_date: "2026-05-03", title: "NaN" },
+      { amount: "80.00", type: "expense" as const, due_date: "2026-05-04", title: "Bar" },
+    ];
+
+    it("keeps only positive-amount expenses", () => {
+      const inputs = buildTransactionInputs(txs);
+      expect(inputs).toHaveLength(2);
+      expect(inputs.map((i) => i.category)).toEqual(["Café", "Bar"]);
+      expect(inputs.every((i) => i.kind === "expense")).toBe(true);
+    });
+
+    it("parses amount and carries the date", () => {
+      const inputs = buildTransactionInputs(txs);
+      expect(inputs[0]).toMatchObject({ amount: 12.5, occurred_on: "2026-05-01" });
+    });
+  });
+});

--- a/app/features/spending-patterns/model/spending-patterns.ts
+++ b/app/features/spending-patterns/model/spending-patterns.ts
@@ -1,0 +1,106 @@
+/**
+ * Domain model for the spending-patterns radar (PROD-04, #568).
+ *
+ * Maps the backend response into a view model, ranks patterns by severity, and
+ * builds the LGPD-safe transaction payload from the user's transaction list
+ * (only amount/date/coarse labels — no personal identifiers).
+ */
+
+import type {
+  SpendingPatternDto,
+  SpendingPatternSeverityDto,
+  SpendingPatternTransactionInputDto,
+  SpendingPatternsResponseDto,
+} from "~/features/spending-patterns/contracts/spending-patterns.dto";
+
+export interface SpendingPattern {
+  description: string;
+  frequency: string;
+  averageValue: number;
+  suggestedAction: string;
+  severity: SpendingPatternSeverityDto;
+}
+
+/** Sort weight — higher severity first. */
+const SEVERITY_RANK: Record<SpendingPatternSeverityDto, number> = {
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+/**
+ * @param severity Pattern severity.
+ * @returns Numeric rank (higher = more severe).
+ */
+export function severityRank(severity: SpendingPatternSeverityDto): number {
+  return SEVERITY_RANK[severity] ?? 0;
+}
+
+/**
+ * Maps a single pattern DTO to the domain model.
+ *
+ * @param dto Backend pattern.
+ * @returns Domain pattern.
+ */
+export function mapPatternDto(dto: SpendingPatternDto): SpendingPattern {
+  return {
+    description: dto.description,
+    frequency: dto.frequency,
+    averageValue: dto.average_value,
+    suggestedAction: dto.suggested_action,
+    severity: dto.severity,
+  };
+}
+
+/**
+ * Maps the response into domain patterns sorted by descending severity.
+ *
+ * @param dto Backend response.
+ * @returns Patterns ordered most-severe first.
+ */
+export function mapSpendingPatternsResponse(
+  dto: SpendingPatternsResponseDto,
+): SpendingPattern[] {
+  return dto.patterns
+    .map(mapPatternDto)
+    .sort((a, b) => severityRank(b.severity) - severityRank(a.severity));
+}
+
+interface TransactionLike {
+  readonly amount: string;
+  readonly type: "income" | "expense";
+  readonly due_date: string;
+  readonly title: string;
+  readonly description?: string | null;
+}
+
+/**
+ * Builds the LGPD-safe transaction inputs from the user's transactions.
+ *
+ * Keeps only expenses with a positive, finite amount; the coarse label uses the
+ * transaction title (no personal identifiers are forwarded).
+ *
+ * @param transactions Transactions from the list query.
+ * @returns Payload transaction inputs.
+ */
+export function buildTransactionInputs(
+  transactions: readonly TransactionLike[],
+): SpendingPatternTransactionInputDto[] {
+  const inputs: SpendingPatternTransactionInputDto[] = [];
+  for (const tx of transactions) {
+    if (tx.type !== "expense") {
+      continue;
+    }
+    const amount = Number.parseFloat(tx.amount);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      continue;
+    }
+    inputs.push({
+      amount,
+      occurred_on: tx.due_date,
+      category: tx.title || undefined,
+      kind: "expense",
+    });
+  }
+  return inputs;
+}

--- a/app/features/spending-patterns/queries/use-spending-patterns-query.ts
+++ b/app/features/spending-patterns/queries/use-spending-patterns-query.ts
@@ -1,0 +1,47 @@
+import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+import { type MaybeRefOrGetter, computed, toValue } from "vue";
+
+import { STALE_TIME } from "~/core/query/stale-time";
+import type { SpendingPatternTransactionInputDto } from "~/features/spending-patterns/contracts/spending-patterns.dto";
+import {
+  useSpendingPatternsApiClient,
+  type SpendingPatternsApiClient,
+} from "~/features/spending-patterns/services/spending-patterns.client";
+import type { SpendingPattern } from "~/features/spending-patterns/model/spending-patterns";
+
+interface UseSpendingPatternsQueryOptions {
+  /** Gate on premium entitlement so free users never hit the backend. */
+  enabled?: MaybeRefOrGetter<boolean>;
+  periodDays?: number;
+}
+
+/**
+ * Vue Query hook for the spending-patterns radar.
+ *
+ * The query is keyed by a lightweight signature (transaction count + window) so
+ * it does not refetch on every render, and only runs when enabled and there is
+ * at least one transaction to analyse.
+ *
+ * @param transactions Reactive LGPD-safe transaction inputs.
+ * @param options Query controls (enabled, periodDays).
+ * @param providedClient Optional injected client for unit tests.
+ * @returns Vue Query state with severity-ordered patterns.
+ */
+export const useSpendingPatternsQuery = (
+  transactions: MaybeRefOrGetter<readonly SpendingPatternTransactionInputDto[]>,
+  options: UseSpendingPatternsQueryOptions = {},
+  providedClient?: SpendingPatternsApiClient,
+): UseQueryReturnType<SpendingPattern[], Error> => {
+  const client = providedClient ?? useSpendingPatternsApiClient();
+  const periodDays = options.periodDays ?? 90;
+
+  const list = computed(() => toValue(transactions));
+
+  return useQuery({
+    queryKey: ["spending-patterns", computed(() => list.value.length), periodDays] as const,
+    queryFn: (): Promise<SpendingPattern[]> => client.detect(list.value, periodDays),
+    enabled: (): boolean => toValue(options.enabled ?? true) && list.value.length > 0,
+    staleTime: STALE_TIME.STATIC,
+    retry: false,
+  });
+};

--- a/app/features/spending-patterns/services/spending-patterns.client.spec.ts
+++ b/app/features/spending-patterns/services/spending-patterns.client.spec.ts
@@ -1,0 +1,41 @@
+import type { AxiosInstance } from "axios";
+import { describe, expect, it, vi } from "vitest";
+
+import { SpendingPatternsApiClient } from "./spending-patterns.client";
+
+const RESPONSE = {
+  model: "stub",
+  generated_count: 1,
+  patterns: [
+    { description: "Cafés diários", frequency: "diária", average_value: 12.5, suggested_action: "Defina um teto", severity: "high" },
+  ],
+};
+
+describe("SpendingPatternsApiClient", () => {
+  it("posts transactions and maps the enveloped response", async () => {
+    const post = vi.fn().mockResolvedValue({ data: { success: true, data: RESPONSE }, headers: {} });
+    const http = { post } as unknown as AxiosInstance;
+    const client = new SpendingPatternsApiClient(http);
+
+    const patterns = await client.detect(
+      [{ amount: 12.5, occurred_on: "2026-05-01", kind: "expense" }],
+      90,
+    );
+
+    expect(post).toHaveBeenCalledWith("/ai/insights/spending-patterns", {
+      transactions: [{ amount: 12.5, occurred_on: "2026-05-01", kind: "expense" }],
+      period_days: 90,
+    });
+    expect(patterns).toHaveLength(1);
+    expect(patterns[0]?.severity).toBe("high");
+  });
+
+  it("tolerates a flat (legacy) payload", async () => {
+    const post = vi.fn().mockResolvedValue({ data: RESPONSE, headers: {} });
+    const http = { post } as unknown as AxiosInstance;
+    const client = new SpendingPatternsApiClient(http);
+
+    const patterns = await client.detect([{ amount: 1, occurred_on: "2026-05-01", kind: "expense" }]);
+    expect(patterns[0]?.description).toBe("Cafés diários");
+  });
+});

--- a/app/features/spending-patterns/services/spending-patterns.client.ts
+++ b/app/features/spending-patterns/services/spending-patterns.client.ts
@@ -1,0 +1,73 @@
+import type { AxiosInstance } from "axios";
+
+import { useHttp } from "~/composables/useHttp";
+import type { V2EnvelopeDTO } from "~/features/ai-insights/contracts/ai-insight";
+import type {
+  SpendingPatternTransactionInputDto,
+  SpendingPatternsResponseDto,
+} from "~/features/spending-patterns/contracts/spending-patterns.dto";
+import {
+  mapSpendingPatternsResponse,
+  type SpendingPattern,
+} from "~/features/spending-patterns/model/spending-patterns";
+
+/**
+ * Unwraps the v2 envelope, tolerating legacy flat payloads.
+ *
+ * @param payload Backend response body.
+ * @returns The inner payload.
+ */
+const unwrap = <T>(payload: V2EnvelopeDTO<T> | T): T => {
+  if (
+    payload !== null &&
+    typeof payload === "object" &&
+    "data" in payload &&
+    (payload as V2EnvelopeDTO<T>).data !== undefined
+  ) {
+    return (payload as V2EnvelopeDTO<T>).data as T;
+  }
+  return payload as T;
+};
+
+const ENDPOINT = "/ai/insights/spending-patterns";
+
+/**
+ * HTTP adapter for the spending-patterns radar (premium gateway to v2).
+ */
+export class SpendingPatternsApiClient {
+  readonly #http: AxiosInstance;
+
+  /**
+   * @param http Axios instance configured with auth and API contract headers.
+   */
+  constructor(http: AxiosInstance) {
+    this.#http = http;
+  }
+
+  /**
+   * Detects compulsive-spending patterns from the supplied expense transactions.
+   *
+   * @param transactions LGPD-safe transaction inputs (amount/date/labels only).
+   * @param periodDays Analysis window in days.
+   * @returns Patterns ordered by descending severity.
+   */
+  async detect(
+    transactions: readonly SpendingPatternTransactionInputDto[],
+    periodDays = 90,
+  ): Promise<SpendingPattern[]> {
+    const response = await this.#http.post<V2EnvelopeDTO<SpendingPatternsResponseDto>>(
+      ENDPOINT,
+      { transactions, period_days: periodDays },
+    );
+    return mapSpendingPatternsResponse(unwrap<SpendingPatternsResponseDto>(response.data));
+  }
+}
+
+/**
+ * Factory wiring the client to the default HTTP composable.
+ *
+ * @returns Ready-to-use client instance.
+ */
+export const useSpendingPatternsApiClient = (): SpendingPatternsApiClient => {
+  return new SpendingPatternsApiClient(useHttp());
+};

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -4,6 +4,23 @@
     "light": "Claro",
     "dark": "Escuro"
   },
+  "spendingPatterns": {
+    "title": "Radar de gastos compulsivos",
+    "unavailable": "O radar está indisponível no momento. Tente novamente mais tarde.",
+    "empty": "Seus gastos estão dentro do padrão. Continue assim! 🎉",
+    "average": "média de {value}",
+    "createBudget": "Criar orçamento",
+    "severity": {
+      "low": "Baixa",
+      "medium": "Média",
+      "high": "Alta"
+    },
+    "locked": {
+      "title": "Detecte padrões de gasto compulsivo",
+      "description": "Nossa IA analisa seus últimos 90 dias e aponta gatilhos de consumo recorrentes. Disponível no plano Premium.",
+      "cta": "Conhecer o Premium"
+    }
+  },
   "error": {
     "404": {
       "title": "Página não encontrada",

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -5,6 +5,7 @@ import { NButton, NDatePicker } from "naive-ui";
 import DashboardControlBar from "~/features/dashboard/components/DashboardControlBar.vue";
 import DashboardMarketPulseWorkspace from "~/features/dashboard/components/DashboardMarketPulseWorkspace.vue";
 import AiInsightSurface from "~/features/ai-insights/components/AiInsightSurface.vue";
+import SpendingInsightCard from "~/features/spending-patterns/components/SpendingInsightCard.vue";
 import OnboardingSkipNudge from "~/features/onboarding/components/OnboardingSkipNudge.vue";
 import { useDashboardOverviewQuery } from "~/features/dashboard/queries/use-dashboard-overview-query";
 import { useDashboardTrendsQuery } from "~/features/dashboard/queries/use-dashboard-trends-query";
@@ -172,6 +173,8 @@ const closeFirstTransactionForm = (): void => {
       />
 
       <AiInsightSurface class="dashboard-page__ai-insights" />
+
+      <SpendingInsightCard class="dashboard-page__spending-insight" />
 
       <UiEmptyState
         v-if="!dashboardQuery.isLoading.value && !summary"


### PR DESCRIPTION
## Contexto
PROD-04 (#537), sub-issue #568. Frontend que consome o endpoint `POST /ai/insights/spending-patterns` (gateway v1 → auraxis-api-v2, PRs auraxis-api#1418 + auraxis-api-v2#50).

## O que entra
- **SpendingInsightCard** no dashboard: gate premium (`useEntitlementQuery('advanced_simulations')`) → free vê teaser + CTA upgrade; **SpendingInsightContent** só monta para premium (free não dispara nenhum fetch).
- Envia os últimos **90 dias de despesas** (amount/data/label coarse, **sem PII** — LGPD), recebe até 3 padrões ordenados por **severidade**, cada um com ação sugerida + **CTA 'Criar orçamento'** (→ /budgets).
- Estados: teaser / skeleton / **indisponível (503 gracioso)** / vazio ('gastos dentro do padrão') / lista.
- feature layer canônica: contracts + model (TDD) + client (TDD) + query + componentes (specs). 12 testes.

## Quality
`pnpm quality-check` PASS (lint + typecheck + cobertura 85.77% branches ≥85% + build 169 páginas). i18n pt; EN via fallback (en.json congelado).

## Notas
- **e2e depende do deploy da v2 + `AURAXIS_API_V2_BASE_URL`**; até lá o proxy responde 503 e o card mostra o estado 'indisponível' (degradação graciosa).
- **Conflito potencial de merge** com #972/#973 (ambos tocam `pt.json`/`dashboard.vue`): quem mergear primeiro pode exigir resolução manual nos outros.
- Página dedicada `/insights/spending` (lista completa paginada) fica como **follow-up** — evita reestruturar a rota `insights.vue` existente; o card já entrega card+lista+CTA+gate.

Closes #568
Refs #537 #567