### PR TITLE
[WEB] Insights Fluida — tela editorial (masthead + lead + beats)

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -249,6 +249,137 @@
   --shadow-brand-glow-sm: 0 0 10px rgba(68, 212, 255, 0.2);
 }
 
+/* ──────────────────────────────────────────────────────────────────────────
+   Insights "Fluida" — editorial reading scope (feature flag web.insights.fluida)
+
+   The Fluida screen carries an editorial palette + serif headline that differ
+   from the app shell. These tokens live here (not in component styles) because
+   the frontend-governance scanner forbids literal px/weights in .vue/.css under
+   app/** EXCEPT app/assets/css/main.css. Components consume only var(--fluida-*).
+
+   `.fluida` defines the LIGHT scope. The reading can be flipped independently of
+   the global app theme via the masthead toggle, which sets
+   `data-fluida-scheme="dark"` on the same element. The global app dark theme
+   (`:root[data-theme="dark"] .fluida`) is honoured too, so the reading follows
+   the app unless the local toggle overrides it.
+   ────────────────────────────────────────────────────────────────────────── */
+.fluida {
+  /* Editorial palette (light) */
+  --fluida-brand: #0e6376;
+  --fluida-brand-soft: #e9f1f3;
+  --fluida-page: #eef1f3;
+  --fluida-surface: #ffffff;
+  --fluida-surface-2: #f1f4f5;
+  --fluida-ink: #15272e;
+  --fluida-body: #52646c;
+  --fluida-muted: #8a979d;
+  --fluida-line: #e7ebed;
+  --fluida-line-soft: #eff2f3;
+  --fluida-track: #e7ebed;
+  --fluida-pos: #11a36b;
+  --fluida-neg: #e5484d;
+  --fluida-warn: #c77d1a;
+  --fluida-sev-ok-bg: #e7f6ee;
+  --fluida-sev-warn-bg: #fbf0d8;
+  --fluida-sev-alert-bg: #fdecec;
+  --fluida-on-accent: #ffffff;
+  --fluida-card-border: transparent;
+  --fluida-shadow: 0 2px 12px rgba(16, 28, 33, 0.06);
+  --fluida-seguir-grad: linear-gradient(135deg, #0e6376, #0a4f5f);
+
+  /* Editorial typography */
+  --fluida-font-serif: "Newsreader", Georgia, "Times New Roman", serif;
+  --fluida-font-mono: var(--font-mono);
+
+  /* Editorial type scale (web) */
+  --fluida-size-headline: 36px;
+  --fluida-size-headline-narrow: 26px;
+  --fluida-size-lead: 19px;
+  --fluida-size-prose: 17px;
+  --fluida-size-pullstat: 34px;
+  --fluida-size-compare-amount: 18px;
+  --fluida-size-tile-value: 18px;
+  --fluida-size-section: 14px;
+  --fluida-size-body-sm: 13px;
+  --fluida-size-caption: 12px;
+  --fluida-size-kicker: 11px;
+  --fluida-size-label: 10px;
+  --fluida-size-capital: 52px;
+
+  /* Editorial line-heights */
+  --fluida-leading-headline: 1.16;
+  --fluida-leading-lead: 1.6;
+  --fluida-leading-prose: 1.72;
+  --fluida-leading-snug: 1.45;
+
+  /* Editorial weights */
+  --fluida-weight-headline: 600;
+  --fluida-weight-strong: 700;
+  --fluida-weight-heavy: 800;
+  --fluida-weight-medium: 500;
+  --fluida-weight-semibold: 600;
+
+  /* Editorial radii */
+  --fluida-radius-card: 14px;
+  --fluida-radius-chart: 16px;
+  --fluida-radius-seguir: 18px;
+  --fluida-radius-pill: 9999px;
+  --fluida-radius-chip: 8px;
+
+  /* Layout */
+  --fluida-max-width: 740px;
+  --fluida-bar-max-width: 30px;
+}
+
+:root[data-theme="dark"] .fluida,
+.fluida[data-fluida-scheme="dark"] {
+  --fluida-brand: #14b0c9;
+  --fluida-brand-soft: #12313b;
+  --fluida-page: #0a1316;
+  --fluida-surface: #15242a;
+  --fluida-surface-2: #1d2e35;
+  --fluida-ink: #eaf1f3;
+  --fluida-body: #aebfc4;
+  --fluida-muted: #708488;
+  --fluida-line: #27383f;
+  --fluida-line-soft: #1d2c32;
+  --fluida-track: #22343b;
+  --fluida-pos: #2fbe85;
+  --fluida-neg: #ff6f79;
+  --fluida-warn: #e3a64a;
+  --fluida-sev-ok-bg: #0f2c22;
+  --fluida-sev-warn-bg: #332710;
+  --fluida-sev-alert-bg: #33191b;
+  --fluida-on-accent: #ffffff;
+  --fluida-card-border: #243740;
+  --fluida-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+  --fluida-seguir-grad: linear-gradient(135deg, #0e6376, #08323c);
+}
+
+/* Local override wins over the global app theme when explicitly set to light. */
+.fluida[data-fluida-scheme="light"] {
+  --fluida-brand: #0e6376;
+  --fluida-brand-soft: #e9f1f3;
+  --fluida-page: #eef1f3;
+  --fluida-surface: #ffffff;
+  --fluida-surface-2: #f1f4f5;
+  --fluida-ink: #15272e;
+  --fluida-body: #52646c;
+  --fluida-muted: #8a979d;
+  --fluida-line: #e7ebed;
+  --fluida-line-soft: #eff2f3;
+  --fluida-track: #e7ebed;
+  --fluida-pos: #11a36b;
+  --fluida-neg: #e5484d;
+  --fluida-warn: #c77d1a;
+  --fluida-sev-ok-bg: #e7f6ee;
+  --fluida-sev-warn-bg: #fbf0d8;
+  --fluida-sev-alert-bg: #fdecec;
+  --fluida-card-border: transparent;
+  --fluida-shadow: 0 2px 12px rgba(16, 28, 33, 0.06);
+  --fluida-seguir-grad: linear-gradient(135deg, #0e6376, #0a4f5f);
+}
+
 /* Reset and base */
 *,
 *::before,

--- a/app/composables/useChartTheme/useChartTheme.spec.ts
+++ b/app/composables/useChartTheme/useChartTheme.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import { useChartTheme } from "./useChartTheme";
+
+const resolvedTheme = ref<"light" | "dark">("light");
+
+// useChartTheme depends on the global useTheme composable. Drive it with a local
+// ref so we can assert the ECharts theme recomputes for both light and dark.
+// vi.mock is hoisted above imports, so the mock applies despite the import order.
+vi.mock("~/composables/useTheme", () => ({
+  useTheme: (): { resolvedTheme: typeof resolvedTheme } => ({ resolvedTheme }),
+}));
+
+describe("useChartTheme", () => {
+  it("builds the light ECharts theme by default", () => {
+    resolvedTheme.value = "light";
+    const { auraxisEChartsTheme } = useChartTheme();
+
+    expect(auraxisEChartsTheme.value.backgroundColor).toBe("transparent");
+    expect(auraxisEChartsTheme.value.tooltip).toMatchObject({
+      backgroundColor: "#FFFFFF",
+    });
+  });
+
+  it("recomputes the theme when the resolved theme flips to dark", () => {
+    resolvedTheme.value = "light";
+    const { auraxisEChartsTheme } = useChartTheme();
+    const lightTooltip = (auraxisEChartsTheme.value.tooltip as { backgroundColor: string })
+      .backgroundColor;
+
+    resolvedTheme.value = "dark";
+    const darkTooltip = (auraxisEChartsTheme.value.tooltip as { backgroundColor: string })
+      .backgroundColor;
+
+    expect(darkTooltip).not.toBe(lightTooltip);
+    expect(darkTooltip).toContain("rgba");
+  });
+});

--- a/app/features/ai-insights/contracts/ai-insight.ts
+++ b/app/features/ai-insights/contracts/ai-insight.ts
@@ -18,6 +18,55 @@ export interface InsightItem {
   readonly evidence?: readonly string[];
 }
 
+/**
+ * Severity vocabulary emitted by the Fluida editorial payload.
+ * `ok | atencao | alerta` tag a section; `alta | media` tag individual alerts.
+ */
+export type InsightFluidaSeverity = "ok" | "atencao" | "alerta" | "alta" | "media";
+
+/** A retrospective comparison entry ("ontem · anteontem · vs. semana"). */
+export interface InsightRetroEntryDTO {
+  readonly when: string;
+  readonly value: number;
+  readonly text: string;
+}
+
+/** A numeric highlight tile / pull-stat. */
+export interface InsightHighlightDTO {
+  readonly label: string;
+  readonly value: string;
+  readonly caption: string;
+}
+
+/** An attention point with its own severity. */
+export interface InsightAlertDTO {
+  readonly severity: InsightFluidaSeverity;
+  readonly text: string;
+}
+
+/** A bar series (7 days / 6 weeks) with its axis labels. */
+export interface InsightSeriesDTO {
+  readonly values: readonly number[];
+  readonly labels: readonly string[];
+}
+
+/**
+ * Additive fields on the `/ai/insights` response that power the Fluida reading
+ * (auraxis-api PR #1502). All optional: the legacy `items`/`content` payload is
+ * unchanged, and clients that do not consume these fields keep working. When
+ * absent, the web falls back to the Fluida mock behind `web.insights.fluida`.
+ */
+export interface InsightFluidaFieldsDTO {
+  readonly severity?: InsightFluidaSeverity;
+  readonly read_min?: number;
+  readonly paragraphs?: readonly string[];
+  readonly retro?: readonly InsightRetroEntryDTO[];
+  readonly highlights?: readonly InsightHighlightDTO[];
+  readonly alerts?: readonly InsightAlertDTO[];
+  readonly series?: InsightSeriesDTO;
+  readonly next_step?: string;
+}
+
 export interface AIInsightDTO {
   readonly id: string;
   readonly content: string;
@@ -40,7 +89,7 @@ export interface GenerateInsightRequestDTO {
   readonly timezone?: string;
 }
 
-export interface GenerateInsightResponseDTO {
+export interface GenerateInsightResponseDTO extends InsightFluidaFieldsDTO {
   readonly id?: string;
   readonly summary: string;
   readonly items: InsightItem[];

--- a/app/features/ai-insights/fluida/components/FluidaAiMeta.vue
+++ b/app/features/ai-insights/fluida/components/FluidaAiMeta.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+
+import type { FluidaMeta } from "../model/insight-fluida";
+
+const props = defineProps<{
+  meta: FluidaMeta;
+}>();
+
+const { t } = useI18n();
+
+const provenance = t("insights.fluida.provenance", {
+  model: props.meta.model,
+  generatedAt: props.meta.generatedAt,
+  reference: props.meta.referenceLabel,
+});
+</script>
+
+<template>
+  <footer class="fluida-meta">
+    <p class="fluida-meta__text">{{ meta.privacyNote }}</p>
+    <p class="fluida-meta__provenance">{{ provenance }}</p>
+  </footer>
+</template>
+
+<style scoped>
+.fluida-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: var(--space-4);
+  border-radius: var(--fluida-radius-card);
+  background: var(--fluida-surface-2);
+}
+
+.fluida-meta__text,
+.fluida-meta__provenance {
+  margin: 0;
+  font-size: var(--fluida-size-caption);
+  line-height: var(--fluida-leading-snug);
+  color: var(--fluida-muted);
+}
+
+.fluida-meta__provenance {
+  opacity: 0.85;
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaAlertList.vue
+++ b/app/features/ai-insights/fluida/components/FluidaAlertList.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import type { FluidaAlertCard } from "../model/insight-fluida";
+
+defineProps<{
+  alerts: readonly FluidaAlertCard[];
+}>();
+</script>
+
+<template>
+  <ul class="fluida-alerts">
+    <li
+      v-for="(alert, index) in alerts"
+      :key="index"
+      class="fluida-alerts__item"
+      :class="`fluida-alerts__item--${alert.severity.tone}`"
+    >
+      <span class="fluida-alerts__dot" aria-hidden="true" />
+      <span class="fluida-alerts__text">{{ alert.text }}</span>
+    </li>
+  </ul>
+</template>
+
+<style scoped>
+.fluida-alerts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.fluida-alerts__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+}
+
+.fluida-alerts__item--danger {
+  background: var(--fluida-sev-alert-bg);
+}
+
+.fluida-alerts__item--warning {
+  background: var(--fluida-sev-warn-bg);
+}
+
+.fluida-alerts__item--success {
+  background: var(--fluida-sev-ok-bg);
+}
+
+.fluida-alerts__item--neutral {
+  background: var(--fluida-surface-2);
+}
+
+.fluida-alerts__dot {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--fluida-radius-chip);
+  background: var(--fluida-warn);
+}
+
+.fluida-alerts__item--danger .fluida-alerts__dot {
+  background: var(--fluida-neg);
+}
+
+.fluida-alerts__item--success .fluida-alerts__dot {
+  background: var(--fluida-pos);
+}
+
+.fluida-alerts__text {
+  font-size: var(--fluida-size-body-sm);
+  font-weight: var(--fluida-weight-semibold);
+  line-height: var(--fluida-leading-snug);
+  color: var(--fluida-ink);
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaCadenceToggle.vue
+++ b/app/features/ai-insights/fluida/components/FluidaCadenceToggle.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+
+import type { FluidaCadence } from "../model/insight-fluida";
+
+defineProps<{
+  cadence: FluidaCadence;
+}>();
+
+const emit = defineEmits<{
+  (event: "update:cadence", value: FluidaCadence): void;
+}>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <div class="fluida-cadence" role="group" :aria-label="t('insights.fluida.cadence.daily')">
+    <button
+      type="button"
+      class="fluida-cadence__option"
+      :class="{ 'fluida-cadence__option--on': cadence === 'daily' }"
+      :aria-pressed="cadence === 'daily'"
+      @click="emit('update:cadence', 'daily')"
+    >
+      {{ t("insights.fluida.cadence.daily") }}
+    </button>
+    <button
+      type="button"
+      class="fluida-cadence__option"
+      :class="{ 'fluida-cadence__option--on': cadence === 'weekly' }"
+      :aria-pressed="cadence === 'weekly'"
+      @click="emit('update:cadence', 'weekly')"
+    >
+      {{ t("insights.fluida.cadence.weekly") }}
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.fluida-cadence {
+  display: inline-flex;
+  gap: 3px;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  background: var(--fluida-surface-2);
+}
+
+.fluida-cadence__option {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  white-space: nowrap;
+  padding: var(--space-2) var(--space-4);
+  border: none;
+  border-radius: var(--fluida-radius-chip);
+  background: transparent;
+  color: var(--fluida-body);
+  font-family: inherit;
+  font-size: var(--fluida-size-body-sm);
+  font-weight: var(--fluida-weight-strong);
+  cursor: pointer;
+  transition: background var(--motion-fast), color var(--motion-fast);
+}
+
+.fluida-cadence__option--on {
+  background: var(--fluida-surface);
+  color: var(--fluida-brand);
+  box-shadow: var(--shadow-sm);
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaChartBeat.vue
+++ b/app/features/ai-insights/fluida/components/FluidaChartBeat.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import type { EChartsOption } from "echarts";
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+
+import {
+  formatFluidaCurrency,
+  type FluidaCadence,
+  type FluidaChart,
+} from "../model/insight-fluida";
+
+const props = defineProps<{
+  chart: FluidaChart;
+  cadence: FluidaCadence;
+}>();
+
+const { t } = useI18n();
+
+const title = computed(() =>
+  props.cadence === "daily" ? t("insights.fluida.chart.daily") : t("insights.fluida.chart.weekly"),
+);
+
+const peakLabel = computed(() =>
+  t("insights.fluida.chart.peak", { value: formatFluidaCurrency(props.chart.peakValue) }),
+);
+
+/**
+ * Reads a CSS custom property off the document root, falling back when running
+ * server-side (no DOM) or when the variable is unset.
+ *
+ * @param token CSS variable name, e.g. "--fluida-track".
+ * @param fallback Value used during SSR or when the token is empty.
+ * @returns The resolved colour string.
+ */
+const resolveCssVar = (token: string, fallback: string): string => {
+  if (typeof window === "undefined") {
+    return fallback;
+  }
+  const value = getComputedStyle(document.documentElement).getPropertyValue(token).trim();
+  return value.length > 0 ? value : fallback;
+};
+
+/**
+ * ECharts bar option for the "ritmo de saídas" beat. The peak bar is painted
+ * with the editorial negative colour; the others use the muted track colour.
+ * Colours resolve `var(--fluida-*)` at runtime so they follow the active theme.
+ */
+const option = computed<EChartsOption>(() => {
+  const trackColor = resolveCssVar("--fluida-track", "#e7ebed");
+  const peakColor = resolveCssVar("--fluida-neg", "#e5484d");
+  const axisColor = resolveCssVar("--fluida-muted", "#8a979d");
+
+  return {
+    grid: { top: 8, right: 4, bottom: 22, left: 4, containLabel: true },
+    tooltip: {
+      trigger: "axis",
+      valueFormatter: (value): string => formatFluidaCurrency(Number(value)),
+    },
+    xAxis: {
+      type: "category",
+      data: [...props.chart.labels],
+      axisTick: { show: false },
+      axisLine: { show: false },
+      axisLabel: { color: axisColor, fontSize: 10, fontWeight: 600 },
+    },
+    yAxis: {
+      type: "value",
+      show: false,
+    },
+    series: [
+      {
+        type: "bar",
+        data: props.chart.values.map((value, index) => ({
+          value,
+          itemStyle: {
+            color: index === props.chart.peakIndex ? peakColor : trackColor,
+            borderRadius: [5, 5, 0, 0],
+          },
+        })),
+        barMaxWidth: 30,
+      },
+    ],
+  };
+});
+
+const chartKey = computed(
+  () => `${props.cadence}-${props.chart.values.length}-${props.chart.peakIndex}`,
+);
+</script>
+
+<template>
+  <div class="fluida-chart">
+    <div class="fluida-chart__head">
+      <span class="fluida-chart__title">{{ title }}</span>
+      <span class="fluida-chart__peak">{{ peakLabel }}</span>
+    </div>
+    <UiChart
+      :option="option"
+      :update-key="chartKey"
+      height="120px"
+      :aria-label="t('insights.fluida.chart.ariaLabel')"
+    />
+  </div>
+</template>
+
+<style scoped>
+.fluida-chart {
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--fluida-radius-chart);
+  background: var(--fluida-surface);
+  box-shadow: var(--fluida-shadow);
+}
+
+.fluida-chart__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.fluida-chart__title {
+  font-size: var(--fluida-size-section);
+  font-weight: var(--fluida-weight-heavy);
+  color: var(--fluida-ink);
+}
+
+.fluida-chart__peak {
+  font-size: var(--fluida-size-caption);
+  font-weight: var(--fluida-weight-semibold);
+  color: var(--fluida-muted);
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaCompareBeat.vue
+++ b/app/features/ai-insights/fluida/components/FluidaCompareBeat.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import type { FluidaCompareCard } from "../model/insight-fluida";
+
+defineProps<{
+  cards: readonly FluidaCompareCard[];
+}>();
+</script>
+
+<template>
+  <div class="fluida-compare">
+    <article
+      v-for="card in cards"
+      :key="card.when"
+      class="fluida-compare__card"
+      :class="{ 'fluida-compare__card--neg': card.isNegative }"
+    >
+      <span class="fluida-compare__when">{{ card.when }}</span>
+      <span class="fluida-compare__amount">{{ card.amountLabel }}</span>
+      <span class="fluida-compare__text">{{ card.text }}</span>
+    </article>
+  </div>
+</template>
+
+<style scoped>
+.fluida-compare {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-3);
+}
+
+.fluida-compare__card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--fluida-radius-card);
+  border-left: 3px solid var(--fluida-pos);
+  background: var(--fluida-surface);
+  box-shadow: var(--fluida-shadow);
+}
+
+.fluida-compare__card--neg {
+  border-left-color: var(--fluida-neg);
+}
+
+.fluida-compare__when {
+  font-size: var(--fluida-size-kicker);
+  font-weight: var(--fluida-weight-heavy);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fluida-muted);
+}
+
+.fluida-compare__amount {
+  font-family: var(--fluida-font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--fluida-size-compare-amount);
+  font-weight: var(--fluida-weight-strong);
+  white-space: nowrap;
+  color: var(--fluida-pos);
+}
+
+.fluida-compare__card--neg .fluida-compare__amount {
+  color: var(--fluida-neg);
+}
+
+.fluida-compare__text {
+  font-size: var(--fluida-size-caption);
+  line-height: var(--fluida-leading-snug);
+  color: var(--fluida-body);
+}
+
+@media (max-width: 720px) {
+  .fluida-compare {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaLead.vue
+++ b/app/features/ai-insights/fluida/components/FluidaLead.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import FluidaReadTime from "./FluidaReadTime.vue";
+import FluidaSevChip from "./FluidaSevChip.vue";
+import type { FluidaLeadView } from "../model/insight-fluida";
+
+defineProps<{
+  lead: FluidaLeadView;
+}>();
+</script>
+
+<template>
+  <header class="fluida-lead">
+    <div class="fluida-lead__meta">
+      <span class="fluida-lead__kicker" :style="{ color: lead.accentColor }">{{
+        lead.kicker
+      }}</span>
+      <FluidaSevChip :severity="lead.severity" />
+      <span class="fluida-lead__spacer" />
+      <FluidaReadTime :minutes="lead.readMinutes" />
+    </div>
+    <h1 class="fluida-lead__headline">{{ lead.title }}</h1>
+    <p class="fluida-lead__summary">{{ lead.summary }}</p>
+  </header>
+</template>
+
+<style scoped>
+.fluida-lead {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.fluida-lead__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.fluida-lead__kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--fluida-size-kicker);
+  font-weight: var(--fluida-weight-heavy);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.fluida-lead__spacer {
+  flex: 1;
+}
+
+.fluida-lead__headline {
+  margin: 0;
+  font-family: var(--fluida-font-serif);
+  font-size: var(--fluida-size-headline);
+  line-height: var(--fluida-leading-headline);
+  font-weight: var(--fluida-weight-headline);
+  letter-spacing: -0.02em;
+  color: var(--fluida-ink);
+}
+
+.fluida-lead__summary {
+  margin: 0;
+  font-size: var(--fluida-size-lead);
+  line-height: var(--fluida-leading-lead);
+  font-weight: var(--fluida-weight-medium);
+  color: var(--fluida-body);
+}
+
+@media (max-width: 720px) {
+  .fluida-lead__headline {
+    font-size: var(--fluida-size-headline-narrow);
+  }
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaMasthead.vue
+++ b/app/features/ai-insights/fluida/components/FluidaMasthead.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+
+import FluidaCadenceToggle from "./FluidaCadenceToggle.vue";
+import FluidaThemeTabs from "./FluidaThemeTabs.vue";
+import type { FluidaCadence, FluidaThemeId, FluidaThemeMeta } from "../model/insight-fluida";
+
+const props = defineProps<{
+  cadence: FluidaCadence;
+  theme: FluidaThemeId;
+  tabs: readonly FluidaThemeMeta[];
+  scheme: "light" | "dark";
+}>();
+
+const emit = defineEmits<{
+  (event: "update:cadence", value: FluidaCadence): void;
+  (event: "update:theme", value: FluidaThemeId): void;
+  (event: "toggle-scheme"): void;
+}>();
+
+const { t } = useI18n();
+
+const cadenceSubtitle = computed(() =>
+  props.cadence === "daily"
+    ? t("insights.fluida.cadence.dailyReading")
+    : t("insights.fluida.cadence.weeklyReading"),
+);
+
+const schemeToggleLabel = computed(() =>
+  props.scheme === "dark" ? t("insights.fluida.theme.toLight") : t("insights.fluida.theme.toDark"),
+);
+</script>
+
+<template>
+  <header class="fluida-masthead">
+    <div class="fluida-masthead__inner">
+      <div class="fluida-masthead__top">
+        <div class="fluida-masthead__brand">
+          <span class="fluida-masthead__mark" aria-hidden="true">AI</span>
+          <span class="fluida-masthead__brand-copy">
+            <span class="fluida-masthead__brand-name">{{ t("insights.fluida.brand") }}</span>
+            <span class="fluida-masthead__brand-sub">{{ cadenceSubtitle }}</span>
+          </span>
+        </div>
+        <div class="fluida-masthead__controls">
+          <FluidaCadenceToggle
+            :cadence="cadence"
+            @update:cadence="emit('update:cadence', $event)"
+          />
+          <button
+            type="button"
+            class="fluida-masthead__scheme"
+            :title="schemeToggleLabel"
+            :aria-label="schemeToggleLabel"
+            @click="emit('toggle-scheme')"
+          >
+            <span aria-hidden="true">{{ scheme === "dark" ? "☀" : "☾" }}</span>
+          </button>
+        </div>
+      </div>
+      <FluidaThemeTabs :tabs="tabs" :active="theme" @update:active="emit('update:theme', $event)" />
+    </div>
+  </header>
+</template>
+
+<style scoped>
+.fluida-masthead {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  border-bottom: 1px solid var(--fluida-line);
+  background: var(--fluida-surface);
+  padding: var(--space-4) var(--space-5);
+}
+
+.fluida-masthead__inner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 940px;
+  margin: 0 auto;
+}
+
+.fluida-masthead__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.fluida-masthead__brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.fluida-masthead__mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--fluida-radius-chip);
+  background: var(--fluida-brand);
+  color: var(--fluida-on-accent);
+  font-size: var(--fluida-size-caption);
+  font-weight: var(--fluida-weight-heavy);
+}
+
+.fluida-masthead__brand-copy {
+  display: flex;
+  flex-direction: column;
+}
+
+.fluida-masthead__brand-name {
+  font-size: var(--fluida-size-section);
+  font-weight: var(--fluida-weight-heavy);
+  letter-spacing: -0.02em;
+  color: var(--fluida-ink);
+}
+
+.fluida-masthead__brand-sub {
+  font-size: var(--fluida-size-caption);
+  color: var(--fluida-muted);
+}
+
+.fluida-masthead__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.fluida-masthead__scheme {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: var(--fluida-radius-pill);
+  border: 1px solid var(--fluida-line);
+  background: var(--fluida-surface);
+  color: var(--fluida-body);
+  font-size: var(--fluida-size-prose);
+  cursor: pointer;
+  box-shadow: var(--fluida-shadow);
+  transition: transform var(--motion-fast), background var(--motion-fast);
+}
+
+.fluida-masthead__scheme:hover {
+  transform: translateY(-1px);
+}
+
+@media (max-width: 720px) {
+  .fluida-masthead {
+    position: static;
+  }
+
+  .fluida-masthead__top {
+    flex-wrap: wrap;
+  }
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaPullStat.vue
+++ b/app/features/ai-insights/fluida/components/FluidaPullStat.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import type { FluidaStat } from "../model/insight-fluida";
+
+withDefaults(
+  defineProps<{
+    stat: FluidaStat;
+    accentColor?: string;
+  }>(),
+  {
+    accentColor: "var(--fluida-brand)",
+  },
+);
+</script>
+
+<template>
+  <div class="fluida-pull-stat" :style="{ '--fluida-pull-accent': accentColor }">
+    <span class="fluida-pull-stat__label">{{ stat.label }}</span>
+    <span class="fluida-pull-stat__value">{{ stat.value }}</span>
+    <span class="fluida-pull-stat__caption">{{ stat.caption }}</span>
+  </div>
+</template>
+
+<style scoped>
+.fluida-pull-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-left: var(--space-4);
+  border-left: 3px solid var(--fluida-pull-accent);
+}
+
+.fluida-pull-stat__label {
+  font-size: var(--fluida-size-label);
+  font-weight: var(--fluida-weight-strong);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fluida-muted);
+}
+
+.fluida-pull-stat__value {
+  font-family: var(--fluida-font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--fluida-size-pullstat);
+  font-weight: var(--fluida-weight-strong);
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+  color: var(--fluida-ink);
+}
+
+.fluida-pull-stat__caption {
+  font-size: var(--fluida-size-body-sm);
+  font-weight: var(--fluida-weight-semibold);
+  color: var(--fluida-body);
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaReadTime.vue
+++ b/app/features/ai-insights/fluida/components/FluidaReadTime.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+
+defineProps<{
+  minutes: number;
+}>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <span class="fluida-read-time">{{ t("insights.fluida.readTime", { min: minutes }) }}</span>
+</template>
+
+<style scoped>
+.fluida-read-time {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  white-space: nowrap;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--fluida-radius-pill);
+  background: var(--fluida-brand-soft);
+  color: var(--fluida-brand);
+  font-size: var(--fluida-size-caption);
+  font-weight: var(--fluida-weight-strong);
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaSeguir.vue
+++ b/app/features/ai-insights/fluida/components/FluidaSeguir.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+
+defineProps<{
+  text: string;
+}>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <aside class="fluida-seguir">
+    <span class="fluida-seguir__eyebrow">{{ t("insights.fluida.nextStep") }}</span>
+    <p class="fluida-seguir__text">{{ text }}</p>
+  </aside>
+</template>
+
+<style scoped>
+.fluida-seguir {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-5) var(--space-5);
+  border-radius: var(--fluida-radius-seguir);
+  background: var(--fluida-seguir-grad);
+  color: var(--fluida-on-accent);
+}
+
+.fluida-seguir__eyebrow {
+  position: relative;
+  font-size: var(--fluida-size-caption);
+  font-weight: var(--fluida-weight-heavy);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.9;
+}
+
+.fluida-seguir__text {
+  position: relative;
+  margin: 0;
+  font-size: var(--fluida-size-prose);
+  line-height: var(--fluida-leading-lead);
+  font-weight: var(--fluida-weight-medium);
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaSevChip.vue
+++ b/app/features/ai-insights/fluida/components/FluidaSevChip.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import type { FluidaSeverityPresentation } from "../model/insight-fluida";
+
+const props = defineProps<{
+  severity: FluidaSeverityPresentation;
+}>();
+
+const toneClass = computed(() => `fluida-sev-chip--${props.severity.tone}`);
+</script>
+
+<template>
+  <span class="fluida-sev-chip" :class="toneClass">{{ severity.label }}</span>
+</template>
+
+<style scoped>
+.fluida-sev-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  white-space: nowrap;
+  padding: 3px var(--space-2);
+  border-radius: var(--fluida-radius-pill);
+  font-size: var(--fluida-size-kicker);
+  font-weight: var(--fluida-weight-strong);
+}
+
+.fluida-sev-chip--success {
+  color: var(--fluida-pos);
+  background: var(--fluida-sev-ok-bg);
+}
+
+.fluida-sev-chip--warning {
+  color: var(--fluida-warn);
+  background: var(--fluida-sev-warn-bg);
+}
+
+.fluida-sev-chip--danger {
+  color: var(--fluida-neg);
+  background: var(--fluida-sev-alert-bg);
+}
+
+.fluida-sev-chip--neutral {
+  color: var(--fluida-muted);
+  background: var(--fluida-surface-2);
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaStatTiles.vue
+++ b/app/features/ai-insights/fluida/components/FluidaStatTiles.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import type { FluidaStat } from "../model/insight-fluida";
+
+defineProps<{
+  tiles: readonly FluidaStat[];
+}>();
+</script>
+
+<template>
+  <div class="fluida-tiles">
+    <div v-for="tile in tiles" :key="tile.label" class="fluida-tiles__tile">
+      <span class="fluida-tiles__label">{{ tile.label }}</span>
+      <span class="fluida-tiles__value">{{ tile.value }}</span>
+      <span class="fluida-tiles__caption">{{ tile.caption }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.fluida-tiles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-3);
+}
+
+.fluida-tiles__tile {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--fluida-radius-card);
+  background: var(--fluida-surface);
+  box-shadow: var(--fluida-shadow);
+}
+
+.fluida-tiles__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fluida-size-label);
+  font-weight: var(--fluida-weight-strong);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fluida-muted);
+}
+
+.fluida-tiles__value {
+  font-family: var(--fluida-font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--fluida-size-tile-value);
+  font-weight: var(--fluida-weight-strong);
+  white-space: nowrap;
+  color: var(--fluida-ink);
+}
+
+.fluida-tiles__caption {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fluida-size-caption);
+  font-weight: var(--fluida-weight-semibold);
+  color: var(--fluida-muted);
+}
+
+@media (max-width: 720px) {
+  .fluida-tiles {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaTextBeat.vue
+++ b/app/features/ai-insights/fluida/components/FluidaTextBeat.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    text: string;
+    /** Render the first letter as an editorial drop-cap (capitular). */
+    lead?: boolean;
+    /** Accent colour token for the drop-cap. */
+    accentColor?: string;
+  }>(),
+  {
+    lead: false,
+    accentColor: "var(--fluida-brand)",
+  },
+);
+
+const firstLetter = computed(() => (props.lead ? props.text.slice(0, 1) : ""));
+const remainder = computed(() => (props.lead ? props.text.slice(1) : props.text));
+</script>
+
+<template>
+  <p class="fluida-text" :class="{ 'fluida-text--lead': lead }">
+    <span
+      v-if="lead"
+      class="fluida-text__capital"
+      :style="{ color: accentColor }"
+      aria-hidden="true"
+      >{{ firstLetter }}</span
+    >{{ remainder }}
+  </p>
+</template>
+
+<style scoped>
+.fluida-text {
+  margin: 0;
+  font-size: var(--fluida-size-prose);
+  line-height: var(--fluida-leading-prose);
+  color: var(--fluida-body);
+}
+
+.fluida-text__capital {
+  float: left;
+  font-family: var(--fluida-font-serif);
+  font-size: var(--fluida-size-capital);
+  line-height: 0.82;
+  font-weight: var(--fluida-weight-headline);
+  padding-right: var(--space-2);
+  padding-top: 3px;
+}
+</style>

