### PR TITLE
fix(goals): parse v2 paginated/wrapped envelopes (#1002)

### DIFF
--- a/app/features/goals/services/goals.client.spec.ts
+++ b/app/features/goals/services/goals.client.spec.ts
@@ -67,6 +67,33 @@ describe("GoalsClient", () => {
       expect(result).toEqual([]);
     });
 
+    it("unwraps the v2 paginated envelope ({data:{items:[...]}})", async () => {
+      vi.mocked(http.get).mockResolvedValueOnce({
+        data: {
+          success: true,
+          message: "Metas listadas com sucesso",
+          data: { items: [makeGoalDto(), makeGoalDto({ id: "goal-002", name: "Viagem" })] },
+          meta: { pagination: { page: 1, pages: 1, per_page: 10, total: 2 } },
+        },
+      });
+
+      const result = await client.listGoals();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.id).toBe("goal-001");
+      expect(result[1]?.name).toBe("Viagem");
+    });
+
+    it("returns an empty array for a paginated envelope with no items", async () => {
+      vi.mocked(http.get).mockResolvedValueOnce({
+        data: { success: true, data: { items: [] }, meta: { pagination: { total: 0 } } },
+      });
+
+      const result = await client.listGoals();
+
+      expect(result).toEqual([]);
+    });
+
     it("normalizes API title into the UI name field", async () => {
       vi.mocked(http.get).mockResolvedValueOnce({
         data: [
@@ -121,6 +148,36 @@ describe("GoalsClient", () => {
       });
       expect(JSON.stringify(vi.mocked(http.post).mock.calls[0]?.[1])).not.toContain("\"name\"");
       expect(result.name).toBe("PC AMD");
+    });
+
+    it("unwraps the v2 create envelope ({data:{goal:{...}}})", async () => {
+      vi.mocked(http.post).mockResolvedValueOnce({
+        data: {
+          success: true,
+          message: "Meta criada com sucesso",
+          data: {
+            goal: {
+              id: "748b822b",
+              title: "Montar PC novo",
+              description: "RTX 5080",
+              target_amount: "35000.00",
+              current_amount: "0.00",
+              target_date: "2026-12-31",
+              status: "active",
+              created_at: "2026-06-03T22:06:24Z",
+            },
+          },
+        },
+      });
+
+      const result = await client.createGoal({
+        name: "Montar PC novo",
+        target_amount: 35000,
+        target_date: "2026-12-31",
+      });
+
+      expect(result.id).toBe("748b822b");
+      expect(result.name).toBe("Montar PC novo");
     });
   });
 

--- a/app/features/goals/services/goals.client.ts
+++ b/app/features/goals/services/goals.client.ts
@@ -63,6 +63,24 @@ const normalizeGoal = (goal: GoalWireDto | GoalDto): GoalDto => {
 };
 
 /**
+ * Coerces a single-goal payload to the bare goal object.
+ *
+ * The v2 create/update endpoints wrap the goal as `{goal:{...}}` inside the
+ * envelope `data`; legacy/mocks return the goal fields directly. Unwrapping
+ * `{goal}` here keeps `normalizeGoal` working for both shapes (mapping the
+ * `{goal}` wrapper directly produced an empty `name`).
+ *
+ * @param unwrapped Envelope `data` already stripped of `{success,...}`.
+ * @returns The bare goal wire object.
+ */
+const coerceGoalObject = (unwrapped: GoalWireDto | { goal?: GoalWireDto }): GoalWireDto => {
+  if (unwrapped !== null && typeof unwrapped === "object" && "goal" in unwrapped) {
+    return (unwrapped.goal ?? {}) as GoalWireDto;
+  }
+  return unwrapped as GoalWireDto;
+};
+
+/**
  * Converts UI goal payloads to the v2 API payload shape.
  *
  * @param payload Goal payload produced by forms/composables.
@@ -112,8 +130,18 @@ export class GoalsClient {
    */
   async listGoals(): Promise<GoalDto[]> {
     try {
-      const response = await this.#http.get<ApiEnvelope<GoalWireDto[]> | GoalWireDto[]>("/goals");
-      return unwrapApiEnvelope<GoalWireDto[]>(response.data).map(normalizeGoal);
+      const response = await this.#http.get<
+        ApiEnvelope<GoalWireDto[] | { items?: GoalWireDto[] }> | GoalWireDto[]
+      >("/goals");
+      // The v2 list endpoint returns a paginated envelope `{data:{items:[...]}}`,
+      // while legacy/mocks return a bare array under `data`. Coerce both to an
+      // array before mapping — calling `.map` on the `{items}` object was the
+      // cause of the "Não foi possível carregar as metas" error.
+      const unwrapped = unwrapApiEnvelope<GoalWireDto[] | { items?: GoalWireDto[] }>(
+        response.data,
+      );
+      const list = Array.isArray(unwrapped) ? unwrapped : (unwrapped?.items ?? []);
+      return list.map(normalizeGoal);
     } catch (error) {
       if (isEmptyGoalsNotFound(error)) {
         return [];
@@ -130,11 +158,10 @@ export class GoalsClient {
    * @returns Created GoalDto.
    */
   async createGoal(payload: CreateGoalPayload): Promise<GoalDto> {
-    const response = await this.#http.post<ApiEnvelope<GoalWireDto> | GoalWireDto>(
-      "/goals",
-      toGoalWirePayload(payload),
-    );
-    return normalizeGoal(unwrapApiEnvelope<GoalWireDto>(response.data));
+    const response = await this.#http.post<
+      ApiEnvelope<GoalWireDto | { goal?: GoalWireDto }> | GoalWireDto
+    >("/goals", toGoalWirePayload(payload));
+    return normalizeGoal(coerceGoalObject(unwrapApiEnvelope(response.data)));
   }
 
   /**
@@ -145,11 +172,10 @@ export class GoalsClient {
    * @returns Updated GoalDto.
    */
   async updateGoal(id: string, payload: UpdateGoalPayload): Promise<GoalDto> {
-    const response = await this.#http.patch<ApiEnvelope<GoalWireDto> | GoalWireDto>(
-      `/goals/${id}`,
-      toGoalWirePayload(payload),
-    );
-    return normalizeGoal(unwrapApiEnvelope<GoalWireDto>(response.data));
+    const response = await this.#http.patch<
+      ApiEnvelope<GoalWireDto | { goal?: GoalWireDto }> | GoalWireDto
+    >(`/goals/${id}`, toGoalWirePayload(payload));
+    return normalizeGoal(coerceGoalObject(unwrapApiEnvelope(response.data)));
   }
 
   /**


### PR DESCRIPTION
## Problema
`/goals` mostrava "Não foi possível carregar as metas" e o widget "Progresso de metas" ficava vazio mesmo com metas criadas.

## Causa
`listGoals` fazia `.map` sobre o envelope `data` (=`{items:[...]}` no v2 paginado) → lançava. `createGoal`/`updateGoal` idem: resposta é `{data:{goal:{...}}}`.

## Fix
- `listGoals` coage para array (`.items` ou array bare).
- `createGoal`/`updateGoal` extraem `.goal`.
- Mantém 404→[] e normalização title→name. +5 testes (10 no spec, verde; eslint+typecheck ok).

Closes #1002