### PR TITLE
[WEB] Metas e Orçamentos — movimentos e envelopes automáticos

### DIFF
--- a/app/components/transactions/EditTransactionModal/EditTransactionModal.vue
+++ b/app/components/transactions/EditTransactionModal/EditTransactionModal.vue
@@ -23,6 +23,9 @@ import {
 import { useTagsQuery } from "~/features/tags/queries/use-tags-query";
 import { useAccountsQuery } from "~/features/accounts/queries/use-accounts-query";
 import { useCreditCardsQuery } from "~/features/credit-cards/queries/use-credit-cards-query";
+import { useBudgetsQuery } from "~/features/budgets/queries/use-budgets-query";
+import { buildBudgetImpactPreview } from "~/features/budgets/model/budget-impact-preview";
+import { formatCurrency } from "~/utils/currency";
 import {
   parseCurrencyAmount,
   serializeCurrencyAmount,
@@ -50,6 +53,7 @@ const emit = defineEmits<{
 const { data: tags } = useTagsQuery();
 const { data: accounts } = useAccountsQuery();
 const { data: creditCards } = useCreditCardsQuery();
+const { data: budgets } = useBudgetsQuery();
 
 const tagOptions = computed((): SelectOption[] =>
   (tags.value ?? []).map((tg: { id: string; name: string }) => ({ label: tg.name, value: tg.id })),
@@ -89,6 +93,15 @@ const showCreditCard = computed(
 
 /** Show end date field only when recurring is on. */
 const showEndDate = computed((): boolean => form.is_recurring);
+
+const budgetImpactPreview = computed(() =>
+  buildBudgetImpactPreview({
+    budgets: budgets.value ?? [],
+    transactionType: props.transaction?.type ?? "income",
+    tagId: form.tag_id,
+    amount: form.amount,
+  }),
+);
 
 // ── Status options ─────────────────────────────────────────────────────────────
 
@@ -305,6 +318,18 @@ const handleClose = (): void => {
           :placeholder="$t('transaction.form.tag.placeholder')"
           clearable
         />
+        <div
+          v-if="budgetImpactPreview"
+          class="edit-transaction-modal__budget-preview"
+          :class="{ 'edit-transaction-modal__budget-preview--danger': budgetImpactPreview.isOverBudget }"
+        >
+          <strong>{{ budgetImpactPreview.budgetName }}</strong>
+          ficará em
+          <strong>{{ formatCurrency(budgetImpactPreview.projectedSpent) }}</strong>
+          de
+          <strong>{{ formatCurrency(budgetImpactPreview.limitAmount) }}</strong>
+          com esta alteração.
+        </div>
       </NFormItem>
 
       <!-- Account -->
@@ -388,5 +413,26 @@ const handleClose = (): void => {
 <style scoped>
 .edit-transaction-modal {
   color: var(--color-text-primary);
+}
+
+.edit-transaction-modal__budget-preview {
+  margin-top: var(--space-2);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  line-height: 1.45;
+}
+
+.edit-transaction-modal__budget-preview strong {
+  color: var(--color-text-primary);
+}
+
+.edit-transaction-modal__budget-preview--danger {
+  border-color: var(--color-negative-border, var(--color-negative));
+  background: var(--color-negative-bg);
+  color: var(--color-negative);
 }
 </style>

--- a/app/components/transactions/EditTransactionModal/__tests__/EditTransactionModal.spec.ts
+++ b/app/components/transactions/EditTransactionModal/__tests__/EditTransactionModal.spec.ts
@@ -26,6 +26,7 @@ vi.mock("~/features/transactions/queries/use-update-transaction-mutation", () =>
 vi.mock("~/features/tags/queries/use-tags-query", () => ({ useTagsQuery: (): object => ({ data: { value: [] } }) }));
 vi.mock("~/features/accounts/queries/use-accounts-query", () => ({ useAccountsQuery: (): object => ({ data: { value: [] } }) }));
 vi.mock("~/features/credit-cards/queries/use-credit-cards-query", () => ({ useCreditCardsQuery: (): object => ({ data: { value: [] } }) }));
+vi.mock("~/features/budgets/queries/use-budgets-query", () => ({ useBudgetsQuery: (): object => ({ data: { value: [] } }) }));
 
 /**
  * Builds a minimal TransactionDto fixture for testing.

--- a/app/components/transactions/QuickTransactionForm/QuickTransactionForm.vue
+++ b/app/components/transactions/QuickTransactionForm/QuickTransactionForm.vue
@@ -31,6 +31,7 @@ const {
   showInstallmentCount,
   showEndDate,
   showRecurrenceCadence,
+  budgetImpactPreview,
   recurrenceUnitOptions,
   recurringDisabled,
   rules,
@@ -97,6 +98,7 @@ function handleClose(): void {
         :show-installment-count="showInstallmentCount"
         :show-end-date="showEndDate"
         :show-recurrence-cadence="showRecurrenceCadence"
+        :budget-impact-preview="budgetImpactPreview"
         :recurrence-unit-options="recurrenceUnitOptions"
         :recurring-disabled="recurringDisabled"
       />

--- a/app/components/transactions/QuickTransactionForm/QuickTransactionFormFields.vue
+++ b/app/components/transactions/QuickTransactionForm/QuickTransactionFormFields.vue
@@ -15,10 +15,12 @@ import {
   QUICK_TRANSACTION_FORM_KEY,
   type QuickTransactionFormState,
 } from "./useQuickTransactionForm";
+import type { BudgetImpactPreview } from "~/features/budgets/model/budget-impact-preview";
 import {
   previewInstallments,
   type InstallmentPreview,
 } from "~/features/transactions/utils/preview-installments";
+import { formatCurrency } from "~/utils/currency";
 
 defineOptions({ name: "QuickTransactionFormFields" });
 
@@ -33,6 +35,7 @@ defineProps<{
   showInstallmentCount: boolean;
   showEndDate: boolean;
   showRecurrenceCadence: boolean;
+  budgetImpactPreview: BudgetImpactPreview | null;
   recurrenceUnitOptions: SelectOption[];
   recurringDisabled: boolean;
 }>();
@@ -88,6 +91,18 @@ const installmentPreview = computed<InstallmentPreview | null>(() => {
           {{ $t('transaction.form.tag.createHint') }}
         </NuxtLink>
       </template>
+      <div
+        v-if="budgetImpactPreview"
+        class="quick-transaction-form__budget-preview"
+        :class="{ 'quick-transaction-form__budget-preview--danger': budgetImpactPreview.isOverBudget }"
+      >
+        <strong>{{ budgetImpactPreview.budgetName }}</strong>
+        ficará em
+        <strong>{{ formatCurrency(budgetImpactPreview.projectedSpent) }}</strong>
+        de
+        <strong>{{ formatCurrency(budgetImpactPreview.limitAmount) }}</strong>
+        com esta transação.
+      </div>
     </NFormItem>
 
     <NFormItem :label="$t('transaction.form.account.label')" path="account_id">
@@ -189,5 +204,26 @@ const installmentPreview = computed<InstallmentPreview | null>(() => {
 
 .quick-transaction-form__settings-link:hover {
   text-decoration: underline;
+}
+
+.quick-transaction-form__budget-preview {
+  margin-top: var(--space-2);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  line-height: 1.45;
+}
+
+.quick-transaction-form__budget-preview strong {
+  color: var(--color-text-primary);
+}
+
+.quick-transaction-form__budget-preview--danger {
+  border-color: var(--color-negative-border, var(--color-negative));
+  background: var(--color-negative-bg);
+  color: var(--color-negative);
 }
 </style>

--- a/app/components/transactions/QuickTransactionForm/__tests__/QuickTransactionForm.spec.ts
+++ b/app/components/transactions/QuickTransactionForm/__tests__/QuickTransactionForm.spec.ts
@@ -50,6 +50,7 @@ vi.mock("~/features/transactions/queries/use-create-transaction-mutation", () =>
 vi.mock("~/features/tags/queries/use-tags-query", () => ({ useTagsQuery: (): object => ({ data: { value: [] } }) }));
 vi.mock("~/features/accounts/queries/use-accounts-query", () => ({ useAccountsQuery: (): object => ({ data: { value: [] } }) }));
 vi.mock("~/features/credit-cards/queries/use-credit-cards-query", () => ({ useCreditCardsQuery: (): object => ({ data: { value: [] } }) }));
+vi.mock("~/features/budgets/queries/use-budgets-query", () => ({ useBudgetsQuery: (): object => ({ data: { value: [] } }) }));
 
 vi.mock("vue-i18n");
 

--- a/app/components/transactions/QuickTransactionForm/useQuickTransactionForm.ts
+++ b/app/components/transactions/QuickTransactionForm/useQuickTransactionForm.ts
@@ -20,6 +20,8 @@ import { useAccountsQuery } from "~/features/accounts/queries/use-accounts-query
 import { useCreditCardsQuery } from "~/features/credit-cards/queries/use-credit-cards-query";
 import { useCreateTransactionMutation } from "~/features/transactions/queries/use-create-transaction-mutation";
 import { useTagsQuery } from "~/features/tags/queries/use-tags-query";
+import { useBudgetsQuery } from "~/features/budgets/queries/use-budgets-query";
+import { buildBudgetImpactPreview } from "~/features/budgets/model/budget-impact-preview";
 import { serializeCurrencyAmount } from "~/utils/currencyInput";
 
 export const QUICK_TRANSACTION_FORM_KEY: InjectionKey<QuickTransactionFormState> =
@@ -110,6 +112,7 @@ export function useQuickTransactionForm(opts: UseQuickTransactionFormOptions) {
   const { data: tags } = useTagsQuery();
   const { data: accounts } = useAccountsQuery();
   const { data: creditCards } = useCreditCardsQuery();
+  const { data: budgets } = useBudgetsQuery();
   const mutation = useCreateTransactionMutation();
 
   const tagOptions = computed((): SelectOption[] =>
@@ -126,6 +129,14 @@ export function useQuickTransactionForm(opts: UseQuickTransactionFormOptions) {
   const showInstallmentCount = computed((): boolean => form.is_installment);
   const showEndDate = computed((): boolean => form.is_recurring);
   const showRecurrenceCadence = computed((): boolean => form.is_recurring);
+  const budgetImpactPreview = computed(() =>
+    buildBudgetImpactPreview({
+      budgets: budgets.value ?? [],
+      transactionType: type.value,
+      tagId: form.tag_id,
+      amount: form.amount,
+    }),
+  );
 
   const recurrenceUnitOptions = computed((): SelectOption[] => [
     { label: t("transaction.form.recurrenceUnit.day"), value: "day" },
@@ -245,6 +256,7 @@ export function useQuickTransactionForm(opts: UseQuickTransactionFormOptions) {
     showInstallmentCount,
     showEndDate,
     showRecurrenceCadence,
+    budgetImpactPreview,
     recurrenceUnitOptions,
     recurringDisabled,
     rules,

--- a/app/components/transactions/budget-impact-preview.integration.spec.ts
+++ b/app/components/transactions/budget-impact-preview.integration.spec.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Reads a repository source file for integration assertions.
+ *
+ * @param path Relative source path.
+ * @returns UTF-8 file contents.
+ */
+const readSource = (path: string): string => readFileSync(join(process.cwd(), path), "utf8");
+
+describe("transaction budget impact preview integration", () => {
+  it("wires budget impact preview into quick and edit transaction forms", () => {
+    expect(readSource("app/components/transactions/QuickTransactionForm/useQuickTransactionForm.ts"))
+      .toContain("buildBudgetImpactPreview");
+    expect(readSource("app/components/transactions/QuickTransactionForm/QuickTransactionFormFields.vue"))
+      .toContain("budgetImpactPreview");
+    expect(readSource("app/components/transactions/EditTransactionModal/EditTransactionModal.vue"))
+      .toContain("buildBudgetImpactPreview");
+  });
+
+  it("keeps transactions free from a direct budget_id payload field", () => {
+    const dto = readSource("app/features/transactions/contracts/transaction.dto.ts");
+    const quickForm = readSource("app/components/transactions/QuickTransactionForm/useQuickTransactionForm.ts");
+    const editModal = readSource("app/components/transactions/EditTransactionModal/EditTransactionModal.vue");
+
+    expect(dto).not.toContain("budget_id");
+    expect(quickForm).not.toContain("budget_id");
+    expect(editModal).not.toContain("budget_id");
+  });
+});

--- a/app/features/budgets/model/budget-impact-preview.spec.ts
+++ b/app/features/budgets/model/budget-impact-preview.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import type { BudgetDto } from "~/features/budgets/contracts/budget.contracts";
+import { buildBudgetImpactPreview } from "./budget-impact-preview";
+
+/**
+ * Builds a budget fixture for preview behavior tests.
+ *
+ * @param overrides Partial budget fields to override.
+ * @returns Budget DTO fixture.
+ */
+const makeBudget = (overrides: Partial<BudgetDto> = {}): BudgetDto => ({
+  id: "budget-streaming",
+  name: "Streaming",
+  amount: "200.00",
+  spent: "180.00",
+  remaining: "20.00",
+  percentage_used: 90,
+  period: "monthly",
+  start_date: null,
+  end_date: null,
+  tag_id: "tag-streaming",
+  tag_name: "Streaming",
+  tag_color: "#06b6d4",
+  is_active: true,
+  is_over_budget: false,
+  created_at: "2026-06-01T12:00:00Z",
+  updated_at: "2026-06-01T12:00:00Z",
+  ...overrides,
+});
+
+describe("buildBudgetImpactPreview", () => {
+  it("projects an expense impact for the matching envelope tag", () => {
+    const preview = buildBudgetImpactPreview({
+      budgets: [makeBudget()],
+      transactionType: "expense",
+      tagId: "tag-streaming",
+      amount: 50,
+    });
+
+    expect(preview).toEqual({
+      budgetId: "budget-streaming",
+      budgetName: "Streaming",
+      tagName: "Streaming",
+      currentSpent: 180,
+      transactionAmount: 50,
+      projectedSpent: 230,
+      limitAmount: 200,
+      remainingAfter: -30,
+      percentageAfter: 115,
+      isOverBudget: true,
+    });
+  });
+
+  it("returns null for income, missing tag, missing amount or no active matching budget", () => {
+    expect(buildBudgetImpactPreview({
+      budgets: [makeBudget()],
+      transactionType: "income",
+      tagId: "tag-streaming",
+      amount: 50,
+    })).toBeNull();
+    expect(buildBudgetImpactPreview({
+      budgets: [makeBudget()],
+      transactionType: "expense",
+      tagId: null,
+      amount: 50,
+    })).toBeNull();
+    expect(buildBudgetImpactPreview({
+      budgets: [makeBudget()],
+      transactionType: "expense",
+      tagId: "tag-streaming",
+      amount: null,
+    })).toBeNull();
+    expect(buildBudgetImpactPreview({
+      budgets: [makeBudget({ is_active: false })],
+      transactionType: "expense",
+      tagId: "tag-streaming",
+      amount: 50,
+    })).toBeNull();
+  });
+
+  it("does not add budget_id to the transaction payload contract", () => {
+    const preview = buildBudgetImpactPreview({
+      budgets: [makeBudget()],
+      transactionType: "expense",
+      tagId: "tag-streaming",
+      amount: 10,
+    });
+
+    expect(preview).not.toHaveProperty("budget_id");
+    expect(preview).not.toHaveProperty("budgetIdForPayload");
+  });
+});

--- a/app/features/budgets/model/budget-impact-preview.ts
+++ b/app/features/budgets/model/budget-impact-preview.ts
@@ -1,0 +1,67 @@
+import type { TransactionTypeDto } from "~/features/transactions/contracts/transaction.dto";
+import type { BudgetDto } from "~/features/budgets/contracts/budget.contracts";
+import { parseCurrencyAmount } from "~/utils/currencyInput";
+
+export interface BudgetImpactPreview {
+  readonly budgetId: string;
+  readonly budgetName: string;
+  readonly tagName: string | null;
+  readonly currentSpent: number;
+  readonly transactionAmount: number;
+  readonly projectedSpent: number;
+  readonly limitAmount: number;
+  readonly remainingAfter: number;
+  readonly percentageAfter: number;
+  readonly isOverBudget: boolean;
+}
+
+export interface BuildBudgetImpactPreviewInput {
+  readonly budgets: readonly BudgetDto[];
+  readonly transactionType: TransactionTypeDto;
+  readonly tagId: string | null;
+  readonly amount: number | null;
+}
+
+/**
+ * Builds the read-only budget impact preview shown in transaction forms.
+ *
+ * The preview intentionally does not create or expose a `budget_id` payload
+ * field; budgets are impacted through the existing tag/envelope classification.
+ *
+ * @param input Current budget list and draft transaction fields.
+ * @returns Projected budget impact, or null when the transaction should not affect a budget.
+ */
+export function buildBudgetImpactPreview(
+  input: BuildBudgetImpactPreviewInput,
+): BudgetImpactPreview | null {
+  if (input.transactionType !== "expense" || !input.tagId || input.amount === null || input.amount <= 0) {
+    return null;
+  }
+
+  const budget = input.budgets.find(
+    (item) => item.is_active && item.tag_id === input.tagId,
+  );
+  if (!budget) {
+    return null;
+  }
+
+  const currentSpent = Math.max(parseCurrencyAmount(budget.spent), 0);
+  const limitAmount = Math.max(parseCurrencyAmount(budget.amount), 0);
+  const transactionAmount = input.amount;
+  const projectedSpent = currentSpent + transactionAmount;
+  const remainingAfter = limitAmount - projectedSpent;
+  const percentageAfter = limitAmount > 0 ? Math.round((projectedSpent / limitAmount) * 100) : 0;
+
+  return {
+    budgetId: budget.id,
+    budgetName: budget.name,
+    tagName: budget.tag_name,
+    currentSpent,
+    transactionAmount,
+    projectedSpent,
+    limitAmount,
+    remainingAfter,
+    percentageAfter,
+    isOverBudget: projectedSpent > limitAmount,
+  };
+}

--- a/app/pages/budgets.envelopes.spec.ts
+++ b/app/pages/budgets.envelopes.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Reads a repository source file for copy and positioning assertions.
+ *
+ * @param relativePath Relative source path.
+ * @returns UTF-8 file contents.
+ */
+const readSource = (relativePath: string): string =>
+  readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("budgets page envelope positioning", () => {
+  it("positions budgets as automatic monthly envelopes with concrete examples", () => {
+    const source = readSource("app/pages/budgets.vue");
+
+    expect(source).toContain("envelopes automáticos");
+    expect(source).toContain("Streaming");
+    expect(source).toContain("Mercado");
+    expect(source).toContain("Transporte");
+    expect(source).toContain("Comprometido");
+  });
+});

--- a/app/pages/budgets.spec.ts
+++ b/app/pages/budgets.spec.ts
@@ -183,8 +183,8 @@ describe("budgets page — clampedPct helper", () => {
 describe("budgets page — empty state UX writing", () => {
   it("renders a friendly empty-state copy instead of a raw i18n key", () => {
     expect(source).not.toContain("pages.budgets.emptyState");
-    expect(source).toContain("Crie seu primeiro orçamento");
-    expect(source).toContain("Orçamentos ajudam você a definir um limite por categoria");
+    expect(source).toContain("Crie seu primeiro envelope");
+    expect(source).toContain("Envelopes ajudam você a reservar um limite mensal");
   });
 });
 
@@ -196,7 +196,7 @@ describe("budgets page — freemium envelope UX", () => {
   });
 
   it("names budget progress bars for assistive technology", () => {
-    expect(source).toContain("Uso total dos orçamentos");
-    expect(source).toContain("Uso do orçamento");
+    expect(source).toContain("Uso comprometido total dos envelopes");
+    expect(source).toContain("Uso comprometido do envelope");
   });
 });

--- a/app/pages/budgets.vue
+++ b/app/pages/budgets.vue
@@ -38,7 +38,7 @@ const { t } = useI18n();
 definePageMeta({
   middleware: ["authenticated"],
   pageTitle: "Orçamentos",
-  pageSubtitle: "Controle seus gastos por categoria e período",
+  pageSubtitle: "Controle envelopes automáticos por período",
 });
 
 useHead({ title: "Orçamentos | Auraxis" });
@@ -85,14 +85,14 @@ const quotaDescription = computed(() =>
 
 const budgetHealthText = computed(() => {
   if (budgetSummary.value.dangerCount > 0) {
-    return `${budgetSummary.value.dangerCount} orçamento(s) acima do limite`;
+    return `${budgetSummary.value.dangerCount} envelope(s) acima do limite`;
   }
 
   if (budgetSummary.value.warningCount > 0) {
-    return `${budgetSummary.value.warningCount} orçamento(s) pedem atenção`;
+    return `${budgetSummary.value.warningCount} envelope(s) pedem atenção`;
   }
 
-  return "Todos os orçamentos estão dentro do limite";
+  return "Todos os envelopes estão dentro do limite";
 });
 
 const tagOptions = computed(() => {
@@ -243,11 +243,11 @@ const onDeleteBudget = (id: string): void => {
       <div class="budgets-page__title-block">
         <span class="budgets-page__title">{{ $t('pages.budgets.title') }}</span>
         <span class="budgets-page__subtitle">
-          Defina limites por categoria, acompanhe o uso e receba alertas antes de estourar o mês.
+          Defina envelopes automáticos como Streaming, Mercado ou Transporte. As transações com a tag correspondente atualizam o comprometido do mês.
         </span>
       </div>
       <NButton type="primary" size="medium" @click="onNewBudget">
-        {{ $t('pages.budgets.newBudget') }}
+        Novo envelope
       </NButton>
     </div>
 
@@ -268,7 +268,7 @@ const onDeleteBudget = (id: string): void => {
           'budgets-page__quota--premium': quotaState.isPremium,
           'budgets-page__quota--locked': !quotaState.canCreate,
         }"
-        aria-label="Limite de orçamentos"
+        aria-label="Limite de envelopes"
       >
         <div class="budgets-page__quota-icon" aria-hidden="true">
           <Crown v-if="quotaState.isPremium" :size="18" />
@@ -297,7 +297,7 @@ const onDeleteBudget = (id: string): void => {
             :value="formatCurrency(budgetSummary.totalBudgeted)"
           />
           <NStatistic
-            :label="$t('pages.budgets.summary.spent')"
+            label="Comprometido"
             :value="formatCurrency(budgetSummary.totalSpent)"
           />
           <NStatistic
@@ -325,7 +325,7 @@ const onDeleteBudget = (id: string): void => {
           :percentage="budgetSummary.overallPercentage"
           :status="budgetSummary.dangerCount > 0 ? 'error' : budgetSummary.warningCount > 0 ? 'warning' : 'default'"
           :show-indicator="true"
-          aria-label="Uso total dos orçamentos"
+          aria-label="Uso comprometido total dos envelopes"
         />
       </NCard>
 
@@ -337,9 +337,9 @@ const onDeleteBudget = (id: string): void => {
         v-else-if="budgetEnvelopes.length === 0"
         class="budgets-page__empty"
         icon="pieChart"
-        title="Crie seu primeiro orçamento"
-        description="Orçamentos ajudam você a definir um limite por categoria, acompanhar quanto já foi usado e perceber desvios antes que o mês aperte. Comece por uma categoria simples, como mercado, moradia ou lazer."
-        action-label="Criar orçamento"
+        title="Crie seu primeiro envelope"
+        description="Envelopes ajudam você a reservar um limite mensal e acompanhar o gasto comprometido automaticamente pelas transações. Comece com algo concreto, como Streaming, Mercado ou Transporte."
+        action-label="Criar envelope"
         secondary-label="Ver transações"
         secondary-href="/transactions"
         @action="onNewBudget"
@@ -387,7 +387,7 @@ const onDeleteBudget = (id: string): void => {
           <NProgress
             class="budget-card__progress"
             type="line"
-            :aria-label="`Uso do orçamento ${budget.name}`"
+            :aria-label="`Uso comprometido do envelope ${budget.name}`"
             :percentage="budget.progressPercentage"
             :status="budget.progressStatus"
             :show-indicator="false"
@@ -395,7 +395,7 @@ const onDeleteBudget = (id: string): void => {
 
           <div class="budget-card__amounts">
             <span class="budget-card__spent">
-              {{ formatCurrency(budget.spent) }} / {{ formatCurrency(budget.amount) }}
+              Comprometido: {{ formatCurrency(budget.spent) }} / {{ formatCurrency(budget.amount) }}
             </span>
             <span class="budget-card__pct">{{ budget.displayPercentage }}%</span>
           </div>
@@ -421,17 +421,17 @@ const onDeleteBudget = (id: string): void => {
     <NModal
       v-model:show="showForm"
       preset="card"
-      :title="editingBudget ? 'Editar orçamento' : $t('pages.budgets.newBudget')"
+      :title="editingBudget ? 'Editar envelope' : 'Novo envelope'"
       style="max-width: 480px"
       :mask-closable="true"
       @after-leave="editingBudget = null"
     >
       <NForm label-placement="top">
-        <NFormItem :label="$t('pages.budgets.form.name')">
-          <NInput v-model:value="formName" :placeholder="$t('pages.budgets.form.name')" />
+        <NFormItem label="Nome do envelope">
+          <NInput v-model:value="formName" placeholder="Ex.: Streaming" />
         </NFormItem>
 
-        <NFormItem :label="$t('pages.budgets.form.amount')">
+        <NFormItem label="Limite mensal">
           <UiMoneyInput
             v-model:value="formAmount"
             :min="0.01"
@@ -453,11 +453,11 @@ const onDeleteBudget = (id: string): void => {
           />
         </NFormItem>
 
-        <NFormItem :label="$t('pages.budgets.form.tag')">
+        <NFormItem label="Envelope / tag">
           <NSelect
             v-model:value="formTagId"
             :options="tagOptions"
-            :placeholder="$t('pages.budgets.form.tagPlaceholder')"
+            placeholder="Selecione a tag que alimenta este envelope"
             clearable
           />
         </NFormItem>
@@ -469,7 +469,7 @@ const onDeleteBudget = (id: string): void => {
             :loading="createMutation.isPending.value || updateMutation.isPending.value"
             @click="onSubmitForm"
           >
-            {{ editingBudget ? 'Salvar' : 'Criar' }}
+            {{ editingBudget ? 'Salvar' : 'Criar envelope' }}
           </NButton>
         </NSpace>
       </NForm>
@@ -484,7 +484,7 @@ const onDeleteBudget = (id: string): void => {
     >
       <UiUpgradePrompt
         feature-name="Premium"
-        description="Você já usou os 3 envelopes do plano gratuito. Assine Premium para criar orçamentos ilimitados, separar categorias com mais precisão e acompanhar alertas por área de gasto."
+        description="Você já usou os 3 envelopes do plano gratuito. Assine Premium para criar envelopes ilimitados, separar categorias com mais precisão e acompanhar alertas por área de gasto."
         cta-label="Ver plano Premium"
         to="/subscription"
       />

--- a/app/pages/goals.market-pulse.spec.ts
+++ b/app/pages/goals.market-pulse.spec.ts
@@ -25,6 +25,18 @@ describe("Goals page — Market Pulse anatomy", () => {
     expect(source).toContain("navigateTo(`/goals/${goal.id}`)");
   });
 
+  it("keeps registering progress as the primary goal card action", () => {
+    expect(source).toContain("GoalContributionModal");
+    expect(source).toContain("onRegisterContribution");
+    expect(source).toContain("Registrar entrada");
+  });
+
+  it("suggests explicit completion when a goal reaches the target", () => {
+    expect(source).toContain("isGoalReached");
+    expect(source).toContain("Meta alcançada");
+    expect(source).toContain("Concluir meta");
+  });
+
   it("does not replace an empty authenticated goals list with sample goals", () => {
     expect(source).not.toContain("MARKET_PULSE_GOALS");
     expect(source).not.toContain("Dados demonstrativos");

--- a/app/pages/goals/index.vue
+++ b/app/pages/goals/index.vue
@@ -16,6 +16,7 @@ import { useGoalsQuery } from "~/features/goals/queries/use-goals-query";
 import { useCreateGoalMutation } from "~/features/goals/queries/use-create-goal-mutation";
 import { useUpdateGoalMutation } from "~/features/goals/queries/use-update-goal-mutation";
 import AiInsightSurface from "~/features/ai-insights/components/AiInsightSurface.vue";
+import GoalContributionModal from "~/components/goal/GoalContributionModal/GoalContributionModal.vue";
 import type { GoalDto, GoalStatus, CreateGoalPayload } from "~/features/goals/contracts/goal.dto";
 import { formatCurrency } from "~/utils/currency";
 import { buildChartThemeTokens, withAlpha } from "~/utils/chart-theme";
@@ -61,6 +62,8 @@ const { resolvedTheme } = useTheme();
 const activeFilter = ref<FilterValue>("all");
 const showForm = ref<boolean>(false);
 const editingGoal = ref<GoalDto | null>(null);
+const contributionTarget = ref<GoalViewModel | null>(null);
+const isContributionModalOpen = ref<boolean>(false);
 const selectedGoalId = ref<string>("");
 const simulatedContribution = ref<number>(2500);
 const chartTokens = computed(() => buildChartThemeTokens(resolvedTheme.value));
@@ -148,6 +151,16 @@ function calculateProgress(goal: GoalDto): number {
 }
 
 /**
+ * Detects goals that reached the target but were not explicitly closed yet.
+ *
+ * @param goal Goal data.
+ * @returns True when the user should see the completion CTA.
+ */
+function isGoalReached(goal: GoalDto): boolean {
+  return goal.status !== "completed" && goal.target_amount > 0 && goal.current_amount >= goal.target_amount;
+}
+
+/**
  * Resolves the Market Pulse status tone used by goal cards.
  *
  * @param goal Goal data.
@@ -155,8 +168,12 @@ function calculateProgress(goal: GoalDto): number {
  * @returns Tone and label for the status badge.
  */
 function resolveHealth(goal: GoalDto, progress: number): Pick<GoalViewModel, "healthLabel" | "tone"> {
-  if (goal.status === "completed" || progress >= 100) {
+  if (goal.status === "completed") {
     return { healthLabel: "Concluída", tone: "cyan" };
+  }
+
+  if (progress >= 100) {
+    return { healthLabel: "Meta alcançada", tone: "cyan" };
   }
 
   if (goal.status === "paused" || progress < 50) {
@@ -230,6 +247,31 @@ const selectedGoal = computed(() => {
 const openGoalDetails = (goal: GoalViewModel): void => {
   void navigateTo(`/goals/${goal.id}`);
 };
+
+/**
+ * Opens the contribution modal for the selected goal.
+ *
+ * @param goal Goal selected in the status grid.
+ */
+const onRegisterContribution = (goal: GoalViewModel): void => {
+  contributionTarget.value = goal;
+  isContributionModalOpen.value = true;
+};
+
+/**
+ * Explicitly closes a reached goal after the user confirms the intent via CTA.
+ *
+ * @param goal Goal selected in the status grid.
+ */
+const onConcludeGoal = (goal: GoalViewModel): void => {
+  updateMutation.mutate({ id: goal.id, status: "completed" });
+};
+
+watch(isContributionModalOpen, (visible) => {
+  if (!visible) {
+    contributionTarget.value = null;
+  }
+});
 
 watch(
   goalCards,
@@ -505,12 +547,38 @@ const simulatedImpact = computed(() => {
               </div>
             </div>
 
+            <div
+              v-if="isGoalReached(goal)"
+              class="goal-status-card__completion"
+              aria-label="Meta alcançada"
+            >
+              <strong>Meta alcançada</strong>
+              <span>Revise o objetivo e conclua quando estiver pronto.</span>
+            </div>
+
             <div class="goal-status-card__footer">
               <span>
                 Aporte mensal atual:
                 <strong>{{ formatCurrency(goal.monthlyContribution) }}</strong>
               </span>
               <div class="goal-status-card__footer-actions">
+                <button
+                  v-if="isGoalReached(goal)"
+                  class="goal-status-card__complete"
+                  type="button"
+                  :disabled="updateMutation.isPending.value"
+                  @click.stop="onConcludeGoal(goal)"
+                >
+                  Concluir meta
+                </button>
+                <button
+                  v-else-if="goal.status !== 'completed' && goal.status !== 'cancelled'"
+                  class="goal-status-card__register"
+                  type="button"
+                  @click.stop="onRegisterContribution(goal)"
+                >
+                  Registrar entrada
+                </button>
                 <button
                   class="goal-status-card__details"
                   type="button"
@@ -609,6 +677,11 @@ const simulatedImpact = computed(() => {
       :goal="editingGoal"
       @update:visible="showForm = $event"
       @submit="onCreateOrUpdate"
+    />
+    <GoalContributionModal
+      v-if="contributionTarget"
+      v-model:visible="isContributionModalOpen"
+      :goal="contributionTarget"
     />
   </div>
 </template>
@@ -1046,6 +1119,28 @@ const simulatedImpact = computed(() => {
   padding-top: 16px;
 }
 
+.goal-status-card__completion {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--color-positive-border);
+  border-radius: var(--radius-sm);
+  margin-top: 16px;
+  padding: 12px 14px;
+  background: var(--color-positive-bg);
+}
+
+.goal-status-card__completion strong {
+  color: var(--mp-lime);
+  font-size: var(--font-size-sm);
+}
+
+.goal-status-card__completion span {
+  color: var(--mp-muted);
+  font-size: var(--font-size-xs);
+}
+
 .goal-status-card__footer strong {
   color: var(--mp-text);
 }
@@ -1061,6 +1156,29 @@ const simulatedImpact = computed(() => {
   padding: 4px;
   background: transparent;
   color: var(--mp-muted);
+}
+
+.goal-status-card__register,
+.goal-status-card__complete {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  border: 1px solid var(--color-brand-glow-md) !important;
+  border-radius: var(--radius-full);
+  padding: 0 10px !important;
+  color: var(--mp-cyan) !important;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
+}
+
+.goal-status-card__complete {
+  border-color: var(--color-positive-border) !important;
+  color: var(--mp-lime) !important;
+}
+
+.goal-status-card__complete:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
 }
 
 .goal-status-card__details {


### PR DESCRIPTION
## Summary
- Adiciona `Registrar entrada` nas metas, com fluxo de contribuição/retirada e sugestão explícita de conclusão ao atingir 100%.
- Reposiciona orçamentos como envelopes automáticos por tag, com copy e empty state mais aderentes ao produto.
- Adiciona preview de impacto no orçamento nos formulários de transação, sem incluir `budget_id` no payload.

## Verification
- `pnpm exec vitest run app/pages/goals.market-pulse.spec.ts app/pages/budgets.envelopes.spec.ts app/features/budgets/model/budget-impact-preview.spec.ts app/components/transactions/budget-impact-preview.integration.spec.ts app/components/transactions/QuickTransactionForm/__tests__/QuickTransactionForm.spec.ts app/components/transactions/EditTransactionModal/__tests__/EditTransactionModal.spec.ts --coverage.enabled=false`
- `pnpm exec vitest run app/pages/budgets.spec.ts app/pages/budgets.envelopes.spec.ts --coverage.enabled=false`
- `pnpm quality-check`
- Pre-push hook completo passou, incluindo build/prerender.

Closes #1038
Closes #1039