### PR TITLE
fix(wallet): Carteira sem dados hardcoded + CTAs mortos removidos (#979)

### DIFF
--- a/app/pages/portfolio.market-pulse.spec.ts
+++ b/app/pages/portfolio.market-pulse.spec.ts
@@ -5,20 +5,20 @@ import { describe, expect, it } from "vitest";
 const source = readFileSync(join(process.cwd(), "app/pages/portfolio.vue"), "utf8");
 
 describe("Portfolio page — Market Pulse anatomy", () => {
-  it("renders the canonical KPI, performance, allocation and positions sections", () => {
+  it("renders the canonical KPI, allocation and positions sections", () => {
     expect(source).toContain("portfolio-market-pulse");
     expect(source).toContain("summary-kpis");
     expect(source).toContain("NetWorthTimeline");
-    expect(source).toContain("portfolio-performance");
     expect(source).toContain("portfolio-allocation");
     expect(source).toContain("portfolio-positions");
   });
 
-  it("keeps the canonical Portuguese section labels from the HTML prototype", () => {
+  it("keeps the canonical Portuguese section labels backed by real data", () => {
     expect(source).toContain("Visão Geral da Carteira");
     expect(source).toContain("Patrimônio Total");
     expect(source).toContain("Projeção Patrimonial");
-    expect(source).toContain("Rentabilidade (Mês)");
+    expect(source).toContain("Total Investido");
+    expect(source).toContain("Resultado Total");
     expect(source).toContain("Alocação por Classe");
     expect(source).toContain("Posição Detalhada de Ativos");
   });
@@ -28,5 +28,31 @@ describe("Portfolio page — Market Pulse anatomy", () => {
     expect(source).not.toContain("MOCK_PORTFOLIO_SUMMARY");
     expect(source).not.toContain("Carteira demonstrativa");
     expect(source).toContain("Comece adicionando seu primeiro ativo");
+  });
+
+  it("contains no fabricated financial literals or benchmark placeholders (#979)", () => {
+    // Removed: invented monthly/yearly return cards and benchmark pills.
+    expect(source).not.toContain("Rentabilidade (Mês)");
+    expect(source).not.toContain("Rentabilidade (Ano)");
+    expect(source).not.toContain("vs. Ibovespa");
+    expect(source).not.toContain("vs. CDI");
+    expect(source).not.toContain("3,20%");
+    expect(source).not.toContain("14,50%");
+    // Removed: synthetic performance series + its multipliers.
+    expect(source).not.toContain("0.0365");
+    expect(source).not.toContain("0.145");
+    expect(source).not.toContain("0.031");
+    expect(source).not.toContain("day_change_percent: 0.84");
+  });
+
+  it("only wires CTAs that have a real action (#979)", () => {
+    // The single real CTA opens the entry form.
+    expect(source).toContain("@click=\"showEntryForm = true\"");
+    // Removed dead controls.
+    expect(source).not.toContain("Exportar");
+    expect(source).not.toContain("Resgatar");
+    expect(source).not.toContain("Buscar ativo...");
+    expect(source).not.toContain("range-tabs");
+    expect(source).not.toContain("position-filter");
   });
 });

--- a/app/pages/portfolio.market-pulse.spec.ts
+++ b/app/pages/portfolio.market-pulse.spec.ts
@@ -23,6 +23,14 @@ describe("Portfolio page — Market Pulse anatomy", () => {
     expect(source).toContain("Posição Detalhada de Ativos");
   });
 
+  it("binds the real-data KPI cards to the portfolio summary query (#979)", () => {
+    // Positive assertions: the cards read live query values, not hardcoded numbers.
+    expect(source).toContain("computedSummary.total_value");
+    expect(source).toContain("computedSummary.total_cost");
+    expect(source).toContain("computedSummary.total_return_percent");
+    expect(source).toContain("totalReturnAmount");
+  });
+
   it("does not fall back to demo assets when the authenticated wallet is empty", () => {
     expect(source).not.toContain("MOCK_WALLET_ENTRIES");
     expect(source).not.toContain("MOCK_PORTFOLIO_SUMMARY");

--- a/app/pages/portfolio.vue
+++ b/app/pages/portfolio.vue
@@ -44,7 +44,6 @@ const editingEntry = ref<WalletEntryDto | null>(null);
 const chartTokens = computed(() => buildChartThemeTokens(resolvedTheme.value));
 
 const rawEntries = computed(() => entries.value ?? []);
-const displayEntries = computed(() => rawEntries.value);
 const isLoading = computed(() => isSummaryLoading.value || isEntriesLoading.value);
 const isPortfolioEmpty = computed(() => !isLoading.value && rawEntries.value.length === 0);
 const shouldShowPortfolioError = computed(
@@ -56,7 +55,7 @@ const computedSummary = computed<PortfolioSummaryDto>(() => {
     return summary.value;
   }
 
-  if (displayEntries.value.length === 0) {
+  if (rawEntries.value.length === 0) {
     return {
       total_value: 0,
       total_cost: 0,
@@ -66,8 +65,8 @@ const computedSummary = computed<PortfolioSummaryDto>(() => {
     };
   }
 
-  const totalValue = displayEntries.value.reduce((sum, entry) => sum + entry.current_value, 0);
-  const totalCost = displayEntries.value.reduce(
+  const totalValue = rawEntries.value.reduce((sum, entry) => sum + entry.current_value, 0);
+  const totalCost = rawEntries.value.reduce(
     (sum, entry) => sum + (entry.cost_basis ?? entry.current_value),
     0,
   );
@@ -78,7 +77,7 @@ const computedSummary = computed<PortfolioSummaryDto>(() => {
     total_cost: totalCost,
     day_change_percent: null,
     total_return_percent: totalReturnPercent,
-    asset_count: displayEntries.value.length,
+    asset_count: rawEntries.value.length,
   };
 });
 
@@ -272,7 +271,7 @@ const allocationRows = computed<AllocationRow[]>(() => {
   ];
   const totals = new Map<string, number>();
 
-  for (const entry of displayEntries.value) {
+  for (const entry of rawEntries.value) {
     const label = assetTypeLabel(entry.asset_type);
     const currentValue = safeNumber(entry.current_value);
     if (currentValue > 0) {
@@ -390,8 +389,16 @@ const allocationChartOption = computed<EChartsOption>(() => {
               <p>Patrimônio Total</p>
               <strong>{{ formatCurrency(computedSummary.total_value) }}</strong>
             </div>
-            <span class="trend-pill trend-pill--positive">
-              <ArrowUp :size="13" aria-hidden="true" />
+            <span
+              class="trend-pill"
+              :class="
+                (computedSummary.total_return_percent ?? 0) >= 0
+                  ? 'trend-pill--positive'
+                  : 'trend-pill--negative'
+              "
+            >
+              <ArrowUp v-if="(computedSummary.total_return_percent ?? 0) >= 0" :size="13" aria-hidden="true" />
+              <ArrowDownRight v-else :size="13" aria-hidden="true" />
               {{ formatPercent(computedSummary.total_return_percent) }}
             </span>
           </div>
@@ -499,7 +506,7 @@ const allocationChartOption = computed<EChartsOption>(() => {
               </tr>
             </thead>
             <tbody>
-              <tr v-for="entry in displayEntries" :key="entry.id">
+              <tr v-for="entry in rawEntries" :key="entry.id">
                 <td>
                   <div class="asset-cell">
                     <span>{{ (entry.ticker ?? entry.name).slice(0, 4).toUpperCase() }}</span>

--- a/app/pages/portfolio.vue
+++ b/app/pages/portfolio.vue
@@ -1,17 +1,6 @@
 <script setup lang="ts">
 import type { EChartsOption } from "echarts";
-import {
-  ArrowDownRight,
-  ArrowUp,
-  ArrowUpRight,
-  Bell,
-  Download,
-  Filter,
-  Menu,
-  Plus,
-  Search,
-  Shuffle,
-} from "lucide-vue-next";
+import { ArrowDownRight, ArrowUp, ArrowUpRight, Plus } from "lucide-vue-next";
 
 import { usePortfolioSummaryQuery } from "~/features/wallet/queries/use-portfolio-summary-query";
 import { useWalletEntriesQuery } from "~/features/wallet/queries/use-wallet-entries-query";
@@ -24,7 +13,7 @@ import AiInsightSurface from "~/features/ai-insights/components/AiInsightSurface
 import { useGoalsQuery } from "~/features/goals/queries/use-goals-query";
 import { formatCurrency } from "~/utils/currency";
 import { useTheme } from "~/composables/useTheme";
-import { buildChartThemeTokens, withAlpha } from "~/utils/chart-theme";
+import { buildChartThemeTokens } from "~/utils/chart-theme";
 
 definePageMeta({
   middleware: ["authenticated", "coming-soon"],
@@ -87,7 +76,7 @@ const computedSummary = computed<PortfolioSummaryDto>(() => {
   return {
     total_value: totalValue,
     total_cost: totalCost,
-    day_change_percent: 0.84,
+    day_change_percent: null,
     total_return_percent: totalReturnPercent,
     asset_count: displayEntries.value.length,
   };
@@ -259,9 +248,11 @@ function totalReturnPercent(entry: WalletEntryDto): number | null {
   return ((currentValue - costBasis) / costBasis) * 100;
 }
 
-const totalReturnAmount = computed(() => safeNumber(computedSummary.value.total_value) - safeNumber(computedSummary.value.total_cost));
-const monthlyReturnAmount = computed(() => Math.round(safeNumber(computedSummary.value.total_value) * 0.0365));
-const yearlyReturnAmount = computed(() => Math.round(Math.max(totalReturnAmount.value, safeNumber(computedSummary.value.total_value) * 0.145)));
+const totalReturnAmount = computed(
+  () =>
+    safeNumber(computedSummary.value.total_value) -
+    safeNumber(computedSummary.value.total_cost),
+);
 const displayGoals = computed(() => {
   if (goals.value?.length) {
     return goals.value;
@@ -269,7 +260,6 @@ const displayGoals = computed(() => {
 
   return [];
 });
-const projectedMonthlyContribution = computed(() => Math.max(500, Math.round(safeNumber(computedSummary.value.total_value) * 0.012)));
 
 const allocationRows = computed<AllocationRow[]>(() => {
   const tokens = chartTokens.value;
@@ -303,83 +293,6 @@ const allocationRows = computed<AllocationRow[]>(() => {
       percentage: Math.round((value / total) * 100),
       color: colors[index] ?? tokens.mutedText,
     }));
-});
-
-const performanceChartOption = computed<EChartsOption>(() => {
-  const tokens = chartTokens.value;
-  const months = ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"];
-  const base = Math.max(computedSummary.value.total_cost, 1000);
-  const portfolio = months.map((_, index) => Math.round(base * (1 + index * 0.031 + Math.sin(index) * 0.012)));
-  const benchmark = months.map((_, index) => Math.round(base * (1 + index * 0.014)));
-
-  return {
-    backgroundColor: "transparent",
-    color: [tokens.balance, tokens.income],
-    grid: { top: 24, right: 20, bottom: 32, left: 62 },
-    tooltip: {
-      trigger: "axis",
-      backgroundColor: tokens.tooltipBackground,
-      borderColor: tokens.tooltipBorder,
-      textStyle: { color: tokens.tooltipText },
-      valueFormatter: (value): string => formatCurrency(Number(value)),
-    },
-    legend: {
-      top: 0,
-      right: 0,
-      textStyle: { color: tokens.mutedText },
-    },
-    media: [
-      {
-        query: { maxWidth: 520 },
-        option: {
-          grid: { top: 56, right: 10, bottom: 28, left: 44 },
-          legend: {
-            top: 0,
-            left: 0,
-            right: "auto",
-            itemGap: 8,
-            itemHeight: 6,
-            itemWidth: 10,
-            textStyle: { color: tokens.mutedText, fontSize: 10 },
-          },
-        },
-      },
-    ],
-    xAxis: {
-      type: "category",
-      data: months,
-      axisLine: { lineStyle: { color: tokens.border } },
-      axisTick: { show: false },
-      axisLabel: { color: tokens.mutedText },
-    },
-    yAxis: {
-      type: "value",
-      splitLine: { lineStyle: { color: tokens.grid } },
-      axisLabel: {
-        color: tokens.mutedText,
-        formatter: (value: number): string => `${Math.round(value / 1000)}k`,
-      },
-    },
-    series: [
-      {
-        name: "Carteira",
-        type: "line",
-        smooth: true,
-        symbol: "none",
-        lineStyle: { width: 3 },
-        areaStyle: { color: withAlpha(tokens.balance, resolvedTheme.value === "dark" ? 0.1 : 0.16) },
-        data: portfolio,
-      },
-      {
-        name: "Benchmark",
-        type: "line",
-        smooth: true,
-        symbol: "none",
-        lineStyle: { width: 2 },
-        data: benchmark,
-      },
-    ],
-  };
 });
 
 const allocationChartOption = computed<EChartsOption>(() => {
@@ -422,28 +335,10 @@ const allocationChartOption = computed<EChartsOption>(() => {
   <div class="portfolio-market-pulse">
     <section class="portfolio-header" aria-label="Cabeçalho da carteira">
       <div class="portfolio-header__title">
-        <button class="portfolio-menu" type="button" aria-label="Abrir menu">
-          <Menu :size="20" aria-hidden="true" />
-        </button>
         <div>
           <h1>Visão Geral da Carteira</h1>
           <p>Acompanhamento técnico da carteira, alocação e posições.</p>
         </div>
-      </div>
-
-      <div class="portfolio-header__actions">
-        <label class="search-field" for="asset-search">
-          <Search :size="15" aria-hidden="true" />
-          <input id="asset-search" type="search" placeholder="Buscar ativo...">
-        </label>
-        <button class="icon-button" type="button" aria-label="Notificações">
-          <Bell :size="20" aria-hidden="true" />
-          <span aria-hidden="true" />
-        </button>
-        <button class="mp-button mp-button--ghost" type="button">
-          <Download :size="16" aria-hidden="true" />
-          Exportar
-        </button>
       </div>
     </section>
 
@@ -505,47 +400,40 @@ const allocationChartOption = computed<EChartsOption>(() => {
               <Plus :size="16" aria-hidden="true" />
               Aportar
             </button>
-            <button class="mp-button mp-button--secondary" type="button">
-              <Shuffle :size="16" aria-hidden="true" />
-              Resgatar
-            </button>
           </div>
         </article>
 
         <article class="portfolio-kpi">
           <div class="kpi-heading">
             <div>
-              <p>Rentabilidade (Mês)</p>
-              <strong class="is-positive">+ {{ formatCurrency(monthlyReturnAmount) }}</strong>
+              <p>Total Investido</p>
+              <strong>{{ formatCurrency(computedSummary.total_cost) }}</strong>
             </div>
-            <select aria-label="Mês da rentabilidade">
-              <option>Maio</option>
-              <option>Abril</option>
-            </select>
           </div>
           <div class="comparison-line">
-            <span class="trend-pill trend-pill--positive">
-              <ArrowUp :size="13" aria-hidden="true" />
-              3,20%
-            </span>
-            <span>vs. Ibovespa (1,50%)</span>
+            <span>{{ computedSummary.asset_count }} ativo(s) na carteira</span>
           </div>
         </article>
 
         <article class="portfolio-kpi">
           <div class="kpi-heading">
             <div>
-              <p>Rentabilidade (Ano)</p>
-              <strong class="is-positive">+ {{ formatCurrency(yearlyReturnAmount) }}</strong>
+              <p>Resultado Total</p>
+              <strong :class="totalReturnAmount >= 0 ? 'is-positive' : 'is-negative'">
+                {{ totalReturnAmount >= 0 ? "+ " : "- " }}{{ formatCurrency(Math.abs(totalReturnAmount)) }}
+              </strong>
             </div>
-            <span class="kpi-year">2026</span>
           </div>
           <div class="comparison-line">
-            <span class="trend-pill trend-pill--positive">
-              <ArrowUp :size="13" aria-hidden="true" />
-              14,50%
+            <span
+              class="trend-pill"
+              :class="totalReturnAmount >= 0 ? 'trend-pill--positive' : 'trend-pill--negative'"
+            >
+              <ArrowUp v-if="totalReturnAmount >= 0" :size="13" aria-hidden="true" />
+              <ArrowDownRight v-else :size="13" aria-hidden="true" />
+              {{ formatPercent(computedSummary.total_return_percent) }}
             </span>
-            <span>vs. CDI (6,20%)</span>
+            <span>sobre o custo de aquisição</span>
           </div>
         </article>
       </section>
@@ -556,27 +444,10 @@ const allocationChartOption = computed<EChartsOption>(() => {
         aria-label="Projeção Patrimonial"
         :current-net-worth="computedSummary.total_value"
         :invested-amount="computedSummary.total_cost"
-        :monthly-contribution="projectedMonthlyContribution"
         :goals="displayGoals"
       />
 
       <section class="portfolio-analytics-grid">
-        <article id="portfolio-performance" class="mp-panel portfolio-performance">
-          <div class="panel-heading">
-            <div>
-              <h2>Evolução Patrimonial</h2>
-              <p>Acompanhamento histórico da carteira vs. benchmark</p>
-            </div>
-            <div class="range-tabs" aria-label="Intervalo de performance">
-              <button type="button">1M</button>
-              <button type="button">6M</button>
-              <button type="button" class="is-active">1A</button>
-              <button type="button">TUDO</button>
-            </div>
-          </div>
-          <UiChart :option="performanceChartOption" height="320px" />
-        </article>
-
         <article id="portfolio-allocation" class="mp-panel portfolio-allocation">
           <div class="panel-heading panel-heading--stacked">
             <h2>Alocação por Classe</h2>
@@ -611,15 +482,6 @@ const allocationChartOption = computed<EChartsOption>(() => {
             <h2>Posição Detalhada de Ativos</h2>
             <p>Visão técnica avançada (TradeMap View)</p>
           </div>
-          <label class="position-filter" for="portfolio-position-filter">
-            <Filter :size="13" aria-hidden="true" />
-            <select id="portfolio-position-filter">
-              <option>Todos os Ativos</option>
-              <option>Ações</option>
-              <option>FIIs</option>
-              <option>Renda Fixa</option>
-            </select>
-          </label>
         </div>
 
         <div class="positions-table-wrap">
@@ -709,7 +571,6 @@ const allocationChartOption = computed<EChartsOption>(() => {
 
 .portfolio-header,
 .portfolio-header__title,
-.portfolio-header__actions,
 .summary-kpis,
 .portfolio-analytics-grid,
 .kpi-heading,
@@ -748,14 +609,6 @@ const allocationChartOption = computed<EChartsOption>(() => {
   font-size: var(--font-size-sm);
 }
 
-.portfolio-menu {
-  display: none;
-}
-
-.portfolio-header__actions {
-  align-items: center;
-}
-
 .portfolio-empty-state {
   border: 1px solid var(--mp-border);
   border-radius: var(--radius-lg);
@@ -773,36 +626,7 @@ const allocationChartOption = computed<EChartsOption>(() => {
   box-shadow: var(--mp-panel-shadow);
 }
 
-.search-field {
-  display: inline-flex;
-  min-height: 40px;
-  width: 260px;
-  align-items: center;
-  gap: 8px;
-  border: 1px solid var(--mp-border);
-  border-radius: var(--radius-full);
-  padding: 0 14px;
-  background: var(--mp-card);
-  color: var(--mp-muted);
-}
-
-.search-field input {
-  width: 100%;
-  border: 0;
-  outline: 0;
-  background: transparent;
-  color: var(--mp-text);
-  font: inherit;
-  font-size: var(--font-size-sm);
-}
-
-.search-field input::placeholder {
-  color: var(--mp-muted);
-}
-
 .mp-button,
-.icon-button,
-.range-tabs button,
 .table-action {
   border: 1px solid var(--mp-border);
   border-radius: var(--radius-xs);
@@ -828,30 +652,6 @@ const allocationChartOption = computed<EChartsOption>(() => {
   background: var(--mp-cyan);
   color: var(--color-text-on-brand);
   box-shadow: var(--shadow-brand-glow-sm);
-}
-
-.mp-button--ghost {
-  border-color: var(--color-brand-glow-sm);
-  color: var(--mp-cyan);
-  background: var(--mp-brand-soft);
-}
-
-.icon-button {
-  position: relative;
-  width: 40px;
-  padding: 0;
-  color: var(--mp-muted);
-}
-
-.icon-button span {
-  position: absolute;
-  top: 9px;
-  right: 9px;
-  width: 9px;
-  height: 9px;
-  border: 1px solid var(--mp-surface);
-  border-radius: 50%;
-  background: var(--mp-lime);
 }
 
 .summary-kpis {
@@ -914,11 +714,6 @@ const allocationChartOption = computed<EChartsOption>(() => {
   font-size: var(--font-size-xs);
 }
 
-.kpi-year {
-  color: var(--mp-muted);
-  font-size: var(--font-size-xs);
-}
-
 .kpi-actions {
   margin-top: 28px;
 }
@@ -942,6 +737,11 @@ const allocationChartOption = computed<EChartsOption>(() => {
   background: var(--color-positive-bg);
 }
 
+.trend-pill--negative {
+  color: var(--mp-red);
+  background: var(--color-negative-bg);
+}
+
 .comparison-line {
   align-items: center;
   margin-top: 16px;
@@ -963,7 +763,7 @@ const allocationChartOption = computed<EChartsOption>(() => {
 
 .portfolio-analytics-grid {
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr);
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .mp-panel {
@@ -978,26 +778,6 @@ const allocationChartOption = computed<EChartsOption>(() => {
 
 .panel-heading--stacked {
   display: block;
-}
-
-.range-tabs {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.range-tabs button {
-  min-height: 30px;
-  border-color: var(--mp-border);
-  padding: 0 10px;
-  color: var(--mp-muted);
-  background: transparent;
-}
-
-.range-tabs button.is-active {
-  border-color: var(--color-brand-glow-md);
-  background: var(--mp-brand-soft);
-  color: var(--mp-cyan);
 }
 
 .allocation-chart {
@@ -1093,26 +873,6 @@ const allocationChartOption = computed<EChartsOption>(() => {
   border-bottom: 1px solid var(--mp-border);
   padding: 24px;
   background: var(--mp-card-strong);
-}
-
-.position-filter {
-  display: inline-flex;
-  min-height: 34px;
-  align-items: center;
-  gap: 8px;
-  border: 1px solid var(--mp-border);
-  border-radius: var(--radius-xs);
-  padding: 0 10px;
-  background: var(--mp-card-strong);
-  color: var(--mp-muted);
-}
-
-.position-filter select {
-  border: 0;
-  background: transparent;
-  color: var(--mp-text);
-  font: inherit;
-  font-size: var(--font-size-xs);
 }
 
 .positions-table-wrap {
@@ -1224,10 +984,6 @@ td.is-numeric.is-negative {
   .portfolio-analytics-grid {
     grid-template-columns: 1fr;
   }
-
-  .search-field {
-    width: 220px;
-  }
 }
 
 @media (max-width: 760px) {
@@ -1236,32 +992,14 @@ td.is-numeric.is-negative {
   }
 
   .portfolio-header,
-  .portfolio-header__actions,
   .panel-heading,
   .positions-header {
     align-items: stretch;
     flex-direction: column;
   }
 
-  .portfolio-menu {
-    display: inline-flex;
-    width: 40px;
-    height: 40px;
-    align-items: center;
-    justify-content: center;
-    border: 1px solid var(--mp-border);
-    border-radius: var(--radius-sm);
-    background: var(--mp-card);
-    color: var(--mp-muted);
-  }
-
-  .portfolio-header__actions,
   .kpi-actions {
     flex-wrap: wrap;
-  }
-
-  .search-field {
-    width: 100%;
   }
 
   .portfolio-kpi,

--- a/docs/superpowers/reports/2026-06-02-wallet-audit.md
+++ b/docs/superpowers/reports/2026-06-02-wallet-audit.md
@@ -1,0 +1,92 @@
+# Wallet ("Carteira") audit — `pages/portfolio.vue` + `components/wallet/*`
+
+Issue: #979 — [WEB] audit: Carteira (portfolio.vue) — remover hardcoded + CTAs sem ação
+Branch: `fix/979-wallet-audit`
+Date: 2026-06-02
+
+## Method
+
+1. Grep for displayed numeric/financial values and interactive controls in
+   `pages/portfolio.vue` and `components/wallet/*.vue`.
+2. Trace each rendered value back to its source (query / computed / literal).
+3. Confirm which backend fields are actually available
+   (`WalletClient.getPortfolioSummary` → `GET /wallet/valuation`,
+   `getEntries` → `GET /wallet`, `getWalletHistory` → per-entry valuation).
+4. Classify each finding and decide: wire / replace-with-empty-state / remove.
+
+## Backend reality (what data actually exists)
+
+`GET /wallet/valuation` (mapped in `wallet.client.ts:162-176`) provides ONLY:
+
+| Field                  | Source                              |
+| ---------------------- | ----------------------------------- |
+| `total_value`          | `summary.total_current_value`       |
+| `total_cost`           | `summary.total_invested_amount`     |
+| `total_return_percent` | `summary.total_profit_loss_percent` |
+| `asset_count`          | `summary.total_investments`         |
+| `day_change_percent`   | **not provided → mapped to `null`** |
+
+`GET /wallet` provides per-asset entries (incl. per-asset `change_percent`).
+There is **no** portfolio-wide historical series, **no** monthly/yearly return
+breakdown, and **no** benchmark (Ibovespa / CDI) data anywhere in the contract.
+
+## Findings — displayed values
+
+| file:line                                                | Current value / behavior                                                                                                | Classification                                                                                                                                                                                                     | Decision                                                                                                                        |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `portfolio.vue:90`                                       | `day_change_percent: 0.84` in nominal `computedSummary` fallback (entries present, summary absent)                      | **NOT OK** — fabricated literal in nominal flow (not currently rendered on this page, but a fabricated value baked into a computed)                                                                                | Replace with `null` (honest "unknown")                                                                                          |
+| `portfolio.vue:263`                                      | `monthlyReturnAmount = total_value * 0.0365`                                                                            | **NOT OK** — invented 3,65%/mo multiplier rendered as "Rentabilidade (Mês)"                                                                                                                                        | Remove KPI card (no backend source)                                                                                             |
+| `portfolio.vue:264`                                      | `yearlyReturnAmount = max(return, total_value * 0.145)`                                                                 | **NOT OK** — invented 14,5% floor rendered as "Rentabilidade (Ano)"                                                                                                                                                | Remove KPI card (no backend source)                                                                                             |
+| `portfolio.vue:529`                                      | `3,20%` literal (month-vs-benchmark pill)                                                                               | **NOT OK** — hardcoded                                                                                                                                                                                             | Remove (part of removed card)                                                                                                   |
+| `portfolio.vue:531`                                      | `vs. Ibovespa (1,50%)` literal                                                                                          | **NOT OK** — hardcoded benchmark                                                                                                                                                                                   | Remove (no benchmark data)                                                                                                      |
+| `portfolio.vue:546`                                      | `14,50%` literal (year-vs-benchmark pill)                                                                               | **NOT OK** — hardcoded                                                                                                                                                                                             | Remove (part of removed card)                                                                                                   |
+| `portfolio.vue:548`                                      | `vs. CDI (6,20%)` literal                                                                                               | **NOT OK** — hardcoded benchmark                                                                                                                                                                                   | Remove (no benchmark data)                                                                                                      |
+| `portfolio.vue:312`                                      | performance series `base*(1 + i*0.031 + sin(i)*0.012)`                                                                  | **NOT OK** — synthetic 12-month curve presented as "Evolução Patrimonial vs benchmark"                                                                                                                             | Remove the synthetic-history chart (no portfolio history endpoint)                                                              |
+| `portfolio.vue:313`                                      | benchmark series `base*(1 + i*0.014)`                                                                                   | **NOT OK** — synthetic benchmark                                                                                                                                                                                   | Remove (part of removed chart)                                                                                                  |
+| `portfolio.vue:589`                                      | `<strong>100%</strong>` allocation-total label                                                                          | OK — static design label inside donut center (allocation always sums to 100% by definition; the slices come from real `allocationRows`)                                                                            | Keep                                                                                                                            |
+| `portfolio.vue:541`                                      | `<span class="kpi-year">2026</span>`                                                                                    | OK after change — was static; will bind to current year                                                                                                                                                            | Wire to `new Date().getFullYear()` (kept only if year card survives — card removed, so N/A)                                     |
+| `portfolio.vue:496,500,519,539`                          | `formatCurrency(computedSummary.total_value)`, `formatPercent(total_return_percent)` etc.                               | OK — bound to query-backed `computedSummary`                                                                                                                                                                       | Keep (519/539 removed with their cards)                                                                                         |
+| `portfolio.vue:272`                                      | `projectedMonthlyContribution = max(500, total_value*0.012)` feeding `NetWorthTimeline`                                 | **Borderline** — heuristic, but it is a _projection input_ to a forward-looking simulator (not a reported actual), and `NetWorthTimeline` is an explicit projection widget. Still, the 1.2%/floor-500 is invented. | Remove — `NetWorthTimeline` already defaults `monthly-contribution` to `0`; pass real `0` rather than an invented contribution. |
+| `portfolio.vue:312` base / allocation rows / table cells | `allocationRows`, `averageCost`, `currentQuote`, `entryAllocationPercent`, `totalReturnPercent`, table `change_percent` | OK — all derived from real `entries` query                                                                                                                                                                         | Keep                                                                                                                            |
+| `components/wallet/PositionsList.vue:23`                 | `toFixed(2)` in `formatPercent`                                                                                         | OK — formats a passed-in value, not a literal                                                                                                                                                                      | Keep                                                                                                                            |
+| `components/wallet/WalletSummaryCard.vue:23`             | `toFixed(2)` in `formatPercent`                                                                                         | OK — formats a passed-in value                                                                                                                                                                                     | Keep                                                                                                                            |
+
+> Note: `components/wallet/PositionsList.vue` and `WalletSummaryCard.vue` are
+> NOT imported by `portfolio.vue` (the page renders its own table/KPIs). They
+> receive all data via props and contain no hardcoded financial literals.
+> Mock data in `features/portfolio/mock/portfolio.mock.ts` is gated behind
+> `NUXT_PUBLIC_MOCK_DATA` (dev/test only) — legitimate, not nominal-flow.
+
+## Findings — interactive elements
+
+| file:line                             | Control                        | Has action?                                 | Decision                                                                       |
+| ------------------------------------- | ------------------------------ | ------------------------------------------- | ------------------------------------------------------------------------------ |
+| `portfolio.vue:425`                   | "Abrir menu" hamburger button  | No `@click`                                 | Remove — global layout already provides nav; this is a dead prototype control. |
+| `portfolio.vue:437`                   | "Buscar ativo..." search input | No binding/handler                          | Remove — no search feature exists for this page.                               |
+| `portfolio.vue:439`                   | Notifications bell button      | No `@click`                                 | Remove — no notifications feature on this page.                                |
+| `portfolio.vue:443`                   | "Exportar" button              | No `@click`                                 | Remove — no export implemented.                                                |
+| `portfolio.vue:504`                   | "Aportar" button               | `@click="showEntryForm = true"`             | Keep — real action.                                                            |
+| `portfolio.vue:508`                   | "Resgatar" button              | No `@click`                                 | Remove — no redeem/sell flow exists.                                           |
+| `portfolio.vue:521`                   | Month `<select>` (Maio/Abril)  | No binding                                  | Removed with the monthly KPI card.                                             |
+| `portfolio.vue:571-574`               | Range tabs 1M/6M/1A/TUDO       | No `@click` (only static `is-active` on 1A) | Removed with the synthetic performance chart.                                  |
+| `portfolio.vue:616`                   | Position filter `<select>`     | No binding                                  | Remove — filtering not wired; the table shows all entries.                     |
+| `portfolio.vue:471-474` (empty state) | `action`/`secondary-href`      | Real (`@action` opens form, href `/tools`)  | Keep.                                                                          |
+
+## Summary of decisions
+
+- **Remove** (fabricated / no data source): monthly KPI card, yearly KPI card,
+  both benchmark pills, the synthetic "Evolução Patrimonial" performance chart +
+  its range tabs, the invented `projectedMonthlyContribution`.
+- **Fix to honest value**: `day_change_percent` literal → `null`.
+- **Remove dead CTAs**: hamburger, search box, notifications bell, "Exportar",
+  "Resgatar", position filter select.
+- **Keep** (real, query-backed): Patrimônio Total KPI, total-return pill,
+  "Aportar", allocation donut + list, detailed positions table, AI insight
+  surface, `NetWorthTimeline` (real projection — now fed `monthly-contribution=0`),
+  empty state, error/loading states.
+
+## Outcome
+
+PO suspicion **confirmed**. Multiple fabricated financial values and several
+dead CTAs in the nominal flow. Fixed per decisions above; no placeholder numbers
+remain in the nominal flow.


### PR DESCRIPTION
Closes #979

Auditoria da tela Carteira (`portfolio.vue`) confirmou a suspeita do PO. Removidos/corrigidos:
- Valores fabricados: `day_change 0.84%`, multiplicadores inventados de rentabilidade mês/ano, pills de benchmark Ibovespa/CDI hardcoded, série sintética do gráfico de evolução
- CTAs sem ação removidos: busca, sino de notificações, Exportar, Resgatar, abas de período (1M/6M/1A/TUDO), selects de mês e filtro
- 2 KPIs fabricados → cards com dados reais (Total Investido = total_cost+asset_count; Resultado Total = total_value−total_cost + % real, sign-aware)
- Pill do hero (Patrimônio Total) agora sign-aware (vermelho/seta-baixo em perda)
- Relatório: `docs/superpowers/reports/2026-06-02-wallet-audit.md`

Mantido o que era real (Patrimônio Total, alocação, tabela de posições, Aportar, AI surface, projeção NetWorthTimeline).
`pnpm quality-check` verde, cobertura ≥85%.