### PR TITLE
fix(auth): capture unexpected /auth/refresh failures in Sentry (#998)

### DIFF
--- a/app/composables/useHttp/useHttp.spec.ts
+++ b/app/composables/useHttp/useHttp.spec.ts
@@ -28,6 +28,11 @@ const messageStub = vi.hoisted(() => ({ error: vi.fn() }));
 const dialogStub = vi.hoisted(() => ({ warning: vi.fn() }));
 const verificationGateStub = vi.hoisted(() => ({ open: vi.fn() }));
 const navigateToMock = vi.hoisted(() => vi.fn());
+const captureExceptionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@sentry/nuxt", () => ({
+  captureException: captureExceptionMock,
+}));
 
 vi.mock("~/stores/session", () => ({
   useSessionStore: useSessionStoreMock,
@@ -217,6 +222,29 @@ describe("refreshAccessToken (SEC-GAP-01 — cookie-based)", () => {
     expect(sessionStore.signOut).toHaveBeenCalledOnce();
   });
 
+  it("captures unexpected refresh failures (network/CORS/5xx) in Sentry", async () => {
+    // A network error (no response) is the exact shape a blocked CORS preflight
+    // produces — the silent failure that masked #1437. It must reach Sentry.
+    const sessionStore = {
+      signOut: vi.fn(),
+      updateTokens: vi.fn(),
+    } as unknown as Parameters<typeof refreshAccessToken>[1];
+
+    const networkError = new Error("Network Error");
+    vi.spyOn(axios, "post").mockRejectedValueOnce(networkError);
+
+    await refreshAccessToken("http://api", sessionStore);
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      networkError,
+      expect.objectContaining({
+        tags: expect.objectContaining({ flow: "session-refresh" }),
+      }),
+    );
+    expect(sessionStore.signOut).toHaveBeenCalledOnce();
+  });
+
   it("signs out and returns null when the server returns 401 (expired cookie)", async () => {
     const sessionStore = {
       signOut: vi.fn(),
@@ -232,6 +260,24 @@ describe("refreshAccessToken (SEC-GAP-01 — cookie-based)", () => {
     const result = await refreshAccessToken("http://api", sessionStore);
 
     expect(result).toBeNull();
+    expect(sessionStore.signOut).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT capture a 401 in Sentry — an expired cookie is an expected sign-out", async () => {
+    const sessionStore = {
+      signOut: vi.fn(),
+      updateTokens: vi.fn(),
+    } as unknown as Parameters<typeof refreshAccessToken>[1];
+
+    const axiosError = Object.assign(new Error("Unauthorized"), {
+      isAxiosError: true,
+      response: { status: 401 },
+    });
+    vi.spyOn(axios, "post").mockRejectedValueOnce(axiosError);
+
+    await refreshAccessToken("http://api", sessionStore);
+
+    expect(captureExceptionMock).not.toHaveBeenCalled();
     expect(sessionStore.signOut).toHaveBeenCalledOnce();
   });
 });

--- a/app/composables/useHttp/useHttp.ts
+++ b/app/composables/useHttp/useHttp.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nuxt";
 import axios, { type AxiosInstance, type RawAxiosRequestHeaders } from "axios";
 import { useDialog } from "naive-ui";
 
@@ -126,7 +127,20 @@ export const refreshAccessToken = async (
       sessionStore.updateTokens(token);
     }
     return token;
-  } catch {
+  } catch (error) {
+    // A 401 means the refresh cookie is genuinely expired/absent — an expected
+    // sign-out, not an incident, so it stays out of Sentry to avoid flooding it
+    // on every normal session expiry. Anything else (network error, a blocked
+    // CORS preflight, 5xx — i.e. no/unexpected response) IS an incident and must
+    // be visible: this silent catch previously masked a CORS misconfig that
+    // logged users out on every reload (api #1437 / web #998).
+    const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+    if (status !== 401) {
+      Sentry.captureException(error, {
+        tags: { feature: "auth", flow: "session-refresh" },
+        extra: { apiBase, httpStatus: status ?? null },
+      });
+    }
     sessionStore.signOut();
     return null;
   }


### PR DESCRIPTION
## Contexto

O `catch {}` silencioso em `refreshAccessToken` engolia todo erro do `POST /auth/refresh` e só fazia `signOut()`, sem telemetria. Isso mascarou o bug api #1437 (CORS sem `X-CSRF-TOKEN` bloqueava o preflight) — usuários deslogados em todo reload e nada no Sentry.

## Mudança

No `catch`, distingue:
- **401** → cookie de refresh genuinamente expirado/ausente = sign-out esperado → **fora do Sentry** (evita ruído nos logouts normais).
- **Qualquer outro erro** (network error, preflight CORS bloqueado, 5xx, sem response) → **incidente** → `Sentry.captureException` com tags `feature=auth` / `flow=session-refresh` + status HTTP.

`signOut()` + `return null` preservados. Sem vazar segredos (o scrubber do `sentry.client.ts` já redige rotas `/auth/`; extra carrega só `apiBase`+status).

## Testes

- `captures unexpected refresh failures (network/CORS/5xx) in Sentry`
- `does NOT capture a 401 in Sentry`
- 26 testes do `useHttp.spec.ts` verdes; eslint + typecheck ok.

Closes #998