### PR TITLE
feat(ai-insights): relatórios longos (reading-time/markdown) + modal 'nada mudou' (#1046)

### DIFF
--- a/app/features/ai-insights/api/ai-insights-api.spec.ts
+++ b/app/features/ai-insights/api/ai-insights-api.spec.ts
@@ -60,6 +60,36 @@ describe("AIInsightsApiClient", () => {
     expect(result.items[0]?.dimension).toBe("general");
   });
 
+  it("checks change-status via GET with period params and timezone header", async () => {
+    const http = {
+      get: vi.fn().mockResolvedValue({
+        data: {
+          data: {
+            period_type: "daily",
+            period_label: "2026-05-18",
+            changed: false,
+            current_context_hash: "h",
+            last_context_hash: "h",
+            last_generated_at: "2026-05-18T03:00:00Z",
+          },
+        },
+      }),
+    };
+    const client = new AIInsightsApiClient(http as never);
+
+    const result = await client.checkChangeStatus({
+      periodType: "daily",
+      anchorDate: "2026-05-18",
+    });
+
+    expect(http.get).toHaveBeenCalledWith("/ai/insights/change-status", {
+      params: { period_type: "daily", anchor_date: "2026-05-18" },
+      headers: { "X-Auraxis-Timezone": "America/Sao_Paulo" },
+    });
+    expect(result.changed).toBe(false);
+    expect(result.last_generated_at).toBe("2026-05-18T03:00:00Z");
+  });
+
   it("does not send financial context from the browser when generating insights", async () => {
     const http = {
       post: vi.fn().mockResolvedValue({

--- a/app/features/ai-insights/api/ai-insights-api.ts
+++ b/app/features/ai-insights/api/ai-insights-api.ts
@@ -6,6 +6,7 @@ import type {
   GenerateInsightRequestDTO,
   GenerateInsightResponseDTO,
   GenerateInsightResponseWithMetaDTO,
+  InsightChangeStatusDTO,
   InsightFeedbackDTO,
   InsightPeriodType,
   InsightSourceSurface,
@@ -123,6 +124,37 @@ export class AIInsightsApiClient {
         response.headers["x-ai-calls-remaining-month"],
       ),
     };
+  }
+
+  /**
+   * Checks whether the financial snapshot changed since the last insight for a
+   * period — without triggering an LLM call (no token cost, no quota use).
+   *
+   * Used by the UI to confirm "nothing changed, generate anyway?" before the
+   * user spends their daily generation.
+   *
+   * @param variables Change-status query variables.
+   * @param variables.periodType Daily, weekly or monthly granularity.
+   * @param variables.anchorDate Optional YYYY-MM-DD anchor date.
+   * @returns The change status for the requested period.
+   */
+  async checkChangeStatus(variables: {
+    readonly periodType: InsightPeriodType;
+    readonly anchorDate?: string;
+  }): Promise<InsightChangeStatusDTO> {
+    const timezone = resolveBrowserTimezone();
+    const response = await this.#http.get<V2EnvelopeDTO<InsightChangeStatusDTO>>(
+      "/ai/insights/change-status",
+      {
+        params: {
+          period_type: variables.periodType,
+          ...(variables.anchorDate ? { anchor_date: variables.anchorDate } : {}),
+        },
+        ...(timezone ? { headers: { "X-Auraxis-Timezone": timezone } } : {}),
+      },
+    );
+
+    return unwrap<InsightChangeStatusDTO>(response.data);
   }
 
   /**

--- a/app/features/ai-insights/components/AiInsightButton.spec.ts
+++ b/app/features/ai-insights/components/AiInsightButton.spec.ts
@@ -139,6 +139,61 @@ describe("AiInsightButton", () => {
     });
   });
 
+  it("confirms before generating when nothing changed since the last insight", async () => {
+    const generate = vi.fn().mockResolvedValue(null);
+    const checkChangeStatus = vi.fn().mockResolvedValue({ changed: false });
+    useAIInsightsMock.mockReturnValue({
+      hasPremium: ref(true),
+      isLoading: ref(false),
+      callsRemaining: ref(1),
+      callsRemainingMonth: ref(null),
+      hasAIConsent: vi.fn().mockResolvedValue(true),
+      checkChangeStatus,
+      generate,
+    });
+
+    const wrapper = mount(AiInsightButton, {
+      props: { sourceSurface: "transactions" },
+      global: { stubs },
+    });
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    // The confirmation modal is shown and generation is held back.
+    expect(checkChangeStatus).toHaveBeenCalledOnce();
+    expect(wrapper.find("[data-testid='ai-generate-anyway']").exists()).toBe(true);
+    expect(generate).not.toHaveBeenCalled();
+
+    // Confirming generates anyway.
+    await wrapper.get("[data-testid='ai-generate-anyway']").trigger("click");
+    await flushPromises();
+
+    expect(generate).toHaveBeenCalledOnce();
+  });
+
+  it("generates directly when the snapshot changed since the last insight", async () => {
+    const generate = vi.fn().mockResolvedValue(null);
+    const checkChangeStatus = vi.fn().mockResolvedValue({ changed: true });
+    useAIInsightsMock.mockReturnValue({
+      hasPremium: ref(true),
+      isLoading: ref(false),
+      callsRemaining: ref(1),
+      callsRemainingMonth: ref(null),
+      hasAIConsent: vi.fn().mockResolvedValue(true),
+      checkChangeStatus,
+      generate,
+    });
+
+    const wrapper = mount(AiInsightButton, { global: { stubs } });
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    expect(generate).toHaveBeenCalledOnce();
+    expect(wrapper.find("[data-testid='ai-generate-anyway']").exists()).toBe(false);
+  });
+
   it("asks for AI consent when the backend requires it and retries after approval", async () => {
     const generate = vi.fn().mockResolvedValue(null);
     const grantAIConsent = vi.fn().mockResolvedValue(undefined);

--- a/app/features/ai-insights/components/AiInsightButton.vue
+++ b/app/features/ai-insights/components/AiInsightButton.vue
@@ -18,6 +18,7 @@ const props = withDefaults(defineProps<{
 
 const {
   generate,
+  checkChangeStatus,
   grantAIConsent,
   hasAIConsent,
   hasPremium,
@@ -30,6 +31,7 @@ const {
 const showLoadingModal = ref(false);
 const showPaywallModal = ref(false);
 const showConsentModal = ref(false);
+const showNoChangeModal = ref(false);
 
 /**
  * Detects the API error emitted when AI consent has not been granted yet.
@@ -60,7 +62,43 @@ const generateWithLoading = async (): Promise<void> => {
 };
 
 /**
- * Handles the AI insight trigger, gating free users behind the upgrade modal.
+ * Runs generation, recovering from the backend AI-consent gate.
+ */
+const runGenerate = async (): Promise<void> => {
+  try {
+    await generateWithLoading();
+  } catch (error) {
+    if (isAIConsentRequiredError(error)) {
+      showConsentModal.value = true;
+      return;
+    }
+    throw error;
+  }
+};
+
+/**
+ * Returns true when nothing changed since the last insight for the period.
+ *
+ * Degrades gracefully: any failure (e.g. endpoint unavailable) is treated as
+ * "changed" so generation is never blocked by the pre-check.
+ *
+ * @returns Whether the snapshot is unchanged since the last insight.
+ */
+const isUnchangedSinceLastInsight = async (): Promise<boolean> => {
+  try {
+    const status = await checkChangeStatus({
+      periodType: "daily",
+      ...(props.anchorDate ? { anchorDate: props.anchorDate } : {}),
+    });
+    return status.changed === false;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Handles the AI insight trigger, gating free users behind the upgrade modal
+ * and confirming generation when nothing has changed since the last insight.
  */
 const handleClick = async (): Promise<void> => {
   if (!hasPremium.value) {
@@ -73,15 +111,20 @@ const handleClick = async (): Promise<void> => {
     return;
   }
 
-  try {
-    await generateWithLoading();
-  } catch (error) {
-    if (isAIConsentRequiredError(error)) {
-      showConsentModal.value = true;
-      return;
-    }
-    throw error;
+  if (await isUnchangedSinceLastInsight()) {
+    showNoChangeModal.value = true;
+    return;
   }
+
+  await runGenerate();
+};
+
+/**
+ * Confirms generation from the "nothing changed" modal and proceeds anyway.
+ */
+const handleGenerateAnyway = async (): Promise<void> => {
+  showNoChangeModal.value = false;
+  await runGenerate();
 };
 
 /**
@@ -145,6 +188,33 @@ const handleConsentAccept = async (): Promise<void> => {
         description="Usuários free recebem 1 insight automático por mês. Para gerar novas análises quando quiser, assine o plano Premium."
         cta-label="Assinar Premium"
       />
+    </NModal>
+
+    <NModal
+      v-model:show="showNoChangeModal"
+      preset="card"
+      class="ai-insight-button__no-change"
+      style="width: min(480px, calc(100vw - 32px))"
+      title="Gerar novo insight?"
+      data-testid="ai-no-change-modal"
+    >
+      <section class="ai-insight-no-change">
+        <p>
+          Notamos que não houve movimentação desde o último insight gerado.
+          Deseja gerar mesmo assim? Isso consome 1 geração do seu dia.
+        </p>
+        <footer class="ai-insight-no-change__actions">
+          <NButton @click="showNoChangeModal = false">Cancelar</NButton>
+          <NButton
+            type="primary"
+            :loading="isLoading"
+            data-testid="ai-generate-anyway"
+            @click="handleGenerateAnyway"
+          >
+            Gerar mesmo assim
+          </NButton>
+        </footer>
+      </section>
     </NModal>
 
     <NModal
@@ -237,6 +307,23 @@ const handleConsentAccept = async (): Promise<void> => {
 }
 
 .ai-insight-consent__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.ai-insight-no-change {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.ai-insight-no-change p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.ai-insight-no-change__actions {
   display: flex;
   justify-content: flex-end;
   gap: var(--space-2);

--- a/app/features/ai-insights/components/AiInsightSection.vue
+++ b/app/features/ai-insights/components/AiInsightSection.vue
@@ -13,6 +13,11 @@ import {
   formatInsightPeriod,
   getInsightPresentation,
 } from "~/features/ai-insights/model/ai-insight";
+import {
+  estimateReadingMinutes,
+  parseInlineEmphasis,
+  splitParagraphs,
+} from "~/features/ai-insights/model/insight-text";
 import { filterInsightItemsByDimension } from "~/features/ai-insights/composables/use-insights-by-dimension";
 import type { InsightDimension, InsightItem } from "~/features/ai-insights/contracts/ai-insight";
 
@@ -32,6 +37,7 @@ const visibleInsights = computed(() => {
   const items = props.insight ?? [];
   return props.dimension ? filterInsightItemsByDimension(items, props.dimension) : items;
 });
+const readingMinutes = computed(() => estimateReadingMinutes(visibleInsights.value));
 const costLabel = computed(() =>
   props.costUsd.toLocaleString("pt-BR", {
     style: "currency",
@@ -67,9 +73,21 @@ const iconForType = (type: string): typeof BarChart2 => {
         <span class="ai-insight-section__eyebrow">Análise inteligente</span>
         <h2>Insights de IA — {{ formattedPeriodLabel }}</h2>
       </div>
-      <NTag size="small" round class="ai-insight-section__meta">
-        {{ model || 'modelo IA' }} · {{ tokensUsed }} tokens · {{ costLabel }}
-      </NTag>
+      <div class="ai-insight-section__meta-group">
+        <NTag
+          v-if="readingMinutes > 0"
+          size="small"
+          round
+          type="info"
+          class="ai-insight-section__reading"
+          data-testid="insight-reading-time"
+        >
+          {{ readingMinutes }} min de leitura
+        </NTag>
+        <NTag size="small" round class="ai-insight-section__meta">
+          {{ model || 'modelo IA' }} · {{ tokensUsed }} tokens · {{ costLabel }}
+        </NTag>
+      </div>
     </header>
 
     <NAlert
@@ -99,7 +117,19 @@ const iconForType = (type: string): typeof BarChart2 => {
             {{ getInsightPresentation(item.type).label }}
           </span>
           <h3>{{ item.title }}</h3>
-          <p>{{ item.message }}</p>
+          <p
+            v-for="(paragraph, paragraphIndex) in splitParagraphs(item.message)"
+            :key="paragraphIndex"
+            class="ai-insight-card__paragraph"
+          >
+            <template
+              v-for="(segment, segmentIndex) in parseInlineEmphasis(paragraph)"
+              :key="segmentIndex"
+            >
+              <strong v-if="segment.bold">{{ segment.text }}</strong>
+              <template v-else>{{ segment.text }}</template>
+            </template>
+          </p>
         </div>
       </article>
     </div>
@@ -148,6 +178,22 @@ const iconForType = (type: string): typeof BarChart2 => {
 
 .ai-insight-section__meta {
   flex-shrink: 0;
+}
+
+.ai-insight-section__meta-group {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-1);
+}
+
+.ai-insight-card__paragraph + .ai-insight-card__paragraph {
+  margin-top: var(--space-2);
+}
+
+.ai-insight-card__paragraph {
+  white-space: pre-line;
 }
 
 .ai-insight-section__grid {

--- a/app/features/ai-insights/composables/useAIInsights.ts
+++ b/app/features/ai-insights/composables/useAIInsights.ts
@@ -11,7 +11,17 @@ import {
   type GeneratedAIInsight,
   type GenerateAIInsightVariables,
 } from "~/features/ai-insights/model/ai-insight";
-import type { GenerateInsightResponseWithMetaDTO, InsightItem } from "~/features/ai-insights/contracts/ai-insight";
+import type {
+  GenerateInsightResponseWithMetaDTO,
+  InsightChangeStatusDTO,
+  InsightItem,
+  InsightPeriodType,
+} from "~/features/ai-insights/contracts/ai-insight";
+
+export interface CheckChangeStatusVariables {
+  readonly periodType: InsightPeriodType;
+  readonly anchorDate?: string;
+}
 
 interface EntitlementLike {
   readonly data: Ref<boolean | undefined>;
@@ -33,11 +43,18 @@ interface ConsentStatusLike {
   readonly hasAIConsent: () => Promise<boolean>;
 }
 
+interface ChangeStatusCheckerLike {
+  readonly checkChangeStatus: (
+    variables: CheckChangeStatusVariables,
+  ) => Promise<InsightChangeStatusDTO>;
+}
+
 interface UseAIInsightsDeps {
   readonly entitlement?: EntitlementLike;
   readonly mutation?: MutationLike;
   readonly consentMutation?: ConsentMutationLike;
   readonly consentStatus?: ConsentStatusLike;
+  readonly changeStatus?: ChangeStatusCheckerLike;
 }
 
 type DerivedAIInsightState = Pick<
@@ -77,6 +94,9 @@ export interface UseAIInsightsResult {
   readonly hasPremium: ComputedRef<boolean>;
   readonly entitlementLoading: ComputedRef<boolean>;
   readonly hasAIConsent: () => Promise<boolean>;
+  readonly checkChangeStatus: (
+    variables: CheckChangeStatusVariables,
+  ) => Promise<InsightChangeStatusDTO>;
   readonly grantAIConsent: () => Promise<void>;
   readonly isGrantingAIConsent: ComputedRef<boolean>;
   readonly insightPeriodLabel: ComputedRef<string>;
@@ -255,8 +275,22 @@ export const useAIInsights = (deps?: UseAIInsightsDeps): UseAIInsightsResult => 
    */
   const hasAIConsentStatus = async (): Promise<boolean> => consentStatus.hasAIConsent();
 
+  /**
+   * Checks whether the snapshot changed since the last insight (no LLM call).
+   *
+   * @param variables Period and optional anchor date to check.
+   * @returns The backend change-status payload.
+   */
+  const checkChangeStatus = (
+    variables: CheckChangeStatusVariables,
+  ): Promise<InsightChangeStatusDTO> =>
+    deps?.changeStatus
+      ? deps.changeStatus.checkChangeStatus(variables)
+      : apiClient!.checkChangeStatus(variables);
+
   return {
     generate,
+    checkChangeStatus,
     isLoading: state.isLoading,
     currentInsight: state.currentInsight,
     currentInsightId: state.currentInsightId,

--- a/app/features/ai-insights/contracts/ai-insight.ts
+++ b/app/features/ai-insights/contracts/ai-insight.ts
@@ -62,6 +62,15 @@ export interface GenerateInsightResponseWithMetaDTO extends GenerateInsightRespo
   readonly callsRemainingMonth: number | null;
 }
 
+export interface InsightChangeStatusDTO {
+  readonly period_type: InsightPeriodType;
+  readonly period_label: string;
+  readonly changed: boolean;
+  readonly current_context_hash: string;
+  readonly last_context_hash: string | null;
+  readonly last_generated_at: string | null;
+}
+
 export interface SubmitInsightFeedbackRequestDTO {
   readonly relevance: number;
   readonly truthfulness: number;

--- a/app/features/ai-insights/model/insight-text.spec.ts
+++ b/app/features/ai-insights/model/insight-text.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  estimateReadingMinutes,
+  parseInlineEmphasis,
+  splitParagraphs,
+} from "./insight-text";
+import type { InsightItem } from "~/features/ai-insights/contracts/ai-insight";
+
+/**
+ * Builds a minimal insight item for reading-time tests.
+ *
+ * @param title Item title.
+ * @param message Item message.
+ * @returns Insight item fixture.
+ */
+const makeItem = (title: string, message: string): InsightItem => ({
+  type: "saude_financeira",
+  dimension: "transactions",
+  title,
+  message,
+});
+
+describe("estimateReadingMinutes", () => {
+  it("returns 0 for empty input", () => {
+    expect(estimateReadingMinutes([])).toBe(0);
+  });
+
+  it("rounds to at least 1 minute for short content", () => {
+    expect(estimateReadingMinutes([makeItem("Oi", "poucas palavras aqui")])).toBe(1);
+  });
+
+  it("scales with word count (~200 wpm)", () => {
+    const longMessage = Array.from({ length: 600 }, () => "palavra").join(" ");
+    expect(estimateReadingMinutes([makeItem("Título", longMessage)])).toBe(3);
+  });
+});
+
+describe("splitParagraphs", () => {
+  it("splits on blank lines and trims", () => {
+    expect(splitParagraphs("Primeiro parágrafo.\n\nSegundo parágrafo.")).toEqual([
+      "Primeiro parágrafo.",
+      "Segundo parágrafo.",
+    ]);
+  });
+
+  it("returns a single paragraph when there are no blank lines", () => {
+    expect(splitParagraphs("Texto único")).toEqual(["Texto único"]);
+  });
+
+  it("drops empty paragraphs", () => {
+    expect(splitParagraphs("A\n\n\n\nB")).toEqual(["A", "B"]);
+  });
+});
+
+describe("parseInlineEmphasis", () => {
+  it("splits bold spans from plain text", () => {
+    expect(parseInlineEmphasis("Saldo de **R$ 1.000** hoje")).toEqual([
+      { text: "Saldo de ", bold: false },
+      { text: "R$ 1.000", bold: true },
+      { text: " hoje", bold: false },
+    ]);
+  });
+
+  it("returns a single plain segment when there is no emphasis", () => {
+    expect(parseInlineEmphasis("sem destaque")).toEqual([
+      { text: "sem destaque", bold: false },
+    ]);
+  });
+
+  it("handles multiple bold spans", () => {
+    const segments = parseInlineEmphasis("**a** e **b**");
+    expect(segments.filter((s) => s.bold).map((s) => s.text)).toEqual(["a", "b"]);
+  });
+});

--- a/app/features/ai-insights/model/insight-text.ts
+++ b/app/features/ai-insights/model/insight-text.ts
@@ -1,0 +1,88 @@
+import type { InsightItem } from "~/features/ai-insights/contracts/ai-insight";
+
+/** Average adult reading speed (words per minute) used for the badge. */
+const WORDS_PER_MINUTE = 200;
+
+/** A single inline text segment, optionally emphasised (bold). */
+export interface InlineSegment {
+  readonly text: string;
+  readonly bold: boolean;
+}
+
+/**
+ * Counts whitespace-delimited words in a string.
+ *
+ * @param text Source text.
+ * @returns Word count (0 for empty/whitespace).
+ */
+const countWords = (text: string): number => {
+  const trimmed = text.trim();
+  return trimmed.length === 0 ? 0 : trimmed.split(/\s+/).length;
+};
+
+/**
+ * Estimates how many minutes it takes to read a set of insight items.
+ *
+ * Sums the words across every item's title and message and divides by an
+ * average reading speed, rounding to the nearest minute (never below 1 when
+ * there is any text).
+ *
+ * @param items Insight items rendered in a section.
+ * @returns Estimated reading time in whole minutes (minimum 1 when non-empty).
+ */
+export const estimateReadingMinutes = (items: readonly InsightItem[]): number => {
+  const words = items.reduce(
+    (total, item) => total + countWords(item.title) + countWords(item.message),
+    0,
+  );
+  if (words === 0) {
+    return 0;
+  }
+  return Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+};
+
+/**
+ * Splits a (possibly markdown) message into display paragraphs.
+ *
+ * Paragraphs are separated by one or more blank lines; single newlines inside a
+ * paragraph are preserved as-is so the renderer can keep soft breaks.
+ *
+ * @param message Insight message text.
+ * @returns Non-empty trimmed paragraphs (always at least one when there is text).
+ */
+export const splitParagraphs = (message: string): string[] => {
+  return message
+    .split(/\n\s*\n/)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0);
+};
+
+/**
+ * Parses inline `**bold**` markdown emphasis into renderable segments.
+ *
+ * Avoids any HTML injection: the caller renders each segment as plain text
+ * inside a `<strong>` or text node, so untrusted content is never set as HTML.
+ *
+ * @param text Paragraph text possibly containing `**bold**` spans.
+ * @returns Ordered segments with a `bold` flag.
+ */
+export const parseInlineEmphasis = (text: string): InlineSegment[] => {
+  const segments: InlineSegment[] = [];
+  const pattern = /\*\*(.+?)\*\*/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ text: text.slice(lastIndex, match.index), bold: false });
+    }
+    segments.push({ text: match[1] ?? "", bold: true });
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ text: text.slice(lastIndex), bold: false });
+  }
+
+  return segments.length > 0 ? segments : [{ text, bold: false }];
+};


### PR DESCRIPTION
## Summary

Parte do épico **Insights de IA v2** (platform #835). UX dos relatórios profundos + modal "nada mudou".

### Modal "nada mudou"
- Novo `checkChangeStatus` no API client (`GET /ai/insights/change-status`) + no composable `useAIInsights`.
- Antes de gerar, o botão checa se houve mudança. Se `changed=false`, abre o modal **"Notamos que não houve movimentação desde o último insight gerado. Deseja gerar mesmo assim?"** (Cancelar / Gerar mesmo assim). Em "Gerar mesmo assim" → gera normalmente (consome a cota do dia).
- **Degradação graciosa**: se o endpoint falhar/estiver indisponível, segue gerando normalmente (nunca bloqueia).

### Render longo
- Helpers puros (`insight-text.ts`): `estimateReadingMinutes`, `splitParagraphs`, `parseInlineEmphasis` (negrito `**...**` sem injeção de HTML).
- `AiInsightSection`: badge de **tempo de leitura**, mensagens em **parágrafos** com **negrito** inline e `white-space: pre-line`.

## Tests
- `insight-text.spec.ts` (reading-time, parágrafos, ênfase), `ai-insights-api.spec.ts` (change-status), `AiInsightButton.spec.ts` (fluxo do modal: confirma/gera direto). 85 testes da feature verdes; lint + typecheck limpos.

## Refs
Closes #1046
Épico #835

> Depende do endpoint `change-status` (api #1482 / PR #1483). Até o deploy da api, o pré-check degrada graciosamente e a geração segue normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
