### PR TITLE
feat(ui): header responsivo de dois níveis no mobile (#981)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,10 @@
 import { type Preview, type StoryContext, type StoryFn, setup } from "@storybook/vue3";
 import { darkTheme, NConfigProvider, NMessageProvider, NDialogProvider } from "naive-ui";
 import { defineComponent, h } from "vue";
+// Global Auraxis stylesheet: defines the design-system CSS custom properties
+// (--color-*, --space-*, --font-size-*, …) so stories can rely on tokens
+// directly instead of hardcoding hex fallbacks.
+import "../app/assets/css/main.css";
 import { buildNaiveThemeOverrides } from "../app/utils/naive-theme";
 import { themePalettes, type ResolvedTheme } from "../app/theme/tokens/semantic";
 import { fonts } from "../app/theme/tokens/typography";

--- a/app/components/ui/UiPageHeader/UiPageHeader.vue
+++ b/app/components/ui/UiPageHeader/UiPageHeader.vue
@@ -30,4 +30,17 @@ const props = withDefaults(defineProps<UiPageHeaderProps>(), { subtitle: undefin
   color: var(--color-text-muted);
   margin: 0;
 }
+
+/*
+ * Mobile (<=767.98px): shrink the title so it no longer dominates the
+ * two-tier header row. Subtitle steps down to xs to keep the pair compact.
+ */
+@media (max-width: 767.98px) {
+  .ui-page-header__title {
+    font-size: var(--font-size-lg);
+  }
+  .ui-page-header__subtitle {
+    font-size: var(--font-size-xs);
+  }
+}
 </style>

--- a/app/components/ui/UiTopbar/UiTopbar.stories.ts
+++ b/app/components/ui/UiTopbar/UiTopbar.stories.ts
@@ -94,7 +94,7 @@ export const MobileTwoTier: Story = {
       <UiTopbar v-bind="args">
         <template #extras>
           <span
-            style="display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;background:var(--color-warning-bg, #fef3c7);color:var(--color-warning, #b45309);font-size:var(--font-size-sm);font-weight:600;"
+            style="display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;background:var(--color-warning-bg);color:var(--color-warning);font-size:var(--font-size-sm);font-weight:600;"
           >
             ⭐ Premium
           </span>

--- a/app/components/ui/UiTopbar/UiTopbar.stories.ts
+++ b/app/components/ui/UiTopbar/UiTopbar.stories.ts
@@ -67,3 +67,39 @@ export const WithAvatar: Story = {
     ],
   },
 };
+
+/**
+ * Mobile two-tier header (#981): at <=768px the header stacks into two rows.
+ * Row 1: hamburger + (smaller) title/subtitle + theme toggle + avatar.
+ * Row 2: the full Premium badge (slotted via #extras), left-aligned full-width.
+ */
+export const MobileTwoTier: Story = {
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+  },
+  args: {
+    title: "Dashboard",
+    subtitle: "Mês de Dezembro",
+    userName: "João Silva",
+    userDescription: "Investidor Arrojado",
+    userAvatarUrl: "https://i.pravatar.cc/40?img=3",
+    showMenuButton: true,
+  },
+  render: (args) => ({
+    components: { UiTopbar },
+    setup(): { args: typeof args } {
+      return { args };
+    },
+    template: `
+      <UiTopbar v-bind="args">
+        <template #extras>
+          <span
+            style="display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;background:var(--color-warning-bg, #fef3c7);color:var(--color-warning, #b45309);font-size:var(--font-size-sm);font-weight:600;"
+          >
+            ⭐ Premium
+          </span>
+        </template>
+      </UiTopbar>
+    `,
+  }),
+};

--- a/app/components/ui/UiTopbar/UiTopbar.vue
+++ b/app/components/ui/UiTopbar/UiTopbar.vue
@@ -115,7 +115,14 @@ const { isDark, toggle: toggleTheme } = useTheme();
   margin-left: auto;
   margin-right: var(--space-2);
 }
-/* No badge slotted: drop the trailing gap so the right block hugs the edge. */
+/*
+ * No badge slotted: drop the trailing gap so the right block hugs the edge.
+ * NOTE: `:empty` matches only when the wrapper has zero children — but a
+ * conditionally-rendered slot (e.g. TopbarSubscriptionBadge with v-if=false)
+ * leaves a comment node (`<!--v-if-->`), so the wrapper is NOT `:empty`.
+ * Spacing must therefore live on the rendered child (see `> *`), never on the
+ * wrapper, so an empty wrapper contributes 0 width/height regardless.
+ */
 .ui-topbar__extras-row:empty {
   margin-right: 0;
 }
@@ -204,7 +211,13 @@ const { isDark, toggle: toggleTheme } = useTheme();
     min-height: 64px;
     padding-top: var(--space-2);
     padding-bottom: var(--space-2);
-    row-gap: var(--space-2);
+    /*
+     * NO `row-gap` here: a wrapped flex line is created for the extras-row even
+     * when its only child is a comment node (free user → badge renders nothing),
+     * and `row-gap` would add visible space above that empty line. Vertical
+     * spacing for the second row lives on the rendered badge content instead
+     * (`.ui-topbar__extras-row > *`), so an empty wrapper has ZERO footprint.
+     */
   }
   .ui-topbar__left {
     order: 1;
@@ -222,9 +235,14 @@ const { isDark, toggle: toggleTheme } = useTheme();
     margin-right: 0;
     justify-content: flex-start;
   }
-  /* Collapse the extras-row entirely when it has no slotted content. */
-  .ui-topbar__extras-row:empty {
-    display: none;
+  /*
+   * Spacing between row 1 and row 2 is carried by the rendered badge itself.
+   * When the slot renders nothing (only a `<!--v-if-->` comment node), there is
+   * no element child, `> *` matches nothing, and the wrapper collapses to 0
+   * height — no empty second row, no extra vertical space for free users.
+   */
+  .ui-topbar__extras-row > * {
+    margin-top: var(--space-2);
   }
 }
 </style>

--- a/app/components/ui/UiTopbar/UiTopbar.vue
+++ b/app/components/ui/UiTopbar/UiTopbar.vue
@@ -115,17 +115,6 @@ const { isDark, toggle: toggleTheme } = useTheme();
   margin-left: auto;
   margin-right: var(--space-2);
 }
