### PR TITLE
feat(insights): Transações mostra insight de hoje + accordion de passados (#980)

### DIFF
--- a/app/features/ai-insights/components/AiInsightSurface.spec.ts
+++ b/app/features/ai-insights/components/AiInsightSurface.spec.ts
@@ -128,6 +128,64 @@ describe("AiInsightSurface", () => {
     );
   });
 
+  it("renders the inline result by default when a current insight is set", () => {
+    useAIInsightsMock.mockReturnValue({
+      currentInsight: ref([
+        {
+          type: "padrao_gasto",
+          dimension: "transactions",
+          title: "Gastos do período",
+          message: "Suas despesas variáveis subiram.",
+        },
+      ]),
+      currentInsightId: ref("ins-99"),
+      insightPeriodLabel: ref("2026-06"),
+      isStale: ref(false),
+      insightModel: ref("gpt-4o"),
+      tokensUsed: ref(120),
+      costUsd: ref(0.00001),
+      forecast: ref(false),
+    });
+
+    const wrapper = mount(AiInsightSurface, {
+      props: { dimension: "transactions" },
+      global: { stubs },
+    });
+
+    expect(wrapper.find("[data-testid='ai-button']").exists()).toBe(true);
+    expect(wrapper.get("[data-testid='insight-section']").text()).toContain(
+      "Gastos do período",
+    );
+  });
+
+  it("suppresses the inline result when hideInlineResult is set but keeps the generate button", () => {
+    useAIInsightsMock.mockReturnValue({
+      currentInsight: ref([
+        {
+          type: "padrao_gasto",
+          dimension: "transactions",
+          title: "Gastos do período",
+          message: "Suas despesas variáveis subiram.",
+        },
+      ]),
+      currentInsightId: ref("ins-99"),
+      insightPeriodLabel: ref("2026-06"),
+      isStale: ref(false),
+      insightModel: ref("gpt-4o"),
+      tokensUsed: ref(120),
+      costUsd: ref(0.00001),
+      forecast: ref(false),
+    });
+
+    const wrapper = mount(AiInsightSurface, {
+      props: { dimension: "transactions", hideInlineResult: true },
+      global: { stubs },
+    });
+
+    expect(wrapper.find("[data-testid='ai-button']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='insight-section']").exists()).toBe(false);
+  });
+
   it("hides the feedback block when no insight id is available", () => {
     useAIInsightsMock.mockReturnValue({
       currentInsight: ref([

--- a/app/features/ai-insights/components/AiInsightSurface.spec.ts
+++ b/app/features/ai-insights/components/AiInsightSurface.spec.ts
@@ -184,6 +184,12 @@ describe("AiInsightSurface", () => {
 
     expect(wrapper.find("[data-testid='ai-button']").exists()).toBe(true);
     expect(wrapper.find("[data-testid='insight-section']").exists()).toBe(false);
+    // Feedback is intentionally NOT gated by hideInlineResult: Transactions
+    // users still rate the insight they just generated even though the inline
+    // result render is owned by the dedicated panel.
+    const feedback = wrapper.find("[data-testid='insight-feedback']");
+    expect(feedback.exists()).toBe(true);
+    expect(feedback.text()).toContain("ins-99");
   });
 
   it("hides the feedback block when no insight id is available", () => {

--- a/app/features/ai-insights/components/AiInsightSurface.vue
+++ b/app/features/ai-insights/components/AiInsightSurface.vue
@@ -16,11 +16,26 @@ import type {
   InsightSourceSurface,
 } from "~/features/ai-insights/contracts/ai-insight";
 
-const props = defineProps<{
-  dimension?: InsightDimension;
-  sourceSurface?: InsightSourceSurface;
-  anchorDate?: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    dimension?: InsightDimension;
+    sourceSurface?: InsightSourceSurface;
+    anchorDate?: string;
+    /**
+     * Opt-in flag to suppress the inline generated-insight result render,
+     * leaving the surface as a generate trigger only. Used on pages where a
+     * dedicated panel (e.g. TransactionsInsightPanel) owns rendering today's
+     * insight. The generate button, loading/consent and feedback UI remain.
+     */
+    hideInlineResult?: boolean;
+  }>(),
+  {
+    dimension: undefined,
+    sourceSurface: undefined,
+    anchorDate: undefined,
+    hideInlineResult: false,
+  },
+);
 
 const route = useRoute();
 const aiInsights = useAIInsights();
@@ -55,7 +70,15 @@ const visibleInsight = computed<InsightItem[] | null>(() => {
 
 const hasGeneratedInsight = computed(() => Boolean(aiInsights.currentInsight.value?.length));
 const shouldShowContextualEmptyState = computed(() =>
-  Boolean(resolvedDimension.value && hasGeneratedInsight.value && !visibleInsight.value?.length),
+  Boolean(
+    !props.hideInlineResult &&
+      resolvedDimension.value &&
+      hasGeneratedInsight.value &&
+      !visibleInsight.value?.length,
+  ),
+);
+const shouldShowInlineResult = computed(() =>
+  Boolean(!props.hideInlineResult && visibleInsight.value?.length),
 );
 </script>
 
@@ -63,7 +86,7 @@ const shouldShowContextualEmptyState = computed(() =>
   <section class="ai-insight-surface" aria-label="Insights de IA">
     <AiInsightButton :source-surface="resolvedSourceSurface" :anchor-date="anchorDate" />
     <AiInsightSection
-      v-if="visibleInsight?.length"
+      v-if="shouldShowInlineResult"
       :insight="visibleInsight"
       :period-label="aiInsights.insightPeriodLabel.value"
       :is-stale="aiInsights.isStale.value"

--- a/app/features/ai-insights/components/TransactionsInsightPanel.spec.ts
+++ b/app/features/ai-insights/components/TransactionsInsightPanel.spec.ts
@@ -1,6 +1,6 @@
 import { ref } from "vue";
 import { mount } from "@vue/test-utils";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import TransactionsInsightPanel from "./TransactionsInsightPanel.vue";
 import type { AIInsightDTO, AIInsightHistoryDTO } from "~/features/ai-insights/contracts/ai-insight";
@@ -67,19 +67,22 @@ const makeInsight = (id: string, createdAt: string): AIInsightDTO => ({
   created_at: createdAt,
 });
 
-/**
- * Returns today's local date as YYYY-MM-DD.
- *
- * @returns Local today ISO date.
- */
-const localToday = (): string => {
-  const now = new Date();
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(
-    now.getDate(),
-  ).padStart(2, "0")}`;
-};
+// Pin the clock so "today" is deterministic regardless of the runner's
+// timezone (the repo has a documented CI UTC-vs-local flake hazard). The
+// component derives today from `new Date()`; freezing it to noon UTC keeps the
+// fixture timestamp (2026-06-03T10:00:00Z) on the same local calendar day.
+const FIXED_TODAY = "2026-06-03";
 
 describe("TransactionsInsightPanel", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T12:00:00Z"));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     historyState.data.value = undefined;
     historyState.isLoading.value = false;
@@ -89,7 +92,7 @@ describe("TransactionsInsightPanel", () => {
   it("renders today's insight on top and past insights in the accordion below", () => {
     historyState.data.value = {
       items: [
-        makeInsight("today", `${localToday()}T10:00:00Z`),
+        makeInsight("today", `${FIXED_TODAY}T10:00:00Z`),
         makeInsight("yesterday", "2026-01-02T10:00:00Z"),
       ],
       page: 1,

--- a/app/features/ai-insights/components/TransactionsInsightPanel.spec.ts
+++ b/app/features/ai-insights/components/TransactionsInsightPanel.spec.ts
@@ -1,0 +1,157 @@
+import { ref } from "vue";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import TransactionsInsightPanel from "./TransactionsInsightPanel.vue";
+import type { AIInsightDTO, AIInsightHistoryDTO } from "~/features/ai-insights/contracts/ai-insight";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: (): { t: (k: string) => string } => ({ t: (k: string) => k }),
+}));
+vi.mock("#imports", () => ({
+  useI18n: (): { t: (k: string) => string } => ({ t: (k: string) => k }),
+}));
+
+const historyState = {
+  data: ref<AIInsightHistoryDTO | undefined>(undefined),
+  isLoading: ref(false),
+  isError: ref(false),
+};
+
+vi.mock("~/features/ai-insights/queries/use-ai-insights-history", () => ({
+  useAIInsightsHistory: (): typeof historyState => historyState,
+}));
+
+const stubs = {
+  NCollapse: { template: "<div data-testid='past-collapse'><slot /></div>" },
+  AiInsightSection: {
+    props: ["insight"],
+    template:
+      "<section data-testid='today-section'>{{ insight.map((item) => item.title).join(', ') }}</section>",
+  },
+  AiInsightAccordionItem: {
+    props: ["item"],
+    template: "<article data-testid='past-item'>{{ item.id }}</article>",
+  },
+  UiInlineError: { props: ["title", "message"], template: "<div data-testid='error'>{{ title }}</div>" },
+  AppSkeleton: { template: "<div data-testid='skeleton' />" },
+};
+
+/**
+ * Builds a transactions-dimension insight DTO for a given id and timestamp.
+ *
+ * @param id Insight id.
+ * @param createdAt ISO datetime string.
+ * @returns Insight history DTO entry.
+ */
+const makeInsight = (id: string, createdAt: string): AIInsightDTO => ({
+  id,
+  content: JSON.stringify({
+    summary: "",
+    items: [
+      {
+        type: "padrao_gasto",
+        dimension: "transactions",
+        title: `Insight ${id}`,
+        message: "Mensagem",
+      },
+    ],
+  }),
+  insight_type: "daily",
+  period_label: createdAt.slice(0, 10),
+  period_start: createdAt.slice(0, 10),
+  period_end: createdAt.slice(0, 10),
+  model: "gpt-4o-mini",
+  tokens_used: 100,
+  cost_usd: 0.0001,
+  created_at: createdAt,
+});
+
+/**
+ * Returns today's local date as YYYY-MM-DD.
+ *
+ * @returns Local today ISO date.
+ */
+const localToday = (): string => {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(
+    now.getDate(),
+  ).padStart(2, "0")}`;
+};
+
+describe("TransactionsInsightPanel", () => {
+  beforeEach(() => {
+    historyState.data.value = undefined;
+    historyState.isLoading.value = false;
+    historyState.isError.value = false;
+  });
+
+  it("renders today's insight on top and past insights in the accordion below", () => {
+    historyState.data.value = {
+      items: [
+        makeInsight("today", `${localToday()}T10:00:00Z`),
+        makeInsight("yesterday", "2026-01-02T10:00:00Z"),
+      ],
+      page: 1,
+      per_page: 20,
+      total: 2,
+    };
+
+    const wrapper = mount(TransactionsInsightPanel, { global: { stubs } });
+
+    expect(wrapper.get("[data-testid='transactions-today-insight']").text()).toContain(
+      "Insight today",
+    );
+    expect(wrapper.find("[data-testid='transactions-no-today']").exists()).toBe(false);
+
+    const pastItems = wrapper.findAll("[data-testid='past-item']");
+    expect(pastItems).toHaveLength(1);
+    expect(pastItems[0]?.text()).toBe("yesterday");
+  });
+
+  it("renders the alt copy plus the past accordion when no insight was generated today", () => {
+    historyState.data.value = {
+      items: [
+        makeInsight("yesterday", "2026-01-02T10:00:00Z"),
+        makeInsight("older", "2026-01-01T10:00:00Z"),
+      ],
+      page: 1,
+      per_page: 20,
+      total: 2,
+    };
+
+    const wrapper = mount(TransactionsInsightPanel, { global: { stubs } });
+
+    expect(wrapper.find("[data-testid='today-section']").exists()).toBe(false);
+    expect(wrapper.get("[data-testid='transactions-no-today']").text()).toBe(
+      "insights.history.noTodayYet",
+    );
+    expect(wrapper.findAll("[data-testid='past-item']")).toHaveLength(2);
+  });
+
+  it("shows the empty state when there are no insights at all", () => {
+    historyState.data.value = { items: [], page: 1, per_page: 20, total: 0 };
+
+    const wrapper = mount(TransactionsInsightPanel, { global: { stubs } });
+
+    expect(wrapper.text()).toContain("insights.history.empty");
+    expect(wrapper.find("[data-testid='today-section']").exists()).toBe(false);
+    expect(wrapper.find("[data-testid='past-item']").exists()).toBe(false);
+  });
+
+  it("renders a skeleton while the first history page is loading", () => {
+    historyState.isLoading.value = true;
+
+    const wrapper = mount(TransactionsInsightPanel, { global: { stubs } });
+
+    expect(wrapper.find("[data-testid='skeleton']").exists()).toBe(true);
+  });
+
+  it("renders an inline error when the history query fails", () => {
+    historyState.isError.value = true;
+
+    const wrapper = mount(TransactionsInsightPanel, { global: { stubs } });
+
+    expect(wrapper.get("[data-testid='error']").text()).toBe("insights.history.loadErrorTitle");
+  });
+});

--- a/app/features/ai-insights/components/TransactionsInsightPanel.vue
+++ b/app/features/ai-insights/components/TransactionsInsightPanel.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { NCollapse } from "naive-ui";
+
+import AiInsightAccordionItem from "./AiInsightAccordionItem.vue";
+import AiInsightSection from "./AiInsightSection.vue";
+import type { InsightDimension } from "~/features/ai-insights/contracts/ai-insight";
+import { splitTodayAndPast } from "~/features/ai-insights/model/insight-history";
+import { mapAIInsightDto, type AIInsight } from "~/features/ai-insights/model/ai-insight";
+import { useAIInsightsHistory } from "~/features/ai-insights/queries/use-ai-insights-history";
+
+const props = withDefaults(
+  defineProps<{
+    dimension?: InsightDimension;
+  }>(),
+  { dimension: "transactions" },
+);
+
+const { t } = useI18n();
+
+const historyQuery = useAIInsightsHistory();
+
+/**
+ * Resolves the local current date (YYYY-MM-DD) without UTC drift.
+ *
+ * @returns Today's date in the user's local timezone.
+ */
+const todayIso = computed(() => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+});
+
+const split = computed(() =>
+  splitTodayAndPast(historyQuery.data.value?.items ?? [], todayIso.value),
+);
+
+const todayInsight = computed<AIInsight | null>(() =>
+  split.value.todayInsight ? mapAIInsightDto(split.value.todayInsight) : null,
+);
+
+const pastInsights = computed<AIInsight[]>(() => split.value.past.map(mapAIInsightDto));
+
+const hasAnyInsight = computed(() =>
+  Boolean(todayInsight.value) || pastInsights.value.length > 0,
+);
+
+const isInitialLoading = computed(
+  () => historyQuery.isLoading.value && !historyQuery.data.value,
+);
+</script>
+
+<template>
+  <section class="transactions-insight-panel" aria-label="Histórico de insights de IA">
+    <UiInlineError
+      v-if="historyQuery.isError.value"
+      :title="t('insights.history.loadErrorTitle')"
+      :message="t('insights.history.loadErrorMessage')"
+    />
+
+    <AppSkeleton v-else-if="isInitialLoading" :rows="3" />
+
+    <p v-else-if="!hasAnyInsight" class="transactions-insight-panel__empty">
+      {{ t("insights.history.empty") }}
+    </p>
+
+    <template v-else>
+      <AiInsightSection
+        v-if="todayInsight"
+        :insight="todayInsight.items"
+        :dimension="props.dimension"
+        :period-label="todayInsight.periodLabel"
+        :is-stale="false"
+        :model="todayInsight.model"
+        :tokens-used="todayInsight.tokensUsed"
+        :cost-usd="todayInsight.costUsd"
+        data-testid="transactions-today-insight"
+      />
+      <p v-else class="transactions-insight-panel__no-today" data-testid="transactions-no-today">
+        {{ t("insights.history.noTodayYet") }}
+      </p>
+
+      <div v-if="pastInsights.length > 0" class="transactions-insight-panel__history">
+        <h3 class="transactions-insight-panel__history-title">
+          {{ t("insights.history.pastTitle") }}
+        </h3>
+        <NCollapse data-testid="transactions-past-insights">
+          <AiInsightAccordionItem
+            v-for="item in pastInsights"
+            :key="item.id"
+            :item="item"
+          />
+        </NCollapse>
+      </div>
+    </template>
+  </section>
+</template>
+
+<style scoped>
+.transactions-insight-panel {
+  display: grid;
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.transactions-insight-panel__empty,
+.transactions-insight-panel__no-today {
+  margin: 0;
+  padding: var(--space-3);
+  border: 1px dashed var(--color-outline-soft);
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  background: color-mix(in srgb, var(--color-bg-elevated) 86%, transparent);
+}
+
+.transactions-insight-panel__history {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.transactions-insight-panel__history-title {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+</style>

--- a/app/features/ai-insights/model/insight-history.spec.ts
+++ b/app/features/ai-insights/model/insight-history.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { splitTodayAndPast } from "./insight-history";
+import type { AIInsightDTO } from "~/features/ai-insights/contracts/ai-insight";
+
+/**
+ * Builds a minimal AIInsightDTO with a given id and created_at for tests.
+ *
+ * @param id Insight id.
+ * @param createdAt ISO datetime string.
+ * @returns Test insight DTO.
+ */
+const makeInsight = (id: string, createdAt: string): AIInsightDTO => ({
+  id,
+  content: "{}",
+  insight_type: "daily",
+  period_label: createdAt.slice(0, 10),
+  period_start: createdAt.slice(0, 10),
+  period_end: createdAt.slice(0, 10),
+  model: "gpt-4o-mini",
+  tokens_used: 100,
+  cost_usd: 0.0001,
+  created_at: createdAt,
+});
+
+const TODAY = "2026-06-03";
+
+describe("splitTodayAndPast", () => {
+  it("splits today's insight from past insights when a today item is present", () => {
+    const items = [
+      makeInsight("today", `${TODAY}T10:00:00Z`),
+      makeInsight("yesterday", "2026-06-02T10:00:00Z"),
+      makeInsight("older", "2026-06-01T10:00:00Z"),
+    ];
+
+    const result = splitTodayAndPast(items, TODAY);
+
+    expect(result.todayInsight?.id).toBe("today");
+    expect(result.past.map((item) => item.id)).toEqual(["yesterday", "older"]);
+  });
+
+  it("picks the most recent today insight when multiple exist regardless of input order", () => {
+    const items = [
+      makeInsight("today-early", `${TODAY}T08:00:00Z`),
+      makeInsight("today-late", `${TODAY}T18:00:00Z`),
+      makeInsight("yesterday", "2026-06-02T10:00:00Z"),
+    ];
+
+    const result = splitTodayAndPast(items, TODAY);
+
+    expect(result.todayInsight?.id).toBe("today-late");
+    expect(result.past.map((item) => item.id)).toEqual(["today-early", "yesterday"]);
+  });
+
+  it("returns null today insight and keeps every item in past when none was generated today", () => {
+    const items = [
+      makeInsight("yesterday", "2026-06-02T10:00:00Z"),
+      makeInsight("older", "2026-06-01T10:00:00Z"),
+    ];
+
+    const result = splitTodayAndPast(items, TODAY);
+
+    expect(result.todayInsight).toBeNull();
+    expect(result.past.map((item) => item.id)).toEqual(["yesterday", "older"]);
+  });
+
+  it("returns null today insight and an empty past list for an empty input", () => {
+    const result = splitTodayAndPast([], TODAY);
+
+    expect(result.todayInsight).toBeNull();
+    expect(result.past).toEqual([]);
+  });
+
+  it("orders past insights newest-first even when input is unsorted", () => {
+    const items = [
+      makeInsight("older", "2026-06-01T10:00:00Z"),
+      makeInsight("today", `${TODAY}T10:00:00Z`),
+      makeInsight("yesterday", "2026-06-02T10:00:00Z"),
+    ];
+
+    const result = splitTodayAndPast(items, TODAY);
+
+    expect(result.todayInsight?.id).toBe("today");
+    expect(result.past.map((item) => item.id)).toEqual(["yesterday", "older"]);
+  });
+});

--- a/app/features/ai-insights/model/insight-history.ts
+++ b/app/features/ai-insights/model/insight-history.ts
@@ -1,0 +1,46 @@
+import type { AIInsightDTO } from "~/features/ai-insights/contracts/ai-insight";
+
+export interface InsightHistorySplit {
+  readonly todayInsight: AIInsightDTO | null;
+  readonly past: AIInsightDTO[];
+}
+
+/**
+ * Returns the date portion (YYYY-MM-DD) of an ISO timestamp.
+ *
+ * @param createdAt ISO datetime string.
+ * @returns The first ten characters (date portion).
+ */
+const toDay = (createdAt: string): string => createdAt.slice(0, 10);
+
+/**
+ * Splits a list of insights into today's insight and the past history.
+ *
+ * "Today" is determined by comparing the date portion of `created_at` against
+ * `todayIso` (YYYY-MM-DD). The most recent insight generated today becomes
+ * `todayInsight`; every remaining insight (older today items plus all earlier
+ * days) goes to `past`, ordered newest-first. Input order is not trusted.
+ *
+ * @param items Raw insight history items.
+ * @param todayIso Local current date as YYYY-MM-DD.
+ * @returns The today/past split.
+ */
+export const splitTodayAndPast = (
+  items: AIInsightDTO[],
+  todayIso: string,
+): InsightHistorySplit => {
+  const sorted = [...items].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+
+  const todayIndex = sorted.findIndex((item) => toDay(item.created_at) === todayIso);
+
+  if (todayIndex === -1) {
+    return { todayInsight: null, past: sorted };
+  }
+
+  const todayInsight = sorted[todayIndex] ?? null;
+  const past = sorted.filter((_, index) => index !== todayIndex);
+
+  return { todayInsight, past };
+};

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -1822,6 +1822,15 @@
       "ctaUpgrade": "Ver planos"
     }
   },
+  "insights": {
+    "history": {
+      "pastTitle": "Insights anteriores",
+      "noTodayYet": "Você ainda não gerou um insight hoje — veja seus insights anteriores:",
+      "empty": "Nenhum insight gerado ainda. Gere o primeiro insight para começar.",
+      "loadErrorTitle": "Não foi possível carregar os insights",
+      "loadErrorMessage": "Tente novamente em alguns instantes."
+    }
+  },
   "transactions": {
     "title": "Transações",
     "subtitle": "Receitas e despesas registradas",

--- a/app/pages/transactions/index.vue
+++ b/app/pages/transactions/index.vue
@@ -11,6 +11,7 @@ import TransactionToolbar from "~/features/transactions/components/TransactionTo
 import TransactionExportModal from "~/features/transactions/components/TransactionExportModal.vue";
 import TransactionPaymentModal from "~/features/transactions/components/TransactionPaymentModal.vue";
 import AiInsightSurface from "~/features/ai-insights/components/AiInsightSurface.vue";
+import TransactionsInsightPanel from "~/features/ai-insights/components/TransactionsInsightPanel.vue";
 import { resolveInsightAnchorDate } from "~/features/ai-insights/model/ai-insight";
 import { formatCurrency } from "~/utils/currency";
 
@@ -218,6 +219,11 @@ const totalBalance = computed(() => totalIncome.value - totalExpense.value);
       class="transactions-page__ai-insights"
       dimension="transactions"
       :anchor-date="insightAnchorDate"
+    />
+
+    <TransactionsInsightPanel
+      class="transactions-page__ai-insights"
+      dimension="transactions"
     />
 
   </div>

--- a/app/pages/transactions/index.vue
+++ b/app/pages/transactions/index.vue
@@ -215,17 +215,15 @@ const totalBalance = computed(() => totalIncome.value - totalExpense.value);
     <!-- ── Financial calendar ──────────────────────────────────────────────── -->
     <FinancialCalendar v-else-if="viewMode === 'calendar'" class="transactions-page__calendar" @day-click="onDayClick" />
 
-    <AiInsightSurface
-      class="transactions-page__ai-insights"
-      dimension="transactions"
-      :anchor-date="insightAnchorDate"
-      :hide-inline-result="true"
-    />
+    <div class="transactions-page__ai-insights">
+      <AiInsightSurface
+        dimension="transactions"
+        :anchor-date="insightAnchorDate"
+        :hide-inline-result="true"
+      />
 
-    <TransactionsInsightPanel
-      class="transactions-page__ai-insights"
-      dimension="transactions"
-    />
+      <TransactionsInsightPanel dimension="transactions" />
+    </div>
 
   </div>
 </template>
@@ -349,10 +347,11 @@ const totalBalance = computed(() => totalIncome.value - totalExpense.value);
   overflow: hidden;
 }
 
+/* Wrapper only owns the spacing between the trigger surface and the history
+   panel; each component declares its own internal grid layout. */
 .transactions-page__ai-insights {
   display: grid;
-  gap: var(--space-3);
-  align-items: start;
+  gap: var(--space-4);
 }
 
 .transactions-page__table :deep(.tx-table-row) { cursor: default; transition: background-color 0.15s ease, transform 0.12s ease; }

--- a/app/pages/transactions/index.vue
+++ b/app/pages/transactions/index.vue
@@ -219,6 +219,7 @@ const totalBalance = computed(() => totalIncome.value - totalExpense.value);
       class="transactions-page__ai-insights"
       dimension="transactions"
       :anchor-date="insightAnchorDate"
+      :hide-inline-result="true"
     />
 
     <TransactionsInsightPanel


### PR DESCRIPTION
Closes #980

- `splitTodayAndPast(items, todayIso)` (model + TDD): separa o insight de hoje (`created_at` = hoje) dos passados.
- Novo `TransactionsInsightPanel`: hoje no topo + accordion de passados; quando não há insight hoje → texto alternativo + accordion. History-only (sem generate no load).
- `AiInsightSurface` ganha `hideInlineResult` (default false → outras 5 páginas inalteradas); na tela de Transações vira trigger de geração apenas → o painel é o único a renderizar o insight de hoje (sem duplicação). Feedback mantido no surface.
- i18n PT `insights.history.*`. Testes hermético (clock pinado). `pnpm quality-check` verde, cobertura ≥85%.