### PR TITLE
fix(http): cliente HTTP singleton elimina refresh storm (#976)

### DIFF
--- a/app/composables/useHttp/useHttp.spec.ts
+++ b/app/composables/useHttp/useHttp.spec.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosRequestConfig } from "axios";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   CSRF_HEADER_NAME,
@@ -9,13 +10,49 @@ import {
   normalizeBaseUrl,
   readCookieValue,
   refreshAccessToken,
+  useHttp,
+  __resetHttpClientForTests,
 } from "./useHttp";
 
 const useSessionStoreMock = vi.hoisted(() => vi.fn());
+const sessionStoreStub = vi.hoisted(() => ({
+  getAccessToken: vi.fn(() => "live-token"),
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  updateTokens: vi.fn(),
+  emailVerificationRequiredNow: false,
+  emailVerified: true,
+}));
+
+const messageStub = vi.hoisted(() => ({ error: vi.fn() }));
+const dialogStub = vi.hoisted(() => ({ warning: vi.fn() }));
+const verificationGateStub = vi.hoisted(() => ({ open: vi.fn() }));
+const navigateToMock = vi.hoisted(() => vi.fn());
 
 vi.mock("~/stores/session", () => ({
   useSessionStore: useSessionStoreMock,
 }));
+
+vi.mock("naive-ui", (): Record<string, unknown> => ({
+  useMessage: (): typeof messageStub => messageStub,
+  useDialog: (): typeof dialogStub => dialogStub,
+}));
+
+vi.mock("~/features/auth/composables/use-email-verification-gate", (): Record<string, unknown> => ({
+  useEmailVerificationGate: (): typeof verificationGateStub => verificationGateStub,
+}));
+
+vi.mock("~/features/admin/impersonation/composables/use-admin-impersonation-session", (): Record<string, unknown> => ({
+  isAdminImpersonationReadOnlyActive: (): boolean => false,
+}));
+
+mockNuxtImport("useRuntimeConfig", () => (): { public: { apiBase: string } } => ({
+  public: { apiBase: "http://localhost:5000" },
+}));
+mockNuxtImport("useI18n", () => (): { t: (key: string) => string } => ({
+  t: (key: string): string => key,
+}));
+mockNuxtImport("navigateTo", () => navigateToMock);
 
 describe("useHttp helpers", () => {
   beforeEach(() => {
@@ -347,5 +384,104 @@ describe("CSRF double-submit (SEC-AUD-03)", () => {
         restore();
       }
     });
+  });
+});
+
+describe("useHttp singleton (#976)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetHttpClientForTests();
+    sessionStoreStub.getAccessToken.mockReturnValue("live-token");
+    useSessionStoreMock.mockReturnValue(sessionStoreStub);
+  });
+
+  afterEach(() => {
+    __resetHttpClientForTests();
+  });
+
+  it("returns the SAME Axios instance across calls (shared singleton)", () => {
+    const first = useHttp();
+    const second = useHttp();
+
+    expect(first).toBe(second);
+  });
+
+  it("the cached client always reads the live token via the lazy resolver", () => {
+    const client = useHttp();
+    const requestHandlers = (
+      client.interceptors.request as unknown as {
+        handlers: Array<{
+          fulfilled: (config: AxiosRequestConfig) => AxiosRequestConfig;
+        } | null>;
+      }
+    ).handlers.filter(Boolean) as Array<{
+      fulfilled: (config: AxiosRequestConfig) => AxiosRequestConfig;
+    }>;
+    const authInterceptor = requestHandlers[0]!.fulfilled;
+
+    sessionStoreStub.getAccessToken.mockReturnValueOnce("rotated-token");
+    const config = authInterceptor({ headers: {} });
+
+    expect((config.headers as Record<string, string>).Authorization).toBe(
+      "Bearer rotated-token",
+    );
+  });
+
+  it("runs the refresh exactly ONCE for concurrent 401s across shared callers", async () => {
+    // Single-flight regression: two callers fetch the SAME shared client. Two
+    // concurrent requests both get 401 → the shared refresh closure (now bound
+    // to one Axios instance for all 37 feature factories) must fire only once.
+    const client = useHttp();
+
+    let refreshCalls = 0;
+    let okResponses = 0;
+    let resolveRefresh: (token: string) => void = vi.fn();
+    const refreshGate = new Promise<string>((resolve) => {
+      resolveRefresh = resolve;
+    });
+
+    // Stub the underlying refresh endpoint so both 401s funnel through the
+    // shared single-flight closure registered by registerResponseInterceptors.
+    // The gate keeps the first refresh pending until both 401s have arrived,
+    // proving they collapse into a single in-flight refresh.
+    vi.spyOn(axios, "post").mockImplementation(async () => {
+      refreshCalls += 1;
+      const token = await refreshGate;
+      sessionStoreStub.getAccessToken.mockReturnValue(token);
+      return { data: { success: true, data: { token } } };
+    });
+
+    // Replace the transport adapter: first hit per request → 401 (no _retry),
+    // retried request (carries Authorization from the refreshed token) → 200.
+    client.defaults.adapter = (async (config: AxiosRequestConfig): Promise<unknown> => {
+      const headers = (config.headers ?? {}) as Record<string, unknown>;
+      const isRetry = typeof headers.Authorization === "string"
+        && headers.Authorization === "Bearer rotated-token";
+      if (isRetry) {
+        okResponses += 1;
+        return { status: 200, statusText: "OK", data: { ok: true }, headers: {}, config };
+      }
+      return Promise.reject(
+        Object.assign(new Error("Unauthorized"), {
+          isAxiosError: true,
+          config,
+          response: { status: 401, statusText: "Unauthorized", data: {}, headers: {}, config },
+        }),
+      );
+    }) as unknown as typeof client.defaults.adapter;
+
+    const reqA = client.get("/a");
+    const reqB = client.get("/b");
+
+    // Let both 401s reach the shared refresh before releasing the gate.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    resolveRefresh("rotated-token");
+
+    await Promise.all([reqA, reqB]);
+
+    expect(refreshCalls).toBe(1);
+    expect(okResponses).toBe(2);
   });
 });

