### PR TITLE
fix(dashboard): due-range query 400 + alinha specs E2E ao revamp

### DIFF
--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -81,9 +81,30 @@ const trendsSeries = computed(() => trendsQuery.data.value?.series ?? []);
 
 // ── Insight carousel data (replaces the empty month-over-month strip) ─────────
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const UPCOMING_WINDOW_DAYS = 30;
+
+/**
+ * Formats a Date as the YYYY-MM-DD key expected by the due-range endpoint.
+ *
+ * @param date Date to format.
+ * @returns ISO date string.
+ */
+function toDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
 
 const goalsQuery = useGoalsQuery();
-const dueRangeQuery = useDueRangeQuery();
+// The due-range endpoint requires at least one of start_date/end_date (400
+// otherwise), so always scope the upcoming-bills window explicitly.
+const dueRangeFilters = computed(() => {
+  const start = new Date();
+  const end = new Date(start.getTime() + UPCOMING_WINDOW_DAYS * MS_PER_DAY);
+  return { start_date: toDateKey(start), end_date: toDateKey(end) };
+});
+const dueRangeQuery = useDueRangeQuery(dueRangeFilters);
 
 const carouselDues = computed<CarouselDue[]>(() => {
   const items = dueRangeQuery.data.value?.transactions ?? [];

--- a/e2e/specs/ai-insights.spec.ts
+++ b/e2e/specs/ai-insights.spec.ts
@@ -160,8 +160,22 @@ const mockAuthenticatedInsights = async (page: Page): Promise<void> => {
 	await page.route("**/tags**", async (route) => json(route, { data: { tags: [] } }));
 	await page.route("**/accounts**", async (route) => json(route, { data: { accounts: [] } }));
 	await page.route("**/credit-cards**", async (route) => json(route, { data: { credit_cards: [] } }));
+	await page.route("**/goals", async (route) => json(route, { data: [] }));
 	await page.route("**/ai/insights/generate", async (route) => json(route, generatedInsight));
 	await page.route("**/ai/insights/history**", async (route) => json(route, insightHistory));
+};
+
+/**
+ * Builds the local current date as YYYY-MM-DD (matches the panel's todayIso).
+ *
+ * @returns Today's date in ISO date form.
+ */
+const localTodayIso = (): string => {
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = String(now.getMonth() + 1).padStart(2, "0");
+	const day = String(now.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
 };
 
 /**
@@ -198,6 +212,36 @@ const openInsightsHub = async (page: Page): Promise<void> => {
 test.describe("AI Insights — surface slices", () => {
 	test("transactions generates a global insight request and shows only transaction slice", async ({ page }) => {
 		await login(page);
+
+		// The transactions surface hides the inline result (PROD-13/#980) and shows
+		// the insight via TransactionsInsightPanel, which renders today's insight
+		// from /ai/insights/history. Seed a today-dated insight so the panel
+		// surfaces the transaction slice (past insights live in a collapsed list).
+		const todayIso = localTodayIso();
+		await page.route("**/ai/insights/history**", async (route) => json(route, {
+			success: true,
+			message: "Histórico de insights carregado",
+			data: {
+				items: [{
+					id: "ai-today",
+					content: JSON.stringify({ summary: "Resumo do período.", items: insightItems }),
+					items: insightItems,
+					insight_type: "daily",
+					period_type: "daily",
+					period_label: todayIso,
+					period_start: todayIso,
+					period_end: todayIso,
+					model: "gpt-4o-mini",
+					tokens_used: 320,
+					cost_usd: 0.000048,
+					created_at: `${todayIso}T08:15:00Z`,
+				}],
+				page: 1,
+				per_page: 20,
+				total: 1,
+			},
+		}));
+
 		await page.goto("/transactions");
 		await waitForHydration(page);
 

--- a/e2e/specs/dashboard.spec.ts
+++ b/e2e/specs/dashboard.spec.ts
@@ -179,6 +179,29 @@ const mockAuthAndDashboard = async (page: Page): Promise<void> => {
 			body: JSON.stringify({ data: { credit_cards: [] } }),
 		});
 	});
+
+	// Insight carousel data sources (PROD dashboard revamp).
+	await page.route("**/goals", (route) => {
+		route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({ data: [] }),
+		});
+	});
+
+	await page.route("**/transactions/due-range**", (route) => {
+		route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({
+				transactions: [],
+				total: 0,
+				page: 1,
+				per_page: 20,
+				counts: { total: 0, overdue: 0, pending: 0 },
+			}),
+		});
+	});
 };
 
 test.describe("Dashboard — MSW-backed flows", () => {
@@ -209,9 +232,11 @@ test.describe("Dashboard — MSW-backed flows", () => {
 
 		await expect(page.locator(".market-pulse")).toBeVisible({ timeout: 10_000 });
 		await expect(page.getByText("Receitas (Mês)")).toBeVisible();
-		await expect(page.getByText("Fluxo de Caixa Acumulado")).toBeVisible();
+		await expect(page.getByText("Fluxo de Caixa (mensal)")).toBeVisible();
 		await expect(page.getByText("Gastos por Categoria")).toBeVisible();
-		await expect(page.getByText("Comparativo com o mês anterior")).toBeVisible();
+		// The empty month-over-month strip was replaced by the insight carousel.
+		await expect(page.locator("[data-testid='dashboard-insight-carousel']")).toBeVisible();
+		await expect(page.getByText("Comparativo com o mês anterior")).toHaveCount(0);
 		await expect(page.getByText("Transações Recentes")).toHaveCount(0);
 		await expect(page.getByText("Anomalias Detectadas")).toHaveCount(0);
 		await expect(page.locator(".n-message")).toHaveCount(0);


### PR DESCRIPTION
## Contexto
Pós-revamp do dashboard: corrige um bug real + alinha os specs E2E (job estava vermelho em main).

## Fixes
- **fix(dashboard)**: o carrossel chamava `GET /transactions/due-range` sem params, mas o endpoint exige ao menos `start_date`/`end_date` (senão 400 — confirmado nos logs de prod). Agora escopa a janela 'Próximos vencimentos' para hoje..+30d.
- **test(e2e)**: dashboard.spec assert 'Fluxo de Caixa (mensal)' + carrossel (`data-testid=dashboard-insight-carousel`), 'Comparativo...' count 0, mocks de `/goals` e `/transactions/due-range`. ai-insights.spec (falha pré-existente do #980): semeia insight de hoje em `/ai/insights/history` para o slice de transactions ficar visível (resultado inline escondido por `hide-inline-result`).

## Verificação
E2E local: 10 passed / 0 failed (chromium + mobile-chrome). lint + typecheck limpos.

Closes #996