### PR TITLE
fix(dashboard): corrige 6 bugs S7727 (.map com índice)

### DIFF
--- a/app/features/dashboard/services/dashboard-overview.mapper.ts
+++ b/app/features/dashboard/services/dashboard-overview.mapper.ts
@@ -321,7 +321,7 @@ const toExpenseCategoriesFromTopCategories = (
   raw: Record<string, unknown>,
 ): DashboardExpenseCategory[] => {
   if (Array.isArray(raw.expenses_by_category)) {
-    return (raw.expenses_by_category as unknown[]).map(toExpenseCategory);
+    return (raw.expenses_by_category as unknown[]).map((item, index) => toExpenseCategory(item, index));
   }
 
   if (isRecord(raw.top_categories) && Array.isArray((raw.top_categories as Record<string, unknown>).expense)) {
@@ -387,20 +387,20 @@ export const mapDashboardOverviewDto = (input: unknown): DashboardOverview => {
       summary: toSummary(data.summary),
       comparison: toComparison(data.comparison),
       timeseries: Array.isArray(data.timeseries)
-        ? (data.timeseries as unknown[]).map(toTimeseriesPoint)
+        ? (data.timeseries as unknown[]).map((item, index) => toTimeseriesPoint(item, index))
         : [],
       expensesByCategory: Array.isArray(data.expenses_by_category)
-        ? (data.expenses_by_category as unknown[]).map(toExpenseCategory)
+        ? (data.expenses_by_category as unknown[]).map((item, index) => toExpenseCategory(item, index))
         : [],
       upcomingDues: Array.isArray(data.upcoming_dues)
-        ? (data.upcoming_dues as unknown[]).map(toUpcomingDue)
+        ? (data.upcoming_dues as unknown[]).map((item, index) => toUpcomingDue(item, index))
         : [],
       goals: Array.isArray(data.goals)
-        ? (data.goals as unknown[]).map(toGoalSummary)
+        ? (data.goals as unknown[]).map((item, index) => toGoalSummary(item, index))
         : [],
       portfolio: isRecord(data.portfolio) ? toPortfolio(data.portfolio) : { currentValue: 0, changePercent: null },
       alerts: Array.isArray(data.alerts)
-        ? (data.alerts as unknown[]).map(toAlert)
+        ? (data.alerts as unknown[]).map((item, index) => toAlert(item, index))
         : [],
     };
   }


### PR DESCRIPTION
## O que muda

Corrige os **6 bugs reais** `typescript:S7727` em `dashboard-overview.mapper.ts`: as funções `toXxx` usam o índice, então passar a função direta ao `.map` disparava a regra. Explicitado `(item, index) => fn(item, index)` — **comportamento inalterado**.

## Contexto (resto do esforço Sonar)

- Os outros **18 "bugs"** (`InputWithoutLabelCheck`) são **falsos positivos** (inputs já têm `<label for>` via `UiFormField`) → marcar como "Falso positivo" no SonarCloud.
- O **1 hotspot** (Turnstile sem SRI) é "safe" → marcar no SonarCloud.
- Plano geral dos ratings A: #1063.

## Verificação

- `pnpm typecheck` 0 erros · 108 testes do dashboard verdes · pre-push (build) verde.

Closes #1067
Refs #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ntwUbw8qCHMkXKvGkBy2F
