### PR TITLE
ci(semgrep): substituir SonarCloud por Semgrep SAST blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@
 # Executa em todo PR e push para master.
 #
 # Secrets necessários (Settings → Secrets and variables → Actions):
-#   SONAR_AURAXIS_WEB_TOKEN — SonarCloud (sonarcloud.io → My Account → Security)
 #   LHCI_GITHUB_APP_TOKEN  — Lighthouse CI GitHub App (opcional — status checks no PR)
+# SAST: job `semgrep` (OSS, blocking). Dashboard de qualidade: SonarQube Community
+# Build local — auraxis-platform `make sonar` (wiki SAST-Local-SonarQube-and-Semgrep).
 
 name: CI
 
@@ -406,60 +407,38 @@ jobs:
       - name: Audit deps (high/critical) with temporary minimatch allowlist
         run: node scripts/ci-audit-gate.cjs
 
-  # ── 9. SonarCloud ──────────────────────────────────────────────────────
-  # Requer SONAR_AURAXIS_WEB_TOKEN configurado nos secrets do repositório.
-  # sonar-project.properties deve existir na raiz.
-  sonarcloud:
-    name: SonarCloud Analysis
+  # ── 9. Semgrep SAST ─────────────────────────────────────────────────────
+  # SAST OSS cross-file/dataflow (standalone, sem conta). Bloqueia merge em
+  # finding de severidade ERROR. SARIF publicado como artifact — a aba Code
+  # Scanning exige GitHub Advanced Security (pago) em repo privado, então o gate
+  # é o exit code. Dashboard de qualidade: SonarQube Community Build local
+  # (auraxis-platform: make sonar). Ver wiki SAST-Local-SonarQube-and-Semgrep.
+  semgrep:
+    name: Semgrep SAST
     runs-on: ubuntu-latest
-    needs: [test]
     permissions:
       contents: read
     steps:
-      - name: Check Sonar capability
-        id: capability
-        env:
-          SONAR_TOKEN_VALUE: ${{ secrets.SONAR_AURAXIS_WEB_TOKEN }}
-        run: |
-          if [ -n "${SONAR_TOKEN_VALUE:-}" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::SonarCloud skipped: token not available for this run."
-          fi
-
       - uses: actions/checkout@v4
-        if: steps.capability.outputs.enabled == 'true'
+      - uses: actions/setup-python@v5
         with:
-          fetch-depth: 0
-      - uses: pnpm/action-setup@v6
-        if: steps.capability.outputs.enabled == 'true'
+          python-version: '3.13'
+      - name: Install Semgrep
+        run: pip install --quiet semgrep
+      - name: Run Semgrep (blocking on ERROR)
+        run: |
+          semgrep scan \
+            --config p/typescript --config p/javascript \
+            --config p/security-audit --config p/owasp-top-ten \
+            --severity ERROR --error --metrics=off \
+            --sarif --output semgrep.sarif
+      - name: Upload Semgrep SARIF
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        if: steps.capability.outputs.enabled == 'true'
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-      - if: steps.capability.outputs.enabled == 'true'
-        run: pnpm install --frozen-lockfile
-      - name: Generate coverage for Sonar
-        if: steps.capability.outputs.enabled == 'true'
-        run: pnpm test:coverage
-      - name: Validate LCOV report exists
-        if: steps.capability.outputs.enabled == 'true'
-        run: test -f coverage/lcov.info
-      - name: SonarCloud Scan
-        if: steps.capability.outputs.enabled == 'true'
-        # Advisory gate (non-required): a present-but-expired/invalid token must
-        # not fail CI. The capability check above only verifies presence, not
-        # validity, so soft-fail here keeps Sonar informational. Regenerate
-        # SONAR_AURAXIS_WEB_TOKEN on sonarcloud.io to restore reporting.
-        continue-on-error: true
-        uses: SonarSource/sonarcloud-github-action@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_AURAXIS_WEB_TOKEN }}
+          name: semgrep-sarif
+          path: semgrep.sarif
+          if-no-files-found: ignore
 
   # ── 10. Lighthouse CI ──────────────────────────────────────────────────
   # Mede performance, acessibilidade, SEO e boas práticas.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,16 +45,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set deployment parameters
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IN_ENVIRONMENT: ${{ inputs.environment }}
+          IN_API_BASE_URL: ${{ inputs.api_base_url }}
+          IN_RUN_SMOKE_TEST: ${{ inputs.run_smoke_test }}
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
+          if [ "$EVENT_NAME" == "push" ]; then
             echo "DEPLOY_ENVIRONMENT=prod"                       >> $GITHUB_ENV
             echo "DEPLOY_API_BASE_URL=https://api.auraxis.com.br" >> $GITHUB_ENV
             echo "DEPLOY_RUN_SMOKE_TEST=true"                   >> $GITHUB_ENV
             echo "Automatic deployment triggered by push to main"
           else
-            echo "DEPLOY_ENVIRONMENT=${{ inputs.environment }}"   >> $GITHUB_ENV
-            echo "DEPLOY_API_BASE_URL=${{ inputs.api_base_url }}" >> $GITHUB_ENV
-            echo "DEPLOY_RUN_SMOKE_TEST=${{ inputs.run_smoke_test }}" >> $GITHUB_ENV
+            echo "DEPLOY_ENVIRONMENT=$IN_ENVIRONMENT"   >> $GITHUB_ENV
+            echo "DEPLOY_API_BASE_URL=$IN_API_BASE_URL" >> $GITHUB_ENV
+            echo "DEPLOY_RUN_SMOKE_TEST=$IN_RUN_SMOKE_TEST" >> $GITHUB_ENV
             echo "Manual deployment triggered by workflow_dispatch"
           fi
 
@@ -128,13 +133,17 @@ jobs:
       url: https://${{ env.WEB_OFFICIAL_HOSTNAME }}
     steps:
       - name: Set deployment parameters
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IN_ENVIRONMENT: ${{ inputs.environment }}
+          IN_RUN_SMOKE_TEST: ${{ inputs.run_smoke_test }}
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
+          if [ "$EVENT_NAME" == "push" ]; then
             echo "DEPLOY_ENVIRONMENT=prod"     >> $GITHUB_ENV
             echo "DEPLOY_RUN_SMOKE_TEST=true"  >> $GITHUB_ENV
           else
-            echo "DEPLOY_ENVIRONMENT=${{ inputs.environment }}"       >> $GITHUB_ENV
-            echo "DEPLOY_RUN_SMOKE_TEST=${{ inputs.run_smoke_test }}" >> $GITHUB_ENV
+            echo "DEPLOY_ENVIRONMENT=$IN_ENVIRONMENT"       >> $GITHUB_ENV
+            echo "DEPLOY_RUN_SMOKE_TEST=$IN_RUN_SMOKE_TEST" >> $GITHUB_ENV
           fi
 
       - name: Download build artifact

--- a/.github/workflows/setup-design-infra.yml
+++ b/.github/workflows/setup-design-infra.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Create CloudFront distribution
         id: cf
         if: inputs.dry_run == 'false'
+        env:
+          ACM_CERT_ARN: ${{ inputs.acm_certificate_arn }}
         run: |
           DISTRIBUTION=$(aws cloudfront create-distribution --distribution-config '{
             "CallerReference": "design-auraxis-'$(date +%s)'",
@@ -103,7 +105,7 @@ jobs:
             },
             "Aliases": { "Quantity": 1, "Items": ["design.auraxis.com.br"] },
             "ViewerCertificate": {
-              "ACMCertificateArn": "${{ inputs.acm_certificate_arn }}",
+              "ACMCertificateArn": "'"$ACM_CERT_ARN"'",
               "SSLSupportMethod": "sni-only",
               "MinimumProtocolVersion": "TLSv1.2_2021"
             },
@@ -121,9 +123,12 @@ jobs:
 
       - name: Create Route53 CNAME record
         if: inputs.dry_run == 'false'
+        env:
+          HOSTED_ZONE_ID: ${{ inputs.hosted_zone_id }}
+          CF_DOMAIN: ${{ steps.cf.outputs.cf_domain }}
         run: |
           aws route53 change-resource-record-sets \
-            --hosted-zone-id "${{ inputs.hosted_zone_id }}" \
+            --hosted-zone-id "$HOSTED_ZONE_ID" \
             --change-batch '{
               "Changes": [{
                 "Action": "CREATE",
@@ -131,7 +136,7 @@ jobs:
                   "Name": "design.auraxis.com.br",
                   "Type": "CNAME",
                   "TTL": 300,
-                  "ResourceRecords": [{ "Value": "${{ steps.cf.outputs.cf_domain }}" }]
+                  "ResourceRecords": [{ "Value": "'"$CF_DOMAIN"'" }]
                 }
               }]
             }'

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN pnpm build
 FROM deps AS dev
 
 COPY . .
+# Drop root: dev server runs as the built-in non-root `node` user.
+RUN chown -R node:node /app
+USER node
 EXPOSE 3000
 CMD ["pnpm", "dev"]
 
@@ -30,6 +33,9 @@ WORKDIR /app
 RUN apk add --no-cache dumb-init
 
 COPY --from=builder /app/.output ./.output
+
+# Drop root: production SSR server runs as the built-in non-root `node` user.
+USER node
 
 EXPOSE 3000
 


### PR DESCRIPTION
## O quê
Substitui o job SonarCloud (advisory) por um job **Semgrep** (OSS standalone, bloqueante em finding ERROR). SARIF publicado como artifact.

## Por quê
Migração de SAST para tornar o repo privado sem perder análise estática, custo US$0, OSS. Dashboard de qualidade passa a ser SonarQube Community Build local (auraxis-platform `make sonar`). Plataforma: italofelipe/auraxis-platform#829.

## Notas
- `sonar-project.properties` mantido (scan local + governança).
- Code Scanning UI não é usada (exige GHAS pago em repo privado); o gate é o exit code.
Closes #1036