### PR TITLE
fix(ci): correct TruffleHog base ref on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,10 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
+          # On pull_request, diff against the PR base; on push (incl. to main)
+          # diff against the previous tip. Using the default branch as base on a
+          # push to main makes BASE == HEAD, which the action rejects (exit 1).
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           head: HEAD
           extra_args: --only-verified
 


### PR DESCRIPTION
Secret Scan (TruffleHog) é required e falhava em push p/ main (BASE==HEAD). Mesmo fix do auraxis-api #1451: base condicional (PR base sha em PR, github.event.before em push).

Closes #1014