### PR TITLE
feat(goals): registrar entrada/retirada + timeline de contribuições

### DIFF
--- a/app/components/goal/GoalCard/GoalCard.spec.ts
+++ b/app/components/goal/GoalCard/GoalCard.spec.ts
@@ -136,6 +136,22 @@ describe("GoalCard", () => {
     expect(wrapper.emitted("show-plan")).toBeTruthy();
   });
 
+  it("emits register-contribution when the register button is clicked", async () => {
+    const wrapper = mountGoalCard(makeGoal());
+    const buttons = wrapper.findAll("button");
+    const registerButton = buttons.find((b) => b.text().includes("Registrar entrada"));
+    expect(registerButton).toBeTruthy();
+    await registerButton!.trigger("click");
+    expect(wrapper.emitted("register-contribution")).toBeTruthy();
+  });
+
+  it("renders the remaining amount toward the target", () => {
+    const wrapper = mountGoalCard(makeGoal({ current_amount: 4000, target_amount: 10000 }));
+    // Remaining = 6000; the card shows a formatted BRL value.
+    expect(wrapper.text()).toContain("Faltam");
+    expect(wrapper.text()).toContain("R$");
+  });
+
   // ── Health indicator ──────────────────────────────────────────────────────
 
   it("shows completed health when current_amount equals target_amount", () => {

--- a/app/components/goal/GoalCard/GoalCard.vue
+++ b/app/components/goal/GoalCard/GoalCard.vue
@@ -23,6 +23,7 @@ const emit = defineEmits<{
   edit: [];
   "show-plan": [];
   delete: [];
+  "register-contribution": [];
 }>();
 
 /**
@@ -100,6 +101,10 @@ const progressPercent = computed(() => {
   );
 });
 
+const remainingAmount = computed(() =>
+  Math.max(props.goal.target_amount - props.goal.current_amount, 0),
+);
+
 /**
  * Derives a health status from the goal's progress and deadline proximity.
  *
@@ -172,9 +177,14 @@ const healthLabel = computed((): string => {
           :height="8"
           :border-radius="4"
         />
-        <span class="goal-card__health" :class="`goal-card__health--${healthStatus}`">
-          {{ healthLabel }}
-        </span>
+        <div class="goal-card__progress-meta">
+          <span class="goal-card__health" :class="`goal-card__health--${healthStatus}`">
+            {{ healthLabel }}
+          </span>
+          <span class="goal-card__remaining">
+            {{ $t('goal.card.remaining', { amount: formatCurrency(remainingAmount) }) }}
+          </span>
+        </div>
       </div>
 
       <div class="goal-card__stats">
@@ -189,6 +199,16 @@ const healthLabel = computed((): string => {
           class="goal-card__stat"
         />
       </div>
+
+      <NButton
+        class="goal-card__register"
+        type="primary"
+        size="small"
+        block
+        @click="emit('register-contribution')"
+      >
+        {{ $t('goal.card.registerContribution') }}
+      </NButton>
 
       <div class="goal-card__footer">
         <span class="goal-card__target-date">
@@ -290,9 +310,25 @@ const healthLabel = computed((): string => {
   color: var(--color-text-muted);
 }
 
+.goal-card__progress-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.goal-card__remaining {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.goal-card__register {
+  margin-bottom: var(--space-2);
+}
+
 .goal-card__health {
   display: inline-block;
-  margin-top: var(--space-1);
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
 }

--- a/app/components/goal/GoalContributionModal/GoalContributionModal.types.ts
+++ b/app/components/goal/GoalContributionModal/GoalContributionModal.types.ts
@@ -1,0 +1,16 @@
+import type { GoalDto } from "~/features/goals/contracts/goal.dto";
+
+/** Props for the GoalContributionModal component. */
+export type GoalContributionModalProps = {
+  /** Controls modal visibility. */
+  visible: boolean;
+  /** Goal the contribution will be recorded against. */
+  goal: GoalDto;
+};
+
+/** Emits for the GoalContributionModal component. */
+export type GoalContributionModalEmits = {
+  "update:visible": [value: boolean];
+  /** Emitted after a contribution is successfully recorded. */
+  recorded: [];
+};

--- a/app/components/goal/GoalContributionModal/GoalContributionModal.vue
+++ b/app/components/goal/GoalContributionModal/GoalContributionModal.vue
@@ -1,0 +1,238 @@
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from "vue";
+import { NModal, NForm, NFormItem, NInput, NDatePicker, NButton, NSpace } from "naive-ui";
+
+import UiSegmentedControl from "~/components/ui/UiSegmentedControl/UiSegmentedControl.vue";
+import UiMoneyInput from "~/components/ui/UiMoneyInput/UiMoneyInput.vue";
+import { useToast } from "~/composables/useToast";
+import { useRecordContributionMutation } from "~/features/goals/queries/use-record-contribution-mutation";
+import {
+  computeSignedAmount,
+  type ContributionDirection,
+} from "~/features/goals/model/contribution-amount";
+import type { ApiError } from "~/core/errors";
+import type {
+  GoalContributionModalProps,
+  GoalContributionModalEmits,
+} from "./GoalContributionModal.types";
+
+/** Maximum length accepted for the optional note. */
+const NOTE_MAX_LENGTH = 200;
+
+const { t } = useI18n();
+const toast = useToast();
+
+const props = defineProps<GoalContributionModalProps>();
+const emit = defineEmits<GoalContributionModalEmits>();
+
+const goalId = computed(() => props.goal.id);
+const mutation = useRecordContributionMutation(goalId.value);
+
+/**
+ * Returns today's date (local) as a YYYY-MM-DD string.
+ *
+ * @returns Today's date in ISO YYYY-MM-DD form.
+ */
+const todayIso = (): string => {
+  const now = new Date();
+  const offsetMs = now.getTimezoneOffset() * 60_000;
+  return new Date(now.getTime() - offsetMs).toISOString().slice(0, 10);
+};
+
+const formModel = reactive({
+  magnitude: null as number | null,
+  direction: "deposit" as ContributionDirection,
+  occurred_at: todayIso(),
+  note: "" as string,
+});
+
+const formError = ref<string | null>(null);
+
+const DIRECTION_OPTIONS = computed(
+  (): Array<{ value: ContributionDirection; label: string }> => [
+    { value: "deposit", label: t("goal.contribution.direction.deposit") },
+    { value: "withdrawal", label: t("goal.contribution.direction.withdrawal") },
+  ],
+);
+
+const isSubmitting = computed(() => mutation.isPending.value);
+
+const signedAmount = computed(() =>
+  computeSignedAmount(formModel.magnitude, formModel.direction),
+);
+
+/** Converts the YYYY-MM-DD model value to a timestamp for NDatePicker. */
+const datePickerValue = computed<number | null>(() => {
+  if (!formModel.occurred_at) {
+    return null;
+  }
+  return new Date(`${formModel.occurred_at}T00:00:00`).getTime();
+});
+
+/**
+ * Disables any date strictly after today so future contributions are rejected
+ * at the picker, matching the backend validation.
+ *
+ * @param ts Candidate timestamp from NDatePicker (ms).
+ * @returns True when the date must be disabled.
+ */
+const isFutureDate = (ts: number): boolean => {
+  const candidate = new Date(ts);
+  candidate.setHours(0, 0, 0, 0);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return candidate.getTime() > today.getTime();
+};
+
+/**
+ * Converts the NDatePicker timestamp back to a YYYY-MM-DD string, keeping today
+ * when the field is cleared.
+ *
+ * @param ts Timestamp in milliseconds, or null when cleared.
+ */
+const onDateUpdate = (ts: number | null): void => {
+  formModel.occurred_at = ts === null ? todayIso() : (new Date(ts).toISOString().slice(0, 10));
+};
+
+/** Resets the form to its default state. */
+const resetForm = (): void => {
+  formModel.magnitude = null;
+  formModel.direction = "deposit";
+  formModel.occurred_at = todayIso();
+  formModel.note = "";
+  formError.value = null;
+};
+
+watch(
+  () => props.visible,
+  (visible) => {
+    if (visible) {
+      resetForm();
+    }
+  },
+);
+
+/** Closes the modal by emitting update:visible=false. */
+const onClose = (): void => {
+  emit("update:visible", false);
+};
+
+/**
+ * Maps a mutation error to a friendly message, special-casing the backend
+ * INSUFFICIENT_BALANCE code for withdrawals that would drive the balance below
+ * zero.
+ *
+ * @param error Typed ApiError raised by the mutation.
+ * @returns Localised, user-facing error message.
+ */
+const resolveErrorMessage = (error: ApiError): string => {
+  if (error.code === "INSUFFICIENT_BALANCE") {
+    return t("goal.contribution.toast.insufficientBalance");
+  }
+  return t("goal.contribution.toast.error");
+};
+
+/** Validates the form then records the contribution. */
+const onConfirm = (): void => {
+  const amount = signedAmount.value;
+  if (amount === null) {
+    formError.value = t("goal.contribution.amount.required");
+    return;
+  }
+  formError.value = null;
+
+  mutation.mutate(
+    {
+      amount,
+      occurred_at: formModel.occurred_at,
+      ...(formModel.note.trim() ? { note: formModel.note.trim() } : {}),
+    },
+    {
+      onSuccess: (): void => {
+        toast.success(t("goal.contribution.toast.success"));
+        emit("recorded");
+        emit("update:visible", false);
+      },
+      onError: (error: ApiError): void => {
+        toast.error(resolveErrorMessage(error));
+      },
+    },
+  );
+};
+</script>
+
+<template>
+  <NModal
+    :show="props.visible"
+    :title="$t('goal.contribution.title')"
+    preset="card"
+    class="goal-contribution-modal"
+    style="width: min(480px, calc(100vw - 32px));"
+    :mask-closable="!isSubmitting"
+    @update:show="(v) => emit('update:visible', v)"
+  >
+    <NForm :model="formModel" label-placement="top">
+      <NFormItem :label="$t('goal.contribution.direction.label')">
+        <UiSegmentedControl
+          v-model="formModel.direction"
+          :options="DIRECTION_OPTIONS"
+          :aria-label="$t('goal.contribution.direction.label')"
+        />
+      </NFormItem>
+
+      <NFormItem :label="$t('goal.contribution.amount.label')">
+        <UiMoneyInput
+          v-model:value="formModel.magnitude"
+          placeholder="0,00"
+          :min="0.01"
+        />
+      </NFormItem>
+
+      <p v-if="formError" class="goal-contribution-modal__error" role="alert">
+        {{ formError }}
+      </p>
+
+      <NFormItem :label="$t('goal.contribution.date.label')">
+        <NDatePicker
+          :value="datePickerValue"
+          type="date"
+          format="dd/MM/yyyy"
+          :is-date-disabled="isFutureDate"
+          :placeholder="$t('goal.contribution.date.placeholder')"
+          style="width: 100%"
+          @update:value="onDateUpdate"
+        />
+      </NFormItem>
+
+      <NFormItem :label="$t('goal.contribution.note.label')">
+        <NInput
+          v-model:value="formModel.note"
+          type="textarea"
+          :placeholder="$t('goal.contribution.note.placeholder')"
+          :rows="2"
+          :maxlength="NOTE_MAX_LENGTH"
+          show-count
+        />
+      </NFormItem>
+    </NForm>
+
+    <template #footer>
+      <NSpace justify="end">
+        <NButton :disabled="isSubmitting" @click="onClose">
+          {{ $t('common.cancel') }}
+        </NButton>
+        <NButton type="primary" :loading="isSubmitting" @click="onConfirm">
+          {{ $t('goal.contribution.confirm') }}
+        </NButton>
+      </NSpace>
+    </template>
+  </NModal>
+</template>
+
+<style scoped>
+.goal-contribution-modal__error {
+  margin: calc(var(--space-2) * -1) 0 var(--space-2);
+  color: var(--color-negative);
+  font-size: var(--font-size-xs);
+}
+</style>

--- a/app/components/goal/GoalContributionsTimeline/GoalContributionsTimeline.spec.ts
+++ b/app/components/goal/GoalContributionsTimeline/GoalContributionsTimeline.spec.ts
@@ -1,0 +1,74 @@
+import { mount } from "@vue/test-utils";
+import { describe, it, expect } from "vitest";
+
+import GoalContributionsTimeline from "./GoalContributionsTimeline.vue";
+import UiEmptyState from "~/components/ui/UiEmptyState/UiEmptyState.vue";
+import UiInlineError from "~/components/ui/UiInlineError/UiInlineError.vue";
+import type { GoalContributionDto } from "~/features/goals/contracts/contributions.dto";
+
+/**
+ * Builds a contribution fixture with optional overrides.
+ *
+ * @param overrides - Partial overrides applied on top of the default fixture.
+ * @returns A complete GoalContributionDto fixture.
+ */
+const makeContribution = (
+  overrides: Partial<GoalContributionDto> = {},
+): GoalContributionDto => ({
+  id: "c-1",
+  goal_id: "goal-001",
+  amount: 250,
+  note: "Aporte mensal",
+  occurred_at: "2026-06-01",
+  created_at: "2026-06-01T10:00:00Z",
+  ...overrides,
+});
+
+describe("GoalContributionsTimeline", () => {
+  it("renders the error state when error is true", () => {
+    const wrapper = mount(GoalContributionsTimeline, {
+      props: { error: true },
+    });
+    expect(wrapper.findComponent(UiInlineError).exists()).toBe(true);
+  });
+
+  it("renders skeletons when loading is true", () => {
+    const wrapper = mount(GoalContributionsTimeline, {
+      props: { loading: true },
+    });
+    expect(wrapper.findAll("[data-testid='base-skeleton']").length).toBeGreaterThan(0);
+  });
+
+  it("renders the empty state when there are no items", () => {
+    const wrapper = mount(GoalContributionsTimeline, {
+      props: { items: [] },
+    });
+    expect(wrapper.findComponent(UiEmptyState).exists()).toBe(true);
+  });
+
+  it("renders a deposit with a + sign and the note", () => {
+    const wrapper = mount(GoalContributionsTimeline, {
+      props: { items: [makeContribution({ amount: 250, note: "Aporte mensal" })] },
+    });
+    expect(wrapper.text()).toContain("+");
+    expect(wrapper.text()).toContain("Aporte mensal");
+    expect(wrapper.text()).toContain("R$");
+  });
+
+  it("renders a withdrawal with a − sign and the negative modifier class", () => {
+    const wrapper = mount(GoalContributionsTimeline, {
+      props: { items: [makeContribution({ id: "c-2", amount: -50, note: null })] },
+    });
+    expect(wrapper.text()).toContain("−");
+    expect(
+      wrapper.find(".goal-contributions-timeline__amount--negative").exists(),
+    ).toBe(true);
+  });
+
+  it("formats the occurred_at date as a pt-BR short date", () => {
+    const wrapper = mount(GoalContributionsTimeline, {
+      props: { items: [makeContribution({ occurred_at: "2026-06-01" })] },
+    });
+    expect(wrapper.text()).toContain("01/06/2026");
+  });
+});

--- a/app/components/goal/GoalContributionsTimeline/GoalContributionsTimeline.stories.ts
+++ b/app/components/goal/GoalContributionsTimeline/GoalContributionsTimeline.stories.ts
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/vue3";
+
+import GoalContributionsTimeline from "./GoalContributionsTimeline.vue";
+import type { GoalContributionDto } from "~/features/goals/contracts/contributions.dto";
+
+const meta: Meta<typeof GoalContributionsTimeline> = {
+  title: "Features/Goals/GoalContributionsTimeline",
+  component: GoalContributionsTimeline,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Timeline of a goal's contributions (deposits and withdrawals), newest first, with empty, loading and error states.",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GoalContributionsTimeline>;
+
+const items: GoalContributionDto[] = [
+  {
+    id: "c-1",
+    goal_id: "goal-001",
+    amount: 250,
+    note: "Aporte mensal",
+    occurred_at: "2026-06-01",
+    created_at: "2026-06-01T10:00:00Z",
+  },
+  {
+    id: "c-2",
+    goal_id: "goal-001",
+    amount: -80,
+    note: "Imprevisto",
+    occurred_at: "2026-05-22",
+    created_at: "2026-05-22T10:00:00Z",
+  },
+  {
+    id: "c-3",
+    goal_id: "goal-001",
+    amount: 1000,
+    note: null,
+    occurred_at: "2026-05-05",
+    created_at: "2026-05-05T10:00:00Z",
+  },
+];
+
+export const WithItems: Story = {
+  args: { items },
+};
+
+export const Empty: Story = {
+  args: { items: [] },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+};
+
+export const ErrorState: Story = {
+  args: { error: true },
+};

--- a/app/components/goal/GoalContributionsTimeline/GoalContributionsTimeline.types.ts
+++ b/app/components/goal/GoalContributionsTimeline/GoalContributionsTimeline.types.ts
@@ -1,0 +1,11 @@
+import type { GoalContributionDto } from "~/features/goals/contracts/contributions.dto";
+
+/** Props for the GoalContributionsTimeline component. */
+export type GoalContributionsTimelineProps = {
+  /** Contributions to render, newest first. */
+  items?: GoalContributionDto[];
+  /** Whether the contributions are loading. */
+  loading?: boolean;
+  /** Whether loading the contributions failed. */
+  error?: boolean;
+};

--- a/app/components/goal/GoalContributionsTimeline/GoalContributionsTimeline.vue
+++ b/app/components/goal/GoalContributionsTimeline/GoalContributionsTimeline.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import BaseSkeleton from "~/components/ui/BaseSkeleton.vue";
+import UiEmptyState from "~/components/ui/UiEmptyState/UiEmptyState.vue";
+import UiInlineError from "~/components/ui/UiInlineError/UiInlineError.vue";
+import { formatCurrency } from "~/utils/currency";
+import type { GoalContributionsTimelineProps } from "./GoalContributionsTimeline.types";
+
+const props = withDefaults(defineProps<GoalContributionsTimelineProps>(), {
+  items: () => [],
+  loading: false,
+  error: false,
+});
+
+const hasItems = computed(() => props.items.length > 0);
+
+/**
+ * Formats a YYYY-MM-DD date as a localised short pt-BR date.
+ *
+ * @param value ISO date string (YYYY-MM-DD).
+ * @returns Formatted date like "01/06/2026".
+ */
+const formatDate = (value: string): string =>
+  new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(new Date(`${value}T00:00:00`));
+
+/**
+ * Formats a signed amount as BRL with an explicit +/− sign.
+ *
+ * @param amount Signed contribution amount.
+ * @returns String such as "+ R$ 250,00" or "− R$ 50,00".
+ */
+const formatSigned = (amount: number): string => {
+  const sign = amount < 0 ? "−" : "+";
+  return `${sign} ${formatCurrency(Math.abs(amount))}`;
+};
+</script>
+
+<template>
+  <section class="goal-contributions-timeline" aria-label="Histórico de aportes">
+    <UiInlineError
+      v-if="props.error"
+      :title="$t('goal.contribution.timeline.errorTitle')"
+      :message="$t('goal.contribution.timeline.errorMessage')"
+    />
+
+    <div v-else-if="props.loading" class="goal-contributions-timeline__loading">
+      <BaseSkeleton v-for="n in 3" :key="n" height="44px" />
+    </div>
+
+    <UiEmptyState
+      v-else-if="!hasItems"
+      icon="target"
+      :title="$t('goal.contribution.timeline.emptyTitle')"
+      :description="$t('goal.contribution.timeline.emptyDescription')"
+      compact
+    />
+
+    <ol v-else class="goal-contributions-timeline__list">
+      <li
+        v-for="item in props.items"
+        :key="item.id"
+        class="goal-contributions-timeline__item"
+      >
+        <span class="goal-contributions-timeline__date">{{ formatDate(item.occurred_at) }}</span>
+        <div class="goal-contributions-timeline__body">
+          <span
+            class="goal-contributions-timeline__amount"
+            :class="item.amount < 0
+              ? 'goal-contributions-timeline__amount--negative'
+              : 'goal-contributions-timeline__amount--positive'"
+          >
+            {{ formatSigned(item.amount) }}
+          </span>
+          <span v-if="item.note" class="goal-contributions-timeline__note">{{ item.note }}</span>
+        </div>
+      </li>
+    </ol>
+  </section>
+</template>
+
+<style scoped>
+.goal-contributions-timeline__loading {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.goal-contributions-timeline__list {
+  display: grid;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.goal-contributions-timeline__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--color-outline-soft);
+}
+
+.goal-contributions-timeline__item:last-child {
+  border-bottom: none;
+}
+
+.goal-contributions-timeline__date {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.goal-contributions-timeline__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.goal-contributions-timeline__amount {
+  font-weight: var(--font-weight-semibold);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+}
+
+.goal-contributions-timeline__amount--positive {
+  color: var(--color-positive);
+}
+
+.goal-contributions-timeline__amount--negative {
+  color: var(--color-negative);
+}
+
+.goal-contributions-timeline__note {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  overflow-wrap: anywhere;
+}
+</style>

--- a/app/core/api/__tests__/interceptors.spec.ts
+++ b/app/core/api/__tests__/interceptors.spec.ts
@@ -70,6 +70,25 @@ describe("toApiError", () => {
     expect(err.code).toBe("VALIDATION_ERROR");
   });
 
+  it("extrai o código aninhado do envelope v2 (error.code) quando o flat code está ausente", () => {
+    const axiosErr = Object.assign(new Error("Saldo insuficiente"), {
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: {
+          success: false,
+          message: "Saldo insuficiente",
+          error: { code: "INSUFFICIENT_BALANCE" },
+        },
+      },
+    });
+
+    const err = toApiError(axiosErr);
+
+    expect(err.status).toBe(400);
+    expect(err.code).toBe("INSUFFICIENT_BALANCE");
+  });
+
   it("usa status 500 quando AxiosError não tem response", () => {
     const axiosErr = Object.assign(new Error("Network Error"), {
       isAxiosError: true,

--- a/app/core/api/interceptors.ts
+++ b/app/core/api/interceptors.ts
@@ -57,6 +57,20 @@ interface RetryableConfig extends InternalAxiosRequestConfig {
 }
 
 /**
+ * Resolves the machine-readable error code from an API error body.
+ *
+ * Accepts both the flat `{code}` shape and the v2 envelope that nests the code
+ * under `{error:{code}}` (e.g. `{success:false, error:{code:"INSUFFICIENT_BALANCE"}}`),
+ * preferring the flat field when present.
+ *
+ * @param body Parsed error response body, when available.
+ * @returns The error code, or undefined when absent.
+ */
+const resolveErrorCode = (
+  body: { code?: string; error?: { code?: string } } | undefined,
+): string | undefined => body?.code ?? body?.error?.code;
+
+/**
  * Converts an unknown thrown value to a typed {@link ApiError}.
  *
  * Handles three cases:
@@ -75,11 +89,11 @@ export const toApiError = (error: unknown): ApiError => {
   if (axios.isAxiosError(error)) {
     const status = error.response?.status ?? 500;
     const responseData = error.response?.data as
-      | { message?: string; code?: string }
+      | { message?: string; code?: string; error?: { code?: string; message?: string } }
       | undefined;
     const message =
       responseData?.message ?? error.message ?? "Unexpected error";
-    const code = responseData?.code;
+    const code = resolveErrorCode(responseData);
 
     return new ApiError(status, message, code);
   }

--- a/app/features/goals/contracts/contributions.dto.ts
+++ b/app/features/goals/contracts/contributions.dto.ts
@@ -1,0 +1,60 @@
+/**
+ * A single contribution (deposit or withdrawal) recorded against a goal.
+ *
+ * Mirrors the API response from POST/GET /goals/:id/contributions. The wire
+ * format serialises `amount` as a signed decimal string; the UI contract uses
+ * a signed `number` (positive for deposits, negative for withdrawals).
+ */
+export type GoalContributionDto = {
+  /** UUID of the contribution. */
+  readonly id: string;
+  /** UUID of the parent goal. */
+  readonly goal_id: string;
+  /** Signed amount: positive for a deposit, negative for a withdrawal. */
+  readonly amount: number;
+  /** Optional free-form note (≤200 chars), or null when absent. */
+  readonly note: string | null;
+  /** Date the contribution occurred (YYYY-MM-DD). */
+  readonly occurred_at: string;
+  /** ISO timestamp of when the contribution was created. */
+  readonly created_at: string;
+};
+
+/**
+ * Payload sent to POST /goals/:id/contributions.
+ *
+ * `amount` is a signed UI number; the client serialises it to a decimal string
+ * before sending it over the wire.
+ */
+export type RecordGoalContributionPayload = {
+  /** Signed amount: positive for a deposit, negative for a withdrawal. */
+  readonly amount: number;
+  /** Date the contribution occurred (YYYY-MM-DD). Defaults server-side to today. */
+  readonly occurred_at?: string;
+  /** Optional free-form note (≤200 chars). */
+  readonly note?: string;
+};
+
+/**
+ * Pagination metadata returned by the paginated contributions list endpoint.
+ */
+export type ContributionPagination = {
+  /** Total number of contributions for the goal. */
+  readonly total: number;
+  /** Current page (1-based). */
+  readonly page: number;
+  /** Number of items per page. */
+  readonly per_page: number;
+  /** Total number of pages. */
+  readonly pages: number;
+};
+
+/**
+ * Result of GET /goals/:id/contributions, unwrapped to the UI contract.
+ */
+export type GoalContributionListDto = {
+  /** Contributions ordered newest first. */
+  readonly items: GoalContributionDto[];
+  /** Pagination metadata. */
+  readonly pagination: ContributionPagination;
+};

--- a/app/features/goals/model/contribution-amount.spec.ts
+++ b/app/features/goals/model/contribution-amount.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { computeSignedAmount } from "./contribution-amount";
+
+describe("computeSignedAmount", () => {
+  it("keeps a deposit amount positive", () => {
+    expect(computeSignedAmount(250, "deposit")).toBe(250);
+  });
+
+  it("negates a withdrawal amount", () => {
+    expect(computeSignedAmount(50, "withdrawal")).toBe(-50);
+  });
+
+  it("preserves fractional cents", () => {
+    expect(computeSignedAmount(99.9, "deposit")).toBe(99.9);
+    expect(computeSignedAmount(99.9, "withdrawal")).toBe(-99.9);
+  });
+
+  it("returns null for a null magnitude", () => {
+    expect(computeSignedAmount(null, "deposit")).toBeNull();
+  });
+
+  it("returns null for a zero magnitude", () => {
+    expect(computeSignedAmount(0, "deposit")).toBeNull();
+    expect(computeSignedAmount(0, "withdrawal")).toBeNull();
+  });
+
+  it("returns null for a non-finite magnitude", () => {
+    expect(computeSignedAmount(Number.NaN, "deposit")).toBeNull();
+    expect(computeSignedAmount(Number.POSITIVE_INFINITY, "withdrawal")).toBeNull();
+  });
+
+  it("returns null for a negative magnitude (UI always supplies a positive)", () => {
+    expect(computeSignedAmount(-10, "deposit")).toBeNull();
+  });
+});

--- a/app/features/goals/model/contribution-amount.ts
+++ b/app/features/goals/model/contribution-amount.ts
@@ -1,0 +1,25 @@
+/** Direction of a goal contribution. */
+export type ContributionDirection = "deposit" | "withdrawal";
+
+/**
+ * Computes the signed amount for a contribution from a magnitude and direction.
+ *
+ * The UI captures a positive magnitude plus a direction toggle (Entrada /
+ * Saída). Deposits stay positive; withdrawals are negated. Returns null when
+ * the magnitude is missing or not a positive finite number, so callers can
+ * block submission of an empty or zero amount.
+ *
+ * @param magnitude Positive amount typed by the user, or null when empty.
+ * @param direction Selected toggle: deposit (+) or withdrawal (−).
+ * @returns Signed amount, or null when the magnitude is invalid.
+ */
+export const computeSignedAmount = (
+  magnitude: number | null,
+  direction: ContributionDirection,
+): number | null => {
+  if (magnitude === null || !Number.isFinite(magnitude) || magnitude <= 0) {
+    return null;
+  }
+
+  return direction === "withdrawal" ? -magnitude : magnitude;
+};

--- a/app/features/goals/queries/use-goal-contributions-query.spec.ts
+++ b/app/features/goals/queries/use-goal-contributions-query.spec.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import { useGoalContributionsQuery } from "./use-goal-contributions-query";
+import type { GoalsClient } from "~/features/goals/services/goals.client";
+import type { GoalContributionListDto } from "~/features/goals/contracts/contributions.dto";
+
+const useQueryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/vue-query", () => ({
+  useQuery: useQueryMock,
+}));
+
+/**
+ * Builds a minimal contributions list fixture.
+ *
+ * @returns A complete GoalContributionListDto fixture.
+ */
+const makeListDto = (): GoalContributionListDto => ({
+  items: [
+    {
+      id: "c-1",
+      goal_id: "goal-001",
+      amount: 250,
+      note: "Aporte",
+      occurred_at: "2026-06-01",
+      created_at: "2026-06-01T10:00:00Z",
+    },
+  ],
+  pagination: { total: 1, page: 1, per_page: 10, pages: 1 },
+});
+
+describe("useGoalContributionsQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disables the query when goalId is null", () => {
+    const client = { listContributions: vi.fn() } as unknown as GoalsClient;
+    useQueryMock.mockImplementation((opts: Record<string, unknown>) => opts);
+
+    const goalId = ref<string | null>(null);
+    const result = useGoalContributionsQuery(goalId, 1, client) as unknown as {
+      enabled: { value: boolean } | boolean;
+    };
+
+    const enabledValue =
+      typeof result.enabled === "object" && result.enabled !== null
+        ? (result.enabled as { value: boolean }).value
+        : result.enabled;
+
+    expect(enabledValue).toBe(false);
+    expect(client.listContributions).not.toHaveBeenCalled();
+  });
+
+  it("uses the canonical [goals, goalId, contributions, page] query key", () => {
+    const client = { listContributions: vi.fn() } as unknown as GoalsClient;
+    useQueryMock.mockImplementation((opts: Record<string, unknown>) => opts);
+
+    const goalId = ref<string | null>("goal-001");
+    const result = useGoalContributionsQuery(goalId, ref(2), client) as unknown as {
+      queryKey: readonly [string, unknown, string, { value: number }];
+    };
+
+    expect(result.queryKey[0]).toBe("goals");
+    expect(result.queryKey[2]).toBe("contributions");
+    expect(result.queryKey[3]?.value).toBe(2);
+  });
+
+  it("calls client.listContributions with the page and default per_page", async () => {
+    const client = {
+      listContributions: vi.fn().mockResolvedValue(makeListDto()),
+    } as unknown as GoalsClient;
+    useQueryMock.mockImplementation(
+      (opts: { queryFn: () => Promise<GoalContributionListDto> }) => opts,
+    );
+
+    const goalId = ref<string | null>("goal-001");
+    const result = useGoalContributionsQuery(goalId, ref(3), client) as unknown as {
+      queryFn: () => Promise<GoalContributionListDto>;
+    };
+
+    const data = await result.queryFn();
+
+    expect(client.listContributions).toHaveBeenCalledWith("goal-001", {
+      page: 3,
+      perPage: 10,
+    });
+    expect(data.items[0]?.amount).toBe(250);
+  });
+
+  it("propagates errors from client.listContributions", async () => {
+    const client = {
+      listContributions: vi.fn().mockRejectedValue(new Error("boom")),
+    } as unknown as GoalsClient;
+    useQueryMock.mockImplementation(
+      (opts: { queryFn: () => Promise<GoalContributionListDto> }) => opts,
+    );
+
+    const goalId = ref<string | null>("goal-001");
+    const result = useGoalContributionsQuery(goalId, 1, client) as unknown as {
+      queryFn: () => Promise<GoalContributionListDto>;
+    };
+
+    await expect(result.queryFn()).rejects.toThrow("boom");
+  });
+});

--- a/app/features/goals/queries/use-goal-contributions-query.ts
+++ b/app/features/goals/queries/use-goal-contributions-query.ts
@@ -1,0 +1,44 @@
+import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+import { computed, unref, type Ref } from "vue";
+
+import { STALE_TIME } from "~/core/query/stale-time";
+import {
+  useGoalsClient,
+  type GoalsClient,
+} from "~/features/goals/services/goals.client";
+import type { GoalContributionListDto } from "~/features/goals/contracts/contributions.dto";
+
+/** Default page size for the contributions history. */
+const DEFAULT_PER_PAGE = 10;
+
+/**
+ * Vue Query hook for listing a goal's contributions, paginated and newest
+ * first, from GET /goals/:id/contributions.
+ *
+ * The query is disabled when goalId is null. Errors propagate as query error
+ * state — no silent catch.
+ *
+ * @param goalId Reactive ref to the goal ID. Pass null to disable the query.
+ * @param page Reactive ref (or plain number) for the 1-based page.
+ * @param providedClient Optional injected client for unit tests.
+ * @returns Vue Query state with the typed contributions list.
+ */
+export const useGoalContributionsQuery = (
+  goalId: Ref<string | null>,
+  page: Ref<number> | number = 1,
+  providedClient?: GoalsClient,
+): UseQueryReturnType<GoalContributionListDto, Error> => {
+  const client = providedClient ?? useGoalsClient();
+  const pageValue = computed(() => unref(page));
+
+  return useQuery({
+    queryKey: ["goals", goalId, "contributions", pageValue] as const,
+    queryFn: (): Promise<GoalContributionListDto> =>
+      client.listContributions(goalId.value!, {
+        page: pageValue.value,
+        perPage: DEFAULT_PER_PAGE,
+      }),
+    enabled: computed(() => goalId.value !== null),
+    staleTime: STALE_TIME.STABLE,
+  });
+};

--- a/app/features/goals/queries/use-record-contribution-mutation.spec.ts
+++ b/app/features/goals/queries/use-record-contribution-mutation.spec.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  useRecordContributionMutation,
+  type RecordContributionResult,
+} from "./use-record-contribution-mutation";
+import type { GoalsClient } from "~/features/goals/services/goals.client";
+import type { RecordGoalContributionPayload } from "~/features/goals/contracts/contributions.dto";
+
+const createApiMutationMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/core/query/use-api-mutation", () => ({
+  createApiMutation: createApiMutationMock,
+}));
+
+type CapturedOptions = {
+  invalidates?: ReadonlyArray<ReadonlyArray<unknown>>;
+};
+
+describe("useRecordContributionMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createApiMutationMock.mockImplementation(
+      (
+        fn: (p: RecordGoalContributionPayload) => Promise<RecordContributionResult>,
+        opts: CapturedOptions,
+      ) => ({ mutationFn: fn, options: opts }),
+    );
+  });
+
+  it("calls client.recordContribution with the goal id and payload", async () => {
+    const result: RecordContributionResult = {
+      goal: {
+        id: "goal-001",
+        name: "Reserva",
+        description: null,
+        target_amount: 30000,
+        current_amount: 18750,
+        target_date: "2026-12-31",
+        status: "active",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      contribution: {
+        id: "c-1",
+        goal_id: "goal-001",
+        amount: 250,
+        note: null,
+        occurred_at: "2026-06-01",
+        created_at: "2026-06-01T10:00:00Z",
+      },
+    };
+    const client = {
+      recordContribution: vi.fn().mockResolvedValue(result),
+    } as unknown as GoalsClient;
+
+    const hook = useRecordContributionMutation("goal-001", client) as unknown as {
+      mutationFn: (p: RecordGoalContributionPayload) => Promise<RecordContributionResult>;
+    };
+
+    const data = await hook.mutationFn({ amount: 250 });
+
+    expect(client.recordContribution).toHaveBeenCalledWith("goal-001", { amount: 250 });
+    expect(data.contribution.amount).toBe(250);
+  });
+
+  it("invalidates the goals list, contributions, and projection caches", () => {
+    const client = { recordContribution: vi.fn() } as unknown as GoalsClient;
+
+    useRecordContributionMutation("goal-xyz", client);
+
+    const opts = createApiMutationMock.mock.calls[0]?.[1] as CapturedOptions;
+    expect(opts.invalidates).toEqual([
+      ["goals", "list"],
+      ["goals", "goal-xyz", "contributions"],
+      ["goals", "goal-xyz", "projection"],
+    ]);
+  });
+});