--- a/app/features/ai-insights/fluida/components/FluidaThemeTabs.vue
+++ b/app/features/ai-insights/fluida/components/FluidaThemeTabs.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import type { FluidaThemeId, FluidaThemeMeta } from "../model/insight-fluida";
+
+defineProps<{
+  tabs: readonly FluidaThemeMeta[];
+  active: FluidaThemeId;
+}>();
+
+const emit = defineEmits<{
+  (event: "update:active", value: FluidaThemeId): void;
+}>();
+</script>
+
+<template>
+  <div class="fluida-tabs" role="tablist">
+    <button
+      v-for="tab in tabs"
+      :key="tab.id"
+      type="button"
+      role="tab"
+      class="fluida-tabs__tab"
+      :class="{ 'fluida-tabs__tab--on': tab.id === active }"
+      :style="{ '--fluida-tab-accent': tab.colorVar }"
+      :aria-selected="tab.id === active"
+      @click="emit('update:active', tab.id)"
+    >
+      {{ tab.label }}
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.fluida-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: 2px 0;
+}
+
+.fluida-tabs__tab {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--fluida-line);
+  border-radius: var(--fluida-radius-pill);
+  background: var(--fluida-surface);
+  color: var(--fluida-body);
+  font-family: inherit;
+  font-size: var(--fluida-size-body-sm);
+  font-weight: var(--fluida-weight-strong);
+  cursor: pointer;
+  box-shadow: var(--fluida-shadow);
+  transition: background var(--motion-fast), color var(--motion-fast),
+    transform var(--motion-fast);
+}
+
+.fluida-tabs__tab:hover {
+  transform: translateY(-1px);
+}
+
+.fluida-tabs__tab--on {
+  background: var(--fluida-tab-accent);
+  border-color: transparent;
+  color: var(--fluida-on-accent);
+  box-shadow: none;
+}
+</style>

