### PR TITLE
fix(transactions): unwrap v2 envelope in due-range client (#1004)

### DIFF
--- a/app/features/transactions/services/due-range.client.spec.ts
+++ b/app/features/transactions/services/due-range.client.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import type { AxiosInstance } from "axios";
+
+import type { DueRangeResponseDto } from "~/features/transactions/contracts/due-range.dto";
+
+const { useHttpMock } = vi.hoisted(() => ({ useHttpMock: vi.fn() }));
+vi.mock("~/composables/useHttp", () => ({ useHttp: useHttpMock }));
+
+const { useDueRangeClient } = await import("./due-range.client");
+
+const innerPayload: DueRangeResponseDto = {
+  transactions: [
+    {
+      id: "tx-1",
+      title: "Conta de luz",
+      amount: "485.00",
+      type: "expense",
+      due_date: "2026-06-10",
+      status: "pending",
+      tag_id: null,
+      account_id: null,
+      credit_card_id: null,
+      is_recurring: false,
+    },
+  ],
+  total: 1,
+  page: 1,
+  per_page: 10,
+  counts: { total: 1, overdue: 0, pending: 1 },
+};
+
+describe("useDueRangeClient.getDueRange", () => {
+  it("unwraps the v2 envelope ({data:{transactions,counts}})", async () => {
+    const get = vi.fn().mockResolvedValueOnce({
+      data: { success: true, message: "ok", data: innerPayload },
+    });
+    useHttpMock.mockReturnValue({ get } as unknown as AxiosInstance);
+
+    const result = await useDueRangeClient().getDueRange({ start_date: "2026-06-03" });
+
+    expect(result.transactions).toHaveLength(1);
+    expect(result.transactions[0]?.title).toBe("Conta de luz");
+    expect(get).toHaveBeenCalledWith("/transactions/due-range", {
+      params: { start_date: "2026-06-03" },
+    });
+  });
+
+  it("accepts a flat (non-enveloped) body for backward compatibility", async () => {
+    const get = vi.fn().mockResolvedValueOnce({ data: innerPayload });
+    useHttpMock.mockReturnValue({ get } as unknown as AxiosInstance);
+
+    const result = await useDueRangeClient().getDueRange();
+
+    expect(result.transactions).toHaveLength(1);
+  });
+});

--- a/app/features/transactions/services/due-range.client.ts
+++ b/app/features/transactions/services/due-range.client.ts
@@ -21,6 +21,40 @@ export interface DueRangeClient {
 }
 
 /**
+ * Builds the query-string params from the optional filters.
+ *
+ * @param filters Optional due-range filters.
+ * @returns Sparse params object (only provided keys).
+ */
+const buildDueRangeParams = (filters?: DueRangeFilters): Record<string, string | number> => {
+  const params: Record<string, string | number> = {};
+  if (filters?.start_date) { params["start_date"] = filters.start_date; }
+  if (filters?.end_date) { params["end_date"] = filters.end_date; }
+  if (filters?.order_by) { params["order_by"] = filters.order_by; }
+  if (filters?.page !== undefined) { params["page"] = filters.page; }
+  if (filters?.per_page !== undefined) { params["per_page"] = filters.per_page; }
+  return params;
+};
+
+/**
+ * Unwraps the v2 envelope `{data:{...}}`, tolerating a flat legacy body.
+ *
+ * Returning the raw body left `.transactions` undefined and emptied the
+ * "Próximos vencimentos" widget.
+ *
+ * @param body Raw response body.
+ * @returns Inner due-range payload.
+ */
+const unwrapDueRange = (
+  body: DueRangeResponseDto | { data?: DueRangeResponseDto },
+): DueRangeResponseDto => {
+  if (body && typeof body === "object" && "data" in body && body.data) {
+    return body.data;
+  }
+  return body as DueRangeResponseDto;
+};
+
+/**
  * Creates a DueRangeClient backed by the real Auraxis HTTP layer.
  *
  * @returns DueRangeClient instance.
@@ -30,18 +64,10 @@ export function useDueRangeClient(): DueRangeClient {
 
   return {
     async getDueRange(filters?: DueRangeFilters): Promise<DueRangeResponseDto> {
-      const params: Record<string, string | number> = {};
-      if (filters?.start_date) { params["start_date"] = filters.start_date; }
-      if (filters?.end_date) { params["end_date"] = filters.end_date; }
-      if (filters?.order_by) { params["order_by"] = filters.order_by; }
-      if (filters?.page !== undefined) { params["page"] = filters.page; }
-      if (filters?.per_page !== undefined) { params["per_page"] = filters.per_page; }
-
-      const response = await http.get<DueRangeResponseDto>(
-        "/transactions/due-range",
-        { params },
-      );
-      return response.data;
+      const response = await http.get<
+        DueRangeResponseDto | { data?: DueRangeResponseDto }
+      >("/transactions/due-range", { params: buildDueRangeParams(filters) });
+      return unwrapDueRange(response.data);
     },
   };
 }


### PR DESCRIPTION
## Problema
"Próximos vencimentos" no dashboard sempre vazio, mesmo com vencimentos pendentes.

## Causa
`getDueRange` retornava `response.data` direto; o corpo v2 é `{data:{counts,transactions}}`, então `dueRangeQuery.data.value?.transactions` ficava `undefined`.

## Fix
Desembrulha o envelope (`.data`, com fallback flat). +spec (envelope v2 + flat). eslint/typecheck ok.

Closes #1004