### PR TITLE
feat(ai-insights): parser robusto + headline + recorte — nunca 'Insight indisponível' (#1045)

### DIFF
--- a/app/features/ai-insights/model/ai-insight.spec.ts
+++ b/app/features/ai-insights/model/ai-insight.spec.ts
@@ -73,17 +73,46 @@ describe("AI insight model", () => {
     ]);
   });
 
-  it("returns a safe fallback when backend content is malformed", () => {
+  it("returns a graceful neutral fallback when backend content is malformed", () => {
     const items = parseInsightItems("not-json");
 
-    expect(items).toEqual([
-      {
-        type: "saude_financeira",
-        dimension: "general",
-        title: "Insight indisponível",
-        message: "Não conseguimos interpretar este insight agora.",
-      },
-    ]);
+    expect(items).toHaveLength(1);
+    expect(items[0]?.title).toBe("Sem novidades por aqui");
+    // Never surface a technical error to the user.
+    expect(items[0]?.title).not.toContain("indisponível");
+    expect(items[0]?.message).not.toContain("interpretar");
+  });
+
+  it("parses the spending_patterns shape into transactions-dimension items", () => {
+    const content = JSON.stringify({
+      patterns: [
+        {
+          description: "Picos de consumo logo após o recebimento",
+          frequency: "alta",
+          average_value: 5000,
+          suggested_action: "Reavalie gastos logo após receber.",
+          severity: "high",
+        },
+      ],
+    });
+
+    const items = parseInsightItems(content);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      type: "padrao_gasto",
+      dimension: "transactions",
+      title: "Picos de consumo logo após o recebimento",
+    });
+    expect(items[0]?.message).toContain("Reavalie gastos logo após receber.");
+    expect(items[0]?.message).toContain("alta");
+  });
+
+  it("never returns the error fallback for the spending_patterns shape", () => {
+    const items = parseInsightItems(JSON.stringify({ patterns: [{ description: "X" }] }));
+
+    expect(items.some((i) => i.title.includes("indisponível"))).toBe(false);
+    expect(items[0]?.dimension).toBe("transactions");
   });
 
   it("maps snake_case DTO fields into the dashboard domain model", () => {

--- a/app/features/ai-insights/model/ai-insight.ts
+++ b/app/features/ai-insights/model/ai-insight.ts
@@ -56,8 +56,8 @@ export interface GeneratedAIInsight {
 export const FALLBACK_INSIGHT_ITEM: InsightItem = {
   type: "saude_financeira",
   dimension: "general",
-  title: "Insight indisponível",
-  message: "Não conseguimos interpretar este insight agora.",
+  title: "Sem novidades por aqui",
+  message: "Não há um insight para exibir neste período.",
 };
 
 const DEFAULT_INSIGHT_DIMENSION: InsightDimension = "general";
@@ -180,6 +180,67 @@ interface ParsedInsightContent {
 }
 
 /**
+ * Maps the `spending_patterns` payload (`{ patterns: [...] }`, produced by the
+ * api-v2 "Radar" cron) into canonical transactions-dimension insight items.
+ *
+ * Keeps the headline parseable so it never falls through to the error fallback,
+ * and tags every pattern as `transactions` so it renders on the right surface.
+ *
+ * @param parsed Parsed JSON value.
+ * @returns Transactions insight items, or null when no patterns are present.
+ */
+const resolveSpendingPatternItems = (parsed: unknown): InsightItem[] | null => {
+  if (parsed === null || typeof parsed !== "object") {
+    return null;
+  }
+  const patterns = (parsed as Record<string, unknown>).patterns;
+  if (!Array.isArray(patterns) || patterns.length === 0) {
+    return null;
+  }
+
+  const items = patterns
+    .filter((entry): entry is Record<string, unknown> =>
+      entry !== null && typeof entry === "object",
+    )
+    .map((entry): InsightItem => {
+      const description =
+        typeof entry.description === "string" && entry.description.length > 0
+          ? entry.description
+          : "Padrão de gasto identificado";
+      const suggestion =
+        typeof entry.suggested_action === "string" ? entry.suggested_action : "";
+      const frequency = typeof entry.frequency === "string" ? entry.frequency : "";
+      const average =
+        typeof entry.average_value === "number" ? entry.average_value : null;
+
+      const parts = [description];
+      if (average !== null) {
+        parts.push(
+          `Valor médio: ${average.toLocaleString("pt-BR", {
+            style: "currency",
+            currency: "BRL",
+          })}.`,
+        );
+      }
+      if (frequency) {
+        parts.push(`Frequência: ${frequency}.`);
+      }
+      if (suggestion) {
+        parts.push(suggestion);
+      }
+
+      return {
+        type: "padrao_gasto",
+        dimension: "transactions",
+        title: description,
+        message: parts.join(" "),
+      };
+    });
+
+  return items.length > 0 ? items : null;
+};
+
+/**
  * Extracts structured items from the JSON payload stored by older API paths.
  *
  * @param parsed Parsed JSON value.
@@ -198,6 +259,11 @@ const resolveParsedContent = (parsed: unknown): ParsedInsightContent | null => {
         summary: typeof candidate.summary === "string" ? candidate.summary : "",
         items,
       };
+    }
+
+    const patternItems = resolveSpendingPatternItems(candidate);
+    if (patternItems) {
+      return { summary: "", items: patternItems };
     }
   }
 

--- a/app/features/ai-insights/model/insight-history.spec.ts
+++ b/app/features/ai-insights/model/insight-history.spec.ts
@@ -52,6 +52,31 @@ describe("splitTodayAndPast", () => {
     expect(result.past.map((item) => item.id)).toEqual(["today-early", "yesterday"]);
   });
 
+  it("prefers a rich today insight over a more recent spending_patterns headline", () => {
+    const patterns = {
+      ...makeInsight("today-patterns", `${TODAY}T20:00:00Z`),
+      insight_type: "spending_patterns" as never,
+    };
+    const rich = makeInsight("today-daily", `${TODAY}T07:00:00Z`);
+
+    const result = splitTodayAndPast([patterns, rich], TODAY);
+
+    expect(result.todayInsight?.id).toBe("today-daily");
+    // The patterns insight still surfaces in history, just not as the headline.
+    expect(result.past.map((item) => item.id)).toContain("today-patterns");
+  });
+
+  it("falls back to the spending_patterns insight when it is the only one today", () => {
+    const patterns = {
+      ...makeInsight("today-patterns", `${TODAY}T20:00:00Z`),
+      insight_type: "spending_patterns" as never,
+    };
+
+    const result = splitTodayAndPast([patterns], TODAY);
+
+    expect(result.todayInsight?.id).toBe("today-patterns");
+  });
+
   it("returns null today insight and keeps every item in past when none was generated today", () => {
     const items = [
       makeInsight("yesterday", "2026-06-02T10:00:00Z"),

--- a/app/features/ai-insights/model/insight-history.ts
+++ b/app/features/ai-insights/model/insight-history.ts
@@ -13,13 +13,27 @@ export interface InsightHistorySplit {
  */
 const toDay = (createdAt: string): string => createdAt.slice(0, 10);
 
+const SPENDING_PATTERNS_TYPE = "spending_patterns";
+
 /**
- * Splits a list of insights into today's insight and the past history.
+ * A "rich" insight is a period-aware report (daily/weekly/monthly/recap) — i.e.
+ * anything that is not the lightweight `spending_patterns` Radar payload.
+ *
+ * @param item Insight DTO.
+ * @returns True when the insight is a rich period report.
+ */
+const isRichInsight = (item: AIInsightDTO): boolean =>
+  (item.insight_type as string) !== SPENDING_PATTERNS_TYPE;
+
+/**
+ * Splits a list of insights into today's headline insight and the past history.
  *
  * "Today" is determined by comparing the date portion of `created_at` against
- * `todayIso` (YYYY-MM-DD). The most recent insight generated today becomes
- * `todayInsight`; every remaining insight (older today items plus all earlier
- * days) goes to `past`, ordered newest-first. Input order is not trusted.
+ * `todayIso` (YYYY-MM-DD). Among today's insights the headline prefers the most
+ * recent *rich* report (daily/weekly/monthly) over a `spending_patterns` Radar
+ * payload, falling back to the most recent today insight when no rich one
+ * exists. Every remaining insight goes to `past`, ordered newest-first. Input
+ * order is not trusted.
  *
  * @param items Raw insight history items.
  * @param todayIso Local current date as YYYY-MM-DD.
@@ -33,14 +47,13 @@ export const splitTodayAndPast = (
     (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
   );
 
-  const todayIndex = sorted.findIndex((item) => toDay(item.created_at) === todayIso);
-
-  if (todayIndex === -1) {
+  const todayItems = sorted.filter((item) => toDay(item.created_at) === todayIso);
+  if (todayItems.length === 0) {
     return { todayInsight: null, past: sorted };
   }
 
-  const todayInsight = sorted[todayIndex] ?? null;
-  const past = sorted.filter((_, index) => index !== todayIndex);
+  const todayInsight = todayItems.find(isRichInsight) ?? todayItems[0] ?? null;
+  const past = sorted.filter((item) => item !== todayInsight);
 
   return { todayInsight, past };
 };


### PR DESCRIPTION
## Summary

Parte do épico **Insights de IA v2** (platform #835). Elimina o "Insight indisponível" e dá robustez ao parser.

- **Parser robusto** (`ai-insight.ts`): reconhece o shape `{patterns:[...]}` (Radar via api-v2) e mapeia cada padrão para `InsightItem` com `dimension="transactions"`, `type="padrao_gasto"`, título da `description` e mensagem composta (valor médio, frequência, sugestão).
- **Fallback gracioso**: o item de erro "Insight indisponível / Não conseguimos interpretar" vira um neutro **"Sem novidades por aqui"** — nunca mais texto técnico de erro ao usuário.
- **Headline correto** (`insight-history.ts`): entre os insights de hoje, o headline prioriza o relatório rico (daily/weekly/monthly) sobre o `spending_patterns`, caindo no patterns só quando é o único do dia.
- Recorte por dimensão já é estrito (`item.dimension === dimension`) — transações não exibe metas/orçamentos.

## Tests
- `ai-insight.spec.ts` — parsing de patterns, fallback neutro (sem "indisponível").
- `insight-history.spec.ts` — preferência por relatório rico no headline.
- 24/24 model tests; lint + typecheck limpos. Removidos 9 arquivos `* 2.*` (iCloud) que quebravam o build/test.

## Refs
Closes #1045
Épico #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)