--- a/app/features/ai-insights/fluida/components/InsightsFluida.spec.ts
+++ b/app/features/ai-insights/fluida/components/InsightsFluida.spec.ts
@@ -1,0 +1,92 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+import InsightsFluida from "./InsightsFluida.vue";
+
+// useTheme is a Nuxt auto-import resolved via the ~/composables alias; provide a
+// light-mode stub so the editorial scope starts in light without app state.
+vi.mock("~/composables/useTheme", () => ({
+  useTheme: (): { resolvedTheme: { value: string } } => ({
+    resolvedTheme: { value: "light" },
+  }),
+}));
+
+const stubs = {
+  // UiChart is a global Nuxt component (ECharts). Stub it to a marker element so
+  // the editorial layout renders without pulling the echarts bundle into jsdom.
+  UiChart: { template: "<div class='ui-chart-stub' />" },
+};
+
+/**
+ * Mounts the Fluida screen with the chart stub installed.
+ *
+ * @returns The mounted wrapper.
+ */
+const mountFluida = (): ReturnType<typeof mount> =>
+  mount(InsightsFluida, { global: { stubs } });
+
+describe("InsightsFluida", () => {
+  it("renders the masthead, lead and general comparison beat by default", () => {
+    const wrapper = mountFluida();
+
+    // masthead brand + cadence options
+    expect(wrapper.text()).toContain("Insights de IA");
+    expect(wrapper.text()).toContain("Diário");
+    expect(wrapper.text()).toContain("Semanal");
+
+    // lead headline (general daily) + opening summary
+    expect(wrapper.text()).toContain("Ontem em foco: muita saída, nenhuma entrada");
+    expect(wrapper.text()).toContain("Atenção");
+    expect(wrapper.text()).toContain("15 min de leitura");
+
+    // comparison cards from retro
+    expect(wrapper.text()).toContain("Ontem · 20 jun");
+    expect(wrapper.text()).toContain("Anteontem · 19 jun");
+    expect(wrapper.text()).toContain("vs. semana passada");
+
+    // chart beat is present (stubbed)
+    expect(wrapper.find(".ui-chart-stub").exists()).toBe(true);
+
+    // closing block + provenance
+    expect(wrapper.text()).toContain("Para onde seguir agora");
+    expect(wrapper.text()).toContain("GPT-4o");
+  });
+
+  it("starts in the light editorial scope", () => {
+    const wrapper = mountFluida();
+    expect(wrapper.find(".fluida").attributes("data-fluida-scheme")).toBe("light");
+  });
+
+  it("flips the editorial scope when the theme button is pressed", async () => {
+    const wrapper = mountFluida();
+    await wrapper.find(".fluida-masthead__scheme").trigger("click");
+    expect(wrapper.find(".fluida").attributes("data-fluida-scheme")).toBe("dark");
+  });
+
+  it("switches to a theme reading with highlight tiles when a tab is selected", async () => {
+    const wrapper = mountFluida();
+
+    const cardsTab = wrapper
+      .findAll(".fluida-tabs__tab")
+      .find((tab) => tab.text() === "Cartões");
+    expect(cardsTab).toBeDefined();
+    await cardsTab!.trigger("click");
+
+    // theme lead kicker + a highlight tile value, no comparison cards
+    expect(wrapper.text()).toContain("Cartões");
+    expect(wrapper.text()).toContain("Fatura em atraso");
+    expect(wrapper.text()).not.toContain("Ontem · 20 jun");
+  });
+
+  it("updates the reading time and chart when cadence flips to weekly", async () => {
+    const wrapper = mountFluida();
+
+    const weeklyButton = wrapper
+      .findAll(".fluida-cadence__option")
+      .find((button) => button.text() === "Semanal");
+    await weeklyButton!.trigger("click");
+
+    expect(wrapper.text()).toContain("30 min de leitura");
+    expect(wrapper.text()).toContain("A semana de 15 a 21: o mês inteiro decidido em dois dias");
+  });
+});

