### PR TITLE
feat(transactions): selo "fatura {mês}" em lançamentos de cartão na lista

### DIFF
--- a/app/features/transactions/composables/__tests__/useTransactionTable.spec.ts
+++ b/app/features/transactions/composables/__tests__/useTransactionTable.spec.ts
@@ -224,6 +224,7 @@ describe("useTransactionTable", () => {
       filterStartDate: ref(null),
       filterEndDate: ref(null),
       filterTagId: ref("all"),
+      periodMode: computed(() => "month" as const),
       deleteMutation: { isPending: ref(false) },
       markPaidMutation: { isPending: ref(false) },
       duplicateMutation: { isPending: ref(false) },

--- a/app/features/transactions/composables/useTransactionTable.ts
+++ b/app/features/transactions/composables/useTransactionTable.ts
@@ -19,6 +19,10 @@ import {
 } from "lucide-vue-next";
 import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
 import type { TagLookup } from "./useTransactionFilters";
+import {
+  resolveCreditCardBillBadge,
+  type BillBadgePeriodMode,
+} from "~/features/transactions/utils/credit-card-bill-badge";
 import { formatCurrency } from "~/utils/currency";
 import { parseCurrencyAmount } from "~/utils/currencyInput";
 
@@ -128,6 +132,8 @@ export type UseTransactionTableOptions = {
   filterStartDate: Ref<number | null>;
   filterEndDate: Ref<number | null>;
   filterTagId: Ref<string>;
+  /** Active period mode; drives the credit-card bill badge visibility. */
+  periodMode: ComputedRef<BillBadgePeriodMode>;
   deleteMutation: { isPending: Ref<boolean> };
   markPaidMutation: { isPending: Ref<boolean> };
   duplicateMutation: { isPending: Ref<boolean> };
@@ -283,20 +289,51 @@ function renderAmount(row: TransactionDto): ReturnType<typeof h> {
   return h("span", { class: ["tx-amount", row.type === "income" ? "tx-amount--income" : "tx-amount--expense"] }, [row.type === "expense" ? "−" : "+", formatCurrency(parseCurrencyAmount(row.amount))]);
 }
 
+/** Period context the title cell needs to derive the credit-card bill chip. */
+interface TitleBillContext {
+  /** Start-of-month timestamp of the viewed month, or null. */
+  readonly selectedMonth: number | null;
+  /** Active period mode (`"month"` enables the bill chip). */
+  readonly periodMode: BillBadgePeriodMode;
+}
+
 /**
- * Renders the description cell with optional recurring/installment badges.
+ * Renders the description cell with optional recurring/installment badges and,
+ * for credit-card rows borrowed from another month by the bill cycle, a
+ * discreet "fatura {mmm/aa}" chip.
  *
- * @param row Transaction row data.
- * @param t   i18n translation function.
+ * @param row     Transaction row data.
+ * @param t       i18n translation function.
+ * @param billCtx Selected month and period mode driving the bill chip.
  * @returns VNode for the title cell.
  */
-function renderTitle(row: TransactionDto, t: (key: string, ctx?: Record<string, unknown>) => string): ReturnType<typeof h> {
+function renderTitle(
+  row: TransactionDto,
+  t: (key: string, ctx?: Record<string, unknown>) => string,
+  billCtx: TitleBillContext,
+): ReturnType<typeof h> {
   const paidFeedback = buildPaidStatusFeedback(row);
+  const billBadge = resolveCreditCardBillBadge({
+    creditCardId: row.credit_card_id,
+    dueDate: row.due_date,
+    periodMode: billCtx.periodMode,
+    selectedMonthTimestamp: billCtx.selectedMonth,
+  });
   return h("div", { class: "tx-title-cell" }, [
     h("span", { class: "tx-title-cell__heading" }, [
       h("span", { class: "tx-title-cell__name" }, row.title),
       paidFeedback
         ? h("span", { class: "tx-paid-chip", title: paidFeedback.title }, paidFeedback.label)
+        : null,
+      billBadge
+        ? h(
+            "span",
+            {
+              class: "tx-bill-chip",
+              title: t("transactions.creditCardBill", { month: billBadge.billMonthLabel }),
+            },
+            t("transactions.creditCardBill", { month: billBadge.billMonthLabel }),
+          )
         : null,
     ]),
     row.is_recurring ? h("span", { class: "tx-badge" }, [h(RefreshCw, { size: 9 }), t("transactions.recurring")]) : null,
@@ -431,11 +468,17 @@ export function useTransactionTable(opts: UseTransactionTableOptions): UseTransa
 
   const columns = computed((): DataTableColumns<TransactionDto> => {
     const withSort = !drag.reorderMode.value;
+    // Track the viewed month and period mode so the title column's render
+    // closure (and thus the bill chip) refreshes when the user navigates months.
+    const billCtx: TitleBillContext = {
+      selectedMonth: opts.filterStartDate.value,
+      periodMode: opts.periodMode.value,
+    };
     return [
       ...(drag.reorderMode.value ? [{ key: "__drag" as DataTableRowKey, title: "", width: 36, render: (): ReturnType<typeof h> => h("span", { class: "tx-drag-handle", "aria-hidden": "true" }, [h(GripVertical, { size: 14 })]) }] : []),
       { key: "status" as DataTableRowKey, title: t("transactions.table.status"), width: 64, render: (row: TransactionDto) => renderStatusIcon(row, t) },
       { key: "due_date" as DataTableRowKey, title: t("transactions.table.date"), width: 108, defaultSortOrder: "descend" as const, sorter: withSort ? (a: TransactionDto, b: TransactionDto): number => a.due_date.localeCompare(b.due_date) : undefined, render: (row: TransactionDto): string => formatTransactionDate(row.due_date) },
-      { key: "title" as DataTableRowKey, title: t("transactions.table.description"), ellipsis: { tooltip: true }, sorter: withSort ? (a: TransactionDto, b: TransactionDto): number => a.title.localeCompare(b.title, "pt-BR") : undefined, render: (row: TransactionDto) => renderTitle(row, t) },
+      { key: "title" as DataTableRowKey, title: t("transactions.table.description"), ellipsis: { tooltip: true }, sorter: withSort ? (a: TransactionDto, b: TransactionDto): number => a.title.localeCompare(b.title, "pt-BR") : undefined, render: (row: TransactionDto) => renderTitle(row, t, billCtx) },
       { key: "tag_id" as DataTableRowKey, title: t("transactions.table.category"), width: 150, ellipsis: { tooltip: true }, render: (row: TransactionDto) => renderTagBadge(row, opts.tagDetailMap) },
       { key: "account_id" as DataTableRowKey, title: t("transactions.table.account"), width: 120, ellipsis: { tooltip: true }, render: (row: TransactionDto): string => opts.accountMap.value.get(row.account_id ?? "") ?? "—" },
       { key: "amount" as DataTableRowKey, title: t("transactions.table.amount"), width: 138, sorter: withSort ? (a: TransactionDto, b: TransactionDto): number => parseCurrencyAmount(a.amount) - parseCurrencyAmount(b.amount) : undefined, render: (row: TransactionDto) => renderAmount(row) },

--- a/app/features/transactions/utils/credit-card-bill-badge.spec.ts
+++ b/app/features/transactions/utils/credit-card-bill-badge.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatBillMonthLabel,
+  resolveCreditCardBillBadge,
+} from "./credit-card-bill-badge";
+
+/**
+ * First day of a month as a local timestamp — mirrors how
+ * `useTransactionFilters` stores the selected month (start-of-month epoch ms).
+ *
+ * @param year       Full year.
+ * @param monthIndex Zero-based month index (0 = January).
+ * @returns Epoch milliseconds for the first day of that month.
+ */
+function monthStart(year: number, monthIndex: number): number {
+  return new Date(year, monthIndex, 1).getTime();
+}
+
+describe("formatBillMonthLabel", () => {
+  it("formats a selected month timestamp as short pt-BR mmm/aa", () => {
+    expect(formatBillMonthLabel(monthStart(2026, 6))).toBe("jul/26");
+  });
+
+  it("formats january without a trailing period", () => {
+    expect(formatBillMonthLabel(monthStart(2026, 0))).toBe("jan/26");
+  });
+
+  it("formats december of a previous year", () => {
+    expect(formatBillMonthLabel(monthStart(2025, 11))).toBe("dez/25");
+  });
+
+  it("derives the month from any day inside it, not only the first", () => {
+    expect(formatBillMonthLabel(new Date(2026, 2, 31, 23, 59).getTime())).toBe(
+      "mar/26",
+    );
+  });
+});
+
+describe("resolveCreditCardBillBadge", () => {
+  it("returns the bill badge when a card purchase fell on another month", () => {
+    // Selected month = July/26, purchase due_date in June → temporal borrow.
+    const badge = resolveCreditCardBillBadge({
+      creditCardId: "card-1",
+      dueDate: "2026-06-19",
+      periodMode: "month",
+      selectedMonthTimestamp: monthStart(2026, 6),
+    });
+
+    expect(badge).toEqual({ billMonthLabel: "jul/26" });
+  });
+
+  it("returns null when due_date month matches the selected month", () => {
+    // Purchase in July, viewing July → no borrow, no badge (avoids noise).
+    expect(
+      resolveCreditCardBillBadge({
+        creditCardId: "card-1",
+        dueDate: "2026-07-04",
+        periodMode: "month",
+        selectedMonthTimestamp: monthStart(2026, 6),
+      }),
+    ).toBeNull();
+  });
+
+  it("distinguishes the same month across different years", () => {
+    // due_date July/2025 while viewing July/2026 → still a borrow.
+    expect(
+      resolveCreditCardBillBadge({
+        creditCardId: "card-1",
+        dueDate: "2025-07-19",
+        periodMode: "month",
+        selectedMonthTimestamp: monthStart(2026, 6),
+      }),
+    ).toEqual({ billMonthLabel: "jul/26" });
+  });
+
+  it("returns null for non credit-card transactions", () => {
+    expect(
+      resolveCreditCardBillBadge({
+        creditCardId: null,
+        dueDate: "2026-06-19",
+        periodMode: "month",
+        selectedMonthTimestamp: monthStart(2026, 6),
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null in custom period mode even with a date mismatch", () => {
+    // Custom range keeps the raw due_date; the badge must not appear.
+    expect(
+      resolveCreditCardBillBadge({
+        creditCardId: "card-1",
+        dueDate: "2026-06-19",
+        periodMode: "custom",
+        selectedMonthTimestamp: monthStart(2026, 6),
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the selected month timestamp is unavailable", () => {
+    expect(
+      resolveCreditCardBillBadge({
+        creditCardId: "card-1",
+        dueDate: "2026-06-19",
+        periodMode: "month",
+        selectedMonthTimestamp: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the due_date is malformed", () => {
+    expect(
+      resolveCreditCardBillBadge({
+        creditCardId: "card-1",
+        dueDate: "not-a-date",
+        periodMode: "month",
+        selectedMonthTimestamp: monthStart(2026, 6),
+      }),
+    ).toBeNull();
+  });
+});

--- a/app/features/transactions/utils/credit-card-bill-badge.ts
+++ b/app/features/transactions/utils/credit-card-bill-badge.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure logic for the "fatura {mmm/aa}" badge shown on credit-card rows in the
+ * transactions list.
+ *
+ * Background: when the list is browsed by month, the backend groups credit-card
+ * entries by their *bill* month (the card's closing cycle) instead of the
+ * purchase date. A purchase made on 19/06 that lands on the July bill therefore
+ * shows up under "July" while still displaying its real date (19/06). The badge
+ * flags that temporal borrow so the date is not misread.
+ *
+ * The decision is fully derivable on the client from the row's `due_date`, the
+ * selected month and the period mode — no card cycle metadata is needed here,
+ * because the backend already performed the bill grouping.
+ */
+
+/** Period navigation mode exposed by `useTransactionFilters`. */
+export type BillBadgePeriodMode = "month" | "custom";
+
+/** Inputs needed to decide whether a row should show the bill badge. */
+export interface CreditCardBillBadgeInput {
+  /** `credit_card_id` of the transaction row (null for non-card entries). */
+  readonly creditCardId: string | null;
+  /** Transaction `due_date` in ISO `YYYY-MM-DD` format. */
+  readonly dueDate: string;
+  /** Active period mode; the badge only applies to `"month"`. */
+  readonly periodMode: BillBadgePeriodMode;
+  /**
+   * Start-of-month timestamp (epoch ms) of the currently selected month, as
+   * stored by `useTransactionFilters` (`filterStartDate` in month mode), or
+   * `null` when it cannot be resolved.
+   */
+  readonly selectedMonthTimestamp: number | null;
+}
+
+/** Result of {@link resolveCreditCardBillBadge} when the badge is visible. */
+export interface CreditCardBillBadge {
+  /** Selected month formatted as short pt-BR `mmm/aa` (e.g. `"jul/26"`). */
+  readonly billMonthLabel: string;
+}
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Formats a timestamp's month as a short pt-BR `mmm/aa` label via `Intl`.
+ *
+ * Uses `formatToParts` so the slash separator is composed explicitly and the
+ * abbreviated month keeps no locale trailing period (e.g. `"jul."` → `"jul"`).
+ *
+ * @param timestamp Epoch milliseconds for any instant inside the target month.
+ * @returns Label such as `"jul/26"`.
+ */
+export function formatBillMonthLabel(timestamp: number): string {
+  const parts = new Intl.DateTimeFormat("pt-BR", {
+    month: "short",
+    year: "2-digit",
+  }).formatToParts(new Date(timestamp));
+
+  const month = (parts.find((part) => part.type === "month")?.value ?? "")
+    .replace(/\.$/, "")
+    .toLowerCase();
+  const year = parts.find((part) => part.type === "year")?.value ?? "";
+
+  return `${month}/${year}`;
+}
+
+/**
+ * Reads the `year`/`month` pair from an ISO `YYYY-MM-DD` string.
+ *
+ * @param isoDate ISO date string.
+ * @returns `{ year, month }` (1-based month) or `null` when malformed.
+ */
+function parseIsoYearMonth(isoDate: string): { year: number; month: number } | null {
+  if (!ISO_DATE_PATTERN.test(isoDate)) {
+    return null;
+  }
+
+  const [year, month] = isoDate.split("-").map(Number);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) {
+    return null;
+  }
+
+  return { year: year as number, month: month as number };
+}
+
+/**
+ * Decides whether a transaction row should display the "fatura {mmm/aa}" badge
+ * and, if so, the month label to render.
+ *
+ * The badge appears only when:
+ *  - the period mode is `"month"` (custom ranges keep the raw `due_date`);
+ *  - the row is a credit-card entry (`creditCardId` is set);
+ *  - the selected month is known; and
+ *  - the `due_date` belongs to a different calendar month than the selected
+ *    one — i.e. the purchase was "borrowed" from another month by the bill
+ *    cycle. When they coincide the badge is suppressed to avoid noise.
+ *
+ * @param input Row and period context.
+ * @returns Badge descriptor, or `null` when no badge should be shown.
+ */
+export function resolveCreditCardBillBadge(
+  input: CreditCardBillBadgeInput,
+): CreditCardBillBadge | null {
+  if (input.periodMode !== "month") {
+    return null;
+  }
+  if (input.creditCardId === null) {
+    return null;
+  }
+  if (input.selectedMonthTimestamp === null) {
+    return null;
+  }
+
+  const due = parseIsoYearMonth(input.dueDate);
+  if (due === null) {
+    return null;
+  }
+
+  const selected = new Date(input.selectedMonthTimestamp);
+  const selectedYear = selected.getFullYear();
+  const selectedMonth = selected.getMonth() + 1;
+
+  if (due.year === selectedYear && due.month === selectedMonth) {
+    return null;
+  }
+
+  return { billMonthLabel: formatBillMonthLabel(input.selectedMonthTimestamp) };
+}

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -1889,6 +1889,7 @@
     },
     "recurring": "Recorrente",
     "installment": "{count}x",
+    "creditCardBill": "fatura {month}",
     "count": "{n} transação | {n} transações",
     "loadError": "Não foi possível carregar as transações",
     "loadErrorMessage": "Tente recarregar a página.",

--- a/app/pages/transactions/index.vue
+++ b/app/pages/transactions/index.vue
@@ -73,6 +73,7 @@ const {
   filterStartDate,
   filterEndDate,
   filterTagId,
+  periodMode,
   deleteMutation,
   markPaidMutation,
   duplicateMutation,
@@ -420,6 +421,19 @@ const totalBalance = computed(() => totalIncome.value - totalExpense.value);
 :deep(.tx-drag-handle) { display: flex; align-items: center; justify-content: center; cursor: grab; color: var(--color-text-muted); }
 :deep(.tx-drag-handle):active { cursor: grabbing; }
 :deep(.tx-tag-badge) { display: inline-block; padding: 2px 8px; border-radius: var(--radius-full, 9999px); font-size: var(--font-size-xs); font-weight: var(--font-weight-medium, 500); line-height: 1.4; white-space: nowrap; }
+:deep(.tx-bill-chip) {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border-radius: var(--radius-full, 9999px);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 28%, transparent);
+  background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  color: var(--color-warning-text, var(--color-warning));
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium, 500);
+  line-height: 1.45;
+  white-space: nowrap;
+}
 
 @media (max-width: 640px) {
   .transactions-page {


### PR DESCRIPTION
Closes #1068

## O que muda

Quando a lista de Transações é navegada **por mês**, um fix de backend (PR à parte) agrupa lançamentos de cartão de crédito pelo mês da **fatura** (ciclo de fechamento) em vez da data da compra. Uma compra de 19/06 que cai na fatura de julho passa a aparecer em "julho" exibindo a data real 19/06 — sem indicador, isso confunde.

Este PR adiciona um **chip discreto `fatura {mmm/aa}`** (ex.: `fatura jul/26`) nas linhas de lançamento de cartão na tabela de transações.

## Decisão de design (quando o selo aparece)

O chip é renderizado na célula de descrição (ao lado do título) **apenas quando TODAS** as condições valem:

1. `periodMode === "month"` (no modo **custom** o backend mantém `due_date` cru → sem chip);
2. a transação é de cartão (`credit_card_id` preenchido);
3. o mês selecionado é conhecido; e
4. o mês do `due_date` **difere** do mês selecionado (a compra "veio de outro mês" pelo ciclo da fatura).

Quando a data e o mês selecionado coincidem, o chip **não** aparece (evita ruído). O label é o mês **selecionado**, formatado curto em pt-BR via `Intl` (`formatToParts` → `mmm/aa`, sem ponto final).

## Implementação

- **Lógica pura + TDD**: `app/features/transactions/utils/credit-card-bill-badge.ts` (`resolveCreditCardBillBadge`, `formatBillMonthLabel`) com testes Vitest escritos primeiro — `credit-card-bill-badge.spec.ts` (11 casos: borrow, mesmo mês, anos diferentes, sem cartão, modo custom, sem mês, data malformada, formatação).
- **Wiring**: `useTransactionTable.ts` passa a receber `periodMode` e deriva o mês selecionado de `filterStartDate` (que em modo month é o início do mês selecionado); `renderTitle` renderiza o chip `.tx-bill-chip`. `pages/transactions/index.vue` repassa `periodMode` e adiciona o estilo do chip usando design tokens (paleta `--color-warning`).
- **i18n**: chave `transactions.creditCardBill = "fatura {month}"` somente em `pt.json`. `en.json` **não** foi tocado (congelado, DEC-186); `i18n:check` passa em modo MVP1 (chave PT-only é warning, não erro).
- Sem import lateral para a feature `credit-cards` — a decisão é 100% derivável de `due_date` + mês selecionado + `periodMode` + `credit_card_id`.

## Quality gates

`pnpm quality-check` **verde** (exit 0): flags:check, i18n:check, lint, typecheck, test:coverage, policy:check, contracts:check, codegen:check, build (179 rotas prerenderizadas, 0 erros).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx