### PR TITLE
fix(auth): single-flight unificado de /auth/refresh (F5 não desloga mais)

### DIFF
--- a/app/composables/useHttp/useHttp.spec.ts
+++ b/app/composables/useHttp/useHttp.spec.ts
@@ -280,6 +280,34 @@ describe("refreshAccessToken (SEC-GAP-01 — cookie-based)", () => {
     expect(captureExceptionMock).not.toHaveBeenCalled();
     expect(sessionStore.signOut).toHaveBeenCalledOnce();
   });
+
+  it("is single-flight: N concurrent callers share ONE POST /auth/refresh", async () => {
+    const sessionStore = {
+      signOut: vi.fn(),
+      updateTokens: vi.fn(),
+      signIn: vi.fn(),
+    } as unknown as Parameters<typeof refreshAccessToken>[1];
+
+    let resolvePost: ((value: unknown) => void) | undefined;
+    const postSpy = vi.spyOn(axios, "post").mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePost = resolve;
+        }),
+    );
+
+    // Fire three concurrent refreshes (boot plugin + middleware + a 401 retry).
+    const calls = [
+      refreshAccessToken("http://api", sessionStore),
+      refreshAccessToken("http://api", sessionStore),
+      refreshAccessToken("http://api", sessionStore),
+    ];
+    resolvePost?.({ data: { success: true, data: { token: "shared-token" } } });
+    const results = await Promise.all(calls);
+
+    expect(postSpy).toHaveBeenCalledOnce();
+    expect(results).toEqual(["shared-token", "shared-token", "shared-token"]);
+  });
 });
 
 describe("CSRF double-submit (SEC-AUD-03)", () => {

--- a/app/composables/useHttp/useHttp.ts
+++ b/app/composables/useHttp/useHttp.ts
@@ -95,7 +95,7 @@ export const readCookieValue = (name: string): string | null => {
  * @param sessionStore Active session Pinia store instance.
  * @returns New access token, or null if the refresh failed.
  */
-export const refreshAccessToken = async (
+const performRefreshRequest = async (
   apiBase: string,
   sessionStore: ReturnType<typeof useSessionStore>,
 ): Promise<string | null> => {
@@ -144,6 +144,40 @@ export const refreshAccessToken = async (
     sessionStore.signOut();
     return null;
   }
+};
+
+/**
+ * Process-wide in-flight refresh promise, shared by every caller so a boot/F5
+ * never fires more than one POST /auth/refresh. See {@link refreshAccessToken}.
+ */
+let inFlightRefresh: Promise<string | null> | null = null;
+
+/**
+ * Process-wide single-flight for POST /auth/refresh.
+ *
+ * Every refresh caller shares one in-flight promise: the boot session-restore
+ * (plugin + `authenticated` middleware via `runSessionRestore`) AND the 401
+ * interceptor (`createSharedRefresh`) previously had independent single-flight
+ * guards, so on boot/F5 they could fire two concurrent refreshes. With token
+ * rotation + reuse-detection on the backend, the loser presented a just-rotated
+ * token and the whole session got revoked → F5 logout (#1023). Collapsing all
+ * callers onto one shared promise means a reload triggers exactly one refresh.
+ *
+ * @param apiBase Absolute base URL of the Auraxis API.
+ * @param sessionStore Active session Pinia store instance.
+ * @returns New access token, or null if the refresh failed.
+ */
+export const refreshAccessToken = (
+  apiBase: string,
+  sessionStore: ReturnType<typeof useSessionStore>,
+): Promise<string | null> => {
+  if (inFlightRefresh) {
+    return inFlightRefresh;
+  }
+  inFlightRefresh = performRefreshRequest(apiBase, sessionStore).finally(() => {
+    inFlightRefresh = null;
+  });
+  return inFlightRefresh;
 };
 
 /**


### PR DESCRIPTION
## Problema
F5/boot disparava `POST /auth/refresh` **concorrente**: o plugin/middleware de sessão (`runSessionRestore`) e o interceptor 401 (`createSharedRefresh`) tinham single-flights **separados**. Com rotação + reuse-detection no backend, o perdedor apresentava o token recém-rotacionado → a sessão era revogada → logout no F5.

## Fix
`refreshAccessToken` vira single-flight a **nível de módulo** — todos os callers compartilham um único in-flight. Um reload dispara **exatamente 1** refresh.

## Verificação
Vitest: novo teste 'N concurrent callers share ONE POST'; 3726 testes verdes; typecheck/lint ok.

Closes #1023
Par do fix backend (api #1458, grace window).