--- a/app/composables/useHttp/useHttp.spec.ts
+++ b/app/composables/useHttp/useHttp.spec.ts
@@ -406,6 +406,28 @@ describe("useHttp singleton (#976)", () => {
     expect(first).toBe(second);
   });
 
+  it("caches client-side only: under import.meta.client the module cache is populated and reused", () => {
+    // The runtime guard is `if (import.meta.client) cachedClient = client`.
+    // The Nuxt vitest environment runs with `import.meta.client === true`, so
+    // the cache must be populated and the next call must hit the early-return
+    // guard (same reference). This is the SSR-safe contract from the other
+    // direction: on the server (`import.meta.client === false`) the write is
+    // skipped and each call builds a throwaway client — that branch is a plain
+    // env constant flip we cannot exercise from the client test env, so it is
+    // documented here and in `useHttp`'s `cachedClient` JSDoc.
+    expect(import.meta.client).toBe(true);
+
+    const first = useHttp();
+    // A reset proves the singleton lives in the module cache (not a per-call
+    // const): drop it, and the next call rebuilds a distinct instance.
+    __resetHttpClientForTests();
+    const afterReset = useHttp();
+    const reused = useHttp();
+
+    expect(afterReset).not.toBe(first);
+    expect(reused).toBe(afterReset);
+  });
+
   it("the cached client always reads the live token via the lazy resolver", () => {
     const client = useHttp();
     const requestHandlers = (
@@ -435,6 +457,7 @@ describe("useHttp singleton (#976)", () => {
 
     let refreshCalls = 0;
     let okResponses = 0;
+    let unauthorizedHits = 0;
     let resolveRefresh: (token: string) => void = vi.fn();
     const refreshGate = new Promise<string>((resolve) => {
       resolveRefresh = resolve;
@@ -461,6 +484,7 @@ describe("useHttp singleton (#976)", () => {
         okResponses += 1;
         return { status: 200, statusText: "OK", data: { ok: true }, headers: {}, config };
       }
+      unauthorizedHits += 1;
       return Promise.reject(
         Object.assign(new Error("Unauthorized"), {
           isAxiosError: true,
@@ -473,10 +497,15 @@ describe("useHttp singleton (#976)", () => {
     const reqA = client.get("/a");
     const reqB = client.get("/b");
 
-    // Let both 401s reach the shared refresh before releasing the gate.
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    // Wait until BOTH initial requests have been rejected with 401 AND the
+    // shared single-flight refresh has actually fired its POST — rather than
+    // advancing a fixed number of microtask ticks (fragile). At that point the
+    // two 401s have collapsed into one in-flight refresh; releasing the gate
+    // lets both originals retry with the rotated token.
+    await vi.waitFor(() => {
+      expect(unauthorizedHits).toBe(2);
+      expect(refreshCalls).toBe(1);
+    });
     resolveRefresh("rotated-token");
 
     await Promise.all([reqA, reqB]);

--- a/app/composables/useHttp/useHttp.ts
+++ b/app/composables/useHttp/useHttp.ts
@@ -145,9 +145,42 @@ export const refreshAccessToken = async (
  *
  * @returns Configured Axios instance with auth and response interceptors.
  */
+/**
+ * Module-level cache holding the single shared Axios instance.
+ *
+ * `useHttp()` is invoked from 37+ feature `*.client.ts` factories. Without
+ * memoization each call built a brand-new Axios instance, and each instance
+ * carried its own `createSharedRefresh` single-flight closure — so the 401
+ * stampede guard only deduped concurrent refreshes WITHIN one instance, never
+ * across callers. On token expiry the dashboard's parallel feature queries
+ * each fired their own `POST /auth/refresh`, tripping the backend
+ * `token_refresh` rate limit (#976).
+ *
+ * Caching the client makes every caller share ONE instance and therefore ONE
+ * global single-flight refresh. The cache is intentionally not reset on the
+ * server: `useHttp()` is only invoked from client-side feature factories, and
+ * the captured Nuxt/naive-ui composables (`useMessage`, `useDialog`,
+ * `navigateTo`, …) are client-only. `getAccessToken` stays a lazy callback so
+ * the cached client always reads the live token from the session store.
+ */
+let cachedClient: AxiosInstance | null = null;
+
+/**
+ * Resets the memoized HTTP client. Test-only — production code never needs to
+ * drop the singleton. Exported so specs can isolate the module-level cache
+ * between cases.
+ */
+export const __resetHttpClientForTests = (): void => {
+  cachedClient = null;
+};
+
 /* v8 ignore start */
 /** @returns {AxiosInstance} Configured Axios instance with auth and response interceptors. */
 export const useHttp = (): AxiosInstance => {
+  if (cachedClient) {
+    return cachedClient;
+  }
+
   const runtimeConfig = useRuntimeConfig();
   const sessionStore = useSessionStore();
   const verificationGate = useEmailVerificationGate();
@@ -218,6 +251,7 @@ export const useHttp = (): AxiosInstance => {
     return config;
   });
 
+  cachedClient = client;
   return client;
 };
 /* v8 ignore stop */

--- a/app/composables/useHttp/useHttp.ts
+++ b/app/composables/useHttp/useHttp.ts
@@ -132,20 +132,6 @@ export const refreshAccessToken = async (
 };
 
 /**
- * Resolves runtime config and instantiates the application HTTP client.
- *
- * Registers global response interceptors that automatically handle:
- * - **401 Unauthorized** → attempts a token refresh via `POST /auth/refresh`
- *   and retries the original request. Signs the user out if the refresh fails.
- * - **403 Forbidden** → shows a "no permission" error toast.
- * - **5xx Server Error** → shows a generic "server error" toast.
- *
- * Must be called from within a Vue component `setup` context so that
- * `useMessage()` and `useRuntimeConfig()` are available.
- *
- * @returns Configured Axios instance with auth and response interceptors.
- */
-/**
  * Module-level cache holding the single shared Axios instance.
  *
  * `useHttp()` is invoked from 37+ feature `*.client.ts` factories. Without
@@ -156,12 +142,17 @@ export const refreshAccessToken = async (
  * each fired their own `POST /auth/refresh`, tripping the backend
  * `token_refresh` rate limit (#976).
  *
- * Caching the client makes every caller share ONE instance and therefore ONE
- * global single-flight refresh. The cache is intentionally not reset on the
- * server: `useHttp()` is only invoked from client-side feature factories, and
- * the captured Nuxt/naive-ui composables (`useMessage`, `useDialog`,
- * `navigateTo`, …) are client-only. `getAccessToken` stays a lazy callback so
- * the cached client always reads the live token from the session store.
+ * Caching the client makes every client-side caller share ONE instance and
+ * therefore ONE global single-flight refresh. `getAccessToken` stays a lazy
+ * callback so the cached client always reads the live token from the session
+ * store.
+ *
+ * SSR safety: the cache is populated and reused ONLY on the client
+ * (`import.meta.client`). `useHttp()` is also reachable server-side from
+ * `middleware/authenticated.ts` and `plugins/session.ts`; on the server we
+ * build a throwaway per-call client and never write it here. Otherwise the
+ * first (possibly server-side) call would freeze client-only naive-ui context
+ * (`useMessage`/`useDialog`) into the singleton for the whole client session.
  */
 let cachedClient: AxiosInstance | null = null;
 
@@ -174,13 +165,34 @@ export const __resetHttpClientForTests = (): void => {
   cachedClient = null;
 };
 
-/* v8 ignore start */
-/** @returns {AxiosInstance} Configured Axios instance with auth and response interceptors. */
+/**
+ * Resolves runtime config and instantiates the application HTTP client.
+ *
+ * Registers global response interceptors that automatically handle:
+ * - **401 Unauthorized** → attempts a token refresh via `POST /auth/refresh`
+ *   and retries the original request. Signs the user out if the refresh fails.
+ * - **403 Forbidden** → shows a "no permission" error toast.
+ * - **5xx Server Error** → shows a generic "server error" toast.
+ *
+ * On the client the instance is memoized at module scope, so all 37+ feature
+ * factories share ONE instance and ONE global single-flight refresh (#976).
+ * On the server (SSR middleware/plugins) a throwaway per-call client is built
+ * and NOT cached — see {@link cachedClient}.
+ *
+ * The cold-start path must run inside a client setup context: it calls
+ * `useRuntimeConfig()`, `useMessage()`, `useDialog()` and `useI18n()`, which
+ * are only available there.
+ *
+ * @returns {AxiosInstance} Configured Axios instance with auth and response interceptors.
+ */
 export const useHttp = (): AxiosInstance => {
+  // Cache-hit guard — the whole point of #976. Must stay OUTSIDE the v8-ignore
+  // range so coverage proves it runs and would fail if it were ever removed.
   if (cachedClient) {
     return cachedClient;
   }
 
+  /* v8 ignore start */
   const runtimeConfig = useRuntimeConfig();
   const sessionStore = useSessionStore();
   const verificationGate = useEmailVerificationGate();
@@ -250,8 +262,13 @@ export const useHttp = (): AxiosInstance => {
 
     return config;
   });
+  /* v8 ignore stop */
 
-  cachedClient = client;
+  // Only memoize on the client. On the server we return a per-call instance so
+  // the singleton never captures server-context (SSR-safe — see cachedClient).
+  if (import.meta.client) {
+    cachedClient = client;
+  }
+
   return client;
 };
-/* v8 ignore stop */


### PR DESCRIPTION
Closes #976

Memoiza `useHttp()` para que todas as 37 features compartilhem **uma** instância Axios → single-flight refresh **global**. Antes, cada call site criava sua própria instância + próprio guard, então a expiração de token disparava N `POST /auth/refresh` concorrentes (estourando `token_refresh` 10/min).

- Cache client-side only (SSR/middleware seguro, sem throw)
- `__resetHttpClientForTests()` + 3 testes (mesma instância, token vivo via resolver lazy, single-flight uma vez)
- Remove dups macOS `simulation-quota.client 2.ts` / `.spec 2.ts`
- `pnpm quality-check` verde, cobertura ≥85%