### PR TITLE
fix(ai): stop retrying 429 daily-limit (mata chamadas duplicadas de insight)

### DIFF
--- a/app/core/http/__tests__/retry-config.spec.ts
+++ b/app/core/http/__tests__/retry-config.spec.ts
@@ -7,8 +7,8 @@ import { DEFAULT_RETRY_CONFIG, isRetryableStatus } from "../retry-config";
 // ---------------------------------------------------------------------------
 
 describe("isRetryableStatus", () => {
-  it("retorna true para 429 (rate-limit)", () => {
-    expect(isRetryableStatus(429)).toBe(true);
+  it("retorna false para 429 (AI daily limit nao e transiente)", () => {
+    expect(isRetryableStatus(429)).toBe(false);
   });
 
   it("retorna true para 502 (Bad Gateway)", () => {
@@ -107,8 +107,8 @@ describe("DEFAULT_RETRY_CONFIG.retryCondition", () => {
     expect(retryCondition(makeError(504))).toBe(true);
   });
 
-  it("retorna true para 429 (rate-limit)", () => {
-    expect(retryCondition(makeError(429))).toBe(true);
+  it("retorna false para 429 (AI daily limit nao e transiente)", () => {
+    expect(retryCondition(makeError(429))).toBe(false);
   });
 
   it("retorna false para 401", () => {

--- a/app/core/http/retry-config.ts
+++ b/app/core/http/retry-config.ts
@@ -3,15 +3,18 @@ import axiosRetry, { type IAxiosRetryConfig } from "axios-retry";
 /**
  * HTTP status codes that qualify for automatic retry.
  *
- * - 429: Too Many Requests (rate-limit)
  * - 502: Bad Gateway
  * - 503: Service Unavailable
  * - 504: Gateway Timeout
  *
- * 4xx errors other than 429 are intentionally excluded — they indicate
- * client-side faults (auth, validation) that retrying cannot fix.
+ * 4xx errors are intentionally excluded — they indicate client-side faults
+ * (auth, validation) that retrying cannot fix. 429 in particular is excluded:
+ * the AI insights daily limit returns 429 `AI_DAILY_LIMIT_EXCEEDED`, a hard
+ * per-day cap that never clears on immediate retry — retrying it only triples
+ * the request count (1 + 2 retries) and risks racing the server-side quota
+ * counter. Genuine transient back-pressure is covered by the 5xx codes.
  */
-const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
+const RETRYABLE_STATUSES = new Set([502, 503, 504]);
 
 /**
  * Returns true when the response status code is eligible for retry.

--- a/app/features/ai-insights/queries/use-generate-ai-insight.ts
+++ b/app/features/ai-insights/queries/use-generate-ai-insight.ts
@@ -56,6 +56,9 @@ export const useGenerateAIInsight = (
       ...(variables?.anchorDate ? { anchorDate: variables.anchorDate } : {}),
       ...(variables?.sourceSurface ? { sourceSurface: variables.sourceSurface } : {}),
     }),
+    // Generation is a one-shot user action; a 429 daily-limit (or any error) is
+    // a legitimate terminal response, never a transient failure to retry.
+    retry: false,
     onSuccess: async (): Promise<void> => {
       await Promise.all(INVALIDATION_KEYS.map((queryKey) => invalidate(queryKey)));
     },

--- a/app/plugins/__tests__/vue-query.spec.ts
+++ b/app/plugins/__tests__/vue-query.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiError } from "~/utils/apiError";
+import { shouldRetryQuery } from "~/plugins/vue-query";
+
+describe("shouldRetryQuery", () => {
+  it("nao retenta 429 (AI daily limit nao e transiente)", () => {
+    expect(shouldRetryQuery(0, new ApiError(429, "limit", "AI_DAILY_LIMIT_EXCEEDED"))).toBe(false);
+  });
+
+  it("nao retenta outros 4xx (401/403/400/404)", () => {
+    for (const status of [400, 401, 403, 404]) {
+      expect(shouldRetryQuery(0, new ApiError(status, "client error"))).toBe(false);
+    }
+  });
+
+  it("retenta 5xx ate o limite", () => {
+    expect(shouldRetryQuery(0, new ApiError(503, "unavailable"))).toBe(true);
+    expect(shouldRetryQuery(1, new ApiError(503, "unavailable"))).toBe(true);
+    expect(shouldRetryQuery(2, new ApiError(503, "unavailable"))).toBe(false);
+  });
+
+  it("retenta erro sem status (rede) ate o limite", () => {
+    expect(shouldRetryQuery(0, new Error("network"))).toBe(true);
+    expect(shouldRetryQuery(2, new Error("network"))).toBe(false);
+  });
+});

--- a/app/plugins/vue-query.ts
+++ b/app/plugins/vue-query.ts
@@ -1,5 +1,7 @@
 import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
 
+import { ApiError } from "~/utils/apiError";
+
 /**
  * Exponential back-off for Vue Query retries (mirrors axios-retry logic).
  *
@@ -11,6 +13,27 @@ import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
  */
 const queryRetryDelay = (attemptIndex: number): number =>
   Math.min(1_000 * 2 ** attemptIndex, 10_000);
+
+/** Max query retries on the client before surfacing the error. */
+const MAX_QUERY_RETRIES = 2;
+
+/**
+ * Retry predicate for Vue Query: never retry a 4xx (client faults like 401/403
+ * validation, and the AI `429 AI_DAILY_LIMIT_EXCEEDED` hard cap which never
+ * clears on retry). Transient failures (5xx, network errors without an
+ * ApiError status) fall back to the bounded retry count.
+ *
+ * @param failureCount Zero-based count of failures so far.
+ * @param error The error thrown by the query function.
+ * @returns Whether the query should be retried.
+ */
+export const shouldRetryQuery = (failureCount: number, error: unknown): boolean => {
+  const status = error instanceof ApiError ? error.status : undefined;
+  if (status !== undefined && status >= 400 && status < 500) {
+    return false;
+  }
+  return failureCount < MAX_QUERY_RETRIES;
+};
 
 /**
  * Instantiates a QueryClient with conservative defaults for server state.
@@ -24,7 +47,7 @@ const createQueryClient = (): QueryClient => {
       queries: {
         staleTime: 30_000,
         gcTime: isServer ? 0 : 300_000,
-        retry: isServer ? false : 2,
+        retry: isServer ? false : shouldRetryQuery,
         retryDelay: queryRetryDelay,
         refetchOnWindowFocus: false,
       },


### PR DESCRIPTION
## Problema
Endpoints de IA retornam 429 `AI_DAILY_LIMIT_EXCEEDED` (cota dura de 1/dia). O axios (`retry-config.ts`) **retentava 429** → 1 + 2 = **3 requests** por chamada; o Vue Query default retentava qualquer erro 2x. Isso amplificava o consumo e arriscava race no contador do servidor.

## Fix
- `retry-config`: remove 429 do `RETRYABLE_STATUSES` (mantém 5xx + rede).
- `vue-query`: predicado de retry que **nunca** retenta 4xx.
- `use-generate-ai-insight`: `retry: false` explícito na mutation de geração.

## Verificação
- `pnpm typecheck` + suite Vitest verde (novos testes de retry-config e do predicado).
- Clique 'gerar insight' → 1 request (não 3).

Parte de #1016. A3 (dashboard lê do read-only) vem em PR separado após o endpoint backend (api #1455).