--- a/app/features/goals/queries/use-record-contribution-mutation.ts
+++ b/app/features/goals/queries/use-record-contribution-mutation.ts
@@ -1,0 +1,53 @@
+import type { UseMutationReturnType } from "@tanstack/vue-query";
+
+import { createApiMutation } from "~/core/query/use-api-mutation";
+import type { ApiError } from "~/core/errors";
+import {
+  useGoalsClient,
+  type GoalsClient,
+} from "~/features/goals/services/goals.client";
+import type { GoalDto } from "~/features/goals/contracts/goal.dto";
+import type {
+  GoalContributionDto,
+  RecordGoalContributionPayload,
+} from "~/features/goals/contracts/contributions.dto";
+
+/** Result returned by a successful contribution mutation. */
+export type RecordContributionResult = {
+  readonly goal: GoalDto;
+  readonly contribution: GoalContributionDto;
+};
+
+/**
+ * Vue Query mutation hook for recording a contribution against a goal.
+ *
+ * On success it invalidates the goals list, this goal's contributions history,
+ * and this goal's projection so progress, timeline, and forecast all refresh.
+ * Errors propagate as mutation error state — no silent catch — so callers can
+ * surface domain errors such as INSUFFICIENT_BALANCE.
+ *
+ * @param goalId Goal the contribution belongs to.
+ * @param providedClient Optional injected client for unit tests.
+ * @returns Vue Query mutation state with the updated goal and contribution.
+ */
+export const useRecordContributionMutation = (
+  goalId: string,
+  providedClient?: GoalsClient,
+): UseMutationReturnType<
+  RecordContributionResult,
+  ApiError,
+  RecordGoalContributionPayload,
+  unknown
+> => {
+  const client = providedClient ?? useGoalsClient();
+  return createApiMutation<RecordContributionResult, RecordGoalContributionPayload>(
+    (payload) => client.recordContribution(goalId, payload),
+    {
+      invalidates: [
+        ["goals", "list"],
+        ["goals", goalId, "contributions"],
+        ["goals", goalId, "projection"],
+      ],
+    },
+  );
+};

