### PR TITLE
chore(ai-insights): ativa flag web.insights.fluida em producao

### DIFF
--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -506,8 +506,8 @@
       "createdAt": "2026-06-21",
       "removeBy": "2027-12-31",
       "type": "release",
-      "status": "draft",
-      "description": "Leitura editorial \"Fluida\" da tela de Insights de IA (masthead + lead + beats). Default OFF até o backend (auraxis-api #1502) entregar paragraphs/retro/series/highlights; ligar via NUXT_PUBLIC_FLAG_WEB_INSIGHTS_FLUIDA=true.",
+      "status": "enabled-prod",
+      "description": "Leitura editorial \"Fluida\" da tela de Insights de IA (masthead + lead + beats). Ativada em producao apos o backend (auraxis-api #1502) entregar paragraphs/retro/series/highlights.",
       "repositories": ["auraxis-web"]
     }
   ]


### PR DESCRIPTION
## Objetivo

Ativacao em **producao (100%)** da feature **Insights de IA — Fluida** na web.

Promove a flag `web.insights.fluida` de `draft` para `enabled-prod` em `config/feature-flags.json`, seguindo o mesmo padrao das demais flags ja ativas em producao (ex.: `web.pages.insights`).

## Contexto

A implementacao da Fluida na web ja foi entregue e mergeada (issues #1070, #1072 — PRs #1071, #1073). O backend (`auraxis-api` #1502, ja em master/producao) entrega `paragraphs/retro/series/highlights`, atendendo a dependencia que mantinha a flag em `draft`.

## Mudanca

- `web.insights.fluida`: `status` `draft` -> `enabled-prod`

No resolver de flags da web (`isStatusEnabledForEnv`), `enabled-prod` habilita em **todos** os ambientes, incluindo producao (`NUXT_PUBLIC_APP_ENV=production`). O merge em `main` re-dispara o deploy oficial (S3 + CloudFront) automaticamente.

## Validacao

- `flags:check` (feature-flags-hygiene): OK (51 flags)
- Pre-push CI-parity gate completo (flags, lint, typecheck, vitest+coverage, policy, contracts, audit, build): verde
- `en.json` **nao** foi tocado (DEC-186 respeitado)
- Staging seletivo (apenas `config/feature-flags.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx