### PR TITLE
[codex] Orçamentos: contrato v2 e hub de envelopes

### DIFF
--- a/app/features/budgets/model/budget-envelope.spec.ts
+++ b/app/features/budgets/model/budget-envelope.spec.ts
@@ -4,9 +4,11 @@ import type { BudgetDto } from "~/features/budgets/contracts/budget.contracts";
 import type { Subscription } from "~/features/subscription/model/subscription";
 import {
   BUDGET_FREE_ENVELOPE_LIMIT,
+  buildBudgetTransactionFilters,
   buildBudgetQuotaState,
   getBudgetUsageLevel,
   normalizeBudgetEnvelope,
+  pickDefaultBudgetEnvelope,
   summarizeBudgetEnvelopes,
 } from "./budget-envelope";
 
@@ -128,6 +130,62 @@ describe("summarizeBudgetEnvelopes", () => {
     expect(summary.overallPercentage).toBe(72);
     expect(summary.warningCount).toBe(1);
     expect(summary.dangerCount).toBe(1);
+  });
+});
+
+describe("pickDefaultBudgetEnvelope", () => {
+  it("selects the most critical envelope by status and percentage used", () => {
+    const healthy = normalizeBudgetEnvelope(makeBudget({ id: "healthy", amount: "1000", spent: "250" }));
+    const warning = normalizeBudgetEnvelope(makeBudget({ id: "warning", amount: "1000", spent: "850" }));
+    const danger = normalizeBudgetEnvelope(makeBudget({ id: "danger", amount: "1200", spent: "31579.16" }));
+
+    expect(pickDefaultBudgetEnvelope([healthy, danger, warning])?.id).toBe("danger");
+  });
+
+  it("returns null when there are no envelopes", () => {
+    expect(pickDefaultBudgetEnvelope([])).toBeNull();
+  });
+});
+
+describe("buildBudgetTransactionFilters", () => {
+  it("builds committed monthly expense filters for the selected envelope", () => {
+    const budget = makeBudget({
+      tag_id: "tag-ai",
+      period: "monthly",
+    });
+
+    expect(buildBudgetTransactionFilters(budget, new Date("2026-06-09T12:00:00Z"))).toEqual({
+      type: "expense",
+      start_date: "2026-06-01",
+      end_date: "2026-06-30",
+      tag_id: "tag-ai",
+    });
+  });
+
+  it("omits tag_id for a global monthly envelope", () => {
+    const budget = makeBudget({ tag_id: null, period: "monthly" });
+
+    expect(buildBudgetTransactionFilters(budget, new Date("2026-06-09T12:00:00Z"))).toEqual({
+      type: "expense",
+      start_date: "2026-06-01",
+      end_date: "2026-06-30",
+    });
+  });
+
+  it("uses the custom budget range when start and end dates are present", () => {
+    const budget = makeBudget({
+      period: "custom",
+      start_date: "2026-06-05",
+      end_date: "2026-06-20",
+      tag_id: "tag-custom",
+    });
+
+    expect(buildBudgetTransactionFilters(budget, new Date("2026-06-09T12:00:00Z"))).toEqual({
+      type: "expense",
+      start_date: "2026-06-05",
+      end_date: "2026-06-20",
+      tag_id: "tag-custom",
+    });
   });
 });
 

--- a/app/features/budgets/model/budget-envelope.ts
+++ b/app/features/budgets/model/budget-envelope.ts
@@ -1,5 +1,6 @@
 import type { BudgetDto } from "~/features/budgets/contracts/budget.contracts";
 import type { Subscription } from "~/features/subscription/model/subscription";
+import type { ListTransactionsFilters } from "~/features/transactions/services/transactions.client";
 import { parseCurrencyAmount } from "~/utils/currencyInput";
 
 export const BUDGET_FREE_ENVELOPE_LIMIT = 3;
@@ -47,6 +48,12 @@ interface BudgetQuotaInput {
   readonly budgetCount: number;
   readonly subscription: Subscription | null | undefined;
 }
+
+const usageRiskRank: Record<BudgetUsageLevel, number> = {
+  healthy: 0,
+  warning: 1,
+  danger: 2,
+};
 
 /**
  * Converts a loose numeric value into a finite number.
@@ -196,6 +203,119 @@ export const summarizeBudgetEnvelopes = (
     overallPercentage,
     warningCount: envelopes.filter((envelope) => envelope.usageLevel === "warning").length,
     dangerCount: envelopes.filter((envelope) => envelope.usageLevel === "danger").length,
+  };
+};
+
+/**
+ * Selects the envelope that deserves attention first.
+ *
+ * @param envelopes Normalized budget envelopes.
+ * @returns Most critical envelope, or null for an empty list.
+ */
+export const pickDefaultBudgetEnvelope = (
+  envelopes: readonly BudgetEnvelopeView[],
+): BudgetEnvelopeView | null => {
+  if (envelopes.length === 0) {
+    return null;
+  }
+
+  return [...envelopes].sort((left, right) => {
+    const riskDelta = usageRiskRank[right.usageLevel] - usageRiskRank[left.usageLevel];
+    if (riskDelta !== 0) {
+      return riskDelta;
+    }
+
+    const percentageDelta = right.percentageUsed - left.percentageUsed;
+    if (percentageDelta !== 0) {
+      return percentageDelta;
+    }
+
+    const spentDelta = right.spent - left.spent;
+    if (spentDelta !== 0) {
+      return spentDelta;
+    }
+
+    return left.name.localeCompare(right.name, "pt-BR");
+  })[0] ?? null;
+};
+
+/**
+ * Formats a Date using local calendar parts instead of ISO UTC conversion.
+ *
+ * @param date Date to format.
+ * @returns YYYY-MM-DD string.
+ */
+const formatDateOnly = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+/**
+ * Gets the first and last day of the current month.
+ *
+ * @param today Reference date.
+ * @returns Monthly range.
+ */
+const buildMonthlyRange = (today: Date): Pick<ListTransactionsFilters, "start_date" | "end_date"> => {
+  const start = new Date(today.getFullYear(), today.getMonth(), 1);
+  const end = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+  return {
+    start_date: formatDateOnly(start),
+    end_date: formatDateOnly(end),
+  };
+};
+
+/**
+ * Gets the Monday-Sunday week range for a reference date.
+ *
+ * @param today Reference date.
+ * @returns Weekly range.
+ */
+const buildWeeklyRange = (today: Date): Pick<ListTransactionsFilters, "start_date" | "end_date"> => {
+  const start = new Date(today);
+  const day = start.getDay();
+  const mondayOffset = day === 0 ? -6 : 1 - day;
+  start.setDate(start.getDate() + mondayOffset);
+
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+
+  return {
+    start_date: formatDateOnly(start),
+    end_date: formatDateOnly(end),
+  };
+};
+
+/**
+ * Builds the transaction preview filters for a selected budget envelope.
+ *
+ * @param budget Raw budget DTO.
+ * @param today Reference date used for monthly/weekly envelopes.
+ * @returns Expense filters compatible with the transactions client.
+ */
+export const buildBudgetTransactionFilters = (
+  budget: BudgetDto,
+  today: Date = new Date(),
+): ListTransactionsFilters => {
+  let periodFilters: Pick<ListTransactionsFilters, "start_date" | "end_date">;
+
+  if (budget.period === "custom" && budget.start_date && budget.end_date) {
+    periodFilters = {
+      start_date: budget.start_date,
+      end_date: budget.end_date,
+    };
+  } else if (budget.period === "weekly") {
+    periodFilters = buildWeeklyRange(today);
+  } else {
+    periodFilters = buildMonthlyRange(today);
+  }
+
+  return {
+    type: "expense",
+    ...periodFilters,
+    ...(budget.tag_id ? { tag_id: budget.tag_id } : {}),
   };
 };
 