--- a/app/features/goals/services/goals.client.contributions.spec.ts
+++ b/app/features/goals/services/goals.client.contributions.spec.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AxiosInstance } from "axios";
+
+import { GoalsClient } from "./goals.client";
+import type { GoalDto } from "~/features/goals/contracts/goal.dto";
+
+/**
+ * Creates a minimal valid GoalDto for testing.
+ *
+ * @param overrides - Partial properties to override defaults.
+ * @returns A complete GoalDto fixture.
+ */
+const makeGoalDto = (overrides: Partial<GoalDto> = {}): GoalDto => ({
+  id: "goal-001",
+  name: "Reserva de emergência",
+  description: "6 meses de despesas.",
+  target_amount: 30000,
+  current_amount: 18500,
+  target_date: "2026-09-30",
+  status: "active",
+  created_at: "2025-11-01T10:00:00Z",
+  ...overrides,
+});
+
+describe("GoalsClient contributions", () => {
+  let http: AxiosInstance;
+  let client: GoalsClient;
+
+  beforeEach(() => {
+    http = { get: vi.fn(), post: vi.fn() } as unknown as AxiosInstance;
+    client = new GoalsClient(http);
+  });
+
+  describe("recordContribution", () => {
+    it("serializes the signed amount to a decimal string and posts it", async () => {
+      vi.mocked(http.post).mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: {
+            goal: { ...makeGoalDto({ current_amount: 18750 }), title: "Reserva de emergência" },
+            contribution: {
+              id: "c-1",
+              goal_id: "goal-001",
+              amount: "250.00",
+              note: "Aporte mensal",
+              occurred_at: "2026-06-01",
+              created_at: "2026-06-01T10:00:00Z",
+            },
+          },
+        },
+      });
+
+      const result = await client.recordContribution("goal-001", {
+        amount: 250,
+        occurred_at: "2026-06-01",
+        note: "Aporte mensal",
+      });
+
+      expect(http.post).toHaveBeenCalledWith("/goals/goal-001/contributions", {
+        amount: "250.00",
+        occurred_at: "2026-06-01",
+        note: "Aporte mensal",
+      });
+      expect(result.contribution.amount).toBe(250);
+      expect(result.contribution.note).toBe("Aporte mensal");
+      expect(result.goal.name).toBe("Reserva de emergência");
+    });
+
+    it("serializes a negative (withdrawal) amount to a signed decimal string", async () => {
+      vi.mocked(http.post).mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: {
+            goal: makeGoalDto(),
+            contribution: {
+              id: "c-2",
+              goal_id: "goal-001",
+              amount: "-50.00",
+              note: null,
+              occurred_at: "2026-06-02",
+              created_at: "2026-06-02T10:00:00Z",
+            },
+          },
+        },
+      });
+
+      const result = await client.recordContribution("goal-001", { amount: -50 });
+
+      expect(http.post).toHaveBeenCalledWith("/goals/goal-001/contributions", {
+        amount: "-50.00",
+      });
+      expect(result.contribution.amount).toBe(-50);
+    });
+
+    it("propagates an INSUFFICIENT_BALANCE error from the API", async () => {
+      vi.mocked(http.post).mockRejectedValueOnce({
+        isAxiosError: true,
+        response: { status: 400, data: { error: { code: "INSUFFICIENT_BALANCE" } } },
+      });
+
+      await expect(
+        client.recordContribution("goal-001", { amount: -9999 }),
+      ).rejects.toMatchObject({
+        response: { data: { error: { code: "INSUFFICIENT_BALANCE" } } },
+      });
+    });
+  });
+
+  describe("listContributions", () => {
+    it("requests the paginated envelope and coerces amounts to numbers", async () => {
+      vi.mocked(http.get).mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: {
+            items: [
+              {
+                id: "c-1",
+                goal_id: "goal-001",
+                amount: "250.00",
+                note: "Aporte",
+                occurred_at: "2026-06-01",
+                created_at: "2026-06-01T10:00:00Z",
+              },
+              {
+                id: "c-2",
+                goal_id: "goal-001",
+                amount: "-50.00",
+                note: null,
+                occurred_at: "2026-05-20",
+                created_at: "2026-05-20T10:00:00Z",
+              },
+            ],
+          },
+          meta: { pagination: { total: 12, page: 1, per_page: 10, pages: 2 } },
+        },
+      });
+
+      const result = await client.listContributions("goal-001", { page: 1, perPage: 10 });
+
+      expect(http.get).toHaveBeenCalledWith("/goals/goal-001/contributions", {
+        params: { page: 1, per_page: 10 },
+      });
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]?.amount).toBe(250);
+      expect(result.items[1]?.amount).toBe(-50);
+      expect(result.pagination).toEqual({ total: 12, page: 1, per_page: 10, pages: 2 });
+    });
+
+    it("falls back to sane pagination defaults when meta is absent", async () => {
+      vi.mocked(http.get).mockResolvedValueOnce({
+        data: { success: true, data: { items: [] } },
+      });
+
+      const result = await client.listContributions("goal-001", { page: 2, perPage: 5 });
+
+      expect(result.items).toEqual([]);
+      expect(result.pagination).toEqual({ total: 0, page: 2, per_page: 5, pages: 1 });
+    });
+  });
+});

