### PR TITLE
fix(toast): toast único — dedup + máx 1 visível (#977)

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -19,7 +19,13 @@ const { theme, themeOverrides } = useNaiveTheme();
     :theme-overrides="themeOverrides"
     :preflight-style-disabled="true"
   >
-    <NMessageProvider>
+    <!--
+      :max="1" caps the toast stack to a single visible message at a time.
+      Combined with the dedup guard in useToast (#977), concurrent failures
+      (e.g. a token expiry firing many requests) can never stack identical
+      error toasts.
+    -->
+    <NMessageProvider :max="1">
       <NDialogProvider>
         <NuxtLoadingIndicator color="var(--color-brand-500)" />
         <NuxtLayout>

--- a/app/composables/useHttp/useHttp.ts
+++ b/app/composables/useHttp/useHttp.ts
@@ -157,12 +157,26 @@ export const refreshAccessToken = async (
 let cachedClient: AxiosInstance | null = null;
 
 /**
+ * Guards the session-expiry dialog against stacking (#977).
+ *
+ * When the refresh token is also expired, `onUnauthorized` opens a blocking
+ * "session expired" dialog. Concurrent 401s — even though #976's single-flight
+ * collapses the refresh itself — can still fan out into multiple
+ * `onUnauthorized` rejections, each trying to open its own dialog. This boolean
+ * ensures only the first one opens; the flag resets when the user acknowledges
+ * (or the dialog otherwise closes) so a later, genuinely new session loss can
+ * surface again.
+ */
+let isSessionDialogOpen = false;
+
+/**
  * Resets the memoized HTTP client. Test-only — production code never needs to
  * drop the singleton. Exported so specs can isolate the module-level cache
  * between cases.
  */
 export const __resetHttpClientForTests = (): void => {
   cachedClient = null;
+  isSessionDialogOpen = false;
 };
 
 /**
@@ -209,10 +223,14 @@ export const useHttp = (): AxiosInstance => {
       onUnauthorized: async (): Promise<string | null> => {
         const newToken = await refreshAccessToken(apiBase, sessionStore);
 
-        if (!newToken) {
+        if (!newToken && !isSessionDialogOpen) {
           // Both the access token and the refresh token are expired.
           // Show a non-dismissable modal so the user acknowledges the
-          // session loss before being sent to the login page.
+          // session loss before being sent to the login page. The
+          // `isSessionDialogOpen` guard keeps concurrent 401s from stacking
+          // multiple identical dialogs (#977); it resets once acknowledged so
+          // a future, genuinely new session loss can surface again.
+          isSessionDialogOpen = true;
           dialog.warning({
             title: t("auth.sessionExpired.title"),
             content: t("auth.sessionExpired.message"),
@@ -220,7 +238,13 @@ export const useHttp = (): AxiosInstance => {
             closable: false,
             closeOnEsc: false,
             maskClosable: false,
-            onPositiveClick: () => navigateTo("/login"),
+            onPositiveClick: () => {
+              isSessionDialogOpen = false;
+              return navigateTo("/login");
+            },
+            onClose: () => {
+              isSessionDialogOpen = false;
+            },
           });
         }
 

--- a/app/composables/useHttp/useHttp.ts
+++ b/app/composables/useHttp/useHttp.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosInstance, type RawAxiosRequestHeaders } from "axios";
-import { useDialog, useMessage } from "naive-ui";
+import { useDialog } from "naive-ui";
 
+import { useToast } from "~/composables/useToast";
 import { createHttpClient } from "~/core/http/http-client";
 import { isAdminImpersonationReadOnlyActive } from "~/features/admin/impersonation/composables/use-admin-impersonation-session";
 import { useEmailVerificationGate } from "~/features/auth/composables/use-email-verification-gate";
@@ -210,7 +211,7 @@ export const useHttp = (): AxiosInstance => {
   const runtimeConfig = useRuntimeConfig();
   const sessionStore = useSessionStore();
   const verificationGate = useEmailVerificationGate();
-  const message = useMessage();
+  const toast = useToast();
   const dialog = useDialog();
   const { t } = useI18n();
 
@@ -262,10 +263,10 @@ export const useHttp = (): AxiosInstance => {
         });
       },
       onForbidden: (msg: string): void => {
-        message.error(msg, { duration: 5_000 });
+        toast.error(msg, { duration: 5_000 });
       },
       onServerError: (msg: string): void => {
-        message.error(msg, { duration: 5_000 });
+        toast.error(msg, { duration: 5_000 });
       },
     },
   );

--- a/app/composables/useToast/useToast.spec.ts
+++ b/app/composables/useToast/useToast.spec.ts
@@ -1,11 +1,19 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
-import { useToast } from "./useToast";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+import { useToast, __resetToastDedupForTests } from "./useToast";
 
 // ── Mock Naive UI useMessage ───────────────────────────────────────────────────
-const mockSuccess = vi.fn();
-const mockError = vi.fn();
-const mockWarning = vi.fn();
-const mockInfo = vi.fn();
+// Each call returns a message handle exposing a `destroy` spy, mirroring the
+// real Naive UI `MessageReactive` so the dedup lifecycle can be exercised.
+const mockDestroy = vi.fn();
+/**
+ * Builds a fake Naive UI message handle exposing a `destroy` spy.
+ * @returns A minimal `MessageReactive`-like object.
+ */
+const makeHandle = (): { destroy: typeof mockDestroy } => ({ destroy: mockDestroy });
+const mockSuccess = vi.fn(makeHandle);
+const mockError = vi.fn(makeHandle);
+const mockWarning = vi.fn(makeHandle);
+const mockInfo = vi.fn(makeHandle);
 
 vi.mock("naive-ui", (): Record<string, unknown> => ({
   useMessage: (): Record<string, unknown> => ({
@@ -21,6 +29,12 @@ vi.mock("naive-ui", (): Record<string, unknown> => ({
 describe("useToast", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetToastDedupForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    __resetToastDedupForTests();
   });
 
   it("returns the four toast helpers", () => {
@@ -41,6 +55,7 @@ describe("useToast", () => {
       expect(mockSuccess).toHaveBeenCalledWith("Operação realizada com sucesso.", {
         duration: 4_000,
         closable: true,
+        onClose: expect.any(Function),
       });
     });
 
@@ -51,6 +66,7 @@ describe("useToast", () => {
       expect(mockSuccess).toHaveBeenCalledWith("OK", {
         duration: 2_000,
         closable: false,
+        onClose: expect.any(Function),
       });
     });
   });
@@ -64,6 +80,7 @@ describe("useToast", () => {
       expect(mockError).toHaveBeenCalledWith("Algo deu errado.", {
         duration: 4_000,
         closable: true,
+        onClose: expect.any(Function),
       });
     });
 
@@ -74,6 +91,7 @@ describe("useToast", () => {
       expect(mockError).toHaveBeenCalledWith("Erro grave", {
         duration: 8_000,
         closable: true,
+        onClose: expect.any(Function),
       });
     });
   });
@@ -87,6 +105,7 @@ describe("useToast", () => {
       expect(mockWarning).toHaveBeenCalledWith("Atenção.", {
         duration: 4_000,
         closable: true,
+        onClose: expect.any(Function),
       });
     });
 
@@ -97,6 +116,7 @@ describe("useToast", () => {
       expect(mockWarning).toHaveBeenCalledWith("Aviso persistente", {
         duration: 4_000,
         closable: false,
+        onClose: expect.any(Function),
       });
     });
   });
@@ -110,6 +130,7 @@ describe("useToast", () => {
       expect(mockInfo).toHaveBeenCalledWith("Dica do sistema.", {
         duration: 4_000,
         closable: true,
+        onClose: expect.any(Function),
       });
     });
 
@@ -120,6 +141,7 @@ describe("useToast", () => {
       expect(mockInfo).toHaveBeenCalledWith("Informação breve", {
         duration: 1_000,
         closable: false,
+        onClose: expect.any(Function),
       });
     });
   });
@@ -135,5 +157,57 @@ describe("useToast", () => {
     expect(mockError).toHaveBeenCalledOnce();
     expect(mockWarning).toHaveBeenCalledOnce();
     expect(mockInfo).toHaveBeenCalledOnce();
+  });
+
+  describe("dedup (#977)", () => {
+    it("suppresses an identical toast while one with the same key is active", () => {
+      const { error } = useToast();
+      error("X");
+      error("X");
+
+      // Second identical call is swallowed — Naive UI is hit only once.
+      expect(mockError).toHaveBeenCalledOnce();
+    });
+
+    it("shows the toast again after the active one expires", () => {
+      vi.useFakeTimers();
+      const { error } = useToast();
+
+      error("X");
+      error("X");
+      expect(mockError).toHaveBeenCalledOnce();
+
+      // Advance past duration + buffer so the key is released.
+      vi.advanceTimersByTime(4_000 + 500);
+
+      error("X");
+      expect(mockError).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not suppress two DIFFERENT messages of the same severity", () => {
+      const { error } = useToast();
+      error("X");
+      error("Y");
+
+      expect(mockError).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not suppress the same text across different severities", () => {
+      const toast = useToast();
+      toast.error("Same");
+      toast.warning("Same");
+
+      expect(mockError).toHaveBeenCalledOnce();
+      expect(mockWarning).toHaveBeenCalledOnce();
+    });
+
+    it("create/update/delete each still show exactly one success toast", () => {
+      const { success } = useToast();
+      success("Criado com sucesso.");
+      success("Atualizado com sucesso.");
+      success("Removido com sucesso.");
+
+      expect(mockSuccess).toHaveBeenCalledTimes(3);
+    });
   });
 });

--- a/app/composables/useToast/useToast.spec.ts
+++ b/app/composables/useToast/useToast.spec.ts
@@ -169,17 +169,21 @@ describe("useToast", () => {
       expect(mockError).toHaveBeenCalledOnce();
     });
 
-    it("shows the toast again after the active one expires", () => {
+    it("suppresses mid-window but shows again only after duration + buffer elapse", () => {
       vi.useFakeTimers();
       const { error } = useToast();
 
-      error("X");
+      // First call shows the toast.
       error("X");
       expect(mockError).toHaveBeenCalledOnce();
 
-      // Advance past duration + buffer so the key is released.
-      vi.advanceTimersByTime(4_000 + 500);
+      // Mid-window (well before duration + buffer = 4500ms): still suppressed.
+      vi.advanceTimersByTime(2_000);
+      error("X");
+      expect(mockError).toHaveBeenCalledOnce();
 
+      // Past duration + buffer (total > 4500ms): key released, shows again.
+      vi.advanceTimersByTime(2_600);
       error("X");
       expect(mockError).toHaveBeenCalledTimes(2);
     });

--- a/app/composables/useToast/useToast.ts
+++ b/app/composables/useToast/useToast.ts
@@ -1,11 +1,36 @@
 import { useMessage } from "naive-ui";
-import type { ToastOptions, UseToastReturn } from "./useToast.types";
+import type { ToastType, ToastOptions, UseToastReturn } from "./useToast.types";
 
 /**
  * Default duration in milliseconds for toast messages.
  * Matches the value used in createApiMutation for consistency.
  */
 const DEFAULT_DURATION_MS = 4_000;
+
+/**
+ * Extra time (ms) added on top of a toast's `duration` before its dedup key is
+ * released. Covers the leave animation so a key isn't freed while the toast is
+ * still fading out, which would let a rapid duplicate slip through (#977).
+ */
+const DEDUP_RELEASE_BUFFER_MS = 500;
+
+/**
+ * Module-level set of currently-active dedup keys (`${severity}:${msg}`).
+ *
+ * Shared across every `useToast()` caller so concurrent failures (e.g. a token
+ * expiry firing many requests) collapse into a single visible toast instead of
+ * stacking identical copies. Combined with `:max="1"` on `<NMessageProvider>`,
+ * this guarantees at most one toast on screen and no duplicate-while-active.
+ */
+const activeToastKeys = new Set<string>();
+
+/**
+ * Clears the module-level dedup set. Test-only — production code never needs to
+ * drop active keys. Exported so specs can isolate state between cases.
+ */
+export const __resetToastDedupForTests = (): void => {
+  activeToastKeys.clear();
+};
 
 /**
  * Unified toast composable for Auraxis Web.
@@ -47,13 +72,53 @@ export function useToast(): UseToastReturn {
   }
 
   /**
+   * Shows a toast of the given severity, deduping identical-while-active ones.
+   *
+   * Suppresses the call when a toast with the same `${severity}:${msg}` key is
+   * already active. Otherwise it registers the key, forwards to Naive UI, and
+   * schedules the key's release after `duration + buffer` (and also on the
+   * message's own `onClose`, so manual dismissal frees it early). Different text
+   * or a different severity is never suppressed.
+   *
+   * @param severity - Toast severity level.
+   * @param msg - Message content.
+   * @param options - Display options.
+   */
+  function show(severity: ToastType, msg: string, options?: ToastOptions): void {
+    const key = `${severity}:${msg}`;
+    if (activeToastKeys.has(key)) {
+      return;
+    }
+
+    const { duration, closable } = resolveOptions(options);
+    activeToastKeys.add(key);
+
+    /** Frees the dedup key so an identical toast can be shown again. */
+    const release = (): void => {
+      activeToastKeys.delete(key);
+    };
+
+    // Timer-based release covers auto-dismiss; `onClose` releases early on
+    // manual dismissal. The timer also guarantees the key is freed even if
+    // Naive UI never fires `onClose`, so dedup can't wedge permanently.
+    const timer = setTimeout(release, duration + DEDUP_RELEASE_BUFFER_MS);
+
+    /** Releases the key early when the user dismisses the toast manually. */
+    const onClose = (): void => {
+      clearTimeout(timer);
+      release();
+    };
+
+    message[severity](msg, { duration, closable, onClose });
+  }
+
+  /**
    * Shows a success toast.
    * @param msg - Message content.
    * @param options - Display options.
    */
   function success(msg: string, options?: ToastOptions): void {
-    const { duration, closable } = resolveOptions(options);
-    message.success(msg, { duration, closable });
+    show("success", msg, options);
   }
 
   /**
@@ -62,8 +127,7 @@ export function useToast(): UseToastReturn {
    * @param options - Display options.
    */
   function error(msg: string, options?: ToastOptions): void {
-    const { duration, closable } = resolveOptions(options);
-    message.error(msg, { duration, closable });
+    show("error", msg, options);
   }
 
   /**
@@ -72,8 +136,7 @@ export function useToast(): UseToastReturn {
    * @param options - Display options.
    */
   function warning(msg: string, options?: ToastOptions): void {
-    const { duration, closable } = resolveOptions(options);
-    message.warning(msg, { duration, closable });
+    show("warning", msg, options);
   }
 
   /**
@@ -82,8 +145,7 @@ export function useToast(): UseToastReturn {
    * @param options - Display options.
    */
   function info(msg: string, options?: ToastOptions): void {
-    const { duration, closable } = resolveOptions(options);
-    message.info(msg, { duration, closable });
+    show("info", msg, options);
   }
 
   return { success, error, warning, info };

--- a/app/composables/useToast/useToast.ts
+++ b/app/composables/useToast/useToast.ts
@@ -98,9 +98,15 @@ export function useToast(): UseToastReturn {
       activeToastKeys.delete(key);
     };
 
-    // Timer-based release covers auto-dismiss; `onClose` releases early on
-    // manual dismissal. The timer also guarantees the key is freed even if
-    // Naive UI never fires `onClose`, so dedup can't wedge permanently.
+    // The unconditional `setTimeout(duration + buffer)` is the GUARANTEED
+    // release path — do not remove it in favour of an onClose-only design.
+    // Naive UI's `:max="1"` eviction drops the oldest toast via an internal
+    // `shift()` that does NOT fire `onClose`, so an onClose-only release would
+    // leak the dedup key forever for any toast pushed out by a newer one,
+    // wedging dedup permanently. `onClose` here is only an optimisation that
+    // ACCELERATES release when the user dismisses the toast manually (or it
+    // auto-expires and Naive UI does fire the callback); the timer is the
+    // backstop that covers the eviction case the callback misses.
     const timer = setTimeout(release, duration + DEDUP_RELEASE_BUFFER_MS);
 
     /** Releases the key early when the user dismisses the toast manually. */


### PR DESCRIPTION
Closes #977

- `NMessageProvider :max="1"` em app.vue
- Dedup em `useToast`: chave `severity:msg` num Set module-level; libera no `onClose` ou via timeout `duration+500ms` (Naive UI `:max` despeja com `shift()` sem disparar onClose → timer é o release garantido)
- 403/5xx (`onForbidden`/`onServerError`) agora passam pelo `useToast` deduplicado (antes `message.error` cru empilhava)
- `dialog.warning` de sessão expirada idempotente (`isSessionDialogOpen`)
- `pnpm quality-check` verde, cobertura ≥85%