--- a/app/features/ai-insights/fluida/components/InsightsFluida.vue
+++ b/app/features/ai-insights/fluida/components/InsightsFluida.vue
@@ -1,0 +1,198 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+import FluidaAiMeta from "./FluidaAiMeta.vue";
+import FluidaAlertList from "./FluidaAlertList.vue";
+import FluidaChartBeat from "./FluidaChartBeat.vue";
+import FluidaCompareBeat from "./FluidaCompareBeat.vue";
+import FluidaLead from "./FluidaLead.vue";
+import FluidaMasthead from "./FluidaMasthead.vue";
+import FluidaPullStat from "./FluidaPullStat.vue";
+import FluidaSeguir from "./FluidaSeguir.vue";
+import FluidaStatTiles from "./FluidaStatTiles.vue";
+import FluidaTextBeat from "./FluidaTextBeat.vue";
+import { useInsightsFluida } from "../composables/use-insights-fluida";
+import { useI18n } from "vue-i18n";
+import { useTheme } from "~/composables/useTheme";
+
+const fluida = useInsightsFluida();
+const { t } = useI18n();
+
+// Local editorial light/dark scope. Initialised from the global app theme, then
+// toggled independently via the masthead without touching the app-wide theme.
+const { resolvedTheme } = useTheme();
+const schemeOverride = ref<"light" | "dark" | null>(null);
+const scheme = computed<"light" | "dark">(
+  () => schemeOverride.value ?? (resolvedTheme.value === "dark" ? "dark" : "light"),
+);
+
+/**
+ * Flips the editorial reading between light and dark, independent of the global
+ * app theme. The first toggle pins an explicit scheme; subsequent toggles invert
+ * it.
+ */
+const toggleScheme = (): void => {
+  schemeOverride.value = scheme.value === "dark" ? "light" : "dark";
+};
+
+const view = fluida.view;
+
+// Beat layout helpers — keep the orchestrator template declarative.
+const paragraphs = computed(() => view.value.paragraphs);
+const sectionLabels = computed(() => ({
+  compare: t("insights.fluida.sections.compare"),
+  rhythm: t("insights.fluida.sections.rhythm"),
+  alerts: t("insights.fluida.sections.alerts"),
+  highlights: t("insights.fluida.sections.highlights"),
+}));
+</script>
+
+<template>
+  <div class="fluida" :data-fluida-scheme="scheme">
+    <FluidaMasthead
+      :cadence="fluida.cadence.value"
+      :theme="fluida.theme.value"
+      :tabs="fluida.tabs.value"
+      :scheme="scheme"
+      @update:cadence="fluida.setCadence"
+      @update:theme="fluida.setTheme"
+      @toggle-scheme="toggleScheme"
+    />
+
+    <div class="fluida__body">
+      <article class="fluida__wrap">
+        <FluidaLead :lead="view.lead" />
+
+        <!-- General reading: comparison cards + chart + alerts -->
+        <template v-if="view.isGeneral">
+          <section v-if="view.compare" class="fluida__beat" aria-labelledby="fluida-compare">
+            <span id="fluida-compare" class="fluida__kicker">{{ sectionLabels.compare }}</span>
+            <FluidaCompareBeat :cards="view.compare" />
+          </section>
+
+          <hr class="fluida__divider" >
+
+          <FluidaTextBeat
+            v-if="paragraphs[0]"
+            :text="paragraphs[0]"
+            lead
+            :accent-color="view.lead.accentColor"
+          />
+
+          <section class="fluida__beat" aria-labelledby="fluida-rhythm">
+            <span id="fluida-rhythm" class="fluida__kicker">{{ sectionLabels.rhythm }}</span>
+            <FluidaChartBeat :chart="view.chart" :cadence="view.cadence" />
+          </section>
+
+          <FluidaTextBeat v-if="paragraphs[1]" :text="paragraphs[1]" />
+
+          <div v-if="paragraphs[2] && view.pullStat" class="fluida__split">
+            <FluidaTextBeat :text="paragraphs[2]" />
+            <FluidaPullStat :stat="view.pullStat" :accent-color="view.lead.accentColor" />
+          </div>
+          <FluidaTextBeat v-else-if="paragraphs[2]" :text="paragraphs[2]" />
+
+          <FluidaTextBeat v-if="paragraphs[3]" :text="paragraphs[3]" />
+
+          <section v-if="view.alerts" class="fluida__beat" aria-labelledby="fluida-alerts">
+            <span id="fluida-alerts" class="fluida__kicker">{{ sectionLabels.alerts }}</span>
+            <FluidaAlertList :alerts="view.alerts" />
+          </section>
+        </template>
+
+        <!-- Theme reading: numeric tiles + interleaved text/pull-stat -->
+        <template v-else>
+          <section
+            v-if="view.highlights"
+            class="fluida__beat"
+            aria-labelledby="fluida-highlights"
+          >
+            <span id="fluida-highlights" class="fluida__kicker">{{
+              sectionLabels.highlights
+            }}</span>
+            <FluidaStatTiles :tiles="view.highlights" />
+          </section>
+
+          <hr class="fluida__divider" >
+
+          <FluidaTextBeat
+            v-if="paragraphs[0]"
+            :text="paragraphs[0]"
+            lead
+            :accent-color="view.lead.accentColor"
+          />
+
+          <div v-if="paragraphs[1] && view.highlights?.[0]" class="fluida__split">
+            <FluidaTextBeat :text="paragraphs[1]" />
+            <FluidaPullStat :stat="view.highlights[0]" :accent-color="view.lead.accentColor" />
+          </div>
+          <FluidaTextBeat v-else-if="paragraphs[1]" :text="paragraphs[1]" />
+
+          <FluidaTextBeat v-if="paragraphs[2]" :text="paragraphs[2]" />
+        </template>
+
+        <FluidaSeguir :text="view.nextStep" />
+        <FluidaAiMeta :meta="view.meta" />
+      </article>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.fluida {
+  background: var(--fluida-page);
+  color: var(--fluida-ink);
+  min-height: 100%;
+}
+
+.fluida__body {
+  padding: var(--space-6) var(--space-5) var(--space-8);
+}
+
+.fluida__wrap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  max-width: var(--fluida-max-width);
+  margin: 0 auto;
+}
+
+.fluida__beat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.fluida__kicker {
+  font-size: var(--fluida-size-label);
+  font-weight: var(--fluida-weight-strong);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fluida-muted);
+}
+
+.fluida__divider {
+  width: 100%;
+  height: 1px;
+  margin: 0;
+  border: none;
+  background: var(--fluida-line-soft);
+}
+
+.fluida__split {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: var(--space-5);
+  align-items: center;
+}
+
+@media (max-width: 720px) {
+  .fluida__body {
+    padding: var(--space-5) var(--space-4) var(--space-7);
+  }
+
+  .fluida__split {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/app/features/ai-insights/fluida/composables/use-insights-fluida.spec.ts
+++ b/app/features/ai-insights/fluida/composables/use-insights-fluida.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { useInsightsFluida } from "./use-insights-fluida";
+import { FLUIDA_MOCK_SOURCE } from "../model/insight-fluida-mock";
+
+describe("useInsightsFluida", () => {
+  it("defaults to the general daily reading", () => {
+    const fluida = useInsightsFluida();
+    expect(fluida.cadence.value).toBe("daily");
+    expect(fluida.theme.value).toBe("general");
+    expect(fluida.view.value.isGeneral).toBe(true);
+    expect(fluida.view.value.lead.readMinutes).toBe(15);
+  });
+
+  it("exposes the tab list in stable order with the general tab first", () => {
+    const fluida = useInsightsFluida();
+    expect(fluida.tabs.value[0]?.id).toBe("general");
+    expect(fluida.tabs.value.map((tab) => tab.id)).toEqual([
+      "general",
+      "transactions",
+      "goals",
+      "budgets",
+      "credit_cards",
+    ]);
+    expect(fluida.tabs.value[1]?.label).toBe("Transações");
+  });
+
+  it("recomputes the view when the cadence changes", () => {
+    const fluida = useInsightsFluida();
+    fluida.setCadence("weekly");
+    expect(fluida.cadence.value).toBe("weekly");
+    expect(fluida.view.value.lead.readMinutes).toBe(30);
+    expect(fluida.view.value.chart.values).toHaveLength(6);
+  });
+
+  it("recomputes the view when the theme changes", () => {
+    const fluida = useInsightsFluida();
+    fluida.setTheme("credit_cards");
+    expect(fluida.theme.value).toBe("credit_cards");
+    expect(fluida.view.value.isGeneral).toBe(false);
+    expect(fluida.view.value.lead.kicker).toBe("Cartões");
+    expect(fluida.view.value.highlights).toHaveLength(3);
+  });
+
+  it("derives from an injected source when provided", () => {
+    const fluida = useInsightsFluida(FLUIDA_MOCK_SOURCE);
+    fluida.setTheme("transactions");
+    fluida.setCadence("weekly");
+    expect(fluida.view.value.lead.kicker).toBe("Transações");
+    expect(fluida.view.value.lead.readMinutes).toBe(5);
+  });
+});

--- a/app/features/ai-insights/fluida/composables/use-insights-fluida.ts
+++ b/app/features/ai-insights/fluida/composables/use-insights-fluida.ts
@@ -1,0 +1,69 @@
+import { computed, type ComputedRef, ref, type Ref } from "vue";
+
+import { FLUIDA_MOCK_SOURCE } from "../model/insight-fluida-mock";
+import {
+  deriveFluidaView,
+  resolveFluidaThemeMeta,
+  FLUIDA_THEME_ORDER,
+  type FluidaCadence,
+  type FluidaInsightSource,
+  type FluidaThemeId,
+  type FluidaThemeMeta,
+  type FluidaView,
+} from "../model/insight-fluida";
+
+export interface UseInsightsFluida {
+  readonly cadence: Ref<FluidaCadence>;
+  readonly theme: Ref<FluidaThemeId>;
+  readonly tabs: ComputedRef<readonly FluidaThemeMeta[]>;
+  readonly view: ComputedRef<FluidaView>;
+  readonly setCadence: (cadence: FluidaCadence) => void;
+  readonly setTheme: (theme: FluidaThemeId) => void;
+}
+
+/**
+ * Thin reactive façade over {@link deriveFluidaView}.
+ *
+ * Holds the masthead selection (cadence + theme) and exposes the derived view
+ * model plus the tab list. All business logic lives in the pure model module;
+ * this composable only wires reactivity. The source defaults to the Fluida mock
+ * (behind the `web.insights.fluida` flag) and accepts an injected source so the
+ * real `/ai/insights` payload can replace the mock without touching the UI.
+ *
+ * @param source Insight source object. Defaults to the June/2026 mock.
+ * @returns Reactive selection state, derived view and tab metadata.
+ */
+export function useInsightsFluida(
+  source: FluidaInsightSource = FLUIDA_MOCK_SOURCE,
+): UseInsightsFluida {
+  const cadence = ref<FluidaCadence>("daily");
+  const theme = ref<FluidaThemeId>("general");
+
+  const tabs = computed<readonly FluidaThemeMeta[]>(() =>
+    FLUIDA_THEME_ORDER.map((id) => resolveFluidaThemeMeta(source, id)),
+  );
+
+  const view = computed<FluidaView>(() =>
+    deriveFluidaView(source, { cadence: cadence.value, theme: theme.value }),
+  );
+
+  /**
+   * Updates the selected cadence (daily/weekly), recomputing the view.
+   *
+   * @param next Cadence to activate.
+   */
+  const setCadence = (next: FluidaCadence): void => {
+    cadence.value = next;
+  };
+
+  /**
+   * Updates the selected theme tab, recomputing the view.
+   *
+   * @param next Theme id to activate.
+   */
+  const setTheme = (next: FluidaThemeId): void => {
+    theme.value = next;
+  };
+
+  return { cadence, theme, tabs, view, setCadence, setTheme };
+}

--- a/app/features/ai-insights/fluida/model/insight-fluida-mock.ts
+++ b/app/features/ai-insights/fluida/model/insight-fluida-mock.ts
@@ -1,0 +1,281 @@
+import { formatFluidaCurrency, type FluidaInsightSource } from "./insight-fluida";
+
+/**
+ * Mock source for the Fluida reading, content-anchored to June/2026 data.
+ *
+ * Shape mirrors the additive `/ai/insights` response (`paragraphs` / `retro` /
+ * `series` / `highlights`) and the mobile `InsightFluidaVM`. It exists only so
+ * the screen renders behind the `web.insights.fluida` flag while the backend
+ * (auraxis-api PR #1502) is not yet deployed. Once the DTO ships, a mapper in
+ * `api/` produces the same {@link FluidaInsightSource} from the real payload and
+ * this constant is dropped.
+ */
+export const FLUIDA_MOCK_SOURCE: FluidaInsightSource = {
+  meta: {
+    model: "GPT-4o",
+    generatedAt: "21 de junho de 2026, 06:00",
+    referenceLabel: "movimentação até 20 de junho",
+    privacyNote:
+      "Seus dados não treinam modelos. A IA lê apenas seus registros no Auraxis para preparar esta leitura.",
+  },
+  series: {
+    daily: {
+      values: [1200, 0, 250, 0, 2650, 0, 11950],
+      labels: ["14", "15", "16", "17", "18", "19", "20"],
+    },
+    weekly: {
+      values: [4200, 980, 3100, 1400, 9800, 13650],
+      labels: ["S-5", "S-4", "S-3", "S-2", "S-1", "Atual"],
+    },
+  },
+  general: {
+    daily: {
+      severity: "atencao",
+      readMin: 15,
+      title: "Ontem em foco: muita saída, nenhuma entrada",
+      summary:
+        "No dia 20/06 você teve uma única transação — Mousepad bullpad, R$ 156,30 — mas ela chega num mês já tensionado: as despesas somam R$ 19.906,30 contra R$ 27.675,37 de receita, e a maior parte do gasto está concentrada em poucos dias.",
+      retro: [
+        {
+          when: "Ontem · 20 jun",
+          value: -156.3,
+          text: "Apenas 1 lançamento (Mousepad bullpad). Dia leve, mas dentro de uma sequência de saídas altas.",
+        },
+        {
+          when: "Anteontem · 19 jun",
+          value: -11950,
+          text: "O dia mais pesado do mês: Fatura Maio (R$ 11.000) atrasada + Pagamento Ikaro (R$ 950).",
+        },
+        {
+          when: "vs. semana passada",
+          value: 9800,
+          text: "A semana atual gastou ~40% a mais que a anterior, puxada pela fatura em atraso.",
+        },
+      ],
+      paragraphs: [
+        "A leitura de ontem precisa ser feita no contexto da semana. Isoladamente, o dia 20 foi tranquilo: um único gasto de R$ 156,30 em eletrônicos, sem impacto relevante sobre o saldo. O ponto de atenção não é o que aconteceu ontem, e sim o que ainda está pendente.",
+        "A \"Fatura Maio\", de R$ 11.000,00, segue marcada como atrasada e responde sozinha por 55% de todas as despesas do mês. Enquanto ela não for quitada, qualquer leitura de saldo positivo é otimista demais — o resultado de R$ 7.769,07 já considera essa saída como ocorrida.",
+        "Do lado das entradas, o mês depende de um único evento: o Salário gringo, de R$ 27.675,37, previsto para 30/06. Até lá, o caixa opera no vermelho corrente em vários dias. Essa dependência de uma entrada única, no fim do mês, é o fator estrutural mais importante a observar.",
+      ],
+      pullStat: {
+        label: "Peso da Fatura Maio",
+        value: "55%",
+        caption: "de todas as despesas do mês",
+      },
+      alerts: [
+        { severity: "alta", text: "Fatura Maio (R$ 11.000) em atraso — concentra 55% das despesas." },
+        { severity: "media", text: "Receita do mês depende de um único crédito (30/06)." },
+      ],
+      nextStep:
+        "Priorize quitar ou renegociar a Fatura Maio antes do crédito do salário; ela distorce todos os indicadores. Como hábito, distribua os vencimentos ao longo do mês para não concentrar saídas em 1–2 dias.",
+    },
+    weekly: {
+      severity: "alerta",
+      readMin: 30,
+      title: "A semana de 15 a 21: o mês inteiro decidido em dois dias",
+      summary:
+        "Em sete dias, R$ 13.650,00 saíram do caixa sem nenhuma entrada — e dois lançamentos (Fatura Maio e Parcela de financiamento) explicam quase tudo. A conta entrou em estado de alerta não por volume de transações, mas por concentração.",
+      retro: [
+        {
+          when: "Esta semana · 15–21 jun",
+          value: -13650,
+          text: "4 saídas, 0 entradas. Saldo da semana fortemente negativo.",
+        },
+        {
+          when: "Semana anterior · 8–14 jun",
+          value: -1450,
+          text: "Internet + Visita Pedro. Ritmo de gasto saudável.",
+        },
+        {
+          when: "Tendência (6 semanas)",
+          value: 13650,
+          text: "Clara escalada nas últimas duas semanas, acima da média móvel.",
+        },
+      ],
+      paragraphs: [
+        "A retrospectiva semanal mostra um padrão que não aparece no dia a dia: a conta passa semanas em ritmo controlado e, então, concentra obrigações grandes num intervalo curto. De 15 a 21 de junho, quatro lançamentos somaram R$ 13.650,00, contra R$ 1.450,00 da semana anterior — um salto de mais de 9x.",
+        "Dois itens dominam a semana. A Parcela de financiamento (R$ 2.650, recorrente) é previsível e saudável — entra todo mês. Já a Fatura Maio (R$ 11.000, atrasada) é o evento anômalo: não é recorrente, está em atraso e desequilibra a comparação com qualquer semana típica.",
+        "Sem nenhuma receita na semana, o saldo semanal ficou em -R$ 13.650,00. Isso não significa que o mês fechará negativo — o salário de 30/06 reverte o número — mas evidencia uma fragilidade de fluxo: a conta vive de um único crédito mensal e precisa atravessar três semanas de saídas antes dele.",
+        "Olhando as últimas seis semanas, a média móvel de saídas estava perto de R$ 4.000. As duas últimas romperam esse teto com folga. Mesmo descontando a fatura atrasada como evento único, a tendência recente é de aceleração de gastos fixos.",
+      ],
+      pullStat: {
+        label: "Saldo da semana",
+        value: formatFluidaCurrency(-13650),
+        caption: "sem nenhuma entrada registrada",
+      },
+      alerts: [
+        { severity: "alta", text: "Saldo semanal -R$ 13.650,00, sem nenhuma entrada." },
+        { severity: "alta", text: "Fatura Maio em atraso há mais de 20 dias." },
+        { severity: "media", text: "Saídas das 2 últimas semanas acima da média móvel." },
+      ],
+      nextStep:
+        "Construa um colchão que cubra ao menos 3 semanas de despesas fixas, para deixar de depender do timing do salário. No curto prazo, trate a Fatura Maio como prioridade absoluta e evite novas parcelas até o crédito de 30/06.",
+    },
+  },
+  themes: {
+    transactions: {
+      label: "Transações",
+      color: "#2E7CF6",
+      daily: {
+        severity: "ok",
+        readMin: 3,
+        title: "Dia leve, mas dentro de um mês concentrado",
+        summary:
+          "Ontem houve só Mousepad bullpad (R$ 156,30, Eletrônicos). No mês, 9 despesas e 1 receita; 70% do valor está em 2 lançamentos.",
+        highlights: [
+          { label: "Maior gasto do mês", value: formatFluidaCurrency(11000), caption: "Fatura Maio · Cartão" },
+          { label: "Único crédito", value: formatFluidaCurrency(27675.37), caption: "Salário gringo · 30/06" },
+          { label: "Gasto de ontem", value: formatFluidaCurrency(156.3), caption: "Eletrônicos" },
+        ],
+        paragraphs: [
+          "O lançamento de ontem é pequeno e pontual — um mousepad em Eletrônicos. Não altera categorias nem orçamento de forma material; entra como consumo discricionário isolado.",
+          "O retrato do mês, porém, é de concentração: das nove despesas, Fatura Maio (R$ 11.000) e Parcela de financiamento (R$ 2.650) somam 69% do total. As outras sete dividem o restante em valores pequenos a médios.",
+        ],
+        nextStep:
+          "Categorize a Fatura Maio (hoje em \"Cartão\") para que ela não distorça a leitura de despesas correntes. Vale separar o que é dívida pontual do que é gasto do mês.",
+      },
+      weekly: {
+        severity: "atencao",
+        readMin: 5,
+        title: "Onde o dinheiro foi: 4 saídas, nenhuma entrada",
+        summary:
+          "Na semana, R$ 13.650,00 distribuídos entre Cartão (R$ 11.000), Financiamento (R$ 2.650) e itens menores. Categorias fixas dominam; nenhuma receita registrada.",
+        highlights: [
+          { label: "Saídas da semana", value: formatFluidaCurrency(13650), caption: "4 lançamentos" },
+          { label: "Em despesas fixas", value: "81%", caption: "Financiamento + recorrentes" },
+          { label: "Atrasados", value: "3 itens", caption: "Fatura, Condomínio, Banho" },
+        ],
+        paragraphs: [
+          "A semana é quase inteiramente composta por compromissos fixos e dívidas. A Fatura Maio responde por 81% do valor; a Parcela de financiamento, recorrente, por mais 19%. Não há gasto variável relevante — sinal de que o problema é de calendário e dívida, não de consumo impulsivo.",
+          "Três itens aparecem como atrasados no mês (Fatura Maio, Condomínio, Banho do Caramelo), somando R$ 12.700. Mesmo os dois menores, juntos, indicam que vencimentos do início do mês passaram sem baixa — vale checar se foram pagos fora do app.",
+          "Pelas descrições, parte das saídas tem natureza combinada e previsível (\"Pagamento Ikaro — 3x na semana\", \"Banho do Caramelo — 2 banhos ao mês\"). Transformar esses combinados em recorrências ajuda a antecipá-los no fluxo.",
+        ],
+        nextStep:
+          "Revise os 3 itens em atraso e dê baixa no que já foi pago. Depois, converta os gastos \"combinados\" recorrentes (Ikaro, Caramelo) em lançamentos automáticos para o mês prever melhor o caixa.",
+      },
+    },
+    goals: {
+      label: "Metas",
+      color: "#11A36B",
+      daily: {
+        severity: "ok",
+        readMin: 3,
+        title: "Metas paradas aguardando o crédito do mês",
+        summary:
+          "Nenhum aporte ontem. \"Viagem dos sonhos\" segue em 56% (R$ 8.450 / R$ 15.000) e a Reserva de emergência em 67%.",
+        highlights: [
+          { label: "Viagem dos sonhos", value: "56%", caption: "R$ 8.450 / R$ 15.000" },
+          { label: "Reserva de emergência", value: "67%", caption: "R$ 13.423 / R$ 20.000" },
+          { label: "Aporte de ontem", value: formatFluidaCurrency(0), caption: "sem movimento" },
+        ],
+        paragraphs: [
+          "As metas não tiveram movimentação ontem — comportamento esperado num mês em que o caixa está comprometido com a fatura em atraso. O progresso permanece o mesmo do dia anterior.",
+          "A Reserva de emergência, em 67%, é o ponto positivo: cobre boa parte de um mês de despesas. Avançá-la antes da Viagem reduz a dependência do salário único que aparece na leitura geral.",
+        ],
+        nextStep:
+          "Assim que o salário entrar (30/06), direcione um aporte automático pequeno e fixo para a Reserva antes de qualquer gasto discricionário — ela é a meta que mais reduz seu risco hoje.",
+      },
+      weekly: {
+        severity: "atencao",
+        readMin: 5,
+        title: "Sem aportes na semana — ritmo abaixo do necessário",
+        summary:
+          "Semana sem contribuições para metas. No ritmo atual, a Viagem dos sonhos atrasa frente ao prazo; a Reserva avança devagar.",
+        highlights: [
+          { label: "Aportes na semana", value: formatFluidaCurrency(0), caption: "0 de 2 metas" },
+          { label: "Falta p/ Viagem", value: formatFluidaCurrency(6550), caption: "44% restante" },
+          { label: "Falta p/ Reserva", value: formatFluidaCurrency(6577), caption: "33% restante" },
+        ],
+        paragraphs: [
+          "A semana não registrou aportes — coerente com o aperto de caixa, mas que cobra um custo: as duas metas ficaram estacionadas enquanto o tempo até os prazos diminui. Metas sem aporte semanal tendem a derrapar silenciosamente.",
+          "A Viagem dos sonhos precisa de mais R$ 6.550. Mantido um aporte mensal modesto, o prazo escorrega alguns meses. A Reserva, mais perto do alvo (faltam R$ 6.577 para R$ 20.000), responde melhor a aportes pequenos e constantes.",
+          "A recomendação estrutural da leitura geral se aplica aqui: enquanto a conta depender de um único crédito mensal, as metas competem diretamente com as dívidas pelo mesmo dinheiro — e perdem.",
+        ],
+        nextStep:
+          "Defina aportes automáticos por porcentagem do salário (ex.: 5% Reserva, 5% Viagem) que saem no dia do crédito. Automatizar tira a meta da disputa mês a mês e protege o progresso.",
+      },
+    },
+    budgets: {
+      label: "Orçamentos",
+      color: "#FF8A3D",
+      daily: {
+        severity: "ok",
+        readMin: 3,
+        title: "Eletrônicos consumiu um pouco do limite livre",
+        summary:
+          "O gasto de ontem (R$ 156,30) cai em Eletrônicos, fora dos orçamentos fixos. Categorias fixas seguem dentro do previsto.",
+        highlights: [
+          { label: "Despesa fixa", value: "50% do total", caption: formatFluidaCurrency(15550) },
+          { label: "Sem categoria", value: formatFluidaCurrency(15325.08), caption: "a classificar" },
+          { label: "Livre usado ontem", value: formatFluidaCurrency(156.3), caption: "Eletrônicos" },
+        ],
+        paragraphs: [
+          "O lançamento de ontem é discricionário e pequeno, sem estourar nenhum teto. O alerta de orçamento não está no consumo do dia, e sim na qualidade da classificação: quase metade das saídas do mês está como \"Sem categoria\".",
+          "Com tanto valor não classificado, qualquer orçamento por categoria fica cego. Antes de apertar limites, o passo mais útil é categorizar — sobretudo a Fatura Maio, que infla \"Cartão/Sem categoria\".",
+        ],
+        nextStep:
+          "Classifique os lançamentos sem categoria do mês (R$ 15.325). Só depois os limites por categoria passam a refletir a realidade e os alertas ficam confiáveis.",
+      },
+      weekly: {
+        severity: "atencao",
+        readMin: 5,
+        title: "Metade do mês sem categoria — orçamento às cegas",
+        summary:
+          "Despesa fixa concentra 50% (R$ 15.550). \"Sem categoria\" tem outros R$ 15.325, o que impede orçamentos confiáveis por área.",
+        highlights: [
+          { label: "Despesa fixa", value: formatFluidaCurrency(15550), caption: "50% do total" },
+          { label: "Sem categoria", value: formatFluidaCurrency(15325.08), caption: "49% do total" },
+          { label: "Demais", value: formatFluidaCurrency(175), caption: "Cartão" },
+        ],
+        paragraphs: [
+          "A foto da semana confirma o diagnóstico do dia: o orçamento está dominado por dois blocos enormes — Despesa fixa (R$ 15.550) e Sem categoria (R$ 15.325). Juntos, são 99% das saídas, o que esvazia qualquer planejamento por categoria.",
+          "O bloco \"Sem categoria\" é grande porque a Fatura Maio entra nele. Classificar essa fatura e distribuí-la entre as áreas que a originaram (moradia, lazer, assinaturas) revelaria o consumo real por trás do número.",
+          "Despesa fixa em 50% é alto, mas não anômalo para quem tem financiamento e contas recorrentes. O problema é não enxergar a outra metade. Orçamento só vira ferramenta quando cada real tem um destino nomeado.",
+        ],
+        nextStep:
+          "Crie a regra: nenhuma transação fica sem categoria por mais de 48h. Comece pela Fatura Maio, quebrando-a nas categorias de origem — o orçamento por área passa a fazer sentido na hora.",
+      },
+    },
+    credit_cards: {
+      label: "Cartões",
+      color: "#9B5DE5",
+      daily: {
+        severity: "atencao",
+        readMin: 3,
+        title: "A fatura em atraso domina a leitura de cartão",
+        summary:
+          "Nenhuma compra no crédito ontem. O destaque é a Fatura Maio (R$ 11.000) ainda em aberto — pressão direta sobre limite e juros.",
+        highlights: [
+          { label: "Fatura em atraso", value: formatFluidaCurrency(11000), caption: "Maio · Inter" },
+          { label: "Limite usado (Inter)", value: "44%", caption: "R$ 11.000 / R$ 25.000" },
+          { label: "Compras ontem", value: formatFluidaCurrency(0), caption: "sem uso do crédito" },
+        ],
+        paragraphs: [
+          "Não houve uso de cartão ontem, o que é positivo. A leitura de cartões hoje gira inteiramente em torno de uma fatura vencida: a de maio, R$ 11.000, que mantém 44% do limite do Inter ocupado e tende a gerar encargos a cada dia de atraso.",
+          "Enquanto essa fatura não baixa, o cartão opera com folga de limite reduzida e custo crescente. É o item de maior alavancagem negativa da conta inteira neste momento.",
+        ],
+        nextStep:
+          "Quite ou parcele a Fatura Maio com a IA antes do próximo fechamento. Cada dia de atraso converte dívida barata em cara — é o melhor \"retorno\" disponível hoje.",
+      },
+      weekly: {
+        severity: "alerta",
+        readMin: 5,
+        title: "Cartão: dívida parada custando dinheiro",
+        summary:
+          "Na semana, o cartão não foi usado para novas compras, mas a Fatura Maio (R$ 11.000) seguiu em atraso — o maior fator de risco da conta.",
+        highlights: [
+          { label: "Fatura Maio", value: formatFluidaCurrency(11000), caption: "em atraso" },
+          { label: "% das despesas do mês", value: "55%", caption: "um único item" },
+          { label: "Novas compras", value: formatFluidaCurrency(0), caption: "na semana" },
+        ],
+        paragraphs: [
+          "A boa notícia da semana: você não adicionou novas compras ao crédito. A má: a dívida existente não andou. A Fatura Maio, sozinha, é 55% de todas as despesas do mês e mantém o limite do Inter comprometido.",
+          "Sem novas compras, o problema deixa de ser comportamental e passa a ser financeiro puro — é uma questão de liquidez e timing. O salário de 30/06 cobre a fatura com folga; a decisão é se vale esperar (acumulando juros) ou antecipar com a reserva.",
+          "Os outros cartões (Mercado Pago, Nubank, Unique) estão zerados no mês, então não há fragmentação de dívida — o foco é único e claro, o que facilita o plano.",
+        ],
+        nextStep:
+          "Compare o custo de atraso da fatura com o rendimento da Reserva. Se o juro do atraso superar o rendimento (quase sempre supera), antecipe a quitação parcial agora e recomponha a reserva com o salário.",
+      },
+    },
+  },
+};

--- a/app/features/ai-insights/fluida/model/insight-fluida.spec.ts
+++ b/app/features/ai-insights/fluida/model/insight-fluida.spec.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFluidaSeries,
+  deriveFluidaView,
+  formatFluidaCurrency,
+  formatFluidaSignedCurrency,
+  resolveFluidaReadMinutes,
+  resolveFluidaSeverity,
+  resolveFluidaThemeMeta,
+  FLUIDA_THEME_ORDER,
+  type FluidaInsightSource,
+} from "./insight-fluida";
+
+/**
+ * Normalizes the non-breaking space Intl emits between the BRL symbol and the
+ * amount so currency assertions stay readable with a regular space.
+ *
+ * @param value Formatted currency string, possibly containing a NBSP.
+ * @returns The same string with NBSP replaced by a regular space.
+ */
+const normalizeSpaces = (value: string): string => value.replace(/\u00a0/g, " ");
+
+const sampleSource: FluidaInsightSource = {
+  meta: {
+    model: "GPT-4o",
+    generatedAt: "21 de junho de 2026, 06:00",
+    referenceLabel: "movimentação até 20 de junho",
+    privacyNote: "Seus dados não treinam modelos.",
+  },
+  series: {
+    daily: { values: [1200, 0, 250, 0, 2650, 0, 11950], labels: ["14", "15", "16", "17", "18", "19", "20"] },
+    weekly: { values: [4200, 980, 3100, 1400, 9800, 13650], labels: ["S-5", "S-4", "S-3", "S-2", "S-1", "Atual"] },
+  },
+  general: {
+    daily: {
+      severity: "atencao",
+      readMin: 15,
+      title: "Ontem em foco",
+      summary: "Resumo diário.",
+      paragraphs: ["P1.", "P2.", "P3."],
+      nextStep: "Siga em frente.",
+      retro: [
+        { when: "Ontem · 20 jun", value: -156.3, text: "Apenas 1 lançamento." },
+        { when: "Anteontem · 19 jun", value: -11950, text: "Dia pesado." },
+        { when: "vs. semana passada", value: 9800, text: "Gastou mais." },
+      ],
+      alerts: [{ severity: "alta", text: "Fatura em atraso." }],
+      pullStat: { label: "Peso da Fatura Maio", value: "55%", caption: "de todas as despesas do mês" },
+    },
+    weekly: {
+      severity: "alerta",
+      readMin: 30,
+      title: "A semana de 15 a 21",
+      summary: "Resumo semanal.",
+      paragraphs: ["W1.", "W2.", "W3.", "W4."],
+      nextStep: "Construa um colchão.",
+      retro: [],
+      alerts: [],
+      pullStat: { label: "Peso da Fatura Maio", value: "55%", caption: "do mês" },
+    },
+  },
+  themes: {
+    transactions: {
+      label: "Transações",
+      color: "#2E7CF6",
+      daily: {
+        severity: "ok",
+        readMin: 3,
+        title: "Dia leve",
+        summary: "Resumo tema diário.",
+        paragraphs: ["T1.", "T2."],
+        nextStep: "Categorize.",
+        highlights: [
+          { label: "Maior gasto", value: "R$ 11.000,00", caption: "Fatura Maio" },
+          { label: "Único crédito", value: "R$ 27.675,37", caption: "Salário" },
+          { label: "Gasto de ontem", value: "R$ 156,30", caption: "Eletrônicos" },
+        ],
+      },
+      weekly: {
+        severity: "atencao",
+        readMin: 5,
+        title: "Onde o dinheiro foi",
+        summary: "Resumo tema semanal.",
+        paragraphs: ["TW1.", "TW2.", "TW3."],
+        nextStep: "Revise.",
+        highlights: [
+          { label: "Saídas da semana", value: "R$ 13.650,00", caption: "4 lançamentos" },
+        ],
+      },
+    },
+  },
+};
+
+describe("resolveFluidaSeverity", () => {
+  it("maps 'ok' to a positive tone with green token", () => {
+    const result = resolveFluidaSeverity("ok");
+    expect(result.tone).toBe("success");
+    expect(result.label).toBe("Tudo certo");
+    expect(result.colorVar).toBe("var(--color-positive)");
+  });
+
+  it("maps 'atencao' to a warning tone with amber token", () => {
+    const result = resolveFluidaSeverity("atencao");
+    expect(result.tone).toBe("warning");
+    expect(result.label).toBe("Atenção");
+    expect(result.colorVar).toBe("var(--color-warning)");
+  });
+
+  it("maps 'alerta' to a danger tone with red token", () => {
+    const result = resolveFluidaSeverity("alerta");
+    expect(result.tone).toBe("danger");
+    expect(result.label).toBe("Alerta");
+    expect(result.colorVar).toBe("var(--color-negative)");
+  });
+
+  it("maps alert-level severities 'alta' and 'media'", () => {
+    expect(resolveFluidaSeverity("alta").tone).toBe("danger");
+    expect(resolveFluidaSeverity("alta").label).toBe("Alta");
+    expect(resolveFluidaSeverity("media").tone).toBe("warning");
+    expect(resolveFluidaSeverity("media").label).toBe("Média");
+  });
+
+  it("falls back to the 'ok' presentation for unknown severities", () => {
+    const result = resolveFluidaSeverity("misterio" as never);
+    expect(result.tone).toBe("success");
+  });
+});
+
+describe("resolveFluidaReadMinutes", () => {
+  it("uses the node value when present", () => {
+    expect(resolveFluidaReadMinutes(7, "daily", false)).toBe(7);
+  });
+
+  it("defaults daily theme reading time to 3 minutes", () => {
+    expect(resolveFluidaReadMinutes(undefined, "daily", false)).toBe(3);
+  });
+
+  it("defaults daily general reading time to 15 minutes", () => {
+    expect(resolveFluidaReadMinutes(undefined, "daily", true)).toBe(15);
+  });
+
+  it("defaults weekly theme reading time to 5 minutes", () => {
+    expect(resolveFluidaReadMinutes(undefined, "weekly", false)).toBe(5);
+  });
+
+  it("defaults weekly general reading time to 30 minutes", () => {
+    expect(resolveFluidaReadMinutes(undefined, "weekly", true)).toBe(30);
+  });
+});
+
+describe("buildFluidaSeries", () => {
+  it("selects the daily series and flags the peak bar (the 7th day)", () => {
+    const result = buildFluidaSeries(sampleSource, "daily");
+    expect(result.labels).toEqual(["14", "15", "16", "17", "18", "19", "20"]);
+    expect(result.values).toHaveLength(7);
+    expect(result.peakIndex).toBe(6);
+    expect(result.peakValue).toBe(11950);
+  });
+
+  it("selects the weekly series and flags the peak bar (last week)", () => {
+    const result = buildFluidaSeries(sampleSource, "weekly");
+    expect(result.labels).toEqual(["S-5", "S-4", "S-3", "S-2", "S-1", "Atual"]);
+    expect(result.peakIndex).toBe(5);
+    expect(result.peakValue).toBe(13650);
+  });
+
+  it("keeps the peak index stable at 0 when the series is empty", () => {
+    const empty: FluidaInsightSource = {
+      ...sampleSource,
+      series: { daily: { values: [], labels: [] }, weekly: { values: [], labels: [] } },
+    };
+    const result = buildFluidaSeries(empty, "daily");
+    expect(result.peakIndex).toBe(0);
+    expect(result.peakValue).toBe(0);
+  });
+});
+
+describe("resolveFluidaThemeMeta", () => {
+  it("returns the general meta when the theme id is 'general'", () => {
+    const meta = resolveFluidaThemeMeta(sampleSource, "general");
+    expect(meta.label).toBe("Geral");
+    expect(meta.isGeneral).toBe(true);
+    expect(meta.colorVar).toBe("var(--fluida-brand)");
+  });
+
+  it("returns the theme meta with its accent color for a known theme", () => {
+    const meta = resolveFluidaThemeMeta(sampleSource, "transactions");
+    expect(meta.label).toBe("Transações");
+    expect(meta.isGeneral).toBe(false);
+    expect(meta.colorVar).toBe("#2E7CF6");
+  });
+
+  it("exposes a stable tab order starting with 'general'", () => {
+    expect(FLUIDA_THEME_ORDER[0]).toBe("general");
+    expect(FLUIDA_THEME_ORDER).toContain("transactions");
+  });
+});
+
+describe("formatFluidaCurrency", () => {
+  it("formats a value as pt-BR BRL", () => {
+    expect(normalizeSpaces(formatFluidaCurrency(11000))).toBe("R$ 11.000,00");
+  });
+
+  it("formats the absolute value, dropping the sign", () => {
+    expect(normalizeSpaces(formatFluidaCurrency(-156.3))).toBe("R$ 156,30");
+  });
+});
+
+describe("formatFluidaSignedCurrency", () => {
+  it("prefixes a minus glyph for negative amounts", () => {
+    expect(normalizeSpaces(formatFluidaSignedCurrency(-156.3))).toBe("− R$ 156,30");
+  });
+
+  it("prefixes a plus glyph for positive amounts", () => {
+    expect(normalizeSpaces(formatFluidaSignedCurrency(9800))).toBe("+ R$ 9.800,00");
+  });
+});
+
+describe("deriveFluidaView", () => {
+  it("derives the general daily view with lead, compare beat and chart", () => {
+    const view = deriveFluidaView(sampleSource, { cadence: "daily", theme: "general" });
+
+    expect(view.cadence).toBe("daily");
+    expect(view.themeId).toBe("general");
+    expect(view.isGeneral).toBe(true);
+    expect(view.lead.kicker).toBe("Geral");
+    expect(view.lead.title).toBe("Ontem em foco");
+    expect(view.lead.severity.tone).toBe("warning");
+    expect(view.lead.readMinutes).toBe(15);
+
+    // general view exposes the comparison cards from retro
+    expect(view.compare).toHaveLength(3);
+    expect(normalizeSpaces(view.compare?.[0]?.amountLabel ?? "")).toBe("− R$ 156,30");
+    expect(view.compare?.[0]?.isNegative).toBe(true);
+    expect(view.compare?.[2]?.isNegative).toBe(false);
+
+    // general view exposes the chart series + alerts
+    expect(view.chart.peakIndex).toBe(6);
+    expect(view.alerts).toHaveLength(1);
+    expect(view.highlights).toBeUndefined();
+
+    // paragraphs flow through unchanged
+    expect(view.paragraphs).toEqual(["P1.", "P2.", "P3."]);
+    expect(view.nextStep).toBe("Siga em frente.");
+    expect(view.pullStat?.value).toBe("55%");
+  });
+
+  it("derives a theme view with highlight tiles instead of compare cards", () => {
+    const view = deriveFluidaView(sampleSource, { cadence: "daily", theme: "transactions" });
+
+    expect(view.isGeneral).toBe(false);
+    expect(view.lead.kicker).toBe("Transações");
+    expect(view.lead.accentColor).toBe("#2E7CF6");
+    expect(view.compare).toBeUndefined();
+    expect(view.alerts).toBeUndefined();
+    expect(view.highlights).toHaveLength(3);
+    expect(view.highlights?.[0]?.value).toBe("R$ 11.000,00");
+    // the chart is still derived so the beat list can render it generically
+    expect(view.chart.values).toHaveLength(7);
+  });
+
+  it("switches series and reading time when cadence flips to weekly", () => {
+    const view = deriveFluidaView(sampleSource, { cadence: "weekly", theme: "general" });
+    expect(view.lead.readMinutes).toBe(30);
+    expect(view.chart.peakIndex).toBe(5);
+    expect(view.chart.values).toHaveLength(6);
+  });
+
+  it("falls back to the general node when an unknown theme is requested", () => {
+    const view = deriveFluidaView(sampleSource, { cadence: "daily", theme: "unknown" as never });
+    expect(view.isGeneral).toBe(true);
+    expect(view.themeId).toBe("general");
+  });
+});

--- a/app/features/ai-insights/fluida/model/insight-fluida.ts
+++ b/app/features/ai-insights/fluida/model/insight-fluida.ts
@@ -1,0 +1,393 @@
+/**
+ * Domain model + pure derivation logic for the "Fluida" editorial reading of the
+ * AI Insights screen.
+ *
+ * This module is intentionally framework-free (no Vue, no Pinia, no I/O). It maps
+ * a backend-shaped source object (see {@link FluidaInsightSource}, mirrored by the
+ * mobile `InsightFluidaVM`) into the view model consumed by the Fluida components.
+ *
+ * The source shape is aligned with the additive `/ai/insights` fields
+ * (`paragraphs` / `retro` / `series` / `highlights`) introduced by the backend.
+ * Until that endpoint ships, a mock implementing this exact shape feeds the view.
+ */
+
+/** Reading cadence selected in the masthead toggle. */
+export type FluidaCadence = "daily" | "weekly";
+
+/** Severity vocabulary used by both section badges and per-alert chips. */
+export type FluidaSeverity = "ok" | "atencao" | "alerta" | "alta" | "media";
+
+/** Logical theme tab id. `general` is the cross-cutting reading. */
+export type FluidaThemeId = "general" | "transactions" | "goals" | "budgets" | "credit_cards";
+
+/** Naive-aligned tone used to colour chips and accents. */
+export type FluidaTone = "success" | "warning" | "danger" | "neutral";
+
+/** A single comparison entry ("ontem · anteontem · vs. semana"). */
+export interface FluidaRetroEntry {
+  readonly when: string;
+  readonly value: number;
+  readonly text: string;
+}
+
+/** A single attention point rendered in the alert list. */
+export interface FluidaAlertEntry {
+  readonly severity: FluidaSeverity;
+  readonly text: string;
+}
+
+/** A numeric highlight tile / pull-stat. */
+export interface FluidaStat {
+  readonly label: string;
+  readonly value: string;
+  readonly caption: string;
+}
+
+/** Per-cadence content node shared by the general reading and each theme. */
+export interface FluidaNode {
+  readonly severity: FluidaSeverity;
+  readonly readMin?: number;
+  readonly title: string;
+  readonly summary: string;
+  readonly paragraphs: readonly string[];
+  readonly nextStep: string;
+  /** Comparison cards — only present on the general reading. */
+  readonly retro?: readonly FluidaRetroEntry[];
+  /** Attention points — only present on the general reading. */
+  readonly alerts?: readonly FluidaAlertEntry[];
+  /** Numeric tiles — only present on theme readings. */
+  readonly highlights?: readonly FluidaStat[];
+  /** Optional editorial pull-stat highlighted next to a paragraph. */
+  readonly pullStat?: FluidaStat;
+}
+
+/** A bar series (7 days or 6 weeks) with its axis labels. */
+export interface FluidaSeriesData {
+  readonly values: readonly number[];
+  readonly labels: readonly string[];
+}
+
+/** Provenance footer metadata. */
+export interface FluidaMeta {
+  readonly model: string;
+  readonly generatedAt: string;
+  readonly referenceLabel: string;
+  readonly privacyNote: string;
+}
+
+/** A theme reading: presentation metadata + its two cadence nodes. */
+export interface FluidaThemeSource {
+  readonly label: string;
+  readonly color: string;
+  readonly daily: FluidaNode;
+  readonly weekly: FluidaNode;
+}
+
+/** The full source object mapped into the view model. */
+export interface FluidaInsightSource {
+  readonly meta: FluidaMeta;
+  readonly series: { readonly daily: FluidaSeriesData; readonly weekly: FluidaSeriesData };
+  readonly general: { readonly daily: FluidaNode; readonly weekly: FluidaNode };
+  readonly themes: Partial<Record<Exclude<FluidaThemeId, "general">, FluidaThemeSource>>;
+}
+
+/** Resolved severity presentation (chip label, tone, CSS colour token). */
+export interface FluidaSeverityPresentation {
+  readonly tone: FluidaTone;
+  readonly label: string;
+  readonly colorVar: string;
+}
+
+/** Resolved theme tab presentation. */
+export interface FluidaThemeMeta {
+  readonly id: FluidaThemeId;
+  readonly label: string;
+  readonly colorVar: string;
+  readonly isGeneral: boolean;
+}
+
+/** A chart-ready series with peak detection. */
+export interface FluidaChart {
+  readonly values: readonly number[];
+  readonly labels: readonly string[];
+  readonly peakIndex: number;
+  readonly peakValue: number;
+}
+
+/** A render-ready comparison card. */
+export interface FluidaCompareCard {
+  readonly when: string;
+  readonly amountLabel: string;
+  readonly isNegative: boolean;
+  readonly text: string;
+}
+
+/** A render-ready attention point. */
+export interface FluidaAlertCard {
+  readonly text: string;
+  readonly severity: FluidaSeverityPresentation;
+}
+
+/** Lead (editorial header) view model. */
+export interface FluidaLeadView {
+  readonly kicker: string;
+  readonly accentColor: string;
+  readonly severity: FluidaSeverityPresentation;
+  readonly readMinutes: number;
+  readonly title: string;
+  readonly summary: string;
+}
+
+/** Full derived view model for one (cadence, theme) selection. */
+export interface FluidaView {
+  readonly cadence: FluidaCadence;
+  readonly themeId: FluidaThemeId;
+  readonly isGeneral: boolean;
+  readonly lead: FluidaLeadView;
+  readonly paragraphs: readonly string[];
+  readonly chart: FluidaChart;
+  readonly nextStep: string;
+  readonly meta: FluidaMeta;
+  readonly compare?: readonly FluidaCompareCard[];
+  readonly alerts?: readonly FluidaAlertCard[];
+  readonly highlights?: readonly FluidaStat[];
+  readonly pullStat?: FluidaStat;
+}
+
+/** Selection driving {@link deriveFluidaView}. */
+export interface FluidaSelection {
+  readonly cadence: FluidaCadence;
+  readonly theme: FluidaThemeId;
+}
+
+/** Stable tab order; `general` always leads. */
+export const FLUIDA_THEME_ORDER: readonly FluidaThemeId[] = [
+  "general",
+  "transactions",
+  "goals",
+  "budgets",
+  "credit_cards",
+];
+
+const SEVERITY_PRESENTATION: Record<FluidaSeverity, FluidaSeverityPresentation> = {
+  ok: { tone: "success", label: "Tudo certo", colorVar: "var(--color-positive)" },
+  atencao: { tone: "warning", label: "Atenção", colorVar: "var(--color-warning)" },
+  alerta: { tone: "danger", label: "Alerta", colorVar: "var(--color-negative)" },
+  alta: { tone: "danger", label: "Alta", colorVar: "var(--color-negative)" },
+  media: { tone: "warning", label: "Média", colorVar: "var(--color-warning)" },
+};
+
+const READ_MINUTES_DEFAULT = {
+  daily: { theme: 3, general: 15 },
+  weekly: { theme: 5, general: 30 },
+} as const;
+
+const brlFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+/**
+ * Resolves the chip presentation (tone, label, colour token) for a severity.
+ *
+ * @param severity Raw severity value.
+ * @returns Presentation metadata; falls back to the "ok" preset when unknown.
+ */
+export const resolveFluidaSeverity = (severity: FluidaSeverity): FluidaSeverityPresentation =>
+  SEVERITY_PRESENTATION[severity] ?? SEVERITY_PRESENTATION.ok;
+
+/**
+ * Resolves the reading-time badge value, honouring the node value when present
+ * and otherwise applying the cadence/scope defaults (3/15 daily, 5/30 weekly).
+ *
+ * @param nodeReadMin Reading time declared on the node, if any.
+ * @param cadence Selected cadence.
+ * @param isGeneral Whether the selection is the cross-cutting general reading.
+ * @returns Reading time in minutes.
+ */
+export const resolveFluidaReadMinutes = (
+  nodeReadMin: number | undefined,
+  cadence: FluidaCadence,
+  isGeneral: boolean,
+): number => {
+  if (typeof nodeReadMin === "number" && Number.isFinite(nodeReadMin)) {
+    return nodeReadMin;
+  }
+  const defaults = READ_MINUTES_DEFAULT[cadence];
+  return isGeneral ? defaults.general : defaults.theme;
+};
+
+/**
+ * Builds the chart-ready series for the cadence, detecting the peak bar.
+ *
+ * @param source Insight source object.
+ * @param cadence Selected cadence.
+ * @returns Chart values, labels and the peak index/value.
+ */
+export const buildFluidaSeries = (
+  source: FluidaInsightSource,
+  cadence: FluidaCadence,
+): FluidaChart => {
+  const series = source.series[cadence];
+  const values = series.values;
+
+  let peakIndex = 0;
+  let peakValue = values.length > 0 ? values[0]! : 0;
+  values.forEach((value, index) => {
+    if (value > peakValue) {
+      peakValue = value;
+      peakIndex = index;
+    }
+  });
+
+  return { values, labels: series.labels, peakIndex, peakValue };
+};
+
+/**
+ * Resolves the tab presentation (label, accent colour) for a theme id.
+ *
+ * @param source Insight source object.
+ * @param theme Theme id.
+ * @returns Theme metadata. The general tab uses the brand token.
+ */
+export const resolveFluidaThemeMeta = (
+  source: FluidaInsightSource,
+  theme: FluidaThemeId,
+): FluidaThemeMeta => {
+  if (theme === "general") {
+    return { id: "general", label: "Geral", colorVar: "var(--fluida-brand)", isGeneral: true };
+  }
+
+  const themeSource = source.themes[theme];
+  return {
+    id: theme,
+    label: themeSource?.label ?? "Geral",
+    colorVar: themeSource?.color ?? "var(--fluida-brand)",
+    isGeneral: false,
+  };
+};
+
+/**
+ * Formats a number as pt-BR BRL using its absolute value (sign dropped).
+ *
+ * @param value Amount to format.
+ * @returns e.g. "R$ 11.000,00".
+ */
+export const formatFluidaCurrency = (value: number): string =>
+  brlFormatter.format(Math.abs(value));
+
+/**
+ * Formats a signed amount with a leading glyph ("−"/"+") and pt-BR BRL value.
+ *
+ * @param value Amount to format.
+ * @returns e.g. "− R$ 156,30" or "+ R$ 9.800,00".
+ */
+export const formatFluidaSignedCurrency = (value: number): string => {
+  const glyph = value < 0 ? "−" : "+";
+  return `${glyph} ${formatFluidaCurrency(value)}`;
+};
+
+/**
+ * Resolves the active content node for a selection, falling back to the general
+ * reading when the requested theme is unknown.
+ *
+ * @param source Insight source object.
+ * @param selection Cadence + theme selection.
+ * @returns The node plus the resolved theme id (collapsed to "general" on miss).
+ */
+const resolveActiveNode = (
+  source: FluidaInsightSource,
+  selection: FluidaSelection,
+): { node: FluidaNode; themeId: FluidaThemeId; isGeneral: boolean } => {
+  if (selection.theme === "general") {
+    return { node: source.general[selection.cadence], themeId: "general", isGeneral: true };
+  }
+
+  const themeSource = source.themes[selection.theme];
+  if (!themeSource) {
+    return { node: source.general[selection.cadence], themeId: "general", isGeneral: true };
+  }
+
+  return { node: themeSource[selection.cadence], themeId: selection.theme, isGeneral: false };
+};
+
+/**
+ * Maps a retro entry into a render-ready comparison card.
+ *
+ * @param entry Raw retro entry.
+ * @returns Card with a signed amount label and sign flag.
+ */
+const toCompareCard = (entry: FluidaRetroEntry): FluidaCompareCard => ({
+  when: entry.when,
+  amountLabel: formatFluidaSignedCurrency(entry.value),
+  isNegative: entry.value < 0,
+  text: entry.text,
+});
+
+/**
+ * Maps an alert entry into a render-ready card with resolved severity.
+ *
+ * @param entry Raw alert entry.
+ * @returns Card with severity presentation.
+ */
+const toAlertCard = (entry: FluidaAlertEntry): FluidaAlertCard => ({
+  text: entry.text,
+  severity: resolveFluidaSeverity(entry.severity),
+});
+
+/**
+ * Derives the full Fluida view model for a (cadence, theme) selection.
+ *
+ * General readings expose `compare` (3 retrospective cards) + `alerts`; theme
+ * readings expose `highlights` (numeric tiles). The chart and pull-stat are
+ * derived for every selection so the beat list renders generically.
+ *
+ * @param source Insight source object (mock today, DTO once the backend ships).
+ * @param selection Cadence + theme selection.
+ * @returns The derived view model.
+ */
+export const deriveFluidaView = (
+  source: FluidaInsightSource,
+  selection: FluidaSelection,
+): FluidaView => {
+  const { node, themeId, isGeneral } = resolveActiveNode(source, selection);
+  const themeMeta = resolveFluidaThemeMeta(source, themeId);
+  const chart = buildFluidaSeries(source, selection.cadence);
+
+  const lead: FluidaLeadView = {
+    kicker: themeMeta.label,
+    accentColor: themeMeta.colorVar,
+    severity: resolveFluidaSeverity(node.severity),
+    readMinutes: resolveFluidaReadMinutes(node.readMin, selection.cadence, isGeneral),
+    title: node.title,
+    summary: node.summary,
+  };
+
+  const compare =
+    isGeneral && node.retro && node.retro.length > 0
+      ? node.retro.map(toCompareCard)
+      : undefined;
+  const alerts =
+    isGeneral && node.alerts && node.alerts.length > 0
+      ? node.alerts.map(toAlertCard)
+      : undefined;
+  const highlights =
+    !isGeneral && node.highlights && node.highlights.length > 0 ? node.highlights : undefined;
+
+  return {
+    cadence: selection.cadence,
+    themeId,
+    isGeneral,
+    lead,
+    paragraphs: node.paragraphs,
+    chart,
+    nextStep: node.nextStep,
+    meta: source.meta,
+    compare,
+    alerts,
+    highlights,
+    pullStat: node.pullStat,
+  };
+};

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -1869,6 +1869,48 @@
       "empty": "Nenhum insight gerado ainda. Gere o primeiro insight para começar.",
       "loadErrorTitle": "Não foi possível carregar os insights",
       "loadErrorMessage": "Tente novamente em alguns instantes."
+    },
+    "fluida": {
+      "brand": "Insights de IA",
+      "cadence": {
+        "daily": "Diário",
+        "weekly": "Semanal",
+        "dailyReading": "Leitura diária",
+        "weeklyReading": "Leitura semanal"
+      },
+      "tabs": {
+        "general": "Geral",
+        "transactions": "Transações",
+        "goals": "Metas",
+        "budgets": "Orçamentos",
+        "credit_cards": "Cartões"
+      },
+      "theme": {
+        "toLight": "Mudar para tema claro",
+        "toDark": "Mudar para tema escuro"
+      },
+      "readTime": "{min} min de leitura",
+      "sections": {
+        "compare": "Como se compara",
+        "rhythm": "O ritmo de saídas",
+        "alerts": "Pontos de atenção",
+        "highlights": "Destaques"
+      },
+      "chart": {
+        "daily": "Saídas · últimos 7 dias",
+        "weekly": "Saídas · últimas 6 semanas",
+        "peak": "pico: {value}",
+        "ariaLabel": "Gráfico de barras das saídas recentes, com o pico destacado"
+      },
+      "nextStep": "Para onde seguir agora",
+      "provenance": "Gerado por {model} · {generatedAt} · referente à {reference}.",
+      "severity": {
+        "ok": "Tudo certo",
+        "atencao": "Atenção",
+        "alerta": "Alerta",
+        "alta": "Alta",
+        "media": "Média"
+      }
     }
   },
   "transactions": {

--- a/app/pages/insights.vue
+++ b/app/pages/insights.vue
@@ -3,6 +3,8 @@ import { computed, ref, watch } from "vue";
 import { NButton, NTag } from "naive-ui";
 
 import AiInsightButton from "~/features/ai-insights/components/AiInsightButton.vue";
+import InsightsFluida from "~/features/ai-insights/fluida/components/InsightsFluida.vue";
+import { useFeatureFlag } from "~/shared/feature-flags/use-feature-flag";
 import {
   getInsightDimensionLabel,
   groupInsightItemsByDimension,
@@ -25,6 +27,10 @@ definePageMeta({
 });
 
 useHead({ title: "Insights de IA | Auraxis" });
+
+// Editorial "Fluida" reading, gated behind web.insights.fluida (default OFF).
+// When the flag is off the legacy report below renders unchanged.
+const isFluidaEnabled = useFeatureFlag("web.insights.fluida");
 
 const route = useRoute();
 const currentPage = ref(1);
@@ -162,7 +168,9 @@ watch(
 </script>
 
 <template>
-  <div class="insights-page">
+  <InsightsFluida v-if="isFluidaEnabled" />
+
+  <div v-else class="insights-page">
     <section class="insights-page__hero">
       <div class="insights-page__hero-copy">
         <span class="insights-page__eyebrow">Auraxis AI</span>

--- a/app/shared/types/generated/graphql.ts
+++ b/app/shared/types/generated/graphql.ts
@@ -60,6 +60,14 @@ export type AiInsightFeedbackPayload = {
   usefulness?: Maybe<Scalars['Int']['output']>;
 };
 
+/** One calculated per-theme highlight for the Fluida screen (#1501). */
+export type AiInsightHighlightType = {
+  __typename?: 'AIInsightHighlightType';
+  label: Scalars['String']['output'];
+  sub: Scalars['String']['output'];
+  value: Scalars['Float']['output'];
+};
+
 export type AiInsightHistoryResultType = {
   __typename?: 'AIInsightHistoryResultType';
   items: Array<AiInsightType>;
@@ -76,6 +84,23 @@ export type AiInsightItemType = {
   message: Scalars['String']['output'];
   title: Scalars['String']['output'];
   type: Scalars['String']['output'];
+};
+
+/** One calculated retrospective metric for the Fluida screen (#1501). */
+export type AiInsightRetroEntryType = {
+  __typename?: 'AIInsightRetroEntryType';
+  caption: Scalars['String']['output'];
+  key: Scalars['String']['output'];
+  label: Scalars['String']['output'];
+  sign: Scalars['String']['output'];
+  value: Scalars['Float']['output'];
+};
+
+/** Calculated outflow series: daily over 7 days, weekly over 6 weeks. */
+export type AiInsightSeriesType = {
+  __typename?: 'AIInsightSeriesType';
+  daily: Array<Maybe<Scalars['Float']['output']>>;
+  weekly: Array<Maybe<Scalars['Float']['output']>>;
 };
 
 export type AiInsightType = {
@@ -513,14 +538,18 @@ export type GenerateAiInsightPayload = {
   contextVersion?: Maybe<Scalars['String']['output']>;
   costUsd?: Maybe<Scalars['Float']['output']>;
   forecast?: Maybe<Scalars['Boolean']['output']>;
+  highlights?: Maybe<Array<Maybe<AiInsightHighlightType>>>;
   id?: Maybe<Scalars['String']['output']>;
   items?: Maybe<Array<Maybe<AiInsightItemType>>>;
   model?: Maybe<Scalars['String']['output']>;
   ok: Scalars['Boolean']['output'];
+  paragraphs?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   periodEnd?: Maybe<Scalars['String']['output']>;
   periodLabel?: Maybe<Scalars['String']['output']>;
   periodStart?: Maybe<Scalars['String']['output']>;
   periodType?: Maybe<Scalars['String']['output']>;
+  retro?: Maybe<Array<Maybe<AiInsightRetroEntryType>>>;
+  series?: Maybe<AiInsightSeriesType>;
   summary?: Maybe<Scalars['String']['output']>;
   tokensUsed?: Maybe<Scalars['Int']['output']>;
 };

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -499,6 +499,16 @@
       "status": "enabled-dev",
       "description": "A/B test do novo layout de dashboard. Provider runtime (PostHog) decide variante em staging/prod.",
       "repositories": ["auraxis-web"]
+    },
+    {
+      "key": "web.insights.fluida",
+      "owner": "growth",
+      "createdAt": "2026-06-21",
+      "removeBy": "2027-12-31",
+      "type": "release",
+      "status": "draft",
+      "description": "Leitura editorial \"Fluida\" da tela de Insights de IA (masthead + lead + beats). Default OFF até o backend (auraxis-api #1502) entregar paragraphs/retro/series/highlights; ligar via NUXT_PUBLIC_FLAG_WEB_INSIGHTS_FLUIDA=true.",
+      "repositories": ["auraxis-web"]
     }
   ]
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -298,6 +298,9 @@ export default defineNuxtConfig({
     families: {
       Inter: [400, 500, 600, 700],
       "IBM Plex Mono": [400, 500, 600],
+      // Newsreader: serif headline for the Insights "Fluida" editorial reading
+      // (feature web.insights.fluida). Used only on the headline; body stays Inter.
+      Newsreader: [500, 600],
     },
     subsets: ["latin", "latin-ext"],
     display: "swap",


### PR DESCRIPTION
## Resumo

Recria a leitura **"Fluida"** (editorial) da tela de Insights de IA no web (Nuxt 4 / Vue 3 / Naive UI / ECharts), espelhando a tela mobile já entregue. Substitui o relatório/dump atual por uma narrativa analítica: textos curtos intercalados a comparativos e um gráfico de ritmo de saídas.

Tudo atrás da feature flag **`web.insights.fluida`** (status `draft`, **default OFF**): com a flag desligada, a tela de insights atual em produção **não muda**.

Closes #1070

## O que entra

**Estrutura (tela principal Fluida), espelhando o mobile:**
- **Masthead** — toggle Diário/Semanal + abas de tema (Geral · Transações · Metas · Orçamentos · Cartões) + claro/escuro local.
- **Lead editorial** — kicker (tema) + chip de severidade + tempo de leitura + **headline serifada (Newsreader)** + parágrafo de abertura.
- **Beats** — `CompareBeat` (3 cards ontem/anteontem/vs-semana, **lado a lado** no web), `TextBeat` (capitular no 1º parágrafo), `ChartBeat` "ritmo de saídas" (**ECharts via `UiChart`**, barras 7 dias / 6 semanas conforme cadência, **pico destacado**), `PullStat`, `StatTiles`, `AlertList`, bloco teal "Para onde seguir agora" e procedência da IA.
- Layout web **max-width ~740px**, beats em 2 colunas quando cabe; empilha no estreito.

## Arquitetura

```
app/features/ai-insights/fluida/
  model/insight-fluida.ts        # tipos do VM + lógica pura (severity→tom/cor, read-time, série/pico, derivação)
  model/insight-fluida-mock.ts   # mock alinhado ao contrato novo (espelha o InsightFluidaVM do mobile)
  composables/use-insights-fluida.ts   # façade reativa fina (seleção cadência/tema → view derivada)
  components/                    # InsightsFluida (orquestrador) + masthead, lead, beats e átomos
```

- **Dados**: mock atrás da flag, com a **forma do contrato novo** (`paragraphs`/`retro`/`series`/`highlights`). Um mapper pode trocar pelo DTO real sem mexer na UI quando o backend (auraxis-api #1502) entregar. O schema GraphQL **já** expõe esses tipos — `graphql.ts` foi sincronizado (aditivo).
- **Contratos** de `ai-insights` estendidos de forma **aditiva** (`InsightFluidaFieldsDTO` em `GenerateInsightResponseDTO`, todos opcionais).
- **Tokens**: paleta/escala `.axi` do handoff mapeada para um layer `.fluida` (claro/escuro) em `main.css`, com override local `data-fluida-scheme` para o toggle claro/escuro da tela funcionar independente do tema global do app.
- **Fonte**: **Newsreader** adicionada ao `@nuxtjs/google-fonts` (só na headline); valores em mono tabular (`IBM Plex Mono`) com `Intl` pt-BR/BRL.

## TDD / Qualidade

- **Lógica primeiro (Vitest)**: severity→tom/label/cor, tempos de leitura (3/15 diário, 5/30 semanal), seleção de série + detecção de pico por cadência, derivação completa do VM. Depois testes de componente (renderiza estado derivado, troca de tema/cadência, toggle claro/escuro).
- **en.json congelado (DEC-186)** respeitado: chaves novas **só em `pt.json`** (PT-only, deferidas pela parity).
- **Governança de frontend** respeitada: componentes consomem apenas `var(--fluida-*)`/tokens; sem literais de font-size/weight/line-height/radius.
- `pnpm quality-check` **VERDE** (flags, i18n, lint, typecheck, test:coverage ≥85%, policy, contracts, codegen, build).

## Como testar (ligar a flag)

A flag é `draft` (OFF por padrão). Para ver a Fluida em dev, ligue o override de ambiente e abra `/insights`:

```bash
NUXT_PUBLIC_FLAG_WEB_INSIGHTS_FLUIDA=true pnpm dev
# abra http://localhost:3000/insights
```

Alterne **Diário/Semanal**, troque as abas de tema e use o botão de lua/sol (claro/escuro local). Com a flag OFF, `/insights` mantém o relatório legado.

## Notas

- `nuxt.config.ts`: única mudança é **aditiva** — adiciona a família `Newsreader` ao bloco `googleFonts.families` (sem impacto em build/SSR; o stylesheet de fontes é gerado a partir dessa lista).
- `graphql.ts`: regeneração **aditiva** (0 remoções) — o schema do backend já tinha `AIInsightHighlightType`/`AIInsightRetroEntryType`/`AIInsightSeriesType`; o arquivo commitado estava defasado, então `codegen:check` agora fica verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx
