### PR TITLE
[WEB] Insights Fluida — conectar dados reais (mock→DTO)

### DIFF
--- a/app/features/ai-insights/contracts/ai-insight.ts
+++ b/app/features/ai-insights/contracts/ai-insight.ts
@@ -19,12 +19,6 @@ export interface InsightItem {
 }
 
 /**
- * Severity vocabulary emitted by the Fluida editorial payload.
- * `ok | atencao | alerta` tag a section; `alta | media` tag individual alerts.
- */
-export type InsightFluidaSeverity = "ok" | "atencao" | "alerta" | "alta" | "media";
-
-/**
  * Direction of a retrospective movement, as computed by the backend builder
  * (`insight_fluida_builder.py`). `pos` is a favourable movement (e.g. spending
  * less than the baseline), `neg` unfavourable, `neutral` flat.
@@ -54,12 +48,6 @@ export interface InsightHighlightDTO {
   readonly sub: string;
 }
 
-/** An attention point with its own severity. */
-export interface InsightAlertDTO {
-  readonly severity: InsightFluidaSeverity;
-  readonly text: string;
-}
-
 /**
  * Calculated outflow series: daily over the last 7 days, weekly over the last 6
  * weeks. Both windows end on (and include) the anchor; the backend emits values
@@ -71,21 +59,23 @@ export interface InsightSeriesDTO {
 }
 
 /**
- * Additive fields on the `/ai/insights` response that power the Fluida reading
- * (auraxis-api PR #1501/#1502). All optional: the legacy `items`/`content`
- * payload is unchanged, and clients that do not consume these fields keep
- * working. When absent, the web falls back to the Fluida mock behind
- * `web.insights.fluida`.
+ * Additive **body** fields on the `/ai/insights` response that power the Fluida
+ * reading (auraxis-api PR #1501/#1502). The backend builder
+ * (`insight_fluida_builder.py`) computes ONLY the editorial body and numbers —
+ * `paragraphs` / `retro` / `series` / `highlights`. It does NOT emit the
+ * per-dimension editorial lead (severity / headline / opening / reading time /
+ * next step); that always comes from the mock recorte, mirroring the mobile
+ * mapper (`auraxis-app/features/insights/fluida/insight-to-fluida-vm.ts`).
+ *
+ * All optional: the legacy `items`/`content` payload is unchanged, and clients
+ * that do not consume these fields keep working. When absent, the web falls back
+ * to the Fluida mock behind `web.insights.fluida`.
  */
 export interface InsightFluidaFieldsDTO {
-  readonly severity?: InsightFluidaSeverity;
-  readonly read_min?: number;
   readonly paragraphs?: readonly string[];
   readonly retro?: readonly InsightRetroEntryDTO[];
   readonly highlights?: readonly InsightHighlightDTO[];
-  readonly alerts?: readonly InsightAlertDTO[];
   readonly series?: InsightSeriesDTO;
-  readonly next_step?: string;
 }
 
 export interface AIInsightDTO {

--- a/app/features/ai-insights/contracts/ai-insight.ts
+++ b/app/features/ai-insights/contracts/ai-insight.ts
@@ -59,13 +59,49 @@ export interface InsightSeriesDTO {
 }
 
 /**
- * Additive **body** fields on the `/ai/insights` response that power the Fluida
- * reading (auraxis-api PR #1501/#1502). The backend builder
- * (`insight_fluida_builder.py`) computes ONLY the editorial body and numbers —
- * `paragraphs` / `retro` / `series` / `highlights`. It does NOT emit the
- * per-dimension editorial lead (severity / headline / opening / reading time /
- * next step); that always comes from the mock recorte, mirroring the mobile
- * mapper (`auraxis-app/features/insights/fluida/insight-to-fluida-vm.ts`).
+ * Editorial severity of a Fluida lead, as emitted by the backend heuristic
+ * (auraxis-api #1503): `ok` (green), `attention` (amber) and `alert` (red).
+ * Mirrors `AIInsightLeadType.severity` and the mobile `InsightSeverity`. The
+ * Fluida mapper translates it onto the web's `FluidaSeverity` vocabulary.
+ */
+export type InsightLeadSeverity = "ok" | "attention" | "alert";
+
+/**
+ * Additive editorial **lead** (masthead) of a Fluida insight (auraxis-api #1503
+ * / #1508). `severity` is a deterministic heuristic over the calculated
+ * retro/highlights; `read_min` is fixed by cadence; `title` / `lead` /
+ * `next_step` are derived from the AI `summary` (no extra LLM call).
+ *
+ * Field names are **snake_case** because this is the REST `/ai/insights/generate`
+ * wire shape (`build_lead` in `insight_lead_builder.py`), matching the sibling
+ * Fluida fields (`paragraphs` / `retro` / `series` / `highlights`) and the rest
+ * of the REST contract (`period_label`, `tokens_used`, …). The GraphQL
+ * `AIInsightLeadType` exposes the same data camelCased, but the web consumes the
+ * REST endpoint, so the camelCase generated type is not the runtime shape here.
+ *
+ * When present, the Fluida reading takes its lead (severity / headline / opening
+ * / reading time / next step) from here instead of the mock recorte; when
+ * absent, the mapper falls back to the mock lead — same fallback semantics the
+ * mobile mapper applies to the body.
+ */
+export interface InsightLeadDTO {
+  readonly severity: InsightLeadSeverity;
+  readonly read_min: number;
+  readonly title: string;
+  /** Opening paragraph of the reading (becomes the VM `summary`). */
+  readonly lead: string;
+  readonly next_step: string;
+}
+
+/**
+ * Additive Fluida fields on the `/ai/insights` response that power the editorial
+ * reading. The body + numbers (`paragraphs` / `retro` / `series` / `highlights`)
+ * land in auraxis-api PR #1501/#1502; the editorial **lead** (`lead`) is the
+ * later additive contract (#1503/#1508). When the lead is present the reading
+ * takes its severity / headline / opening / reading time / next step from the
+ * backend; when absent it falls back to the mock recorte — the same fallback the
+ * mobile mapper applies to the body
+ * (`auraxis-app/features/insights/fluida/insight-to-fluida-vm.ts`).
  *
  * All optional: the legacy `items`/`content` payload is unchanged, and clients
  * that do not consume these fields keep working. When absent, the web falls back
@@ -76,6 +112,7 @@ export interface InsightFluidaFieldsDTO {
   readonly retro?: readonly InsightRetroEntryDTO[];
   readonly highlights?: readonly InsightHighlightDTO[];
   readonly series?: InsightSeriesDTO;
+  readonly lead?: InsightLeadDTO;
 }
 
 export interface AIInsightDTO {

--- a/app/features/ai-insights/contracts/ai-insight.ts
+++ b/app/features/ai-insights/contracts/ai-insight.ts
@@ -24,18 +24,34 @@ export interface InsightItem {
  */
 export type InsightFluidaSeverity = "ok" | "atencao" | "alerta" | "alta" | "media";
 
-/** A retrospective comparison entry ("ontem · anteontem · vs. semana"). */
+/**
+ * Direction of a retrospective movement, as computed by the backend builder
+ * (`insight_fluida_builder.py`). `pos` is a favourable movement (e.g. spending
+ * less than the baseline), `neg` unfavourable, `neutral` flat.
+ */
+export type InsightRetroSign = "pos" | "neg" | "neutral";
+
+/**
+ * A retrospective comparison entry of the `general` dimension. Shape mirrors the
+ * backend builder: `value` is a decimal currency amount and `sign` encodes
+ * whether the movement is favourable.
+ */
 export interface InsightRetroEntryDTO {
-  readonly when: string;
+  readonly key: string;
+  readonly label: string;
   readonly value: number;
-  readonly text: string;
+  readonly caption: string;
+  readonly sign: InsightRetroSign;
 }
 
-/** A numeric highlight tile / pull-stat. */
+/**
+ * A per-theme numeric highlight tile. Shape mirrors the backend builder:
+ * `value` is a decimal currency amount and `sub` is the supporting caption.
+ */
 export interface InsightHighlightDTO {
   readonly label: string;
-  readonly value: string;
-  readonly caption: string;
+  readonly value: number;
+  readonly sub: string;
 }
 
 /** An attention point with its own severity. */
@@ -44,17 +60,22 @@ export interface InsightAlertDTO {
   readonly text: string;
 }
 
-/** A bar series (7 days / 6 weeks) with its axis labels. */
+/**
+ * Calculated outflow series: daily over the last 7 days, weekly over the last 6
+ * weeks. Both windows end on (and include) the anchor; the backend emits values
+ * only and the web derives the axis labels.
+ */
 export interface InsightSeriesDTO {
-  readonly values: readonly number[];
-  readonly labels: readonly string[];
+  readonly daily: readonly number[];
+  readonly weekly: readonly number[];
 }
 
 /**
  * Additive fields on the `/ai/insights` response that power the Fluida reading
- * (auraxis-api PR #1502). All optional: the legacy `items`/`content` payload is
- * unchanged, and clients that do not consume these fields keep working. When
- * absent, the web falls back to the Fluida mock behind `web.insights.fluida`.
+ * (auraxis-api PR #1501/#1502). All optional: the legacy `items`/`content`
+ * payload is unchanged, and clients that do not consume these fields keep
+ * working. When absent, the web falls back to the Fluida mock behind
+ * `web.insights.fluida`.
  */
 export interface InsightFluidaFieldsDTO {
   readonly severity?: InsightFluidaSeverity;

--- a/app/features/ai-insights/fluida/components/InsightsFluida.spec.ts
+++ b/app/features/ai-insights/fluida/components/InsightsFluida.spec.ts
@@ -103,7 +103,7 @@ describe("InsightsFluida", () => {
     expect(wrapper.text()).toContain("A semana de 15 a 21: o mês inteiro decidido em dois dias");
   });
 
-  it("renders the real AI paragraphs when a generated insight is present", () => {
+  it("renders the real AI body while keeping the mock editorial lead", () => {
     currentResult.value = {
       id: "real-1",
       summary: "Resumo real",
@@ -119,27 +119,31 @@ describe("InsightsFluida", () => {
       forecast: false,
       callsRemaining: 1,
       callsRemainingMonth: 10,
+      // Only the body the backend builder computes — no lead fields.
       fluida: {
-        severity: "alerta",
-        read_min: 7,
         paragraphs: ["Leitura real da IA sobre o seu dia.", "Segundo parágrafo real."],
         retro: [
           { key: "yesterday", label: "Ontem (real)", value: -156.3, caption: "Saídas de ontem", sign: "neg" },
         ],
         series: { daily: [1, 2, 3, 4, 5, 6, 7], weekly: [1, 2, 3, 4, 5, 6] },
-        next_step: "Próximo passo real.",
       },
     };
 
     const wrapper = mountFluida();
+    // body comes from the real payload…
     expect(wrapper.text()).toContain("Leitura real da IA sobre o seu dia.");
     expect(wrapper.text()).toContain("Ontem (real)");
-    expect(wrapper.text()).toContain("Próximo passo real.");
-    expect(wrapper.text()).toContain("7 min de leitura");
-    // the mock prose for the overlaid (general daily) node is replaced by the
-    // real AI paragraphs — the editorial lead title stays (backend sends no title)
+    // the real paragraphs replace the mock prose on the overlaid node
     expect(wrapper.text()).not.toContain(
       "A leitura de ontem precisa ser feita no contexto da semana",
     );
+    // …while the editorial lead (title, reading time, next step) stays from the
+    // mock — the backend sends none of those (parity with the mobile mapper).
+    expect(wrapper.text()).toContain("Ontem em foco: muita saída, nenhuma entrada");
+    expect(wrapper.text()).toContain("15 min de leitura");
+    expect(wrapper.text()).toContain(
+      "Priorize quitar ou renegociar a Fatura Maio",
+    );
+    expect(wrapper.text()).not.toContain("Próximo passo real.");
   });
 });

--- a/app/features/ai-insights/fluida/components/InsightsFluida.spec.ts
+++ b/app/features/ai-insights/fluida/components/InsightsFluida.spec.ts
@@ -1,7 +1,9 @@
 import { mount } from "@vue/test-utils";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
 
 import InsightsFluida from "./InsightsFluida.vue";
+import type { GeneratedAIInsight } from "~/features/ai-insights/model/ai-insight";
 
 // useTheme is a Nuxt auto-import resolved via the ~/composables alias; provide a
 // light-mode stub so the editorial scope starts in light without app state.
@@ -10,6 +12,17 @@ vi.mock("~/composables/useTheme", () => ({
     resolvedTheme: { value: "light" },
   }),
 }));
+
+// Shared generated-insight state is the real data source. Default: no insight
+// (currentResult null) → the screen falls back to the Fluida mock.
+const currentResult = ref<GeneratedAIInsight | null>(null);
+vi.mock("~/features/ai-insights/composables/useAIInsights", () => ({
+  useAIInsights: (): { currentResult: typeof currentResult } => ({ currentResult }),
+}));
+
+afterEach(() => {
+  currentResult.value = null;
+});
 
 const stubs = {
   // UiChart is a global Nuxt component (ECharts). Stub it to a marker element so
@@ -88,5 +101,45 @@ describe("InsightsFluida", () => {
 
     expect(wrapper.text()).toContain("30 min de leitura");
     expect(wrapper.text()).toContain("A semana de 15 a 21: o mês inteiro decidido em dois dias");
+  });
+
+  it("renders the real AI paragraphs when a generated insight is present", () => {
+    currentResult.value = {
+      id: "real-1",
+      summary: "Resumo real",
+      items: [],
+      periodType: "daily",
+      periodLabel: "2026-06-20",
+      periodStart: "2026-06-20",
+      periodEnd: "2026-06-20",
+      model: "gpt-4o",
+      tokensUsed: 100,
+      costUsd: 0.0001,
+      cached: false,
+      forecast: false,
+      callsRemaining: 1,
+      callsRemainingMonth: 10,
+      fluida: {
+        severity: "alerta",
+        read_min: 7,
+        paragraphs: ["Leitura real da IA sobre o seu dia.", "Segundo parágrafo real."],
+        retro: [
+          { key: "yesterday", label: "Ontem (real)", value: -156.3, caption: "Saídas de ontem", sign: "neg" },
+        ],
+        series: { daily: [1, 2, 3, 4, 5, 6, 7], weekly: [1, 2, 3, 4, 5, 6] },
+        next_step: "Próximo passo real.",
+      },
+    };
+
+    const wrapper = mountFluida();
+    expect(wrapper.text()).toContain("Leitura real da IA sobre o seu dia.");
+    expect(wrapper.text()).toContain("Ontem (real)");
+    expect(wrapper.text()).toContain("Próximo passo real.");
+    expect(wrapper.text()).toContain("7 min de leitura");
+    // the mock prose for the overlaid (general daily) node is replaced by the
+    // real AI paragraphs — the editorial lead title stays (backend sends no title)
+    expect(wrapper.text()).not.toContain(
+      "A leitura de ontem precisa ser feita no contexto da semana",
+    );
   });
 });

--- a/app/features/ai-insights/fluida/components/InsightsFluida.vue
+++ b/app/features/ai-insights/fluida/components/InsightsFluida.vue
@@ -14,8 +14,16 @@ import FluidaTextBeat from "./FluidaTextBeat.vue";
 import { useInsightsFluida } from "../composables/use-insights-fluida";
 import { useI18n } from "vue-i18n";
 import { useTheme } from "~/composables/useTheme";
+import { useAIInsights } from "~/features/ai-insights/composables/useAIInsights";
 
-const fluida = useInsightsFluida();
+// Real AI source: the shared generated insight carries the additive Fluida
+// fields (`paragraphs` / `retro` / `series` / `highlights`). When absent the
+// mapper falls back to the mock so the screen is never empty. The /insights hub
+// reads the cross-cutting `general` dimension.
+const { currentResult } = useAIInsights();
+const insight = computed(() => currentResult.value?.fluida ?? null);
+
+const fluida = useInsightsFluida({ insight, dimension: "general" });
 const { t } = useI18n();
 
 // Local editorial light/dark scope. Initialised from the global app theme, then

--- a/app/features/ai-insights/fluida/composables/use-insights-fluida.spec.ts
+++ b/app/features/ai-insights/fluida/composables/use-insights-fluida.spec.ts
@@ -5,9 +5,11 @@ import { useInsightsFluida } from "./use-insights-fluida";
 import { FLUIDA_MOCK_SOURCE } from "../model/insight-fluida-mock";
 import type { InsightFluidaFieldsDTO } from "~/features/ai-insights/contracts/ai-insight";
 
+// Real payloads carry ONLY the body the backend builder computes
+// (`paragraphs` / `retro` / `series` / `highlights`). The editorial lead
+// (severity / title / opening / reading time / next step) always comes from
+// the mock recorte — same contract the mobile app honours.
 const realGeneralDaily: InsightFluidaFieldsDTO = {
-  severity: "alerta",
-  read_min: 8,
   paragraphs: ["Real A.", "Real B.", "Real C."],
   retro: [
     { key: "yesterday", label: "Ontem (real)", value: -156.3, caption: "Saídas de ontem", sign: "neg" },
@@ -15,16 +17,12 @@ const realGeneralDaily: InsightFluidaFieldsDTO = {
     { key: "vs_week", label: "Semana (real)", value: 9800, caption: "Variação", sign: "neg" },
   ],
   series: { daily: [1, 2, 3, 4, 5, 6, 7], weekly: [10, 20, 30, 40, 50, 60] },
-  next_step: "Passo real.",
 };
 
 const realTransactions: InsightFluidaFieldsDTO = {
-  severity: "ok",
-  read_min: 3,
   paragraphs: ["Tx real 1.", "Tx real 2."],
   highlights: [{ label: "Maior gasto", value: 11000, sub: "Fatura" }],
   series: { daily: [9, 9, 9, 9, 9, 9, 9], weekly: [8, 8, 8, 8, 8, 8] },
-  next_step: "Categorize.",
 };
 
 describe("useInsightsFluida — backward-compatible source override", () => {
@@ -58,15 +56,17 @@ describe("useInsightsFluida — backward-compatible source override", () => {
 });
 
 describe("useInsightsFluida — real insight payload", () => {
-  it("maps the real general daily payload onto the view", () => {
+  it("maps the real body onto the view while keeping the mock lead", () => {
     const fluida = useInsightsFluida({ insight: ref(realGeneralDaily) });
     expect(fluida.usingRealData.value).toBe(true);
     expect(fluida.view.value.isGeneral).toBe(true);
+    // body (paragraphs + compare + chart) is real
     expect(fluida.view.value.paragraphs).toEqual(["Real A.", "Real B.", "Real C."]);
-    expect(fluida.view.value.lead.readMinutes).toBe(8);
     expect(fluida.view.value.compare?.[0]?.when).toBe("Ontem (real)");
     expect(fluida.view.value.chart.peakValue).toBe(7);
-    expect(fluida.view.value.nextStep).toBe("Passo real.");
+    // lead (reading time + next step) stays mock-derived
+    expect(fluida.view.value.lead.readMinutes).toBe(FLUIDA_MOCK_SOURCE.general.daily.readMin);
+    expect(fluida.view.value.nextStep).toBe(FLUIDA_MOCK_SOURCE.general.daily.nextStep);
   });
 
   it("falls back to the mock when the insight has no structured fields", () => {

--- a/app/features/ai-insights/fluida/composables/use-insights-fluida.spec.ts
+++ b/app/features/ai-insights/fluida/composables/use-insights-fluida.spec.ts
@@ -1,20 +1,52 @@
 import { describe, expect, it } from "vitest";
+import { ref } from "vue";
 
 import { useInsightsFluida } from "./use-insights-fluida";
 import { FLUIDA_MOCK_SOURCE } from "../model/insight-fluida-mock";
+import type { InsightFluidaFieldsDTO } from "~/features/ai-insights/contracts/ai-insight";
 
-describe("useInsightsFluida", () => {
-  it("defaults to the general daily reading", () => {
+const realGeneralDaily: InsightFluidaFieldsDTO = {
+  severity: "alerta",
+  read_min: 8,
+  paragraphs: ["Real A.", "Real B.", "Real C."],
+  retro: [
+    { key: "yesterday", label: "Ontem (real)", value: -156.3, caption: "Saídas de ontem", sign: "neg" },
+    { key: "daybefore", label: "Anteontem (real)", value: 0, caption: "Saídas de anteontem", sign: "neutral" },
+    { key: "vs_week", label: "Semana (real)", value: 9800, caption: "Variação", sign: "neg" },
+  ],
+  series: { daily: [1, 2, 3, 4, 5, 6, 7], weekly: [10, 20, 30, 40, 50, 60] },
+  next_step: "Passo real.",
+};
+
+const realTransactions: InsightFluidaFieldsDTO = {
+  severity: "ok",
+  read_min: 3,
+  paragraphs: ["Tx real 1.", "Tx real 2."],
+  highlights: [{ label: "Maior gasto", value: 11000, sub: "Fatura" }],
+  series: { daily: [9, 9, 9, 9, 9, 9, 9], weekly: [8, 8, 8, 8, 8, 8] },
+  next_step: "Categorize.",
+};
+
+describe("useInsightsFluida — backward-compatible source override", () => {
+  it("defaults to the general daily reading using the mock when no insight is given", () => {
     const fluida = useInsightsFluida();
     expect(fluida.cadence.value).toBe("daily");
     expect(fluida.theme.value).toBe("general");
     expect(fluida.view.value.isGeneral).toBe(true);
     expect(fluida.view.value.lead.readMinutes).toBe(15);
+    expect(fluida.usingRealData.value).toBe(false);
+  });
+
+  it("derives from an explicit full source override", () => {
+    const fluida = useInsightsFluida({ source: FLUIDA_MOCK_SOURCE });
+    fluida.setTheme("transactions");
+    fluida.setCadence("weekly");
+    expect(fluida.view.value.lead.kicker).toBe("Transações");
+    expect(fluida.view.value.lead.readMinutes).toBe(5);
   });
 
   it("exposes the tab list in stable order with the general tab first", () => {
     const fluida = useInsightsFluida();
-    expect(fluida.tabs.value[0]?.id).toBe("general");
     expect(fluida.tabs.value.map((tab) => tab.id)).toEqual([
       "general",
       "transactions",
@@ -22,31 +54,59 @@ describe("useInsightsFluida", () => {
       "budgets",
       "credit_cards",
     ]);
-    expect(fluida.tabs.value[1]?.label).toBe("Transações");
+  });
+});
+
+describe("useInsightsFluida — real insight payload", () => {
+  it("maps the real general daily payload onto the view", () => {
+    const fluida = useInsightsFluida({ insight: ref(realGeneralDaily) });
+    expect(fluida.usingRealData.value).toBe(true);
+    expect(fluida.view.value.isGeneral).toBe(true);
+    expect(fluida.view.value.paragraphs).toEqual(["Real A.", "Real B.", "Real C."]);
+    expect(fluida.view.value.lead.readMinutes).toBe(8);
+    expect(fluida.view.value.compare?.[0]?.when).toBe("Ontem (real)");
+    expect(fluida.view.value.chart.peakValue).toBe(7);
+    expect(fluida.view.value.nextStep).toBe("Passo real.");
   });
 
-  it("recomputes the view when the cadence changes", () => {
-    const fluida = useInsightsFluida();
-    fluida.setCadence("weekly");
-    expect(fluida.cadence.value).toBe("weekly");
-    expect(fluida.view.value.lead.readMinutes).toBe(30);
-    expect(fluida.view.value.chart.values).toHaveLength(6);
+  it("falls back to the mock when the insight has no structured fields", () => {
+    const fluida = useInsightsFluida({ insight: ref<InsightFluidaFieldsDTO>({}) });
+    expect(fluida.usingRealData.value).toBe(false);
+    expect(fluida.view.value.paragraphs).toEqual(FLUIDA_MOCK_SOURCE.general.daily.paragraphs);
   });
 
-  it("recomputes the view when the theme changes", () => {
-    const fluida = useInsightsFluida();
-    fluida.setTheme("credit_cards");
-    expect(fluida.theme.value).toBe("credit_cards");
-    expect(fluida.view.value.isGeneral).toBe(false);
-    expect(fluida.view.value.lead.kicker).toBe("Cartões");
-    expect(fluida.view.value.highlights).toHaveLength(3);
+  it("falls back to the mock when the insight is null", () => {
+    const fluida = useInsightsFluida({ insight: ref(null) });
+    expect(fluida.usingRealData.value).toBe(false);
+    expect(fluida.view.value.lead.title).toBe(FLUIDA_MOCK_SOURCE.general.daily.title);
   });
 
-  it("derives from an injected source when provided", () => {
-    const fluida = useInsightsFluida(FLUIDA_MOCK_SOURCE);
+  it("re-maps reactively when the insight payload arrives later", async () => {
+    const insight = ref<InsightFluidaFieldsDTO | null>(null);
+    const fluida = useInsightsFluida({ insight });
+    expect(fluida.usingRealData.value).toBe(false);
+
+    insight.value = realGeneralDaily;
+    expect(fluida.usingRealData.value).toBe(true);
+    expect(fluida.view.value.paragraphs).toEqual(["Real A.", "Real B.", "Real C."]);
+  });
+
+  it("respects the reading dimension when selecting the theme node", () => {
+    const fluida = useInsightsFluida({
+      insight: ref(realTransactions),
+      dimension: ref("transactions" as const),
+    });
     fluida.setTheme("transactions");
+    expect(fluida.view.value.isGeneral).toBe(false);
+    expect(fluida.view.value.paragraphs).toEqual(["Tx real 1.", "Tx real 2."]);
+    expect(fluida.view.value.highlights).toHaveLength(1);
+  });
+
+  it("re-maps when the cadence toggle flips, using the real weekly series", () => {
+    const fluida = useInsightsFluida({ insight: ref(realGeneralDaily) });
     fluida.setCadence("weekly");
-    expect(fluida.view.value.lead.kicker).toBe("Transações");
-    expect(fluida.view.value.lead.readMinutes).toBe(5);
+    // weekly general node prose stays from the mock (the real payload addressed
+    // the daily cadence), but the shared real series is applied to both.
+    expect(fluida.view.value.chart.values).toEqual([10, 20, 30, 40, 50, 60]);
   });
 });

--- a/app/features/ai-insights/fluida/composables/use-insights-fluida.ts
+++ b/app/features/ai-insights/fluida/composables/use-insights-fluida.ts
@@ -1,6 +1,17 @@
-import { computed, type ComputedRef, ref, type Ref } from "vue";
+import {
+  computed,
+  type ComputedRef,
+  type MaybeRefOrGetter,
+  ref,
+  type Ref,
+  toValue,
+} from "vue";
 
-import { FLUIDA_MOCK_SOURCE } from "../model/insight-fluida-mock";
+import type {
+  InsightDimension,
+  InsightFluidaFieldsDTO,
+} from "~/features/ai-insights/contracts/ai-insight";
+
 import {
   deriveFluidaView,
   resolveFluidaThemeMeta,
@@ -11,40 +22,88 @@ import {
   type FluidaThemeMeta,
   type FluidaView,
 } from "../model/insight-fluida";
+import { hasFluidaPayload, insightToFluidaVM } from "../model/insight-to-fluida-vm";
+
+/**
+ * Inputs for {@link useInsightsFluida}. All optional so production callers can
+ * mount the screen with no arguments while tests inject deterministic state.
+ */
+export interface UseInsightsFluidaOptions {
+  /**
+   * Full source override. When set, the screen derives from it verbatim and the
+   * real-data mapper is bypassed (kept for the mock/storybook path and tests).
+   */
+  readonly source?: FluidaInsightSource;
+  /**
+   * The real enriched `/ai/insights` payload (additive Fluida fields). Mapped
+   * onto the mock skeleton per `{ dimension, cadence }`; absent/empty falls back
+   * to the mock so the screen is never empty.
+   */
+  readonly insight?: MaybeRefOrGetter<InsightFluidaFieldsDTO | null | undefined>;
+  /**
+   * The dimension the screen is reading. Defaults to `general` (the /insights
+   * hub). Drives which node the real payload overlays onto.
+   */
+  readonly dimension?: MaybeRefOrGetter<InsightDimension>;
+}
 
 export interface UseInsightsFluida {
   readonly cadence: Ref<FluidaCadence>;
   readonly theme: Ref<FluidaThemeId>;
   readonly tabs: ComputedRef<readonly FluidaThemeMeta[]>;
   readonly view: ComputedRef<FluidaView>;
+  /** True when the derived source came from a real enriched payload (not the mock). */
+  readonly usingRealData: ComputedRef<boolean>;
   readonly setCadence: (cadence: FluidaCadence) => void;
   readonly setTheme: (theme: FluidaThemeId) => void;
 }
 
 /**
- * Thin reactive façade over {@link deriveFluidaView}.
+ * Reactive façade over {@link deriveFluidaView} wired to the real AI payload.
  *
  * Holds the masthead selection (cadence + theme) and exposes the derived view
- * model plus the tab list. All business logic lives in the pure model module;
- * this composable only wires reactivity. The source defaults to the Fluida mock
- * (behind the `web.insights.fluida` flag) and accepts an injected source so the
- * real `/ai/insights` payload can replace the mock without touching the UI.
+ * plus the tab list. The source is resolved reactively: an explicit `source`
+ * override wins; otherwise the real `insight` payload is mapped via
+ * {@link insightToFluidaVM} (falling back to the Fluida mock when the additive
+ * fields are absent, so the screen is never empty). All transformation logic
+ * lives in the pure model modules — this composable only wires reactivity.
  *
- * @param source Insight source object. Defaults to the June/2026 mock.
+ * @param options Source/insight/dimension inputs. Defaults to the mock.
  * @returns Reactive selection state, derived view and tab metadata.
  */
 export function useInsightsFluida(
-  source: FluidaInsightSource = FLUIDA_MOCK_SOURCE,
+  options: UseInsightsFluidaOptions = {},
 ): UseInsightsFluida {
   const cadence = ref<FluidaCadence>("daily");
   const theme = ref<FluidaThemeId>("general");
 
+  const insight = computed<InsightFluidaFieldsDTO | null | undefined>(() =>
+    options.insight !== undefined ? toValue(options.insight) : null,
+  );
+  const dimension = computed<InsightDimension>(() =>
+    options.dimension !== undefined ? toValue(options.dimension) : "general",
+  );
+
+  const usingRealData = computed<boolean>(
+    () => options.source === undefined && hasFluidaPayload(insight.value ?? undefined),
+  );
+
+  const source = computed<FluidaInsightSource>(() => {
+    if (options.source !== undefined) {
+      return options.source;
+    }
+    return insightToFluidaVM(insight.value ?? undefined, {
+      dimension: dimension.value,
+      cadence: cadence.value,
+    });
+  });
+
   const tabs = computed<readonly FluidaThemeMeta[]>(() =>
-    FLUIDA_THEME_ORDER.map((id) => resolveFluidaThemeMeta(source, id)),
+    FLUIDA_THEME_ORDER.map((id) => resolveFluidaThemeMeta(source.value, id)),
   );
 
   const view = computed<FluidaView>(() =>
-    deriveFluidaView(source, { cadence: cadence.value, theme: theme.value }),
+    deriveFluidaView(source.value, { cadence: cadence.value, theme: theme.value }),
   );
 
   /**
@@ -65,5 +124,5 @@ export function useInsightsFluida(
     theme.value = next;
   };
 
-  return { cadence, theme, tabs, view, setCadence, setTheme };
+  return { cadence, theme, tabs, view, usingRealData, setCadence, setTheme };
 }

--- a/app/features/ai-insights/fluida/model/insight-to-fluida-vm.spec.ts
+++ b/app/features/ai-insights/fluida/model/insight-to-fluida-vm.spec.ts
@@ -185,6 +185,112 @@ describe("insightToFluidaVM — theme overlay", () => {
   });
 });
 
+describe("hasFluidaPayload — lead", () => {
+  it("returns true when only the editorial lead is present", () => {
+    expect(
+      hasFluidaPayload({
+        lead: {
+          severity: "alert",
+          read_min: 4,
+          title: "Lead real",
+          lead: "Abertura real do lead.",
+          next_step: "Próximo passo real.",
+        },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("insightToFluidaVM — lead overlay", () => {
+  const leadDto: InsightFluidaFieldsDTO = {
+    paragraphs: ["Corpo real 1.", "Corpo real 2."],
+    lead: {
+      severity: "alert",
+      read_min: 9,
+      title: "Título editorial real",
+      lead: "Abertura editorial real do lead.",
+      next_step: "Próximo passo editorial real.",
+    },
+  };
+
+  it("overlays the real lead (severity/title/summary/readMin/nextStep) onto the general node", () => {
+    const vm = insightToFluidaVM(leadDto, { dimension: "general", cadence: "daily" });
+    const node = vm.general.daily;
+    // backend severity "alert" maps onto the Fluida "alerta" vocabulary
+    expect(node.severity).toBe("alerta");
+    expect(node.readMin).toBe(9);
+    expect(node.title).toBe("Título editorial real");
+    // backend `lead` is the opening summary in the VM
+    expect(node.summary).toBe("Abertura editorial real do lead.");
+    expect(node.nextStep).toBe("Próximo passo editorial real.");
+    // body still overlaid from the same payload
+    expect(node.paragraphs).toEqual(["Corpo real 1.", "Corpo real 2."]);
+  });
+
+  it("maps every backend severity onto the Fluida vocabulary", () => {
+    const cases: ReadonlyArray<["ok" | "attention" | "alert", string]> = [
+      ["ok", "ok"],
+      ["attention", "atencao"],
+      ["alert", "alerta"],
+    ];
+    for (const [backendSeverity, fluidaSeverity] of cases) {
+      const dto: InsightFluidaFieldsDTO = {
+        lead: { severity: backendSeverity, read_min: 3, title: "t", lead: "l", next_step: "n" },
+      };
+      const vm = insightToFluidaVM(dto, { dimension: "general", cadence: "daily" });
+      expect(vm.general.daily.severity).toBe(fluidaSeverity);
+    }
+  });
+
+  it("overlays the real lead onto the requested theme + cadence node", () => {
+    const vm = insightToFluidaVM(leadDto, { dimension: "transactions", cadence: "weekly" });
+    const node = vm.themes.transactions?.weekly;
+    expect(node?.severity).toBe("alerta");
+    expect(node?.title).toBe("Título editorial real");
+    expect(node?.summary).toBe("Abertura editorial real do lead.");
+    expect(node?.readMin).toBe(9);
+    expect(node?.nextStep).toBe("Próximo passo editorial real.");
+  });
+
+  it("keeps the mock lead when the payload carries body but no lead (parity with the app body rule)", () => {
+    const bodyOnly: InsightFluidaFieldsDTO = {
+      paragraphs: ["Só corpo real."],
+    };
+    const vm = insightToFluidaVM(bodyOnly, { dimension: "general", cadence: "daily" });
+    const node = vm.general.daily;
+    expect(node.severity).toBe(FLUIDA_MOCK_SOURCE.general.daily.severity);
+    expect(node.title).toBe(FLUIDA_MOCK_SOURCE.general.daily.title);
+    expect(node.summary).toBe(FLUIDA_MOCK_SOURCE.general.daily.summary);
+    expect(node.readMin).toBe(FLUIDA_MOCK_SOURCE.general.daily.readMin);
+    expect(node.nextStep).toBe(FLUIDA_MOCK_SOURCE.general.daily.nextStep);
+    // body still real
+    expect(node.paragraphs).toEqual(["Só corpo real."]);
+  });
+
+  it("uses the mock skeleton when only a lead is present (no body), still overlaying the real lead", () => {
+    const vm = insightToFluidaVM(
+      { lead: { severity: "ok", read_min: 2, title: "Apenas lead", lead: "Abertura.", next_step: "Passo." } },
+      { dimension: "general", cadence: "daily" },
+    );
+    const node = vm.general.daily;
+    expect(node.severity).toBe("ok");
+    expect(node.title).toBe("Apenas lead");
+    expect(node.summary).toBe("Abertura.");
+    // body falls back to the mock (no paragraphs in the payload)
+    expect(node.paragraphs).toEqual(FLUIDA_MOCK_SOURCE.general.daily.paragraphs);
+  });
+
+  it("derives a view whose lead is the real one when the payload carries it", () => {
+    const vm = insightToFluidaVM(leadDto, { dimension: "general", cadence: "daily" });
+    const view = deriveFluidaView(vm, { cadence: "daily", theme: "general" });
+    expect(view.lead.title).toBe("Título editorial real");
+    expect(view.lead.summary).toBe("Abertura editorial real do lead.");
+    expect(view.lead.readMinutes).toBe(9);
+    expect(view.lead.severity.tone).toBe("danger");
+    expect(view.nextStep).toBe("Próximo passo editorial real.");
+  });
+});
+
 describe("insightToFluidaVM — partial payloads", () => {
   it("overlays only the series when that is the sole field provided", () => {
     const vm = insightToFluidaVM(

--- a/app/features/ai-insights/fluida/model/insight-to-fluida-vm.spec.ts
+++ b/app/features/ai-insights/fluida/model/insight-to-fluida-vm.spec.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+
+import { insightToFluidaVM, hasFluidaPayload } from "./insight-to-fluida-vm";
+import { FLUIDA_MOCK_SOURCE } from "./insight-fluida-mock";
+import { deriveFluidaView } from "./insight-fluida";
+import type { InsightFluidaFieldsDTO } from "~/features/ai-insights/contracts/ai-insight";
+
+/**
+ * Normalizes the non-breaking space Intl emits between the BRL symbol and the
+ * amount so currency assertions stay readable with a regular space.
+ *
+ * @param value Formatted currency string, possibly containing a NBSP.
+ * @returns The same string with NBSP replaced by a regular space.
+ */
+const normalizeSpaces = (value: string): string => value.replace(/\u00a0/g, " ");
+
+/** A complete, realistic `general` daily payload mirroring the backend builder. */
+const generalDailyDto: InsightFluidaFieldsDTO = {
+  severity: "alerta",
+  read_min: 9,
+  paragraphs: ["Parágrafo real 1.", "Parágrafo real 2.", "Parágrafo real 3."],
+  retro: [
+    { key: "yesterday", label: "Ontem", value: 156.3, caption: "Saídas de ontem", sign: "neg" },
+    { key: "daybefore", label: "Anteontem", value: 0, caption: "Saídas de anteontem", sign: "neutral" },
+    { key: "vs_week", label: "Semana vs. anterior", value: -420, caption: "Variação de saídas", sign: "pos" },
+  ],
+  series: {
+    daily: [10, 20, 0, 50, 0, 0, 999],
+    weekly: [100, 200, 300, 400, 500, 600],
+  },
+  highlights: [
+    { label: "Maior gasto do mês", value: 11000, sub: "Fatura Maio" },
+    { label: "Único crédito", value: 27675.37, sub: "Salário gringo" },
+  ],
+  next_step: "Quite a fatura em atraso.",
+};
+
+describe("hasFluidaPayload", () => {
+  it("returns false when none of the structured fields are present", () => {
+    expect(hasFluidaPayload({})).toBe(false);
+    expect(hasFluidaPayload(undefined)).toBe(false);
+    expect(
+      hasFluidaPayload({ paragraphs: [], retro: [], highlights: [], series: { daily: [], weekly: [] } }),
+    ).toBe(false);
+  });
+
+  it("returns true when at least one structured field carries data", () => {
+    expect(hasFluidaPayload({ paragraphs: ["x"] })).toBe(true);
+    expect(hasFluidaPayload({ retro: [{ key: "k", label: "l", value: 1, caption: "c", sign: "neg" }] })).toBe(true);
+    expect(hasFluidaPayload({ series: { daily: [1], weekly: [] } })).toBe(true);
+    expect(hasFluidaPayload({ highlights: [{ label: "l", value: 1, sub: "s" }] })).toBe(true);
+  });
+});
+
+describe("insightToFluidaVM — fallback", () => {
+  it("returns the mock source unchanged when the DTO has no structured fields", () => {
+    const vm = insightToFluidaVM({}, { dimension: "general", cadence: "daily" });
+    expect(vm).toBe(FLUIDA_MOCK_SOURCE);
+  });
+
+  it("returns the mock source unchanged when the DTO is undefined", () => {
+    const vm = insightToFluidaVM(undefined, { dimension: "general", cadence: "daily" });
+    expect(vm).toBe(FLUIDA_MOCK_SOURCE);
+  });
+});
+
+describe("insightToFluidaVM — general daily overlay", () => {
+  const vm = insightToFluidaVM(generalDailyDto, { dimension: "general", cadence: "daily" });
+
+  it("does not mutate the shared mock source", () => {
+    expect(vm).not.toBe(FLUIDA_MOCK_SOURCE);
+    expect(FLUIDA_MOCK_SOURCE.general.daily.paragraphs[0]).not.toBe("Parágrafo real 1.");
+  });
+
+  it("overlays the real paragraphs onto the general daily node", () => {
+    expect(vm.general.daily.paragraphs).toEqual([
+      "Parágrafo real 1.",
+      "Parágrafo real 2.",
+      "Parágrafo real 3.",
+    ]);
+  });
+
+  it("overlays severity, reading time and next step", () => {
+    expect(vm.general.daily.severity).toBe("alerta");
+    expect(vm.general.daily.readMin).toBe(9);
+    expect(vm.general.daily.nextStep).toBe("Quite a fatura em atraso.");
+  });
+
+  it("maps the backend retro shape into Fluida retro entries", () => {
+    const retro = vm.general.daily.retro ?? [];
+    expect(retro).toHaveLength(3);
+    expect(retro[0]?.when).toBe("Ontem");
+    expect(retro[0]?.value).toBe(156.3);
+    expect(retro[0]?.text).toBe("Saídas de ontem");
+  });
+
+  it("overlays both series with generated daily/weekly axis labels", () => {
+    expect(vm.series.daily.values).toEqual([10, 20, 0, 50, 0, 0, 999]);
+    expect(vm.series.daily.labels).toHaveLength(7);
+    expect(vm.series.weekly.values).toEqual([100, 200, 300, 400, 500, 600]);
+    expect(vm.series.weekly.labels).toHaveLength(6);
+    // last weekly bucket is the current week
+    expect(vm.series.weekly.labels[5]).toBe("Atual");
+  });
+
+  it("keeps the weekly general node from the mock (single insight only covers one cadence)", () => {
+    expect(vm.general.weekly.paragraphs).toEqual(FLUIDA_MOCK_SOURCE.general.weekly.paragraphs);
+  });
+
+  it("produces a derivable general daily view with the real lead and compare cards", () => {
+    const view = deriveFluidaView(vm, { cadence: "daily", theme: "general" });
+    expect(view.isGeneral).toBe(true);
+    expect(view.lead.title).toBe(FLUIDA_MOCK_SOURCE.general.daily.title);
+    expect(view.paragraphs).toEqual(["Parágrafo real 1.", "Parágrafo real 2.", "Parágrafo real 3."]);
+    expect(view.compare).toHaveLength(3);
+    expect(normalizeSpaces(view.compare?.[0]?.amountLabel ?? "")).toBe("+ R$ 156,30");
+    expect(view.chart.peakValue).toBe(999);
+  });
+});
+
+describe("insightToFluidaVM — theme overlay", () => {
+  const themeDto: InsightFluidaFieldsDTO = {
+    severity: "atencao",
+    read_min: 4,
+    paragraphs: ["Tema real 1.", "Tema real 2."],
+    highlights: [
+      { label: "Saídas da semana", value: 13650, sub: "4 lançamentos" },
+      { label: "Maior gasto", value: 11000, sub: "Fatura" },
+    ],
+    series: { daily: [1, 2, 3, 4, 5, 6, 7], weekly: [1, 2, 3, 4, 5, 6] },
+    next_step: "Revise os lançamentos.",
+  };
+
+  it("overlays highlights (formatted BRL) onto the requested theme + cadence node", () => {
+    const vm = insightToFluidaVM(themeDto, { dimension: "transactions", cadence: "weekly" });
+    const node = vm.themes.transactions?.weekly;
+    expect(node?.paragraphs).toEqual(["Tema real 1.", "Tema real 2."]);
+    expect(node?.severity).toBe("atencao");
+    expect(node?.readMin).toBe(4);
+    expect(node?.highlights).toHaveLength(2);
+    expect(normalizeSpaces(node?.highlights?.[0]?.value ?? "")).toBe("R$ 13.650,00");
+    expect(node?.highlights?.[0]?.label).toBe("Saídas da semana");
+    expect(node?.highlights?.[0]?.caption).toBe("4 lançamentos");
+  });
+
+  it("derives a theme view with real highlight tiles", () => {
+    const vm = insightToFluidaVM(themeDto, { dimension: "credit_cards", cadence: "daily" });
+    const view = deriveFluidaView(vm, { cadence: "daily", theme: "credit_cards" });
+    expect(view.isGeneral).toBe(false);
+    expect(view.highlights).toHaveLength(2);
+    expect(normalizeSpaces(view.highlights?.[0]?.value ?? "")).toBe("R$ 13.650,00");
+  });
+
+  it("maps the goals dimension onto the goals theme node", () => {
+    const vm = insightToFluidaVM(themeDto, { dimension: "goals", cadence: "daily" });
+    expect(vm.themes.goals?.daily.paragraphs).toEqual(["Tema real 1.", "Tema real 2."]);
+  });
+
+  it("maps the budgets dimension onto the budgets theme node", () => {
+    const vm = insightToFluidaVM(themeDto, { dimension: "budgets", cadence: "weekly" });
+    expect(vm.themes.budgets?.weekly.paragraphs).toEqual(["Tema real 1.", "Tema real 2."]);
+  });
+
+  it("falls back to the general node for the wallet dimension (no Fluida tab), still overlaying series", () => {
+    const vm = insightToFluidaVM(themeDto, { dimension: "wallet", cadence: "daily" });
+    // wallet has no Fluida theme tab → general node receives the prose
+    expect(vm.general.daily.paragraphs).toEqual(["Tema real 1.", "Tema real 2."]);
+    expect(vm.series.daily.values).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+});
+
+describe("insightToFluidaVM — partial payloads", () => {
+  it("overlays only the series when that is the sole field provided", () => {
+    const vm = insightToFluidaVM(
+      { series: { daily: [5, 5, 5, 5, 5, 5, 5], weekly: [9, 9, 9, 9, 9, 9] } },
+      { dimension: "general", cadence: "daily" },
+    );
+    expect(vm.series.daily.values).toEqual([5, 5, 5, 5, 5, 5, 5]);
+    // prose untouched → still the mock's general daily paragraphs
+    expect(vm.general.daily.paragraphs).toEqual(FLUIDA_MOCK_SOURCE.general.daily.paragraphs);
+  });
+
+  it("keeps mock paragraphs when the DTO sends an empty paragraphs array", () => {
+    const vm = insightToFluidaVM(
+      { paragraphs: [], retro: [{ key: "k", label: "Ontem", value: 1, caption: "c", sign: "neg" }] },
+      { dimension: "general", cadence: "daily" },
+    );
+    expect(vm.general.daily.paragraphs).toEqual(FLUIDA_MOCK_SOURCE.general.daily.paragraphs);
+    expect(vm.general.daily.retro?.[0]?.when).toBe("Ontem");
+  });
+});

--- a/app/features/ai-insights/fluida/model/insight-to-fluida-vm.spec.ts
+++ b/app/features/ai-insights/fluida/model/insight-to-fluida-vm.spec.ts
@@ -14,10 +14,14 @@ import type { InsightFluidaFieldsDTO } from "~/features/ai-insights/contracts/ai
  */
 const normalizeSpaces = (value: string): string => value.replace(/\u00a0/g, " ");
 
-/** A complete, realistic `general` daily payload mirroring the backend builder. */
+/**
+ * A complete, realistic `general` daily payload mirroring the backend builder
+ * (`insight_fluida_builder.py`). The builder emits ONLY the editorial body and
+ * numbers — `paragraphs` / `retro` / `series` / `highlights`. It does NOT emit
+ * the per-dimension lead (`severity` / title / opening / reading time / next
+ * step); those always come from the mock recorte, mirroring the mobile mapper.
+ */
 const generalDailyDto: InsightFluidaFieldsDTO = {
-  severity: "alerta",
-  read_min: 9,
   paragraphs: ["Parágrafo real 1.", "Parágrafo real 2.", "Parágrafo real 3."],
   retro: [
     { key: "yesterday", label: "Ontem", value: 156.3, caption: "Saídas de ontem", sign: "neg" },
@@ -32,7 +36,6 @@ const generalDailyDto: InsightFluidaFieldsDTO = {
     { label: "Maior gasto do mês", value: 11000, sub: "Fatura Maio" },
     { label: "Único crédito", value: 27675.37, sub: "Salário gringo" },
   ],
-  next_step: "Quite a fatura em atraso.",
 };
 
 describe("hasFluidaPayload", () => {
@@ -80,10 +83,14 @@ describe("insightToFluidaVM — general daily overlay", () => {
     ]);
   });
 
-  it("overlays severity, reading time and next step", () => {
-    expect(vm.general.daily.severity).toBe("alerta");
-    expect(vm.general.daily.readMin).toBe(9);
-    expect(vm.general.daily.nextStep).toBe("Quite a fatura em atraso.");
+  it("keeps the editorial lead (severity, reading time, next step, title) from the mock", () => {
+    // The backend builder never sends the lead — it must come from the mock
+    // recorte, exactly like the mobile mapper.
+    expect(vm.general.daily.severity).toBe(FLUIDA_MOCK_SOURCE.general.daily.severity);
+    expect(vm.general.daily.readMin).toBe(FLUIDA_MOCK_SOURCE.general.daily.readMin);
+    expect(vm.general.daily.nextStep).toBe(FLUIDA_MOCK_SOURCE.general.daily.nextStep);
+    expect(vm.general.daily.title).toBe(FLUIDA_MOCK_SOURCE.general.daily.title);
+    expect(vm.general.daily.summary).toBe(FLUIDA_MOCK_SOURCE.general.daily.summary);
   });
 
   it("maps the backend retro shape into Fluida retro entries", () => {
@@ -107,10 +114,14 @@ describe("insightToFluidaVM — general daily overlay", () => {
     expect(vm.general.weekly.paragraphs).toEqual(FLUIDA_MOCK_SOURCE.general.weekly.paragraphs);
   });
 
-  it("produces a derivable general daily view with the real lead and compare cards", () => {
+  it("produces a derivable general daily view with the mock lead and real body", () => {
     const view = deriveFluidaView(vm, { cadence: "daily", theme: "general" });
     expect(view.isGeneral).toBe(true);
+    // lead (title + opening + reading time) is mock-derived…
     expect(view.lead.title).toBe(FLUIDA_MOCK_SOURCE.general.daily.title);
+    expect(view.lead.summary).toBe(FLUIDA_MOCK_SOURCE.general.daily.summary);
+    expect(view.lead.readMinutes).toBe(FLUIDA_MOCK_SOURCE.general.daily.readMin);
+    // …while the body (paragraphs + compare + chart) is real
     expect(view.paragraphs).toEqual(["Parágrafo real 1.", "Parágrafo real 2.", "Parágrafo real 3."]);
     expect(view.compare).toHaveLength(3);
     expect(normalizeSpaces(view.compare?.[0]?.amountLabel ?? "")).toBe("+ R$ 156,30");
@@ -120,27 +131,32 @@ describe("insightToFluidaVM — general daily overlay", () => {
 
 describe("insightToFluidaVM — theme overlay", () => {
   const themeDto: InsightFluidaFieldsDTO = {
-    severity: "atencao",
-    read_min: 4,
     paragraphs: ["Tema real 1.", "Tema real 2."],
     highlights: [
       { label: "Saídas da semana", value: 13650, sub: "4 lançamentos" },
       { label: "Maior gasto", value: 11000, sub: "Fatura" },
     ],
     series: { daily: [1, 2, 3, 4, 5, 6, 7], weekly: [1, 2, 3, 4, 5, 6] },
-    next_step: "Revise os lançamentos.",
   };
 
   it("overlays highlights (formatted BRL) onto the requested theme + cadence node", () => {
     const vm = insightToFluidaVM(themeDto, { dimension: "transactions", cadence: "weekly" });
     const node = vm.themes.transactions?.weekly;
     expect(node?.paragraphs).toEqual(["Tema real 1.", "Tema real 2."]);
-    expect(node?.severity).toBe("atencao");
-    expect(node?.readMin).toBe(4);
     expect(node?.highlights).toHaveLength(2);
     expect(normalizeSpaces(node?.highlights?.[0]?.value ?? "")).toBe("R$ 13.650,00");
     expect(node?.highlights?.[0]?.label).toBe("Saídas da semana");
     expect(node?.highlights?.[0]?.caption).toBe("4 lançamentos");
+  });
+
+  it("keeps the per-theme lead (severity, reading time, title) from the mock recorte", () => {
+    // The backend sends no lead per theme either — it must come from the mock.
+    const vm = insightToFluidaVM(themeDto, { dimension: "transactions", cadence: "weekly" });
+    const node = vm.themes.transactions?.weekly;
+    const mockNode = FLUIDA_MOCK_SOURCE.themes.transactions?.weekly;
+    expect(node?.severity).toBe(mockNode?.severity);
+    expect(node?.readMin).toBe(mockNode?.readMin);
+    expect(node?.title).toBe(mockNode?.title);
   });
 
   it("derives a theme view with real highlight tiles", () => {

--- a/app/features/ai-insights/fluida/model/insight-to-fluida-vm.ts
+++ b/app/features/ai-insights/fluida/model/insight-to-fluida-vm.ts
@@ -3,15 +3,19 @@
  *
  * The backend (auraxis-api PR #1501/#1502) enriches a single generated insight
  * with the structured Fluida **body** fields (`paragraphs` / `retro` / `series`
- * / `highlights`) for ONE period (daily OR weekly) and ONE dimension. It does
- * NOT emit the editorial lead (severity / headline / opening / reading time /
- * next step) — that always comes from the mock recorte, mirroring the mobile
- * mapper (`auraxis-app/features/insights/fluida/insight-to-fluida-vm.ts`). The
- * Fluida screen, however, renders a full source object covering both cadences
- * and every theme. This mapper therefore OVERLAYS the real body onto the Fluida
- * mock skeleton at the node addressed by `{ dimension, cadence }`, keeping the
- * screen full (and the lead always mock-derived) while the remaining slots fall
- * back to mock content.
+ * / `highlights`) for ONE period (daily OR weekly) and ONE dimension, and — once
+ * #1503/#1508 ships — the editorial **lead** (`lead`: severity / headline /
+ * opening / reading time / next step). The Fluida screen, however, renders a
+ * full source object covering both cadences and every theme. This mapper
+ * therefore OVERLAYS the real body AND the real lead onto the Fluida mock
+ * skeleton at the node addressed by `{ dimension, cadence }`, keeping the screen
+ * full while the remaining slots fall back to mock content.
+ *
+ * Lead fallback (parity with the mobile mapper
+ * `auraxis-app/features/insights/fluida/insight-to-fluida-vm.ts`, which uses the
+ * real value when present and the mock otherwise): when the payload carries a
+ * `lead`, the reading's severity/headline/opening/reading time/next step come
+ * from the backend; when it is absent, they stay on the mock recorte.
  *
  * Fallback rule: when the DTO carries none of the structured fields (backend not
  * deployed, or a legacy payload), the mock source is returned verbatim so the
@@ -24,6 +28,8 @@ import type {
   InsightDimension,
   InsightFluidaFieldsDTO,
   InsightHighlightDTO,
+  InsightLeadDTO,
+  InsightLeadSeverity,
   InsightRetroEntryDTO,
 } from "~/features/ai-insights/contracts/ai-insight";
 
@@ -35,10 +41,22 @@ import {
   type FluidaNode,
   type FluidaRetroEntry,
   type FluidaSeriesData,
+  type FluidaSeverity,
   type FluidaStat,
   type FluidaThemeId,
   type FluidaThemeSource,
 } from "./insight-fluida";
+
+/**
+ * Translates the backend lead severity vocabulary (`ok` | `attention` | `alert`,
+ * mirroring `AIInsightLeadType.severity` and the mobile `InsightSeverity`) onto
+ * the web's `FluidaSeverity` vocabulary that drives the chip presentation.
+ */
+const LEAD_SEVERITY_TO_FLUIDA: Record<InsightLeadSeverity, FluidaSeverity> = {
+  ok: "ok",
+  attention: "atencao",
+  alert: "alerta",
+};
 
 /** The dimension + cadence the screen is currently reading. */
 export interface FluidaMapContext {
@@ -60,9 +78,29 @@ const DAILY_AXIS_LENGTH = 7;
 const WEEKLY_AXIS_LENGTH = 6;
 
 /**
- * Reports whether a DTO carries any of the structured Fluida fields. Empty
- * arrays/series count as "no data" so an enriched-but-empty payload still falls
- * back to the mock instead of blanking the screen.
+ * Reports whether an array field actually carries entries (guards against
+ * `undefined` and empty arrays uniformly).
+ *
+ * @param value Candidate array field.
+ * @returns True when the value is a non-empty array.
+ */
+const hasItems = (value: readonly unknown[] | undefined): boolean =>
+  Array.isArray(value) && value.length > 0;
+
+/**
+ * Reports whether a series object carries at least one cadence with data.
+ *
+ * @param series Candidate series field.
+ * @returns True when the daily or weekly array has entries.
+ */
+const hasSeriesData = (series: InsightFluidaFieldsDTO["series"]): boolean =>
+  series !== undefined && (hasItems(series.daily) || hasItems(series.weekly));
+
+/**
+ * Reports whether a DTO carries any of the structured Fluida fields — body,
+ * numbers OR the editorial lead. Empty arrays/series count as "no data" so an
+ * enriched-but-empty payload still falls back to the mock instead of blanking
+ * the screen; a lead alone is enough to treat the payload as real.
  *
  * @param dto Candidate insight payload (may be undefined).
  * @returns True when at least one structured field has data.
@@ -71,15 +109,14 @@ export const hasFluidaPayload = (dto: InsightFluidaFieldsDTO | undefined): boole
   if (!dto) {
     return false;
   }
-  const hasParagraphs = Array.isArray(dto.paragraphs) && dto.paragraphs.length > 0;
-  const hasRetro = Array.isArray(dto.retro) && dto.retro.length > 0;
-  const hasHighlights = Array.isArray(dto.highlights) && dto.highlights.length > 0;
-  const hasSeries =
-    dto.series !== undefined &&
-    ((Array.isArray(dto.series.daily) && dto.series.daily.length > 0) ||
-      (Array.isArray(dto.series.weekly) && dto.series.weekly.length > 0));
 
-  return hasParagraphs || hasRetro || hasHighlights || hasSeries;
+  return (
+    hasItems(dto.paragraphs) ||
+    hasItems(dto.retro) ||
+    hasItems(dto.highlights) ||
+    hasSeriesData(dto.series) ||
+    (dto.lead !== undefined && dto.lead !== null)
+  );
 };
 
 /**
@@ -163,16 +200,44 @@ const toHighlightStat = (highlight: InsightHighlightDTO): FluidaStat => ({
 });
 
 /**
- * Overlays the DTO's **body** prose (`paragraphs`) onto a base node, keeping the
- * editorial lead (severity, headline, opening summary, reading time, next step)
- * from the mock recorte. The backend builder never emits the lead — it always
- * comes from the mock, mirroring the mobile mapper
- * (`auraxis-app/features/insights/fluida/insight-to-fluida-vm.ts`). Empty prose
- * is ignored so the mock copy survives.
+ * Overlays the DTO's editorial **lead** (severity, headline, opening summary,
+ * reading time, next step) onto a base node when the backend supplies it
+ * (additive #1503/#1508). The backend `lead.lead` is the opening paragraph and
+ * becomes the node `summary`; `lead.severity` is mapped onto the Fluida
+ * vocabulary. When no `lead` is present the mock recorte survives verbatim —
+ * the same fallback the mobile mapper applies to the body.
  *
- * @param base Mock node supplying the editorial lead.
- * @param dto Real payload (body only).
- * @returns A new node with the real paragraphs applied over the mock lead.
+ * @param base Node already carrying the body overlay (and the mock lead).
+ * @param dto Real payload.
+ * @returns A node with the real lead applied, or the base node unchanged.
+ */
+const overlayLead = (base: FluidaNode, dto: InsightFluidaFieldsDTO): FluidaNode => {
+  const lead: InsightLeadDTO | undefined | null = dto.lead;
+  if (!lead) {
+    return base;
+  }
+
+  return {
+    ...base,
+    severity: LEAD_SEVERITY_TO_FLUIDA[lead.severity] ?? base.severity,
+    readMin: lead.read_min,
+    title: lead.title,
+    summary: lead.lead,
+    nextStep: lead.next_step,
+  };
+};
+
+/**
+ * Overlays the DTO's **body** prose (`paragraphs`) and editorial **lead** onto a
+ * base node. The body and the lead are each absence-safe: empty prose keeps the
+ * mock paragraphs, and a missing `lead` keeps the mock recorte's lead — mirroring
+ * the mobile mapper (`auraxis-app/features/insights/fluida/insight-to-fluida-vm.ts`),
+ * where the real reading uses the backend value when present and the mock
+ * otherwise.
+ *
+ * @param base Mock node supplying the fallback lead/prose.
+ * @param dto Real payload.
+ * @returns A new node with the real prose and lead applied over the mock.
  */
 const overlayCommon = (base: FluidaNode, dto: InsightFluidaFieldsDTO): FluidaNode => {
   const paragraphs =
@@ -180,7 +245,7 @@ const overlayCommon = (base: FluidaNode, dto: InsightFluidaFieldsDTO): FluidaNod
       ? [...dto.paragraphs]
       : base.paragraphs;
 
-  return { ...base, paragraphs };
+  return overlayLead({ ...base, paragraphs }, dto);
 };
 
 /**

--- a/app/features/ai-insights/fluida/model/insight-to-fluida-vm.ts
+++ b/app/features/ai-insights/fluida/model/insight-to-fluida-vm.ts
@@ -1,0 +1,290 @@
+/**
+ * Pure mapper: real `/ai/insights` payload → {@link FluidaInsightSource} VM.
+ *
+ * The backend (auraxis-api PR #1501/#1502) enriches a single generated insight
+ * with the structured Fluida fields (`paragraphs` / `retro` / `series` /
+ * `highlights`) for ONE period (daily OR weekly) and ONE dimension. The Fluida
+ * screen, however, renders a full source object covering both cadences and every
+ * theme. This mapper therefore OVERLAYS the real fields onto the Fluida mock
+ * skeleton at the node addressed by `{ dimension, cadence }`, keeping the screen
+ * full while the remaining slots fall back to mock content.
+ *
+ * Fallback rule: when the DTO carries none of the structured fields (backend not
+ * deployed, or a legacy payload), the mock source is returned verbatim so the
+ * screen is never empty.
+ *
+ * This module is framework-free (no Vue, no I/O) and is unit-tested first.
+ */
+
+import type {
+  InsightDimension,
+  InsightFluidaFieldsDTO,
+  InsightHighlightDTO,
+  InsightRetroEntryDTO,
+} from "~/features/ai-insights/contracts/ai-insight";
+
+import { FLUIDA_MOCK_SOURCE } from "./insight-fluida-mock";
+import {
+  formatFluidaCurrency,
+  type FluidaCadence,
+  type FluidaInsightSource,
+  type FluidaNode,
+  type FluidaRetroEntry,
+  type FluidaSeriesData,
+  type FluidaStat,
+  type FluidaThemeId,
+  type FluidaThemeSource,
+} from "./insight-fluida";
+
+/** The dimension + cadence the screen is currently reading. */
+export interface FluidaMapContext {
+  readonly dimension: InsightDimension;
+  readonly cadence: FluidaCadence;
+}
+
+/** Theme dimensions that have a dedicated Fluida tab (i.e. not `general`/`wallet`). */
+type FluidaThemeDimension = Exclude<FluidaThemeId, "general">;
+
+const FLUIDA_THEME_DIMENSIONS: ReadonlySet<FluidaThemeDimension> = new Set<FluidaThemeDimension>([
+  "transactions",
+  "goals",
+  "budgets",
+  "credit_cards",
+]);
+
+const DAILY_AXIS_LENGTH = 7;
+const WEEKLY_AXIS_LENGTH = 6;
+
+/**
+ * Reports whether a DTO carries any of the structured Fluida fields. Empty
+ * arrays/series count as "no data" so an enriched-but-empty payload still falls
+ * back to the mock instead of blanking the screen.
+ *
+ * @param dto Candidate insight payload (may be undefined).
+ * @returns True when at least one structured field has data.
+ */
+export const hasFluidaPayload = (dto: InsightFluidaFieldsDTO | undefined): boolean => {
+  if (!dto) {
+    return false;
+  }
+  const hasParagraphs = Array.isArray(dto.paragraphs) && dto.paragraphs.length > 0;
+  const hasRetro = Array.isArray(dto.retro) && dto.retro.length > 0;
+  const hasHighlights = Array.isArray(dto.highlights) && dto.highlights.length > 0;
+  const hasSeries =
+    dto.series !== undefined &&
+    ((Array.isArray(dto.series.daily) && dto.series.daily.length > 0) ||
+      (Array.isArray(dto.series.weekly) && dto.series.weekly.length > 0));
+
+  return hasParagraphs || hasRetro || hasHighlights || hasSeries;
+};
+
+/**
+ * Builds the daily axis labels (calendar day-of-month) for a 7-day window ending
+ * today. Backend series omit labels; the Fluida chart needs them.
+ *
+ * @param length Number of bars in the daily series.
+ * @param today Reference "today" (overridable for tests).
+ * @returns Day-of-month labels, oldest first.
+ */
+const buildDailyLabels = (length: number, today: Date): string[] => {
+  const labels: string[] = [];
+  for (let offset = length - 1; offset >= 0; offset -= 1) {
+    const day = new Date(today);
+    day.setDate(today.getDate() - offset);
+    labels.push(String(day.getDate()));
+  }
+  return labels;
+};
+
+/**
+ * Builds the weekly axis labels for a 6-week window. The last bucket is the
+ * current week ("Atual"); earlier buckets are relative ("S-1" … "S-5").
+ *
+ * @param length Number of bars in the weekly series.
+ * @returns Relative week labels, oldest first.
+ */
+const buildWeeklyLabels = (length: number): string[] => {
+  const labels: string[] = [];
+  for (let offset = length - 1; offset >= 0; offset -= 1) {
+    labels.push(offset === 0 ? "Atual" : `S-${offset}`);
+  }
+  return labels;
+};
+
+/**
+ * Builds a Fluida series node (values + derived labels) for a single cadence.
+ *
+ * @param values Raw outflow values from the backend.
+ * @param cadence Series cadence.
+ * @param today Reference "today" used to build daily labels.
+ * @returns Chart-ready series data.
+ */
+const toSeriesData = (
+  values: readonly number[],
+  cadence: FluidaCadence,
+  today: Date,
+): FluidaSeriesData => ({
+  values: [...values],
+  labels:
+    cadence === "daily"
+      ? buildDailyLabels(values.length || DAILY_AXIS_LENGTH, today)
+      : buildWeeklyLabels(values.length || WEEKLY_AXIS_LENGTH),
+});
+
+/**
+ * Maps a backend retro entry into a Fluida retro entry. `label` becomes the
+ * "when" line and `caption` the supporting text; the sign is carried implicitly
+ * by the (signed) value the view formatter already handles.
+ *
+ * @param entry Backend retro entry.
+ * @returns Fluida retro entry.
+ */
+const toRetroEntry = (entry: InsightRetroEntryDTO): FluidaRetroEntry => ({
+  when: entry.label,
+  value: entry.value,
+  text: entry.caption,
+});
+
+/**
+ * Maps a backend highlight into a Fluida stat tile, formatting the numeric value
+ * as pt-BR BRL (the tile renders a pre-formatted string).
+ *
+ * @param highlight Backend highlight.
+ * @returns Fluida stat tile.
+ */
+const toHighlightStat = (highlight: InsightHighlightDTO): FluidaStat => ({
+  label: highlight.label,
+  value: formatFluidaCurrency(highlight.value),
+  caption: highlight.sub,
+});
+
+/**
+ * Overlays the DTO's scalar/prose fields (paragraphs, severity, reading time,
+ * next step) onto a base node. Empty prose is ignored so the mock copy survives.
+ *
+ * @param base Mock node to overlay onto.
+ * @param dto Real payload.
+ * @returns A new node with the real fields applied.
+ */
+const overlayCommon = (base: FluidaNode, dto: InsightFluidaFieldsDTO): FluidaNode => {
+  const paragraphs =
+    Array.isArray(dto.paragraphs) && dto.paragraphs.length > 0
+      ? [...dto.paragraphs]
+      : base.paragraphs;
+
+  return {
+    ...base,
+    paragraphs,
+    ...(dto.severity ? { severity: dto.severity } : {}),
+    ...(typeof dto.read_min === "number" && Number.isFinite(dto.read_min)
+      ? { readMin: dto.read_min }
+      : {}),
+    ...(typeof dto.next_step === "string" && dto.next_step.length > 0
+      ? { nextStep: dto.next_step }
+      : {}),
+  };
+};
+
+/**
+ * Overlays the `general`-dimension extras (retro cards) onto a node.
+ *
+ * @param node Node already carrying the common overlay.
+ * @param dto Real payload.
+ * @returns Node with mapped retro entries when present.
+ */
+const overlayGeneral = (node: FluidaNode, dto: InsightFluidaFieldsDTO): FluidaNode =>
+  Array.isArray(dto.retro) && dto.retro.length > 0
+    ? { ...node, retro: dto.retro.map(toRetroEntry) }
+    : node;
+
+/**
+ * Overlays the per-theme extras (highlight tiles) onto a node.
+ *
+ * @param node Node already carrying the common overlay.
+ * @param dto Real payload.
+ * @returns Node with mapped highlight tiles when present.
+ */
+const overlayTheme = (node: FluidaNode, dto: InsightFluidaFieldsDTO): FluidaNode =>
+  Array.isArray(dto.highlights) && dto.highlights.length > 0
+    ? { ...node, highlights: dto.highlights.map(toHighlightStat) }
+    : node;
+
+/**
+ * Resolves the Fluida theme dimension addressed by the context, collapsing the
+ * `wallet` dimension (no Fluida tab) and `general` to "none" so the prose lands
+ * on the general reading instead.
+ *
+ * @param dimension Backend insight dimension.
+ * @returns The matching Fluida theme dimension, or null for general/wallet.
+ */
+const resolveThemeDimension = (
+  dimension: InsightDimension,
+): FluidaThemeDimension | null =>
+  FLUIDA_THEME_DIMENSIONS.has(dimension as FluidaThemeDimension)
+    ? (dimension as FluidaThemeDimension)
+    : null;
+
+/**
+ * Maps a real (enriched) insight payload into a {@link FluidaInsightSource},
+ * overlaying it onto the mock skeleton at the addressed node.
+ *
+ * When the payload carries no structured fields, the mock source is returned
+ * unchanged (full fallback — the screen is never empty).
+ *
+ * @param dto Insight payload with the additive Fluida fields (may be undefined).
+ * @param context Dimension + cadence the screen is reading.
+ * @param today Reference "today" used to derive daily axis labels (tests).
+ * @returns A Fluida source ready for `deriveFluidaView`.
+ */
+export const insightToFluidaVM = (
+  dto: InsightFluidaFieldsDTO | undefined,
+  context: FluidaMapContext,
+  today: Date = new Date(),
+): FluidaInsightSource => {
+  if (!hasFluidaPayload(dto)) {
+    return FLUIDA_MOCK_SOURCE;
+  }
+
+  const payload = dto as InsightFluidaFieldsDTO;
+  const { cadence } = context;
+  const themeDimension = resolveThemeDimension(context.dimension);
+
+  // Series always carries both cadences from the backend; overlay whichever is
+  // present, keeping the mock for any cadence the payload omits.
+  const series: FluidaInsightSource["series"] = {
+    daily:
+      payload.series && payload.series.daily.length > 0
+        ? toSeriesData(payload.series.daily, "daily", today)
+        : FLUIDA_MOCK_SOURCE.series.daily,
+    weekly:
+      payload.series && payload.series.weekly.length > 0
+        ? toSeriesData(payload.series.weekly, "weekly", today)
+        : FLUIDA_MOCK_SOURCE.series.weekly,
+  };
+
+  if (themeDimension === null) {
+    // General (or wallet → general): overlay the general node for this cadence.
+    const baseNode = FLUIDA_MOCK_SOURCE.general[cadence];
+    const overlaid = overlayGeneral(overlayCommon(baseNode, payload), payload);
+    return {
+      ...FLUIDA_MOCK_SOURCE,
+      series,
+      general: { ...FLUIDA_MOCK_SOURCE.general, [cadence]: overlaid },
+    };
+  }
+
+  // Theme reading: overlay the theme node for this cadence, preserving the
+  // theme's presentation metadata (label/color) and its other cadence node.
+  const baseTheme: FluidaThemeSource =
+    FLUIDA_MOCK_SOURCE.themes[themeDimension] ?? FLUIDA_MOCK_SOURCE.themes.transactions!;
+  const overlaidNode = overlayTheme(overlayCommon(baseTheme[cadence], payload), payload);
+
+  return {
+    ...FLUIDA_MOCK_SOURCE,
+    series,
+    themes: {
+      ...FLUIDA_MOCK_SOURCE.themes,
+      [themeDimension]: { ...baseTheme, [cadence]: overlaidNode },
+    },
+  };
+};

--- a/app/features/ai-insights/fluida/model/insight-to-fluida-vm.ts
+++ b/app/features/ai-insights/fluida/model/insight-to-fluida-vm.ts
@@ -2,12 +2,16 @@
  * Pure mapper: real `/ai/insights` payload → {@link FluidaInsightSource} VM.
  *
  * The backend (auraxis-api PR #1501/#1502) enriches a single generated insight
- * with the structured Fluida fields (`paragraphs` / `retro` / `series` /
- * `highlights`) for ONE period (daily OR weekly) and ONE dimension. The Fluida
- * screen, however, renders a full source object covering both cadences and every
- * theme. This mapper therefore OVERLAYS the real fields onto the Fluida mock
- * skeleton at the node addressed by `{ dimension, cadence }`, keeping the screen
- * full while the remaining slots fall back to mock content.
+ * with the structured Fluida **body** fields (`paragraphs` / `retro` / `series`
+ * / `highlights`) for ONE period (daily OR weekly) and ONE dimension. It does
+ * NOT emit the editorial lead (severity / headline / opening / reading time /
+ * next step) — that always comes from the mock recorte, mirroring the mobile
+ * mapper (`auraxis-app/features/insights/fluida/insight-to-fluida-vm.ts`). The
+ * Fluida screen, however, renders a full source object covering both cadences
+ * and every theme. This mapper therefore OVERLAYS the real body onto the Fluida
+ * mock skeleton at the node addressed by `{ dimension, cadence }`, keeping the
+ * screen full (and the lead always mock-derived) while the remaining slots fall
+ * back to mock content.
  *
  * Fallback rule: when the DTO carries none of the structured fields (backend not
  * deployed, or a legacy payload), the mock source is returned verbatim so the
@@ -159,12 +163,16 @@ const toHighlightStat = (highlight: InsightHighlightDTO): FluidaStat => ({
 });
 
 /**
- * Overlays the DTO's scalar/prose fields (paragraphs, severity, reading time,
- * next step) onto a base node. Empty prose is ignored so the mock copy survives.
+ * Overlays the DTO's **body** prose (`paragraphs`) onto a base node, keeping the
+ * editorial lead (severity, headline, opening summary, reading time, next step)
+ * from the mock recorte. The backend builder never emits the lead — it always
+ * comes from the mock, mirroring the mobile mapper
+ * (`auraxis-app/features/insights/fluida/insight-to-fluida-vm.ts`). Empty prose
+ * is ignored so the mock copy survives.
  *
- * @param base Mock node to overlay onto.
- * @param dto Real payload.
- * @returns A new node with the real fields applied.
+ * @param base Mock node supplying the editorial lead.
+ * @param dto Real payload (body only).
+ * @returns A new node with the real paragraphs applied over the mock lead.
  */
 const overlayCommon = (base: FluidaNode, dto: InsightFluidaFieldsDTO): FluidaNode => {
   const paragraphs =
@@ -172,17 +180,7 @@ const overlayCommon = (base: FluidaNode, dto: InsightFluidaFieldsDTO): FluidaNod
       ? [...dto.paragraphs]
       : base.paragraphs;
 
-  return {
-    ...base,
-    paragraphs,
-    ...(dto.severity ? { severity: dto.severity } : {}),
-    ...(typeof dto.read_min === "number" && Number.isFinite(dto.read_min)
-      ? { readMin: dto.read_min }
-      : {}),
-    ...(typeof dto.next_step === "string" && dto.next_step.length > 0
-      ? { nextStep: dto.next_step }
-      : {}),
-  };
+  return { ...base, paragraphs };
 };
 
 /**

--- a/app/features/ai-insights/model/ai-insight.spec.ts
+++ b/app/features/ai-insights/model/ai-insight.spec.ts
@@ -8,8 +8,13 @@ import {
   mapGeneratedInsight,
   parseInsightItems,
   resolveInsightAnchorDate,
+  selectFluidaFields,
 } from "./ai-insight";
-import type { AIInsightDTO, InsightItem } from "~/features/ai-insights/contracts/ai-insight";
+import type {
+  AIInsightDTO,
+  GenerateInsightResponseWithMetaDTO,
+  InsightItem,
+} from "~/features/ai-insights/contracts/ai-insight";
 
 /**
  * Builds a valid AIInsightDTO fixture for model tests.
@@ -290,5 +295,84 @@ describe("resolveInsightAnchorDate", () => {
   it("anchors to the first day of a past month for history", () => {
     const pastMonthStart = new Date(2026, 2, 1).getTime();
     expect(resolveInsightAnchorDate(pastMonthStart, now)).toBe("2026-03-01");
+  });
+});
+
+describe("Fluida fields passthrough", () => {
+  /**
+   * Builds a generation-response fixture carrying the additive Fluida fields.
+   *
+   * @param overrides Partial overrides on the base payload.
+   * @returns Generation response DTO with rate-limit metadata.
+   */
+  const makeGenerated = (
+    overrides: Partial<GenerateInsightResponseWithMetaDTO> = {},
+  ): GenerateInsightResponseWithMetaDTO => ({
+    summary: "Resumo",
+    items: [
+      { type: "saude_financeira", dimension: "general", title: "Ok", message: "Equilibrado." },
+    ],
+    period_type: "daily",
+    period_label: "2026-06-20",
+    period_start: "2026-06-20",
+    period_end: "2026-06-20",
+    model: "gpt-4o",
+    tokens_used: 100,
+    cost_usd: 0.0001,
+    cached: false,
+    callsRemaining: 1,
+    callsRemainingMonth: 10,
+    ...overrides,
+  });
+
+  it("carries the structured Fluida fields through mapGeneratedInsight", () => {
+    const mapped = mapGeneratedInsight(
+      makeGenerated({
+        paragraphs: ["P1.", "P2."],
+        retro: [{ key: "yesterday", label: "Ontem", value: 156.3, caption: "Saídas", sign: "neg" }],
+        series: { daily: [1, 2, 3, 4, 5, 6, 7], weekly: [1, 2, 3, 4, 5, 6] },
+        highlights: [{ label: "Maior gasto", value: 11000, sub: "Fatura" }],
+        severity: "alerta",
+        read_min: 9,
+        next_step: "Quite a fatura.",
+      }),
+    );
+
+    expect(mapped.fluida).toBeDefined();
+    expect(mapped.fluida?.paragraphs).toEqual(["P1.", "P2."]);
+    expect(mapped.fluida?.retro?.[0]?.label).toBe("Ontem");
+    expect(mapped.fluida?.series?.daily).toHaveLength(7);
+    expect(mapped.fluida?.highlights?.[0]?.value).toBe(11000);
+    expect(mapped.fluida?.severity).toBe("alerta");
+    expect(mapped.fluida?.read_min).toBe(9);
+    expect(mapped.fluida?.next_step).toBe("Quite a fatura.");
+  });
+
+  it("yields a null fluida payload when the backend omits the structured fields", () => {
+    const mapped = mapGeneratedInsight(makeGenerated());
+    expect(mapped.fluida).toBeNull();
+  });
+
+  it("selectFluidaFields extracts only the additive Fluida keys", () => {
+    const fields = selectFluidaFields(
+      makeGenerated({
+        paragraphs: ["only paragraphs"],
+        next_step: "do this",
+      }),
+    );
+    expect(fields).toEqual({
+      severity: undefined,
+      read_min: undefined,
+      paragraphs: ["only paragraphs"],
+      retro: undefined,
+      highlights: undefined,
+      alerts: undefined,
+      series: undefined,
+      next_step: "do this",
+    });
+  });
+
+  it("selectFluidaFields returns null when no Fluida field is present", () => {
+    expect(selectFluidaFields(makeGenerated())).toBeNull();
   });
 });

--- a/app/features/ai-insights/model/ai-insight.spec.ts
+++ b/app/features/ai-insights/model/ai-insight.spec.ts
@@ -361,10 +361,51 @@ describe("Fluida fields passthrough", () => {
       retro: [{ key: "yesterday", label: "Ontem", value: 1, caption: "c", sign: "neg" }],
       highlights: undefined,
       series: undefined,
+      lead: undefined,
     });
   });
 
   it("selectFluidaFields returns null when no Fluida field is present", () => {
     expect(selectFluidaFields(makeGenerated())).toBeNull();
+  });
+
+  it("carries the editorial lead through mapGeneratedInsight (additive #1508)", () => {
+    const mapped = mapGeneratedInsight(
+      makeGenerated({
+        lead: {
+          severity: "alert",
+          read_min: 9,
+          title: "Título real",
+          lead: "Abertura real.",
+          next_step: "Próximo passo real.",
+        },
+      }),
+    );
+
+    expect(mapped.fluida).not.toBeNull();
+    expect(mapped.fluida?.lead).toEqual({
+      severity: "alert",
+      read_min: 9,
+      title: "Título real",
+      lead: "Abertura real.",
+      next_step: "Próximo passo real.",
+    });
+  });
+
+  it("treats a lead-only payload as a usable Fluida payload (not null)", () => {
+    const mapped = mapGeneratedInsight(
+      makeGenerated({
+        lead: {
+          severity: "ok",
+          read_min: 3,
+          title: "Só lead",
+          lead: "Abertura.",
+          next_step: "Passo.",
+        },
+      }),
+    );
+
+    expect(mapped.fluida).not.toBeNull();
+    expect(mapped.fluida?.lead?.title).toBe("Só lead");
   });
 });

--- a/app/features/ai-insights/model/ai-insight.spec.ts
+++ b/app/features/ai-insights/model/ai-insight.spec.ts
@@ -325,16 +325,15 @@ describe("Fluida fields passthrough", () => {
     ...overrides,
   });
 
-  it("carries the structured Fluida fields through mapGeneratedInsight", () => {
+  it("carries the structured Fluida body fields through mapGeneratedInsight", () => {
+    // The backend builder computes only the body (`paragraphs` / `retro` /
+    // `series` / `highlights`); the editorial lead is never in the payload.
     const mapped = mapGeneratedInsight(
       makeGenerated({
         paragraphs: ["P1.", "P2."],
         retro: [{ key: "yesterday", label: "Ontem", value: 156.3, caption: "Saídas", sign: "neg" }],
         series: { daily: [1, 2, 3, 4, 5, 6, 7], weekly: [1, 2, 3, 4, 5, 6] },
         highlights: [{ label: "Maior gasto", value: 11000, sub: "Fatura" }],
-        severity: "alerta",
-        read_min: 9,
-        next_step: "Quite a fatura.",
       }),
     );
 
@@ -343,9 +342,6 @@ describe("Fluida fields passthrough", () => {
     expect(mapped.fluida?.retro?.[0]?.label).toBe("Ontem");
     expect(mapped.fluida?.series?.daily).toHaveLength(7);
     expect(mapped.fluida?.highlights?.[0]?.value).toBe(11000);
-    expect(mapped.fluida?.severity).toBe("alerta");
-    expect(mapped.fluida?.read_min).toBe(9);
-    expect(mapped.fluida?.next_step).toBe("Quite a fatura.");
   });
 
   it("yields a null fluida payload when the backend omits the structured fields", () => {
@@ -353,22 +349,18 @@ describe("Fluida fields passthrough", () => {
     expect(mapped.fluida).toBeNull();
   });
 
-  it("selectFluidaFields extracts only the additive Fluida keys", () => {
+  it("selectFluidaFields extracts only the additive Fluida body keys", () => {
     const fields = selectFluidaFields(
       makeGenerated({
         paragraphs: ["only paragraphs"],
-        next_step: "do this",
+        retro: [{ key: "yesterday", label: "Ontem", value: 1, caption: "c", sign: "neg" }],
       }),
     );
     expect(fields).toEqual({
-      severity: undefined,
-      read_min: undefined,
       paragraphs: ["only paragraphs"],
-      retro: undefined,
+      retro: [{ key: "yesterday", label: "Ontem", value: 1, caption: "c", sign: "neg" }],
       highlights: undefined,
-      alerts: undefined,
       series: undefined,
-      next_step: "do this",
     });
   });
 

--- a/app/features/ai-insights/model/ai-insight.ts
+++ b/app/features/ai-insights/model/ai-insight.ts
@@ -349,7 +349,7 @@ export const mapAIInsightDto = (dto: AIInsightDTO): AIInsight => ({
  * @returns True when at least one structured Fluida field has data.
  */
 const hasAnyFluidaField = (dto: InsightFluidaFieldsDTO): boolean => {
-  const nonEmptyArrays = [dto.paragraphs, dto.retro, dto.highlights, dto.alerts].some(
+  const nonEmptyArrays = [dto.paragraphs, dto.retro, dto.highlights].some(
     (value) => Array.isArray(value) && value.length > 0,
   );
   const nonEmptySeries =
@@ -357,23 +357,22 @@ const hasAnyFluidaField = (dto: InsightFluidaFieldsDTO): boolean => {
     [dto.series.daily, dto.series.weekly].some(
       (value) => Array.isArray(value) && value.length > 0,
     );
-  const hasScalars =
-    dto.severity !== undefined ||
-    typeof dto.read_min === "number" ||
-    (typeof dto.next_step === "string" && dto.next_step.length > 0);
 
-  return nonEmptyArrays || nonEmptySeries || hasScalars;
+  return nonEmptyArrays || nonEmptySeries;
 };
 
 /**
- * Extracts the additive Fluida fields from a generation response, returning null
- * when none are present so callers can cleanly fall back to the mock.
+ * Extracts the additive Fluida **body** fields from a generation response,
+ * returning null when none are present so callers can cleanly fall back to the
+ * mock. Only the body the backend builder computes is carried (`paragraphs` /
+ * `retro` / `highlights` / `series`); the editorial lead is never in the payload
+ * and always comes from the mock recorte (parity with the mobile mapper).
  *
- * The extraction is shallow and lossless: every Fluida key is copied verbatim
- * (the pure Fluida mapper owns the DTO→VM transformation).
+ * The extraction is shallow and lossless: every Fluida body key is copied
+ * verbatim (the pure Fluida mapper owns the DTO→VM transformation).
  *
  * @param dto Generation response payload (may lack the Fluida fields).
- * @returns The Fluida fields, or null when the backend omitted all of them.
+ * @returns The Fluida body fields, or null when the backend omitted all of them.
  */
 export const selectFluidaFields = (
   dto: InsightFluidaFieldsDTO,
@@ -383,14 +382,10 @@ export const selectFluidaFields = (
   }
 
   return {
-    severity: dto.severity,
-    read_min: dto.read_min,
     paragraphs: dto.paragraphs,
     retro: dto.retro,
     highlights: dto.highlights,
-    alerts: dto.alerts,
     series: dto.series,
-    next_step: dto.next_step,
   };
 };
 

--- a/app/features/ai-insights/model/ai-insight.ts
+++ b/app/features/ai-insights/model/ai-insight.ts
@@ -357,22 +357,24 @@ const hasAnyFluidaField = (dto: InsightFluidaFieldsDTO): boolean => {
     [dto.series.daily, dto.series.weekly].some(
       (value) => Array.isArray(value) && value.length > 0,
     );
+  const hasLead = dto.lead !== undefined && dto.lead !== null;
 
-  return nonEmptyArrays || nonEmptySeries;
+  return nonEmptyArrays || nonEmptySeries || hasLead;
 };
 
 /**
- * Extracts the additive Fluida **body** fields from a generation response,
- * returning null when none are present so callers can cleanly fall back to the
- * mock. Only the body the backend builder computes is carried (`paragraphs` /
- * `retro` / `highlights` / `series`); the editorial lead is never in the payload
- * and always comes from the mock recorte (parity with the mobile mapper).
+ * Extracts the additive Fluida fields from a generation response, returning null
+ * when none are present so callers can cleanly fall back to the mock. The body +
+ * numbers (`paragraphs` / `retro` / `highlights` / `series`) and the editorial
+ * `lead` (additive #1503/#1508) are all carried; when the backend omits the lead
+ * the Fluida mapper keeps the mock recorte (parity with the mobile mapper, which
+ * applies the same fallback to the body).
  *
- * The extraction is shallow and lossless: every Fluida body key is copied
- * verbatim (the pure Fluida mapper owns the DTO→VM transformation).
+ * The extraction is shallow and lossless: every Fluida key is copied verbatim
+ * (the pure Fluida mapper owns the DTO→VM transformation).
  *
  * @param dto Generation response payload (may lack the Fluida fields).
- * @returns The Fluida body fields, or null when the backend omitted all of them.
+ * @returns The Fluida fields, or null when the backend omitted all of them.
  */
 export const selectFluidaFields = (
   dto: InsightFluidaFieldsDTO,
@@ -386,6 +388,7 @@ export const selectFluidaFields = (
     retro: dto.retro,
     highlights: dto.highlights,
     series: dto.series,
+    lead: dto.lead,
   };
 };
 

--- a/app/features/ai-insights/model/ai-insight.ts
+++ b/app/features/ai-insights/model/ai-insight.ts
@@ -1,6 +1,7 @@
 import type {
   AIInsightDTO,
   InsightDimension,
+  InsightFluidaFieldsDTO,
   InsightItem,
   InsightPeriodType,
   InsightSourceSurface,
@@ -51,6 +52,12 @@ export interface GeneratedAIInsight {
   readonly forecast: boolean;
   readonly callsRemaining: number | null;
   readonly callsRemainingMonth: number | null;
+  /**
+   * Additive structured fields powering the Fluida reading. Null when the
+   * backend response carries none of them (legacy/undeployed builder), so the
+   * Fluida screen falls back to its mock.
+   */
+  readonly fluida: InsightFluidaFieldsDTO | null;
 }
 
 export const FALLBACK_INSIGHT_ITEM: InsightItem = {
@@ -334,6 +341,60 @@ export const mapAIInsightDto = (dto: AIInsightDTO): AIInsight => ({
 });
 
 /**
+ * Reports whether a generation response carries any meaningful Fluida field.
+ * Empty arrays/series count as "no data" so an enriched-but-empty payload still
+ * resolves to the mock instead of blanking the Fluida screen.
+ *
+ * @param dto Generation response payload.
+ * @returns True when at least one structured Fluida field has data.
+ */
+const hasAnyFluidaField = (dto: InsightFluidaFieldsDTO): boolean => {
+  const nonEmptyArrays = [dto.paragraphs, dto.retro, dto.highlights, dto.alerts].some(
+    (value) => Array.isArray(value) && value.length > 0,
+  );
+  const nonEmptySeries =
+    dto.series !== undefined &&
+    [dto.series.daily, dto.series.weekly].some(
+      (value) => Array.isArray(value) && value.length > 0,
+    );
+  const hasScalars =
+    dto.severity !== undefined ||
+    typeof dto.read_min === "number" ||
+    (typeof dto.next_step === "string" && dto.next_step.length > 0);
+
+  return nonEmptyArrays || nonEmptySeries || hasScalars;
+};
+
+/**
+ * Extracts the additive Fluida fields from a generation response, returning null
+ * when none are present so callers can cleanly fall back to the mock.
+ *
+ * The extraction is shallow and lossless: every Fluida key is copied verbatim
+ * (the pure Fluida mapper owns the DTO→VM transformation).
+ *
+ * @param dto Generation response payload (may lack the Fluida fields).
+ * @returns The Fluida fields, or null when the backend omitted all of them.
+ */
+export const selectFluidaFields = (
+  dto: InsightFluidaFieldsDTO,
+): InsightFluidaFieldsDTO | null => {
+  if (!hasAnyFluidaField(dto)) {
+    return null;
+  }
+
+  return {
+    severity: dto.severity,
+    read_min: dto.read_min,
+    paragraphs: dto.paragraphs,
+    retro: dto.retro,
+    highlights: dto.highlights,
+    alerts: dto.alerts,
+    series: dto.series,
+    next_step: dto.next_step,
+  };
+};
+
+/**
  * Maps the generation endpoint payload into UI state.
  *
  * @param dto Generation endpoint payload with rate-limit metadata.
@@ -356,6 +417,7 @@ export const mapGeneratedInsight = (
   forecast: dto.forecast === true,
   callsRemaining: dto.callsRemaining,
   callsRemainingMonth: dto.callsRemainingMonth,
+  fluida: selectFluidaFields(dto),
 });
 
 /**

--- a/app/shared/types/generated/graphql.ts
+++ b/app/shared/types/generated/graphql.ts
@@ -86,6 +86,23 @@ export type AiInsightItemType = {
   type: Scalars['String']['output'];
 };
 
+/**
+ * Editorial lead (masthead) for the Fluida screen (#1503).
+ *
+ * ``severity`` is a deterministic heuristic over the calculated retro/highlights
+ * (``ok`` | ``attention`` | ``alert``); ``read_min`` is fixed by cadence;
+ * ``title`` / ``lead`` / ``next_step`` are derived from the AI ``summary`` (no
+ * extra LLM call).
+ */
+export type AiInsightLeadType = {
+  __typename?: 'AIInsightLeadType';
+  lead: Scalars['String']['output'];
+  nextStep: Scalars['String']['output'];
+  readMin: Scalars['Int']['output'];
+  severity: Scalars['String']['output'];
+  title: Scalars['String']['output'];
+};
+
 /** One calculated retrospective metric for the Fluida screen (#1501). */
 export type AiInsightRetroEntryType = {
   __typename?: 'AIInsightRetroEntryType';
@@ -541,6 +558,7 @@ export type GenerateAiInsightPayload = {
   highlights?: Maybe<Array<Maybe<AiInsightHighlightType>>>;
   id?: Maybe<Scalars['String']['output']>;
   items?: Maybe<Array<Maybe<AiInsightItemType>>>;
+  lead?: Maybe<AiInsightLeadType>;
   model?: Maybe<Scalars['String']['output']>;
   ok: Scalars['Boolean']['output'];
   paragraphs?: Maybe<Array<Maybe<Scalars['String']['output']>>>;


### PR DESCRIPTION
## O que muda

Conecta a tela **Insights Fluida** (etapa 5) ao **payload real da IA**, trocando o mock pelo DTO enriquecido de `/ai/insights`, com **fallback ao mock** quando os campos novos não chegam (tela nunca vazia). Encadeado sobre `feat/insights-fluida-web`.

## Como

1. **Contrato alinhado ao backend real** (`contracts/ai-insight.ts`, aditivo): `retro {key,label,value,caption,sign}`, `highlights {label,value:number,sub}`, `series {daily,weekly}` (arrays de valores; labels derivados no front). Reflete `insight_fluida_builder.py` (auraxis-api PR #1501/#1502). Nada removido.
2. **Mapper puro** `insightToFluidaVM(dto, { dimension, cadence })` (`fluida/model/insight-to-fluida-vm.ts`): sobrepõe o insight real sobre o esqueleto do mock no nó endereçado por `{dimension, cadence}`, gerando os labels do gráfico. Sem campos estruturados → retorna o mock (guard `hasFluidaPayload`).
3. **Passthrough no domínio** (`model/ai-insight.ts`): `GeneratedAIInsight.fluida` (nullable) populado por `selectFluidaFields`; `mapGeneratedInsight` carrega os campos aditivos.
4. **Wiring reativo**: `useInsightsFluida` vira fachada injetável (recebe `insight` + `dimension`, expõe `usingRealData`); `InsightsFluida.vue` consome o insight gerado compartilhado (`useAIInsights().currentResult.fluida`), dimensão `general` no hub. Toggle de cadência re-mapeia ao vivo. Tudo atrás da flag `web.insights.fluida`.

## Campos mapeados (DTO → VM)

| DTO (`/ai/insights`) | VM (`FluidaInsightSource`) | Nó |
|---|---|---|
| `paragraphs[]` | `node.paragraphs` | dimensão+cadência ativa |
| `retro[{key,label,value,caption,sign}]` | `general.{cad}.retro[{when,value,text}]` | só `general` |
| `highlights[{label,value,sub}]` | `themes.{dim}.{cad}.highlights[{label,value:BRL,caption}]` | só temas |
| `series.{daily,weekly}` | `series.{daily,weekly}` (+ labels gerados) | compartilhado |
| `severity` / `read_min` / `next_step` | `node.severity` / `readMin` / `nextStep` | dimensão+cadência ativa |

## Estratégia de fallback

- `hasFluidaPayload` considera arrays/series vazios como "sem dados" → **mock integral** (`insightToFluidaVM` retorna `FLUIDA_MOCK_SOURCE`).
- Overlay é **parcial e não-destrutivo**: um único insight cobre uma cadência/dimensão; os demais nós seguem do mock, então a tela permanece completa.
- `wallet` (sem aba Fluida) → prosa cai no nó `general`, série ainda aplicada.

## TDD

Teste escrito primeiro em cada camada: mapper (DTO completo → VM; DTO vazio → mock; por cadência/dimensão), domínio (`selectFluidaFields`/passthrough), composable (real vs fallback, reatividade) e componente (renderiza prosa real; cai no mock sem insight).

## Quality gates — `pnpm quality-check` VERDE

- `flags:check` OK (51 flags) · `i18n:check` OK (en.json **não** tocado; PT-only deferido por DEC-186) · `lint` OK · `typecheck` 0 erros
- `test:coverage`: **441 files / 3971 tests** passando — 92.29% lines / 85.37% branches / 89.21% functions / 93.31% statements
- `policy:check` OK · `contracts:check` OK · `codegen:check` OK · `build` OK

Closes #1072