--- a/app/features/budgets/services/budget.client.spec.ts
+++ b/app/features/budgets/services/budget.client.spec.ts
@@ -45,6 +45,29 @@ describe("BudgetClient", () => {
   });
 
   describe("listBudgets", () => {
+    it("unwraps the v2 /budgets envelope from the API contract", async () => {
+      const budget = makeBudgetDto({
+        id: "b7b413f3-e459-4b5e-9102-4ffe8be8bab4",
+        name: "IA's e automações",
+        amount: "1200.00",
+        spent: "31579.16",
+        remaining: "-30379.16",
+        percentage_used: 2631.6,
+        is_over_budget: true,
+      });
+      vi.mocked(http.get).mockResolvedValueOnce({
+        data: {
+          success: true,
+          message: "Orçamentos listados com sucesso",
+          data: { items: [budget] },
+        },
+      });
+
+      const result = await client.listBudgets();
+
+      expect(result).toEqual([budget]);
+    });
+
     it("returns items array from wrapped response", async () => {
       const budgets = [makeBudgetDto()];
       vi.mocked(http.get).mockResolvedValueOnce({ data: { items: budgets } });
@@ -74,6 +97,24 @@ describe("BudgetClient", () => {
   });
 
   describe("createBudget", () => {
+    it("unwraps the v2 create envelope and returns the created budget", async () => {
+      const budget = makeBudgetDto();
+      vi.mocked(http.post).mockResolvedValueOnce({
+        data: {
+          success: true,
+          message: "Orçamento criado com sucesso",
+          data: { budget },
+        },
+      });
+
+      const result = await client.createBudget({
+        name: "Alimentação Mensal",
+        amount: "800.00",
+      });
+
+      expect(result).toEqual(budget);
+    });
+
     it("calls POST /budgets and returns the created budget", async () => {
       const budget = makeBudgetDto();
       vi.mocked(http.post).mockResolvedValueOnce({ data: budget });
@@ -92,6 +133,21 @@ describe("BudgetClient", () => {
   });
 
   describe("updateBudget", () => {
+    it("unwraps the v2 update envelope and returns the updated budget", async () => {
+      const budget = makeBudgetDto({ name: "Alimentação Atualizada" });
+      vi.mocked(http.patch).mockResolvedValueOnce({
+        data: {
+          success: true,
+          message: "Orçamento atualizado com sucesso",
+          data: { budget },
+        },
+      });
+
+      const result = await client.updateBudget("budget-001", { name: "Alimentação Atualizada" });
+
+      expect(result).toEqual(budget);
+    });
+
     it("calls PATCH /budgets/:id and returns updated budget", async () => {
       const budget = makeBudgetDto({ name: "Alimentação Atualizada" });
       vi.mocked(http.patch).mockResolvedValueOnce({ data: budget });
@@ -116,6 +172,27 @@ describe("BudgetClient", () => {
   });
 
   describe("getSummary", () => {
+    it("unwraps the v2 summary envelope", async () => {
+      const summary: BudgetSummaryDto = {
+        total_budgeted: "1200.00",
+        total_spent: "31579.16",
+        total_remaining: "-30379.16",
+        percentage_used: 2631.6,
+        budget_count: 1,
+      };
+      vi.mocked(http.get).mockResolvedValueOnce({
+        data: {
+          success: true,
+          message: "Resumo de orçamentos calculado com sucesso",
+          data: { summary },
+        },
+      });
+
+      const result = await client.getSummary();
+
+      expect(result).toEqual(summary);
+    });
+
     it("calls GET /budgets/summary and returns BudgetSummaryDto", async () => {
       const summary: BudgetSummaryDto = {
         total_budgeted: "1200.00",

--- a/app/features/budgets/services/budget.client.ts
+++ b/app/features/budgets/services/budget.client.ts
@@ -8,6 +8,112 @@ import type {
   UpdateBudgetPayload,
 } from "~/features/budgets/contracts/budget.contracts";
 
+interface ApiEnvelope<T> {
+  readonly success?: boolean;
+  readonly message?: string;
+  readonly data?: T;
+}
+
+interface BudgetListPayload {
+  readonly items?: BudgetDto[];
+}
+
+interface BudgetPayload {
+  readonly budget?: BudgetDto;
+}
+
+interface BudgetSummaryPayload {
+  readonly summary?: BudgetSummaryDto;
+}
+
+type BudgetListResponse =
+  | ApiEnvelope<BudgetListPayload | BudgetDto[]>
+  | BudgetListPayload
+  | BudgetDto[];
+
+type BudgetResponse =
+  | ApiEnvelope<BudgetPayload | BudgetDto>
+  | BudgetPayload
+  | BudgetDto;
+
+type BudgetSummaryResponse =
+  | ApiEnvelope<BudgetSummaryPayload | BudgetSummaryDto>
+  | BudgetSummaryPayload
+  | BudgetSummaryDto;
+
+/**
+ * Unwraps REST v2 response envelopes while preserving legacy direct payloads.
+ *
+ * @param payload Raw Axios response body.
+ * @returns Payload nested under `data`, or the payload itself.
+ */
+const unwrapApiEnvelope = <T>(payload: ApiEnvelope<T> | T): T => {
+  if (
+    payload
+    && typeof payload === "object"
+    && "data" in payload
+    && (payload as ApiEnvelope<T>).data !== undefined
+  ) {
+    return (payload as ApiEnvelope<T>).data as T;
+  }
+
+  return payload as T;
+};
+
+/**
+ * Coerces all supported GET /budgets shapes into an array.
+ *
+ * @param payload Raw response body.
+ * @returns Budget list.
+ */
+const coerceBudgetList = (
+  payload: BudgetListResponse,
+): BudgetDto[] => {
+  const data = unwrapApiEnvelope<BudgetListPayload | BudgetDto[]>(payload);
+
+  if (Array.isArray(data)) {
+    return data;
+  }
+
+  return data.items ?? [];
+};
+
+/**
+ * Coerces single-budget responses into a BudgetDto.
+ *
+ * @param payload Raw response body.
+ * @returns Budget item.
+ */
+const coerceBudget = (
+  payload: BudgetResponse,
+): BudgetDto => {
+  const data = unwrapApiEnvelope<BudgetPayload | BudgetDto>(payload);
+
+  if (data && typeof data === "object" && "budget" in data && data.budget) {
+    return data.budget;
+  }
+
+  return data as BudgetDto;
+};
+
+/**
+ * Coerces summary responses into BudgetSummaryDto.
+ *
+ * @param payload Raw response body.
+ * @returns Budget summary.
+ */
+const coerceBudgetSummary = (
+  payload: BudgetSummaryResponse,
+): BudgetSummaryDto => {
+  const data = unwrapApiEnvelope<BudgetSummaryPayload | BudgetSummaryDto>(payload);
+
+  if (data && typeof data === "object" && "summary" in data && data.summary) {
+    return data.summary;
+  }
+
+  return data as BudgetSummaryDto;
+};
+
 /**
  * API client for the budgets feature.
  *
@@ -29,13 +135,8 @@ export class BudgetClient {
    * @returns Array of BudgetDto objects.
    */
   async listBudgets(): Promise<BudgetDto[]> {
-    const response = await this.#http.get<{ items: BudgetDto[] }>("/budgets");
-    // Handle both direct array and wrapped response shapes
-    const data = response.data as BudgetDto[] | { items: BudgetDto[] };
-    if (Array.isArray(data)) {
-      return data;
-    }
-    return data.items ?? [];
+    const response = await this.#http.get<BudgetListResponse>("/budgets");
+    return coerceBudgetList(response.data);
   }
 
   /**
@@ -45,8 +146,8 @@ export class BudgetClient {
    * @returns BudgetDto.
    */
   async getBudget(id: string): Promise<BudgetDto> {
-    const response = await this.#http.get<BudgetDto>(`/budgets/${id}`);
-    return response.data;
+    const response = await this.#http.get<BudgetResponse>(`/budgets/${id}`);
+    return coerceBudget(response.data);
   }
 
   /**
@@ -56,8 +157,8 @@ export class BudgetClient {
    * @returns Created BudgetDto.
    */
   async createBudget(payload: CreateBudgetPayload): Promise<BudgetDto> {
-    const response = await this.#http.post<BudgetDto>("/budgets", payload);
-    return response.data;
+    const response = await this.#http.post<BudgetResponse>("/budgets", payload);
+    return coerceBudget(response.data);
   }
 
   /**
@@ -68,8 +169,8 @@ export class BudgetClient {
    * @returns Updated BudgetDto.
    */
   async updateBudget(id: string, payload: UpdateBudgetPayload): Promise<BudgetDto> {
-    const response = await this.#http.patch<BudgetDto>(`/budgets/${id}`, payload);
-    return response.data;
+    const response = await this.#http.patch<BudgetResponse>(`/budgets/${id}`, payload);
+    return coerceBudget(response.data);
   }
 
   /**
@@ -87,8 +188,8 @@ export class BudgetClient {
    * @returns BudgetSummaryDto.
    */
   async getSummary(): Promise<BudgetSummaryDto> {
-    const response = await this.#http.get<BudgetSummaryDto>("/budgets/summary");
-    return response.data;
+    const response = await this.#http.get<BudgetSummaryResponse>("/budgets/summary");
+    return coerceBudgetSummary(response.data);
   }
 }
 

--- a/app/pages/budgets.envelopes.spec.ts
+++ b/app/pages/budgets.envelopes.spec.ts
@@ -21,4 +21,23 @@ describe("budgets page envelope positioning", () => {
     expect(source).toContain("Transporte");
     expect(source).toContain("Comprometido");
   });
+
+  it("renders the C+A monthly review structure instead of loose budget cards", () => {
+    const source = readSource("app/pages/budgets.vue");
+
+    expect(source).toContain("Revisão mensal de envelopes");
+    expect(source).toContain("budgets-page__review-grid");
+    expect(source).toContain("budgets-page__envelope-list");
+    expect(source).toContain("budgets-page__detail-panel");
+    expect(source).toContain("selectedEnvelope");
+  });
+
+  it("connects the selected envelope to transaction review without adding budget_id", () => {
+    const source = readSource("app/pages/budgets.vue");
+
+    expect(source).toContain("useListTransactionsQuery");
+    expect(source).toContain("buildBudgetTransactionFilters");
+    expect(source).toContain("Revisar transações");
+    expect(source).not.toContain("budget_id");
+  });
 });

--- a/app/pages/budgets.vue
+++ b/app/pages/budgets.vue
@@ -1,37 +1,69 @@
 <script setup lang="ts">
 import {
   NButton,
-  NCard,
-  NProgress,
-  NTag,
-  NPopconfirm,
-  NModal,
+  NDatePicker,
   NForm,
   NFormItem,
   NInput,
+  NModal,
+  NPopconfirm,
+  NProgress,
   NSelect,
-  NDatePicker,
-  NStatistic,
   NSpace,
+  NTag,
 } from "naive-ui";
-import { AlertTriangle, CheckCircle2, Crown, Gauge } from "lucide-vue-next";
-import { useBudgetsQuery } from "~/features/budgets/queries/use-budgets-query";
-import { useCreateBudgetMutation } from "~/features/budgets/queries/use-create-budget-mutation";
-import { useUpdateBudgetMutation } from "~/features/budgets/queries/use-update-budget-mutation";
-import { useDeleteBudgetMutation } from "~/features/budgets/queries/use-delete-budget-mutation";
-import { useTagsQuery } from "~/features/tags/queries/use-tags-query";
+import {
+  AlertTriangle,
+  ArrowUpRight,
+  BarChart3,
+  CalendarDays,
+  CheckCircle2,
+  Crown,
+  FileSearch,
+  Gauge,
+  LineChart,
+  PiggyBank,
+  Plus,
+  ReceiptText,
+  SlidersHorizontal,
+  Sparkles,
+  Tags,
+  WalletCards,
+} from "lucide-vue-next";
+
 import UiUpgradePrompt from "~/components/paywall/UiUpgradePrompt.vue";
 import AiInsightSurface from "~/features/ai-insights/components/AiInsightSurface.vue";
-import type { BudgetDto, CreateBudgetPayload, BudgetPeriod } from "~/features/budgets/contracts/budget.contracts";
-import { useSubscriptionQuery } from "~/features/subscription/queries/use-subscription-query";
+import type {
+  BudgetDto,
+  BudgetPeriod,
+  CreateBudgetPayload,
+} from "~/features/budgets/contracts/budget.contracts";
 import {
   buildBudgetQuotaState,
+  buildBudgetTransactionFilters,
   normalizeBudgetEnvelope,
+  pickDefaultBudgetEnvelope,
   summarizeBudgetEnvelopes,
+  type BudgetEnvelopeView,
   type BudgetUsageLevel,
 } from "~/features/budgets/model/budget-envelope";
+import { useBudgetsQuery } from "~/features/budgets/queries/use-budgets-query";
+import { useCreateBudgetMutation } from "~/features/budgets/queries/use-create-budget-mutation";
+import { useDeleteBudgetMutation } from "~/features/budgets/queries/use-delete-budget-mutation";
+import { useUpdateBudgetMutation } from "~/features/budgets/queries/use-update-budget-mutation";
+import { useSubscriptionQuery } from "~/features/subscription/queries/use-subscription-query";
+import { useTagsQuery } from "~/features/tags/queries/use-tags-query";
+import type {
+  TransactionDto,
+  TransactionStatusDto,
+} from "~/features/transactions/contracts/transaction.dto";
+import { useListTransactionsQuery } from "~/features/transactions/queries/use-list-transactions-query";
+import type { ListTransactionsFilters } from "~/features/transactions/services/transactions.client";
 import { formatCurrency } from "~/utils/currency";
-import { parseCurrencyAmount, serializeCurrencyAmount } from "~/utils/currencyInput";
+import {
+  parseCurrencyAmount,
+  serializeCurrencyAmount,
+} from "~/utils/currencyInput";
 
 const { t } = useI18n();
 
@@ -43,7 +75,36 @@ definePageMeta({
 
 useHead({ title: "Orçamentos | Auraxis" });
 
-// --- queries ---
+const usageRiskRank: Record<BudgetUsageLevel, number> = {
+  healthy: 0,
+  warning: 1,
+  danger: 2,
+};
+
+const usageLevelLabels: Record<BudgetUsageLevel, string> = {
+  healthy: "Saudável",
+  warning: "Atenção",
+  danger: "Estourado",
+};
+
+const usageLevelTagTypes: Record<BudgetUsageLevel, "success" | "warning" | "error"> = {
+  healthy: "success",
+  warning: "warning",
+  danger: "error",
+};
+
+const committedTransactionStatuses = new Set<TransactionStatusDto>([
+  "paid",
+  "pending",
+  "overdue",
+]);
+
+const dateFormatter = new Intl.DateTimeFormat("pt-BR", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+});
+
 const { data: budgets, isLoading, isError } = useBudgetsQuery();
 const { data: tags } = useTagsQuery();
 const { data: subscription } = useSubscriptionQuery();
@@ -51,24 +112,43 @@ const createMutation = useCreateBudgetMutation();
 const updateMutation = useUpdateBudgetMutation();
 const deleteMutation = useDeleteBudgetMutation();
 
-// --- form state ---
 const showForm = ref<boolean>(false);
 const showUpgradeModal = ref<boolean>(false);
 const editingBudget = ref<BudgetDto | null>(null);
+const selectedBudgetId = ref<string | null>(null);
 const formName = ref<string>("");
 const formAmount = ref<number | null>(null);
 const formPeriod = ref<BudgetPeriod>("monthly");
 const formTagId = ref<string | null>(null);
 const formDateRange = ref<[number, number] | null>(null);
 
-// --- computed ---
 const allBudgets = computed(() => budgets.value ?? []);
 
 const budgetEnvelopes = computed(() =>
   allBudgets.value.map(normalizeBudgetEnvelope),
 );
 
+const sortedBudgetEnvelopes = computed(() =>
+  [...budgetEnvelopes.value].sort((left, right) => {
+    const riskDelta = usageRiskRank[right.usageLevel] - usageRiskRank[left.usageLevel];
+    if (riskDelta !== 0) {
+      return riskDelta;
+    }
+
+    const percentageDelta = right.percentageUsed - left.percentageUsed;
+    if (percentageDelta !== 0) {
+      return percentageDelta;
+    }
+
+    return right.spent - left.spent;
+  }),
+);
+
 const budgetSummary = computed(() => summarizeBudgetEnvelopes(budgetEnvelopes.value));
+
+const riskEnvelopeCount = computed(
+  () => budgetSummary.value.warningCount + budgetSummary.value.dangerCount,
+);
 
 const quotaState = computed(() =>
   buildBudgetQuotaState({
@@ -83,16 +163,76 @@ const quotaDescription = computed(() =>
     : "No plano gratuito, você pode acompanhar até 3 envelopes. Assine Premium para organizar categorias ilimitadas.",
 );
 
-const budgetHealthText = computed(() => {
-  if (budgetSummary.value.dangerCount > 0) {
-    return `${budgetSummary.value.dangerCount} envelope(s) acima do limite`;
+const selectedEnvelope = computed<BudgetEnvelopeView | null>(() => {
+  if (selectedBudgetId.value) {
+    const selected = sortedBudgetEnvelopes.value.find(
+      (envelope) => envelope.id === selectedBudgetId.value,
+    );
+
+    if (selected) {
+      return selected;
+    }
   }
 
-  if (budgetSummary.value.warningCount > 0) {
-    return `${budgetSummary.value.warningCount} envelope(s) pedem atenção`;
+  return pickDefaultBudgetEnvelope(sortedBudgetEnvelopes.value);
+});
+
+watch(
+  sortedBudgetEnvelopes,
+  (envelopes) => {
+    const currentSelectionExists = selectedBudgetId.value
+      ? envelopes.some((envelope) => envelope.id === selectedBudgetId.value)
+      : false;
+
+    if (!currentSelectionExists) {
+      selectedBudgetId.value = pickDefaultBudgetEnvelope(envelopes)?.id ?? null;
+    }
+  },
+  { immediate: true },
+);
+
+const selectedBudget = computed(() => selectedEnvelope.value?.raw ?? null);
+
+/**
+ * Builds a safe monthly filter while no envelope is selected yet.
+ *
+ * @returns Expense filters for the current month.
+ */
+const fallbackTransactionFilters = (): ListTransactionsFilters => {
+  const today = new Date();
+  const start = new Date(today.getFullYear(), today.getMonth(), 1);
+  const end = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+
+  return {
+    type: "expense",
+    start_date: start.toISOString().split("T")[0],
+    end_date: end.toISOString().split("T")[0],
+  };
+};
+
+const selectedTransactionFilters = computed<ListTransactionsFilters>(() =>
+  selectedBudget.value
+    ? buildBudgetTransactionFilters(selectedBudget.value)
+    : fallbackTransactionFilters(),
+);
+
+const {
+  data: transactionPreview,
+  isError: isTransactionPreviewError,
+  isLoading: isTransactionPreviewLoading,
+} = useListTransactionsQuery(selectedTransactionFilters);
+
+const previewTransactions = computed<TransactionDto[]>(() => {
+  if (!selectedBudget.value) {
+    return [];
   }
 
-  return "Todos os envelopes estão dentro do limite";
+  return (transactionPreview.value ?? [])
+    .filter((transaction) =>
+      transaction.type === "expense"
+      && committedTransactionStatuses.has(transaction.status),
+    )
+    .slice(0, 5);
 });
 
 const tagOptions = computed(() => {
@@ -113,17 +253,51 @@ const periodOptions = computed(() => [
 
 const isCustomPeriod = computed(() => formPeriod.value === "custom");
 
-const usageLevelLabels: Record<BudgetUsageLevel, string> = {
-  healthy: "Saudável",
-  warning: "Atenção",
-  danger: "Estourado",
-};
+const budgetHealthText = computed(() => {
+  if (budgetSummary.value.dangerCount > 0) {
+    return `${budgetSummary.value.dangerCount} envelope(s) estourado(s)`;
+  }
 
-const usageLevelTagTypes: Record<BudgetUsageLevel, "success" | "warning" | "error"> = {
-  healthy: "success",
-  warning: "warning",
-  danger: "error",
-};
+  if (budgetSummary.value.warningCount > 0) {
+    return `${budgetSummary.value.warningCount} envelope(s) pedem atenção`;
+  }
+
+  return "Todos os envelopes estão dentro do limite";
+});
+
+const selectedPeriodLabel = computed(() => {
+  const budget = selectedBudget.value;
+  if (!budget) {
+    return "Período";
+  }
+
+  if (budget.period === "custom" && budget.start_date && budget.end_date) {
+    return `${formatDate(budget.start_date)} até ${formatDate(budget.end_date)}`;
+  }
+
+  if (budget.period === "weekly") {
+    return "Semana atual";
+  }
+
+  return "Mês atual";
+});
+
+const selectedDiagnosis = computed(() => {
+  const envelope = selectedEnvelope.value;
+  if (!envelope) {
+    return "Selecione um envelope para revisar limite, comprometido e transações associadas.";
+  }
+
+  if (envelope.usageLevel === "danger") {
+    return "O limite já foi ultrapassado. Revise as transações vinculadas e ajuste o teto caso esse gasto seja recorrente.";
+  }
+
+  if (envelope.usageLevel === "warning") {
+    return "Este envelope está perto do limite. Vale revisar lançamentos pendentes antes de assumir novos gastos.";
+  }
+
+  return "O envelope está saudável. Continue acompanhando as entradas do período para preservar a folga.";
+});
 
 /**
  * Returns the display label for a budget usage level.
@@ -143,12 +317,33 @@ const usageLevelTagType = (
   level: BudgetUsageLevel,
 ): "success" | "warning" | "error" => usageLevelTagTypes[level];
 
+/**
+ * Formats a date-only value for PT-BR display.
+ *
+ * @param value Date string in YYYY-MM-DD format.
+ * @returns Localized date string.
+ */
+function formatDate(value: string | null): string {
+  if (!value) {
+    return "Sem data";
+  }
+
+  return dateFormatter.format(new Date(`${value}T00:00:00`));
+}
+
+/**
+ * Selects an envelope in the monthly review.
+ *
+ * @param id Budget envelope identifier.
+ */
+const onSelectBudget = (id: string): void => {
+  selectedBudgetId.value = id;
+};
+
 /** Opens the premium upgrade modal. */
 const openUpgradeModal = (): void => {
   showUpgradeModal.value = true;
 };
-
-// --- actions ---
 
 /** Opens the create form. */
 const onNewBudget = (): void => {
@@ -169,7 +364,7 @@ const onNewBudget = (): void => {
 /**
  * Opens the edit form pre-filled with existing budget data.
  *
- * @param budget - The budget to edit.
+ * @param budget The budget to edit.
  */
 const onEditBudget = (budget: BudgetDto): void => {
   editingBudget.value = budget;
@@ -188,9 +383,18 @@ const onEditBudget = (budget: BudgetDto): void => {
   showForm.value = true;
 };
 
+/** Opens the edit flow focused on the selected envelope limit. */
+const onAdjustSelectedLimit = (): void => {
+  if (selectedBudget.value) {
+    onEditBudget(selectedBudget.value);
+  }
+};
+
 /** Submits the create/edit form. */
 const onSubmitForm = (): void => {
-  if (!formName.value || !formAmount.value) {return;}
+  if (!formName.value || !formAmount.value) {
+    return;
+  }
 
   const payload: CreateBudgetPayload = {
     name: formName.value,
@@ -229,29 +433,26 @@ const onSubmitForm = (): void => {
 /**
  * Deletes a budget by ID.
  *
- * @param id - The budget ID to delete.
+ * @param id Budget ID to delete.
  */
 const onDeleteBudget = (id: string): void => {
-  deleteMutation.mutate(id);
+  deleteMutation.mutate(id, {
+    onSuccess: (): void => {
+      if (selectedBudgetId.value === id) {
+        selectedBudgetId.value = null;
+      }
+    },
+  });
+};
+
+/** Navigates to the transactions workspace for deeper review. */
+const onReviewTransactions = (): void => {
+  void navigateTo("/transactions");
 };
 </script>
 
 <template>
   <div class="budgets-page">
-    <!-- Header -->
-    <div class="budgets-page__header">
-      <div class="budgets-page__title-block">
-        <span class="budgets-page__title">{{ $t('pages.budgets.title') }}</span>
-        <span class="budgets-page__subtitle">
-          Defina envelopes automáticos como Streaming, Mercado ou Transporte. As transações com a tag correspondente atualizam o comprometido do mês.
-        </span>
-      </div>
-      <NButton type="primary" size="medium" @click="onNewBudget">
-        Novo envelope
-      </NButton>
-    </div>
-
-    <!-- Error state -->
     <UiInlineError
       v-if="isError"
       :title="$t('pages.budgets.loadError')"
@@ -259,6 +460,34 @@ const onDeleteBudget = (id: string): void => {
     />
 
     <template v-else>
+      <section class="budgets-page__command" aria-label="Revisão mensal de envelopes">
+        <div class="budgets-page__command-copy">
+          <span class="budgets-page__eyebrow">
+            <Sparkles :size="16" aria-hidden="true" />
+            Revisão mensal de envelopes
+          </span>
+          <p>
+            Envelopes automáticos como Streaming, Mercado ou Transporte mostram quanto do limite
+            já foi comprometido pelas transações do período.
+          </p>
+        </div>
+
+        <div class="budgets-page__command-actions">
+          <NButton secondary type="primary" @click="onReviewTransactions">
+            <template #icon>
+              <ReceiptText :size="18" />
+            </template>
+            Revisar transações
+          </NButton>
+          <NButton type="primary" @click="onNewBudget">
+            <template #icon>
+              <Plus :size="18" />
+            </template>
+            Novo orçamento
+          </NButton>
+        </div>
+      </section>
+
       <AiInsightSurface dimension="budgets" />
 
       <section
@@ -289,50 +518,8 @@ const onDeleteBudget = (id: string): void => {
         </NButton>
       </section>
 
-      <!-- Summary bar -->
-      <NCard v-if="budgetEnvelopes.length > 0" class="budgets-page__summary-card" :bordered="true">
-        <div class="budgets-page__summary-stats">
-          <NStatistic
-            :label="$t('pages.budgets.summary.budgeted')"
-            :value="formatCurrency(budgetSummary.totalBudgeted)"
-          />
-          <NStatistic
-            label="Comprometido"
-            :value="formatCurrency(budgetSummary.totalSpent)"
-          />
-          <NStatistic
-            :label="$t('pages.budgets.summary.remaining')"
-            :value="formatCurrency(budgetSummary.totalRemaining)"
-          />
-        </div>
-        <div class="budgets-page__health-row">
-          <span class="budgets-page__health-item">
-            <CheckCircle2 :size="16" aria-hidden="true" />
-            {{ budgetHealthText }}
-          </span>
-          <span v-if="budgetSummary.warningCount > 0" class="budgets-page__health-item budgets-page__health-item--warning">
-            <AlertTriangle :size="16" aria-hidden="true" />
-            {{ budgetSummary.warningCount }} perto do limite
-          </span>
-          <span v-if="budgetSummary.dangerCount > 0" class="budgets-page__health-item budgets-page__health-item--danger">
-            <AlertTriangle :size="16" aria-hidden="true" />
-            {{ budgetSummary.dangerCount }} estourado(s)
-          </span>
-        </div>
-        <NProgress
-          class="budgets-page__overall-progress"
-          type="line"
-          :percentage="budgetSummary.overallPercentage"
-          :status="budgetSummary.dangerCount > 0 ? 'error' : budgetSummary.warningCount > 0 ? 'warning' : 'default'"
-          :show-indicator="true"
-          aria-label="Uso comprometido total dos envelopes"
-        />
-      </NCard>
-
-      <!-- Loading -->
       <UiPageLoader v-if="isLoading" :rows="3" />
 
-      <!-- Empty state -->
       <UiEmptyState
         v-else-if="budgetEnvelopes.length === 0"
         class="budgets-page__empty"
@@ -345,104 +532,334 @@ const onDeleteBudget = (id: string): void => {
         @action="onNewBudget"
       >
         <template #illustration>
-          <svg class="ui-empty-state__illustration-svg" viewBox="0 0 220 150" role="img" aria-label="Ilustração de orçamento vazio">
-            <rect x="34" y="28" width="152" height="98" rx="16" fill="var(--color-bg-elevated)" stroke="var(--color-outline-soft)" stroke-width="3" />
-            <path d="M62 100V74m32 26V55m32 45V66m32 34V45" stroke="var(--color-brand-500)" stroke-width="9" stroke-linecap="round" />
-            <path d="M58 116h104" stroke="var(--color-outline-hard)" stroke-width="5" stroke-linecap="round" />
-            <circle cx="168" cy="43" r="18" fill="var(--color-positive-bg)" stroke="var(--color-positive)" stroke-width="4" />
-            <path d="M160 43h16m-8-8v16" stroke="var(--color-positive)" stroke-width="4" stroke-linecap="round" />
+          <svg
+            class="ui-empty-state__illustration-svg budgets-page__empty-illustration"
+            viewBox="0 0 220 150"
+            role="img"
+            aria-label="Ilustração de orçamento vazio"
+          >
+            <rect
+              x="34"
+              y="28"
+              width="152"
+              height="98"
+              rx="16"
+              fill="var(--color-bg-elevated)"
+              stroke="var(--color-outline-soft)"
+              stroke-width="3"
+            />
+            <path
+              d="M62 100V74m32 26V55m32 45V66m32 34V45"
+              stroke="var(--color-brand-500)"
+              stroke-width="9"
+              stroke-linecap="round"
+            />
+            <path
+              d="M58 116h104"
+              stroke="var(--color-outline-hard)"
+              stroke-width="5"
+              stroke-linecap="round"
+            />
+            <circle
+              cx="168"
+              cy="43"
+              r="18"
+              fill="var(--color-positive-bg)"
+              stroke="var(--color-positive)"
+              stroke-width="4"
+            />
+            <path
+              d="M160 43h16m-8-8v16"
+              stroke="var(--color-positive)"
+              stroke-width="4"
+              stroke-linecap="round"
+            />
           </svg>
         </template>
       </UiEmptyState>
 
-      <!-- Budget cards -->
-      <div v-else class="budgets-page__grid">
-        <NCard
-          v-for="budget in budgetEnvelopes"
-          :key="budget.id"
-          class="budgets-page__budget-card"
-          :class="`budgets-page__budget-card--${budget.usageLevel}`"
-          :bordered="true"
-        >
-          <div class="budget-card__top">
-            <div class="budget-card__tag-info">
-              <span
-                v-if="budget.tagColor"
-                class="budget-card__tag-dot"
-                :style="{ backgroundColor: budget.tagColor }"
-              />
-              <span class="budget-card__tag-name">
-                {{
-                  budget.tagName ?? $t('pages.budgets.noCategory')
-                }}
-              </span>
+      <template v-else>
+        <section class="budgets-page__metrics" aria-label="Resumo dos envelopes">
+          <article class="budgets-page__metric">
+            <div class="budgets-page__metric-icon budgets-page__metric-icon--brand">
+              <WalletCards :size="18" aria-hidden="true" />
             </div>
-            <NTag :type="usageLevelTagType(budget.usageLevel)" size="small">
-              {{ usageLevelLabel(budget.usageLevel) }}
-            </NTag>
+            <span>Total orçado</span>
+            <strong>{{ formatCurrency(budgetSummary.totalBudgeted) }}</strong>
+          </article>
+
+          <article class="budgets-page__metric">
+            <div class="budgets-page__metric-icon budgets-page__metric-icon--info">
+              <LineChart :size="18" aria-hidden="true" />
+            </div>
+            <span>Comprometido</span>
+            <strong>{{ formatCurrency(budgetSummary.totalSpent) }}</strong>
+          </article>
+
+          <article
+            class="budgets-page__metric"
+            :class="{ 'budgets-page__metric--danger': budgetSummary.totalRemaining < 0 }"
+          >
+            <div class="budgets-page__metric-icon budgets-page__metric-icon--positive">
+              <PiggyBank :size="18" aria-hidden="true" />
+            </div>
+            <span>Restante</span>
+            <strong>{{ formatCurrency(budgetSummary.totalRemaining) }}</strong>
+          </article>
+
+          <article
+            class="budgets-page__metric"
+            :class="{ 'budgets-page__metric--danger': budgetSummary.dangerCount > 0 }"
+          >
+            <div class="budgets-page__metric-icon budgets-page__metric-icon--warning">
+              <AlertTriangle :size="18" aria-hidden="true" />
+            </div>
+            <span>Em risco</span>
+            <strong>{{ riskEnvelopeCount }}</strong>
+          </article>
+        </section>
+
+        <section class="budgets-page__health" aria-label="Saúde geral dos envelopes">
+          <div class="budgets-page__health-copy">
+            <CheckCircle2 v-if="budgetSummary.dangerCount === 0" :size="18" aria-hidden="true" />
+            <AlertTriangle v-else :size="18" aria-hidden="true" />
+            <span>{{ budgetHealthText }}</span>
           </div>
-
-          <div class="budget-card__name">{{ budget.name }}</div>
-
           <NProgress
-            class="budget-card__progress"
+            class="budgets-page__overall-progress"
             type="line"
-            :aria-label="`Uso comprometido do envelope ${budget.name}`"
-            :percentage="budget.progressPercentage"
-            :status="budget.progressStatus"
-            :show-indicator="false"
+            :percentage="budgetSummary.overallPercentage"
+            :status="budgetSummary.dangerCount > 0 ? 'error' : budgetSummary.warningCount > 0 ? 'warning' : 'default'"
+            :show-indicator="true"
+            aria-label="Uso comprometido total dos envelopes"
           />
+        </section>
 
-          <div class="budget-card__amounts">
-            <span class="budget-card__spent">
-              Comprometido: {{ formatCurrency(budget.spent) }} / {{ formatCurrency(budget.amount) }}
-            </span>
-            <span class="budget-card__pct">{{ budget.displayPercentage }}%</span>
+        <section class="budgets-page__review-grid">
+          <div class="budgets-page__envelope-list" aria-label="Lista de envelopes">
+            <div class="budgets-page__list-header">
+              <div>
+                <span>Envelopes</span>
+                <strong>{{ budgetEnvelopes.length }} ativos</strong>
+              </div>
+              <NTag type="info" size="small">ordenado por risco</NTag>
+            </div>
+
+            <button
+              v-for="budget in sortedBudgetEnvelopes"
+              :key="budget.id"
+              class="budget-row"
+              :class="[
+                `budget-row--${budget.usageLevel}`,
+                { 'budget-row--selected': selectedEnvelope?.id === budget.id },
+              ]"
+              type="button"
+              :aria-pressed="selectedEnvelope?.id === budget.id"
+              @click="onSelectBudget(budget.id)"
+            >
+              <span class="budget-row__accent" aria-hidden="true" />
+
+              <span class="budget-row__main">
+                <span class="budget-row__name">{{ budget.name }}</span>
+                <span class="budget-row__tag">
+                  <span
+                    v-if="budget.tagColor"
+                    class="budget-row__tag-dot"
+                    :style="{ backgroundColor: budget.tagColor }"
+                  />
+                  <Tags v-else :size="14" aria-hidden="true" />
+                  {{ budget.tagName ?? $t('pages.budgets.noCategory') }}
+                </span>
+              </span>
+
+              <span class="budget-row__numbers">
+                <span>
+                  <strong>{{ formatCurrency(budget.spent) }}</strong>
+                  <small>de {{ formatCurrency(budget.amount) }}</small>
+                </span>
+                <NTag :type="usageLevelTagType(budget.usageLevel)" size="small">
+                  {{ usageLevelLabel(budget.usageLevel) }}
+                </NTag>
+              </span>
+
+              <span class="budget-row__progress">
+                <NProgress
+                  type="line"
+                  :aria-label="`Uso comprometido do envelope ${budget.name}`"
+                  :percentage="budget.progressPercentage"
+                  :status="budget.progressStatus"
+                  :show-indicator="false"
+                />
+                <span>{{ budget.displayPercentage }}%</span>
+              </span>
+
+              <span
+                class="budget-row__remaining"
+                :class="{ 'budget-row__remaining--negative': budget.remaining < 0 }"
+              >
+                {{ formatCurrency(budget.remaining) }}
+              </span>
+            </button>
           </div>
 
-          <div class="budget-card__remaining">
-            {{ $t('pages.budgets.summary.remaining') }}: {{ formatCurrency(budget.remaining) }}
-          </div>
+          <aside class="budgets-page__detail-panel" aria-label="Detalhe do envelope selecionado">
+            <template v-if="selectedEnvelope">
+              <div class="detail-panel__header">
+                <div>
+                  <span class="detail-panel__eyebrow">
+                    <BarChart3 :size="16" aria-hidden="true" />
+                    Envelope selecionado
+                  </span>
+                  <h2>{{ selectedEnvelope.name }}</h2>
+                </div>
+                <NTag :type="usageLevelTagType(selectedEnvelope.usageLevel)">
+                  {{ usageLevelLabel(selectedEnvelope.usageLevel) }}
+                </NTag>
+              </div>
 
-          <div class="budget-card__actions">
-            <NButton size="small" @click="onEditBudget(budget.raw)">Editar</NButton>
-            <NPopconfirm @positive-click="onDeleteBudget(budget.id)">
-              <template #trigger>
-                <NButton size="small" type="error">Excluir</NButton>
-              </template>
-              {{ $t('pages.budgets.deleteConfirm') }}
-            </NPopconfirm>
-          </div>
-        </NCard>
-      </div>
+              <div class="detail-panel__hero">
+                <div class="detail-panel__hero-copy">
+                  <span>Comprometido</span>
+                  <strong>{{ formatCurrency(selectedEnvelope.spent) }}</strong>
+                  <small>Limite de {{ formatCurrency(selectedEnvelope.amount) }}</small>
+                </div>
+                <div
+                  class="detail-panel__orb"
+                  :class="`detail-panel__orb--${selectedEnvelope.usageLevel}`"
+                  aria-hidden="true"
+                >
+                  {{ selectedEnvelope.displayPercentage }}%
+                </div>
+              </div>
+
+              <NProgress
+                type="line"
+                :aria-label="`Uso comprometido do envelope ${selectedEnvelope.name}`"
+                :percentage="selectedEnvelope.progressPercentage"
+                :status="selectedEnvelope.progressStatus"
+                :show-indicator="false"
+              />
+
+              <div class="detail-panel__facts">
+                <article>
+                  <CalendarDays :size="17" aria-hidden="true" />
+                  <span>Período</span>
+                  <strong>{{ selectedPeriodLabel }}</strong>
+                </article>
+                <article>
+                  <Tags :size="17" aria-hidden="true" />
+                  <span>Origem</span>
+                  <strong>{{ selectedEnvelope.tagName ?? 'Todas as transações' }}</strong>
+                </article>
+                <article>
+                  <SlidersHorizontal :size="17" aria-hidden="true" />
+                  <span>Restante</span>
+                  <strong>{{ formatCurrency(selectedEnvelope.remaining) }}</strong>
+                </article>
+              </div>
+
+              <div
+                class="detail-panel__diagnosis"
+                :class="`detail-panel__diagnosis--${selectedEnvelope.usageLevel}`"
+              >
+                <AlertTriangle
+                  v-if="selectedEnvelope.usageLevel !== 'healthy'"
+                  :size="18"
+                  aria-hidden="true"
+                />
+                <CheckCircle2 v-else :size="18" aria-hidden="true" />
+                <p>{{ selectedDiagnosis }}</p>
+              </div>
+
+              <div class="detail-panel__actions">
+                <NButton type="primary" @click="onReviewTransactions">
+                  <template #icon>
+                    <FileSearch :size="18" />
+                  </template>
+                  Revisar transações
+                </NButton>
+                <NButton secondary @click="onAdjustSelectedLimit">
+                  Ajustar limite
+                </NButton>
+                <NButton secondary @click="onEditBudget(selectedEnvelope.raw)">
+                  Editar
+                </NButton>
+                <NPopconfirm @positive-click="onDeleteBudget(selectedEnvelope.id)">
+                  <template #trigger>
+                    <NButton secondary type="error">
+                      Excluir
+                    </NButton>
+                  </template>
+                  {{ $t('pages.budgets.deleteConfirm') }}
+                </NPopconfirm>
+              </div>
+
+              <section class="detail-panel__transactions" aria-label="Prévia de transações">
+                <div class="detail-panel__transactions-head">
+                  <div>
+                    <span>Transações do período</span>
+                    <strong>Prévia operacional</strong>
+                  </div>
+                  <NButton size="small" text type="primary" @click="onReviewTransactions">
+                    Abrir
+                    <template #icon>
+                      <ArrowUpRight :size="15" />
+                    </template>
+                  </NButton>
+                </div>
+
+                <UiPageLoader
+                  v-if="isTransactionPreviewLoading"
+                  class="detail-panel__transactions-loader"
+                  :rows="2"
+                />
+
+                <UiInlineError
+                  v-else-if="isTransactionPreviewError"
+                  title="Não foi possível carregar a prévia"
+                  message="A lista principal de envelopes segue disponível. Use Transações para investigar o período."
+                />
+
+                <div v-else-if="previewTransactions.length === 0" class="detail-panel__transactions-empty">
+                  Nenhuma despesa comprometida apareceu na prévia deste período.
+                </div>
+
+                <ul v-else class="detail-panel__transaction-list">
+                  <li v-for="transaction in previewTransactions" :key="transaction.id">
+                    <span>
+                      <strong>{{ transaction.title }}</strong>
+                      <small>{{ formatDate(transaction.due_date) }} · {{ transaction.status }}</small>
+                    </span>
+                    <b>{{ formatCurrency(parseCurrencyAmount(transaction.amount)) }}</b>
+                  </li>
+                </ul>
+              </section>
+            </template>
+          </aside>
+        </section>
+      </template>
     </template>
 
-    <!-- Create/Edit modal -->
     <NModal
       v-model:show="showForm"
+      class="budget-envelope-modal"
       preset="card"
       :title="editingBudget ? 'Editar envelope' : 'Novo envelope'"
-      style="max-width: 480px"
+      style="max-width: 520px"
       :mask-closable="true"
       @after-leave="editingBudget = null"
     >
       <NForm label-placement="top">
         <NFormItem label="Nome do envelope">
-          <NInput v-model:value="formName" placeholder="Ex.: Streaming" />
+          <NInput v-model:value="formName" placeholder="Ex.: Streaming e apps" />
         </NFormItem>
 
-        <NFormItem label="Limite mensal">
-          <UiMoneyInput
-            v-model:value="formAmount"
-            :min="0.01"
-          />
+        <NFormItem label="Limite do período">
+          <UiMoneyInput v-model:value="formAmount" :min="0.01" />
         </NFormItem>
 
         <NFormItem :label="$t('pages.budgets.form.period')">
-          <NSelect
-            v-model:value="formPeriod"
-            :options="periodOptions"
-          />
+          <NSelect v-model:value="formPeriod" :options="periodOptions" />
         </NFormItem>
 
         <NFormItem v-if="isCustomPeriod" :label="$t('pages.budgets.form.startDate')">
@@ -500,31 +917,52 @@ const onDeleteBudget = (id: string): void => {
   padding: var(--space-4);
 }
 
-.budgets-page__header {
+.budgets-page__command {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: flex-start;
-  gap: var(--space-2);
-  flex-wrap: wrap;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-lg);
+  background:
+    radial-gradient(circle at 12% 0%, var(--color-brand-glow-xs), transparent 34%),
+    linear-gradient(135deg, var(--color-bg-surface), var(--color-bg-elevated));
+  box-shadow: var(--shadow-card);
 }
 
-.budgets-page__title-block {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.budgets-page__command-copy {
+  display: grid;
+  gap: var(--space-1);
+  min-width: 0;
 }
 
-.budgets-page__title {
-  font-size: var(--font-size-lg, 1.25rem);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
+.budgets-page__eyebrow,
+.detail-panel__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--color-brand-500);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
+  letter-spacing: 0;
+  text-transform: uppercase;
 }
 
-.budgets-page__subtitle {
-  max-width: 680px;
+.budgets-page__command-copy p {
+  max-width: 760px;
+  margin: 0;
   color: var(--color-text-secondary);
   font-size: var(--font-size-sm);
-  line-height: 1.45;
+  line-height: 1.55;
+}
+
+.budgets-page__command-actions,
+.detail-panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-2);
 }
 
 .budgets-page__quota {
@@ -534,15 +972,15 @@ const onDeleteBudget = (id: string): void => {
   gap: var(--space-3);
   padding: var(--space-3);
   border: 1px solid var(--color-outline-soft);
-  border-radius: var(--radius-lg, 16px);
+  border-radius: var(--radius-lg);
   background:
-    linear-gradient(135deg, rgb(45 212 191 / 10%), transparent 55%),
+    linear-gradient(135deg, var(--color-brand-glow-2xs), transparent 55%),
     var(--color-bg-elevated);
 }
 
 .budgets-page__quota--premium {
   background:
-    linear-gradient(135deg, rgb(251 191 36 / 12%), transparent 60%),
+    linear-gradient(135deg, var(--color-warning-bg), transparent 60%),
     var(--color-bg-elevated);
 }
 
@@ -550,13 +988,17 @@ const onDeleteBudget = (id: string): void => {
   border-color: color-mix(in srgb, var(--color-warning) 42%, transparent);
 }
 
-.budgets-page__quota-icon {
+.budgets-page__quota-icon,
+.budgets-page__metric-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border-radius: var(--radius-full);
+}
+
+.budgets-page__quota-icon {
   width: 40px;
   height: 40px;
-  border-radius: var(--radius-full);
   color: var(--color-brand-600);
   background: var(--color-brand-hover-surface);
 }
@@ -573,168 +1015,545 @@ const onDeleteBudget = (id: string): void => {
   min-width: 0;
 }
 
-.budgets-page__quota-copy strong {
+.budgets-page__quota-copy strong,
+.budgets-page__list-header strong,
+.detail-panel__transactions-head strong {
   color: var(--color-text-primary);
   font-size: var(--font-size-sm);
 }
 
-.budgets-page__quota-copy span {
+.budgets-page__quota-copy span,
+.detail-panel__transactions-head span {
   color: var(--color-text-secondary);
   font-size: var(--font-size-sm);
   line-height: 1.45;
 }
 
-.budgets-page__summary-stats {
+.budgets-page__empty {
+  min-height: 420px;
+  padding: var(--space-5) 0;
+  border: 1px dashed color-mix(in srgb, var(--color-brand-500) 34%, transparent);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(135deg, var(--color-brand-glow-2xs), transparent 44%),
+    color-mix(in srgb, var(--color-bg-surface) 84%, transparent);
+}
+
+.budgets-page__empty-illustration {
+  filter: drop-shadow(0 18px 42px var(--color-brand-glow-xs));
+}
+
+.budgets-page__metrics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: var(--space-3);
-  margin-bottom: var(--space-3);
 }
 
-.budgets-page__health-row {
-  display: flex;
-  flex-wrap: wrap;
+.budgets-page__metric {
+  display: grid;
   gap: var(--space-2);
-  margin-bottom: var(--space-2);
+  min-height: 132px;
+  padding: var(--space-3);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--color-bg-surface) 88%, transparent);
+  box-shadow: var(--shadow-card);
 }
 
-.budgets-page__health-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--color-positive-dark, #066b4d);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium, 500);
+.budgets-page__metric span,
+.detail-panel__facts span,
+.detail-panel__hero-copy span,
+.budget-row__tag,
+.budget-row__numbers small {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0;
+  text-transform: uppercase;
 }
 
-.budgets-page__health-item--warning {
-  color: var(--color-warning-text, #8e5e13);
+.budgets-page__metric strong {
+  align-self: end;
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xl);
+  line-height: 1.15;
 }
 
-.budgets-page__health-item--danger {
-  color: var(--color-negative-dark, #9f303c);
-}
-
-:global(:root[data-theme="dark"]) .budgets-page__health-item {
-  color: var(--color-positive);
-}
-
-:global(:root[data-theme="dark"]) .budgets-page__health-item--warning {
-  color: var(--color-warning-text);
-}
-
-:global(:root[data-theme="dark"]) .budgets-page__health-item--danger {
+.budgets-page__metric--danger strong {
   color: var(--color-negative);
 }
 
-.budgets-page__overall-progress {
-  margin-top: var(--space-2);
+.budgets-page__metric-icon {
+  width: 38px;
+  height: 38px;
 }
 
-.budgets-page__empty {
-  padding: var(--space-5) 0;
+.budgets-page__metric-icon--brand {
+  color: var(--color-brand-500);
+  background: var(--color-brand-hover-surface);
 }
 
-.budgets-page__grid {
+.budgets-page__metric-icon--info {
+  color: var(--color-info);
+  background: var(--color-info-bg);
+}
+
+.budgets-page__metric-icon--positive {
+  color: var(--color-positive);
+  background: var(--color-positive-bg);
+}
+
+.budgets-page__metric-icon--warning {
+  color: var(--color-warning);
+  background: var(--color-warning-bg);
+}
+
+.budgets-page__health {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+}
+
+.budgets-page__health-copy {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.budgets-page__review-grid {
+  display: grid;
+  grid-template-columns: minmax(420px, 1.1fr) minmax(360px, 0.9fr);
   gap: var(--space-4);
+  align-items: start;
 }
 
-.budgets-page__budget-card {
+.budgets-page__envelope-list,
+.budgets-page__detail-panel {
+  min-width: 0;
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  box-shadow: var(--shadow-card);
+}
+
+.budgets-page__envelope-list {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+}
+
+.budgets-page__list-header,
+.detail-panel__header,
+.detail-panel__transactions-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.budgets-page__list-header > div,
+.detail-panel__transactions-head > div {
+  display: grid;
+  gap: 3px;
+}
+
+.budgets-page__list-header span {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+}
+
+.budget-row {
   position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(210px, 0.75fr);
+  gap: var(--space-2) var(--space-3);
+  width: 100%;
+  padding: var(--space-3);
   overflow: hidden;
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    border-color var(--motion-fast),
+    box-shadow var(--motion-fast),
+    transform var(--motion-fast);
 }
 
-.budgets-page__budget-card::before {
-  content: "";
+.budget-row:hover,
+.budget-row--selected {
+  border-color: color-mix(in srgb, var(--color-brand-500) 38%, var(--color-outline-soft));
+  box-shadow: 0 0 0 3px var(--color-brand-glow-2xs);
+  transform: translateY(-1px);
+}
+
+.budget-row__accent {
   position: absolute;
   inset: 0 auto 0 0;
   width: 4px;
   background: var(--color-positive);
 }
 
-.budgets-page__budget-card--warning::before {
-  background: var(--color-warning, #f59e0b);
+.budget-row--warning .budget-row__accent {
+  background: var(--color-warning);
 }
 
-.budgets-page__budget-card--danger::before {
-  background: var(--color-danger, #ef4444);
+.budget-row--danger .budget-row__accent {
+  background: var(--color-negative);
 }
 
-.budget-card__top {
-  display: flex;
-  justify-content: space-between;
+.budget-row__main,
+.budget-row__numbers,
+.budget-row__progress {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.budget-row__name {
+  overflow-wrap: anywhere;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
+  line-height: 1.25;
+}
+
+.budget-row__tag {
+  display: inline-flex;
   align-items: center;
-  margin-bottom: var(--space-1);
+  gap: 6px;
 }
 
-.budget-card__tag-info {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
-}
-
-.budget-card__tag-dot {
-  display: inline-block;
+.budget-row__tag-dot {
   width: 10px;
   height: 10px;
-  border-radius: 50%;
-  flex-shrink: 0;
+  border-radius: var(--radius-full);
 }
 
-.budget-card__tag-name {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
+.budget-row__numbers {
+  justify-items: end;
+  text-align: right;
 }
 
-.budget-card__name {
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
-  margin-bottom: var(--space-2);
+.budget-row__numbers strong,
+.budget-row__remaining,
+.detail-panel__hero-copy strong,
+.detail-panel__facts strong,
+.detail-panel__orb,
+.detail-panel__transaction-list b {
   color: var(--color-text-primary);
+  font-family: var(--font-mono);
 }
 
-.budget-card__progress {
-  margin-bottom: var(--space-1);
+.budget-row__numbers small {
+  display: block;
+  margin-top: 3px;
 }
 
-.budget-card__amounts {
+.budget-row__progress {
+  grid-column: 1 / -1;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+}
+
+.budget-row__progress span {
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+}
+
+.budget-row__remaining {
+  grid-column: 1 / -1;
+  justify-self: end;
+  color: var(--color-positive);
+  font-size: var(--font-size-sm);
+}
+
+.budget-row__remaining--negative {
+  color: var(--color-negative);
+}
+
+.budgets-page__detail-panel {
+  position: sticky;
+  top: var(--space-4);
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-4);
+}
+
+.detail-panel__header h2 {
+  margin: 5px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-2xl);
+  line-height: 1.05;
+}
+
+.detail-panel__hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(135deg, var(--color-brand-glow-2xs), transparent 52%),
+    var(--color-bg-surface);
+}
+
+.detail-panel__hero-copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.detail-panel__hero-copy strong {
+  overflow-wrap: anywhere;
+  font-size: var(--font-size-2xl);
+  line-height: 1.05;
+}
+
+.detail-panel__hero-copy small {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.detail-panel__orb {
+  display: grid;
+  place-items: center;
+  width: 92px;
+  height: 92px;
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-full);
+  background: var(--color-positive-bg);
+  color: var(--color-positive);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-extrabold);
+}
+
+.detail-panel__orb--warning {
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+}
+
+.detail-panel__orb--danger {
+  background: var(--color-negative-bg);
+  color: var(--color-negative);
+}
+
+.detail-panel__facts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.detail-panel__facts article {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  padding: var(--space-2);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+}
+
+.detail-panel__facts svg {
+  color: var(--color-brand-500);
+}
+
+.detail-panel__facts strong {
+  overflow-wrap: anywhere;
+  font-size: var(--font-size-sm);
+  line-height: 1.25;
+}
+
+.detail-panel__diagnosis {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-2);
+  align-items: flex-start;
+  padding: var(--space-3);
+  border: 1px solid var(--color-positive-border);
+  border-radius: var(--radius-md);
+  background: var(--color-positive-bg);
+  color: var(--color-positive);
+}
+
+.detail-panel__diagnosis--warning {
+  border-color: color-mix(in srgb, var(--color-warning) 28%, transparent);
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+}
+
+.detail-panel__diagnosis--danger {
+  border-color: var(--color-negative-border);
+  background: var(--color-negative-bg);
+  color: var(--color-negative);
+}
+
+.detail-panel__diagnosis p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.55;
+}
+
+.detail-panel__actions {
+  justify-content: flex-start;
+}
+
+.detail-panel__transactions {
+  display: grid;
+  gap: var(--space-2);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-outline-soft);
+}
+
+.detail-panel__transactions-loader {
+  padding: var(--space-2);
+}
+
+.detail-panel__transactions-empty {
+  padding: var(--space-3);
+  border: 1px dashed var(--color-outline-soft);
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  text-align: center;
+}
+
+.detail-panel__transaction-list {
+  display: grid;
+  gap: var(--space-2);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.detail-panel__transaction-list li {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
 }
 
-.budget-card__remaining {
+.detail-panel__transaction-list span {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.detail-panel__transaction-list strong {
+  overflow-wrap: anywhere;
+  color: var(--color-text-primary);
   font-size: var(--font-size-sm);
+}
+
+.detail-panel__transaction-list small {
   color: var(--color-text-muted);
-  margin-top: var(--space-1);
+  font-size: var(--font-size-xs);
 }
 
-.budget-card__actions {
+.detail-panel__transaction-list b {
+  white-space: nowrap;
+  font-size: var(--font-size-sm);
+}
+
+:global(.budget-envelope-modal .n-card) {
+  max-height: calc(100dvh - 48px);
   display: flex;
-  gap: var(--space-1);
-  margin-top: var(--space-2);
-  justify-content: flex-end;
+  flex-direction: column;
 }
 
-@media (max-width: 640px) {
+:global(.budget-envelope-modal .n-card__content) {
+  overflow: auto;
+}
+
+@media (max-width: 1180px) {
+  .budgets-page__metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .budgets-page__review-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .budgets-page__detail-panel {
+    position: static;
+  }
+}
+
+@media (max-width: 720px) {
   .budgets-page {
     padding: var(--space-3);
   }
 
-  .budgets-page__quota {
+  .budgets-page__command,
+  .budgets-page__quota,
+  .detail-panel__hero {
     grid-template-columns: 1fr;
   }
 
-  .budgets-page__summary-stats {
+  .budgets-page__command,
+  .detail-panel__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .budgets-page__command-actions,
+  .detail-panel__actions {
+    justify-content: stretch;
+  }
+
+  .budgets-page__command-actions :deep(.n-button),
+  .detail-panel__actions :deep(.n-button) {
+    width: 100%;
+  }
+
+  .budgets-page__metrics,
+  .detail-panel__facts {
     grid-template-columns: 1fr;
   }
 
-  .budgets-page__grid {
+  .budget-row {
     grid-template-columns: 1fr;
+  }
+
+  .budget-row__numbers {
+    justify-items: start;
+    text-align: left;
+  }
+
+  .detail-panel__orb {
+    width: 78px;
+    height: 78px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .budget-row {
+    transition: none;
+  }
+
+  .budget-row:hover,
+  .budget-row--selected {
+    transform: none;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- Corrige o `BudgetClient` para unwrapar respostas REST v2 de orçamentos, detalhes e resumo, preservando formatos legados.
- Redesenha `/budgets` como revisão mensal de envelopes, com métricas executivas, lista por risco, painel de detalhe e preview de transações.
- Adiciona cobertura para o orçamento v2 do caso real `IA's e automações` e para seleção/filtros do envelope crítico.

## Root Cause
A API já retornava o orçamento no contrato REST v2, mas o web esperava apenas formatos legados e não lia `data.items`/`data.budget`/`data.summary`. Isso fazia a tela cair no empty state mesmo com orçamento criado.

## Validation
- `pnpm exec vitest run app/pages/budgets.spec.ts app/features/budgets/services/budget.client.spec.ts app/features/budgets/model/budget-envelope.spec.ts app/pages/budgets.envelopes.spec.ts --coverage.enabled=false`
- `pnpm quality-check`
- Pre-push parity gate: flags, lint, typecheck, tests/coverage, governance/contracts, audit, build. E2E ficou skipped pelo hook porque exige `RUN_E2E=1`.
- Validação visual local com Playwright mockando contrato v2 em desktop/mobile, sem empty state indevido e sem overflow horizontal.

## Notes
- Não altera backend, GraphQL, OpenAPI nem payload de transações.
- Não adiciona `budget_id`; o preview usa filtros de transação por período e `tag_id` quando disponível.