-/*
- * No badge slotted: drop the trailing gap so the right block hugs the edge.
- * NOTE: `:empty` matches only when the wrapper has zero children — but a
- * conditionally-rendered slot (e.g. TopbarSubscriptionBadge with v-if=false)
- * leaves a comment node (`<!--v-if-->`), so the wrapper is NOT `:empty`.
- * Spacing must therefore live on the rendered child (see `> *`), never on the
- * wrapper, so an empty wrapper contributes 0 width/height regardless.
- */
-.ui-topbar__extras-row:empty {
-  margin-right: 0;
-}
 .ui-topbar__menu-btn {
   background: none;
   border: none;

--- a/app/components/ui/UiTopbar/UiTopbar.vue
+++ b/app/components/ui/UiTopbar/UiTopbar.vue
@@ -34,8 +34,6 @@ const { isDark, toggle: toggleTheme } = useTheme();
     </div>
 
     <div class="ui-topbar__right">
-      <slot name="extras" />
-
       <button
         v-for="action in props.actions"
         :key="action.key"
@@ -71,6 +69,13 @@ const { isDark, toggle: toggleTheme } = useTheme();
         @logout="emit('user-logout')"
       />
     </div>
+
+    <div
+      class="ui-topbar__extras-row"
+      data-testid="topbar-extras-row"
+    >
+      <slot name="extras" />
+    </div>
   </header>
 </template>
 
@@ -89,11 +94,30 @@ const { isDark, toggle: toggleTheme } = useTheme();
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  order: 1;
 }
 .ui-topbar__right {
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  order: 3;
+}
+/*
+ * Desktop (>=768px): single-row layout. The extras-row sits inline between the
+ * left block and the right controls (badge → theme → avatar), matching the
+ * previous single-row visual. order + margin-left:auto group it on the right.
+ */
+.ui-topbar__extras-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  order: 2;
+  margin-left: auto;
+  margin-right: var(--space-2);
+}
+/* No badge slotted: drop the trailing gap so the right block hugs the edge. */
+.ui-topbar__extras-row:empty {
+  margin-right: 0;
 }
 .ui-topbar__menu-btn {
   background: none;
@@ -163,5 +187,44 @@ const { isDark, toggle: toggleTheme } = useTheme();
 .ui-topbar__theme-toggle:hover {
   background: var(--color-outline-ghost);
   color: var(--color-text-primary);
+}
+
+/*
+ * Mobile (<=767.98px): two-tier header.
+ * Row 1: left (hamburger + title/subtitle) + theme toggle + avatar.
+ * Row 2: extras-row (Premium badge) full-width, left-aligned.
+ * flex-wrap lets the extras-row drop to its own line; flex-basis:100% makes it
+ * span the full width below row 1.
+ */
+@media (max-width: 767.98px) {
+  .ui-topbar {
+    flex-wrap: wrap;
+    align-items: center;
+    height: auto;
+    min-height: 64px;
+    padding-top: var(--space-2);
+    padding-bottom: var(--space-2);
+    row-gap: var(--space-2);
+  }
+  .ui-topbar__left {
+    order: 1;
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+  .ui-topbar__right {
+    order: 2;
+    margin-left: auto;
+  }
+  .ui-topbar__extras-row {
+    order: 3;
+    flex-basis: 100%;
+    margin-left: 0;
+    margin-right: 0;
+    justify-content: flex-start;
+  }
+  /* Collapse the extras-row entirely when it has no slotted content. */
+  .ui-topbar__extras-row:empty {
+    display: none;
+  }
 }
 </style>

--- a/app/components/ui/UiTopbar/__tests__/UiTopbar.spec.ts
+++ b/app/components/ui/UiTopbar/__tests__/UiTopbar.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
-import { defineComponent, h, ref, computed, type ComputedRef } from "vue";
+import { defineComponent, h, ref, computed, type ComputedRef, type VNode } from "vue";
 import type { GlobalTheme } from "naive-ui";
 import UiTopbar from "../UiTopbar.vue";
 
@@ -207,6 +207,62 @@ describe("UiTopbar", () => {
     });
     const extrasRow = wrapper.find("[data-testid='topbar-extras-row']");
     expect(extrasRow.exists()).toBe(true);
+    expect(extrasRow.find(".premium-badge").exists()).toBe(true);
+    expect(extrasRow.text()).toContain("Premium");
+  });
+
+  // --- Zero-footprint behavior for the extras row (free vs premium) ---
+  // The extras row carries vertical spacing on its rendered child (`> *`), never
+  // on the wrapper itself. So an empty / comment-only wrapper has no element
+  // children and therefore zero footprint — no empty second row for free users.
+
+  it("(a) keeps the extras row free of element children when NO extras slot is provided", () => {
+    const wrapper = mount(UiTopbar, {
+      props: { title: "Dashboard", userName: "João Silva", showMenuButton: true },
+    });
+    const extrasRow = wrapper.find("[data-testid='topbar-extras-row']");
+    expect(extrasRow.exists()).toBe(true);
+    // No element children → `.ui-topbar__extras-row > *` matches nothing →
+    // the wrapper contributes no spacing/height.
+    expect(extrasRow.element.children.length).toBe(0);
+    expect(extrasRow.text()).toBe("");
+  });
+
+  it("(b) keeps the extras row free of element children when the slot renders nothing (free user)", () => {
+    // Mirrors TopbarSubscriptionBadge for a free user: a component whose root is
+    // gated by `v-if=false`, so it renders only a comment node (`<!--v-if-->`).
+    const EmptyBadgeStub = defineComponent({
+      setup() {
+        const show = ref(false);
+        return (): VNode | null => (show.value ? h("span", { class: "premium-badge" }, "Premium") : null);
+      },
+    });
+    const wrapper = mount(UiTopbar, {
+      props: { title: "Dashboard", userName: "João Silva", showMenuButton: true },
+      slots: { extras: (): unknown => h(EmptyBadgeStub) },
+    });
+    const extrasRow = wrapper.find("[data-testid='topbar-extras-row']");
+    expect(extrasRow.exists()).toBe(true);
+    // The slot IS provided, but the badge renders only a comment node, so there
+    // is no element child to receive top-margin → zero footprint, no empty row.
+    expect(extrasRow.element.children.length).toBe(0);
+    expect(extrasRow.find(".premium-badge").exists()).toBe(false);
+    expect(extrasRow.text()).toBe("");
+  });
+
+  it("(c) renders the badge as an element child of the extras row for a premium user", () => {
+    const PremiumBadgeStub = defineComponent({
+      setup() {
+        const show = ref(true);
+        return (): VNode | null => (show.value ? h("span", { class: "premium-badge" }, "Premium") : null);
+      },
+    });
+    const wrapper = mount(UiTopbar, {
+      props: { title: "Dashboard", userName: "João Silva", showMenuButton: true },
+      slots: { extras: (): unknown => h(PremiumBadgeStub) },
+    });
+    const extrasRow = wrapper.find("[data-testid='topbar-extras-row']");
+    expect(extrasRow.element.children.length).toBe(1);
     expect(extrasRow.find(".premium-badge").exists()).toBe(true);
     expect(extrasRow.text()).toContain("Premium");
   });