--- a/app/features/goals/services/goals.client.ts
+++ b/app/features/goals/services/goals.client.ts
@@ -10,10 +10,22 @@ import type {
   CreateGoalPayload,
   UpdateGoalPayload,
 } from "~/features/goals/contracts/goal.dto";
+import type {
+  ContributionPagination,
+  GoalContributionDto,
+  GoalContributionListDto,
+  RecordGoalContributionPayload,
+} from "~/features/goals/contracts/contributions.dto";
 
 type ApiEnvelope<T> = {
   readonly data?: T;
   readonly success?: boolean;
+  readonly meta?: { readonly pagination?: Partial<ContributionPagination> };
+};
+
+/** Wire shape of a contribution: `amount` arrives as a signed decimal string. */
+type GoalContributionWireDto = Omit<GoalContributionDto, "amount"> & {
+  readonly amount: string | number;
 };
 
 type GoalWireDto = Omit<GoalDto, "name"> & {
@@ -90,6 +102,50 @@ const toGoalWirePayload = (payload: CreateGoalPayload | UpdateGoalPayload): Goal
   const { name, ...rest } = payload;
   return name === undefined ? rest : { ...rest, title: name };
 };
+
+/**
+ * Normalizes a wire contribution into the UI contract.
+ *
+ * The API serialises `amount` as a signed decimal string (e.g. "250.00" or
+ * "-50.00"); the UI consumes a signed number. Keeping the coercion at the
+ * client boundary avoids leaking wire details into components.
+ *
+ * @param contribution Raw contribution returned by the API or tests.
+ * @returns GoalContributionDto consumed by the UI.
+ */
+const normalizeContribution = (
+  contribution: GoalContributionWireDto,
+): GoalContributionDto => ({
+  ...contribution,
+  amount:
+    typeof contribution.amount === "number"
+      ? contribution.amount
+      : Number(contribution.amount),
+});
+
+/**
+ * Serializes a signed UI amount to the wire decimal string with two fractional
+ * digits (e.g. 250 → "250.00", -50 → "-50.00").
+ *
+ * @param amount Signed numeric amount from the UI.
+ * @returns Decimal string suitable for the contributions endpoint.
+ */
+const serializeContributionAmount = (amount: number): string => amount.toFixed(2);
+
+/**
+ * Builds the wire payload for a contribution, mapping the signed UI amount to a
+ * decimal string and dropping undefined optional fields.
+ *
+ * @param payload Contribution payload produced by the modal.
+ * @returns Wire payload accepted by POST /goals/:id/contributions.
+ */
+const toContributionWirePayload = (
+  payload: RecordGoalContributionPayload,
+): { amount: string; occurred_at?: string; note?: string } => ({
+  amount: serializeContributionAmount(payload.amount),
+  ...(payload.occurred_at !== undefined ? { occurred_at: payload.occurred_at } : {}),
+  ...(payload.note !== undefined ? { note: payload.note } : {}),
+});
 
 /**
  * Detects the empty-collection response used by some API deployments for users
@@ -233,6 +289,71 @@ export class GoalsClient {
       ApiEnvelope<GoalAIProjectionResponseDto> | GoalAIProjectionResponseDto
     >(`/ai/goals/${id}/projection`, payload);
     return unwrapApiEnvelope<GoalAIProjectionResponseDto>(response.data);
+  }
+
+  /**
+   * Records a contribution (deposit or withdrawal) against a goal.
+   *
+   * The signed UI amount is serialised to a decimal string for the wire. The
+   * v2 endpoint returns `{data:{goal, contribution}}`; the goal is normalised
+   * (title→name) and the contribution amount is coerced back to a number.
+   *
+   * @param goalId Goal identifier.
+   * @param payload Signed amount plus optional date and note.
+   * @returns The updated goal and the created contribution.
+   */
+  async recordContribution(
+    goalId: string,
+    payload: RecordGoalContributionPayload,
+  ): Promise<{ goal: GoalDto; contribution: GoalContributionDto }> {
+    const response = await this.#http.post<
+      ApiEnvelope<{ goal: GoalWireDto; contribution: GoalContributionWireDto }>
+    >(`/goals/${goalId}/contributions`, toContributionWirePayload(payload));
+    const data = unwrapApiEnvelope<{
+      goal: GoalWireDto;
+      contribution: GoalContributionWireDto;
+    }>(response.data);
+    return {
+      goal: normalizeGoal(data.goal),
+      contribution: normalizeContribution(data.contribution),
+    };
+  }
+
+  /**
+   * Lists a goal's contributions, newest first, paginated.
+   *
+   * Unwraps the v2 paginated envelope (`{data:{items:[...]}, meta:{pagination}}`)
+   * and coerces each contribution's wire amount string into a number.
+   *
+   * @param goalId Goal identifier.
+   * @param params Pagination controls.
+   * @param params.page 1-based page number.
+   * @param params.perPage Number of items per page.
+   * @returns Contributions plus pagination metadata.
+   */
+  async listContributions(
+    goalId: string,
+    params: { page: number; perPage: number },
+  ): Promise<GoalContributionListDto> {
+    const response = await this.#http.get<
+      ApiEnvelope<{ items?: GoalContributionWireDto[] }>
+    >(`/goals/${goalId}/contributions`, {
+      params: { page: params.page, per_page: params.perPage },
+    });
+    const data = unwrapApiEnvelope<{ items?: GoalContributionWireDto[] }>(
+      response.data,
+    );
+    const rawPagination = response.data?.meta?.pagination ?? {};
+    const items = (data?.items ?? []).map(normalizeContribution);
+    return {
+      items,
+      pagination: {
+        total: rawPagination.total ?? items.length,
+        page: rawPagination.page ?? params.page,
+        per_page: rawPagination.per_page ?? params.perPage,
+        pages: rawPagination.pages ?? 1,
+      },
+    };
   }
 }
 

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -1440,7 +1440,42 @@
       "edit": "Editar meta",
       "showPlan": "Ver planejamento",
       "delete": "Excluir meta",