--- a/app/components/ui/UiTopbar/__tests__/UiTopbar.spec.ts
+++ b/app/components/ui/UiTopbar/__tests__/UiTopbar.spec.ts
@@ -192,4 +192,22 @@ describe("UiTopbar", () => {
     });
     expect(wrapper.find(".ui-user-menu").exists()).toBe(true);
   });
+
+  it("renders the extras row container", () => {
+    const wrapper = mount(UiTopbar, {
+      props: { title: "Dashboard", userName: "João Silva" },
+    });
+    expect(wrapper.find("[data-testid='topbar-extras-row']").exists()).toBe(true);
+  });
+
+  it("renders slotted extras content inside the extras row (two-tier header)", () => {
+    const wrapper = mount(UiTopbar, {
+      props: { title: "Dashboard", userName: "João Silva", showMenuButton: true },
+      slots: { extras: (): unknown => h("span", { class: "premium-badge" }, "Premium") },
+    });
+    const extrasRow = wrapper.find("[data-testid='topbar-extras-row']");
+    expect(extrasRow.exists()).toBe(true);
+    expect(extrasRow.find(".premium-badge").exists()).toBe(true);
+    expect(extrasRow.text()).toContain("Premium");
+  });
 });


### PR DESCRIPTION
Closes #981

Header de dois níveis em ≤768px: linha 1 = hamburger + título/subtítulo (menores) + tema + avatar; linha 2 = badge Premium full-width. Desktop inalterado.

- Slot `extras` movido para `.ui-topbar__extras-row` (`data-testid`)
- Free user (badge vazio) → linha 2 com footprint zero (sem `row-gap`; spacing via `> * { margin-top }`)
- `UiPageHeader` reduz título no mobile via tokens
- Story `MobileTwoTier` + `.storybook/preview.ts` agora importa `main.css` (tokens resolvem)
- `pnpm quality-check` verde, cobertura ≥85%