-      "deleteConfirm": "Tem certeza que deseja excluir esta meta?"
+      "deleteConfirm": "Tem certeza que deseja excluir esta meta?",
+      "remaining": "Faltam {amount}",
+      "registerContribution": "Registrar entrada"
+    },
+    "contribution": {
+      "title": "Registrar entrada",
+      "confirm": "Confirmar",
+      "direction": {
+        "label": "Tipo de movimentação",
+        "deposit": "Entrada",
+        "withdrawal": "Saída"
+      },
+      "amount": {
+        "label": "Valor (R$)",
+        "required": "Informe um valor maior que zero"
+      },
+      "date": {
+        "label": "Data",
+        "placeholder": "Selecione a data"
+      },
+      "note": {
+        "label": "Observação (opcional)",
+        "placeholder": "Ex: aporte do mês"
+      },
+      "toast": {
+        "success": "Movimentação registrada com sucesso.",
+        "error": "Não foi possível registrar a movimentação. Tente novamente.",
+        "insufficientBalance": "Saldo insuficiente: a retirada deixaria a meta negativa."
+      },
+      "timeline": {
+        "title": "Histórico de aportes",
+        "emptyTitle": "Nenhuma movimentação ainda",
+        "emptyDescription": "Registre uma entrada para começar a acompanhar o histórico desta meta.",
+        "errorTitle": "Não foi possível carregar o histórico",
+        "errorMessage": "Atualize a página ou tente novamente em instantes."
+      }
     },
     "health": {
       "completed": "✓ Concluída",

--- a/app/pages/goals/[id]/index.vue
+++ b/app/pages/goals/[id]/index.vue
@@ -3,7 +3,10 @@ import { ArrowLeft, CalendarClock, PiggyBank, Target, TrendingUp } from "lucide-
 
 import GoalAiContextPanel from "~/components/goal/GoalAiContextPanel/GoalAiContextPanel.vue";
 import GoalProjectionPanel from "~/components/goal/GoalProjectionPanel/GoalProjectionPanel.vue";
+import GoalContributionModal from "~/components/goal/GoalContributionModal/GoalContributionModal.vue";
+import GoalContributionsTimeline from "~/components/goal/GoalContributionsTimeline/GoalContributionsTimeline.vue";
 import { useGoalProjectionQuery } from "~/features/goals/queries/use-goal-projection-query";
+import { useGoalContributionsQuery } from "~/features/goals/queries/use-goal-contributions-query";
 import { useGoalsQuery } from "~/features/goals/queries/use-goals-query";
 import type { GoalDto } from "~/features/goals/contracts/goal.dto";
 import { useListTransactionsQuery } from "~/features/transactions/queries/use-list-transactions-query";
@@ -58,6 +61,17 @@ const savedNote = ref<string | null>(null);
 
 const goalsQuery = useGoalsQuery();
 const projectionQuery = useGoalProjectionQuery(goalIdRef);
+
+const isContributionModalOpen = ref(false);
+const contributionsPage = ref(1);
+const contributionsQuery = useGoalContributionsQuery(goalIdRef, contributionsPage);
+
+const contributions = computed(() => contributionsQuery.data.value?.items ?? []);
+
+/** Opens the contribution modal for the selected goal. */
+const onOpenContributionModal = (): void => {
+  isContributionModalOpen.value = true;
+};
 
 const endDate = computed(() => new Date().toISOString().slice(0, 10));
 const startDate = computed(() => {
@@ -235,7 +249,26 @@ const onSaveNote = (projection: { narrative: string }): void => {
         <p>{{ savedNote }}</p>
       </section>
 
+      <section class="goal-detail-contributions">
+        <header class="goal-detail-contributions__header">
+          <h2>{{ $t('goal.contribution.timeline.title') }}</h2>
+          <NButton type="primary" size="small" @click="onOpenContributionModal">
+            {{ $t('goal.card.registerContribution') }}
+          </NButton>
+        </header>
+        <GoalContributionsTimeline
+          :items="contributions"
+          :loading="contributionsQuery.isLoading.value"
+          :error="contributionsQuery.isError.value"
+        />
+      </section>
+
       <GoalProjectionPanel :goal-id="goalId" />
+
+      <GoalContributionModal
+        v-model:visible="isContributionModalOpen"
+        :goal="selectedGoal"
+      />
     </template>
   </div>
 </template>
@@ -280,12 +313,33 @@ const onSaveNote = (projection: { narrative: string }): void => {
 .goal-detail-metrics article,
 .goal-detail-progress,
 .goal-detail-ai,
-.goal-detail-note {
+.goal-detail-note,
+.goal-detail-contributions {
   min-width: 0;
   border: 1px solid var(--goal-border);
   border-radius: var(--radius-lg);
   background: var(--goal-surface);
   box-shadow: var(--shadow-card);
+}
+
+.goal-detail-contributions {
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+}
+
+.goal-detail-contributions__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.goal-detail-contributions__header h2 {
+  margin: 0;
+  color: var(--goal-text);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-extrabold);
 }
 
 .goal-detail-hero {

--- a/app/shared/types/generated/graphql.ts
+++ b/app/shared/types/generated/graphql.ts
@@ -284,6 +284,19 @@ export type CheckoutSessionType = {
   providerSubscriptionId?: Maybe<Scalars['String']['output']>;
 };
 
+/** Canonical payload for completeOnboarding mutation. */
+export type CompleteOnboardingPayload = {
+  __typename?: 'CompleteOnboardingPayload';
+  /** Field-level validation errors (empty on success). */
+  errors: Array<ValidationError>;
+  /** Human-readable status message. */
+  message: Scalars['String']['output'];
+  /** True when the mutation completed without errors. */
+  ok: Scalars['Boolean']['output'];
+  /** ISO 8601 timestamp when onboarding was completed. */
+  onboardingCompletedAt?: Maybe<Scalars['String']['output']>;
+};
+
 /**
  * Consome 1 simulação da quota freemium (#1409).
  *
@@ -498,6 +511,22 @@ export type GenerateAiInsightPayload = {
   periodType?: Maybe<Scalars['String']['output']>;
   summary?: Maybe<Scalars['String']['output']>;
   tokensUsed?: Maybe<Scalars['Int']['output']>;
+};
+
+export type GoalContributionListPayloadType = {
+  __typename?: 'GoalContributionListPayloadType';
+  items: Array<Maybe<GoalContributionType>>;
+  pagination: PaginationType;
+};
+
+export type GoalContributionType = {
+  __typename?: 'GoalContributionType';
+  amount: Scalars['String']['output'];
+  createdAt?: Maybe<Scalars['String']['output']>;
+  goalId: Scalars['ID']['output'];
+  id: Scalars['ID']['output'];
+  note?: Maybe<Scalars['String']['output']>;
+  occurredAt: Scalars['String']['output'];
 };
 
 export type GoalListPayloadType = {
@@ -758,6 +787,12 @@ export type Mutation = {
   /** @deprecated ADR-0004: use POST /subscription/cancel */
   cancelSubscription?: Maybe<CancelSubscriptionMutation>;
   /**
+   * Mark the authenticated user's onboarding as completed (idempotent).
+   *
+   * REST parity: ``POST /user/onboarding/complete``.
+   */
+  completeOnboarding?: Maybe<CompleteOnboardingPayload>;
+  /**
    * Persist a subset of bank statement entries as transactions.
    *
    * ``mode`` controls how existing data is handled:
@@ -824,6 +859,12 @@ export type Mutation = {
    * together with a bank identifier.  No data is written to the database.
    */
   previewBankStatement?: Maybe<BankImportPreviewPayload>;
+  /**
+   * Register a deposit (+) or withdrawal (-) against a goal.
+   *
+   * REST parity: ``POST /goals/{goal_id}/contributions``.
+   */
+  recordGoalContribution?: Maybe<RecordGoalContributionMutation>;
   registerUser?: Maybe<AuthPayloadType>;
   resendConfirmationEmail?: Maybe<AuthPayloadType>;
   resetPassword?: Maybe<AuthPayloadType>;
@@ -1083,6 +1124,14 @@ export type MutationMarkReceivableReceivedArgs = {
 export type MutationPreviewBankStatementArgs = {
   bankName: Scalars['String']['input'];
   content: Scalars['String']['input'];
+};
+
+
+export type MutationRecordGoalContributionArgs = {
+  amount: Scalars['String']['input'];
+  goalId: Scalars['UUID']['input'];
+  note?: InputMaybe<Scalars['String']['input']>;
+  occurredAt?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1363,6 +1412,7 @@ export type Query = {
   dashboardOverview?: Maybe<TransactionDashboardPayloadType>;
   fiscalDocuments?: Maybe<FiscalDocumentListType>;
   goal?: Maybe<GoalTypeObject>;
+  goalContributions?: Maybe<GoalContributionListPayloadType>;
   goalPlan?: Maybe<GoalPlanType>;
   goals?: Maybe<GoalListPayloadType>;
   installmentVsCashCalculate?: Maybe<InstallmentVsCashCalculationPayloadType>;
@@ -1436,6 +1486,13 @@ export type QueryFiscalDocumentsArgs = {
 
 export type QueryGoalArgs = {
   goalId: Scalars['UUID']['input'];
+};
+
+
+export type QueryGoalContributionsArgs = {
+  goalId: Scalars['UUID']['input'];
+  page?: InputMaybe<Scalars['Int']['input']>;
+  perPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -1633,6 +1690,18 @@ export type ReceivableSummaryType = {
   expectedTotal: Scalars['String']['output'];
   pendingTotal: Scalars['String']['output'];
   receivedTotal: Scalars['String']['output'];
+};
+
+/**
+ * Register a deposit (+) or withdrawal (-) against a goal.
+ *
+ * REST parity: ``POST /goals/{goal_id}/contributions``.
+ */
+export type RecordGoalContributionMutation = {
+  __typename?: 'RecordGoalContributionMutation';
+  contribution: GoalContributionType;
+  goal: GoalTypeObject;
+  message: Scalars['String']['output'];
 };
 
 /** Revoke all active sessions — global logout (#1028). */
@@ -1930,6 +1999,7 @@ export type UserType = {
   name: Scalars['String']['output'];
   netWorth?: Maybe<Scalars['DecimalScalar']['output']>;
   occupation?: Maybe<Scalars['String']['output']>;
+  onboardingCompletedAt?: Maybe<Scalars['String']['output']>;
   profileQuizScore?: Maybe<Scalars['Int']['output']>;
   stateUf?: Maybe<Scalars['String']['output']>;
   taxonomyVersion?: Maybe<Scalars['String']['output']>;


### PR DESCRIPTION
## Summary

Rework de Metas: o usuário agora registra **aportes (+) e retiradas (−)** numa meta via um modal "Registrar entrada", com histórico visível.

### Mudanças
- **Modal `GoalContributionModal`**: input em R$ formatado, toggle Entrada/Saída, date picker (sem datas futuras), nota opcional; confirma via `POST /goals/{id}/contributions`. Toasts de sucesso/erro (mensagem amigável para `INSUFFICIENT_BALANCE`); estado de loading.
- **`GoalContributionsTimeline`**: histórico (data, valor com sinal/cor, nota) na página de detalhe da meta; empty/loading/error states.
- **`GoalCard`**: botão "Registrar entrada" + linha de "faltam R$…" junto à barra de progresso.
- Hooks: `use-record-contribution-mutation` (invalida lista + detalhe + projeção + histórico), `use-goal-contributions-query`.
- Client `recordContribution`/`listContributions`; DTO `contributions.dto.ts`; lógica pura `computeSignedAmount` (testada).
- `interceptors.ts`: superfície do `error.code` aninhado (v2) para o modal tratar `INSUFFICIENT_BALANCE`.
- Tipos GraphQL regenerados (sincroniza com onboarding + contribuições já no master da api).
- i18n só pt-BR (en.json congelado intacto).

### Depende de
- Backend api #1470 (mergeado) — endpoints de contribuição. Precisa estar **deployado** para o fluxo valer em produção.

## Verificação
- `pnpm quality-check` (schema local = master pós-merge): lint, typecheck, testes (suites de goals/contribuições verdes), codegen, **build** — todos verdes.

## Refs
Closes #1032