### PR TITLE
feat: manage credit card statement expenses

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,18 +4,20 @@
 
 The credit-card area is implemented as a hybrid workspace:
 
-- `/credit-cards` is the operational list. It defaults to a table-like view, with optional detailed cards and an analytical summary mode.
-- `/credit-cards/[id]` is the card dashboard. It uses a less dense layout, larger charts, and tabs for `Visão geral`, `Fatura`, `Categorias`, `Parcelamentos`, `Benefícios` and `Analítico`.
-- `CreditCardExpenseDrawer` is the card-specific transaction launcher. It replaces the dense modal for card launches and can be opened globally without requiring a pre-selected card.
+- `/credit-cards` is the operational card workspace. It defaults to `Faturas`, with a rail for card selection, a statement panel and an analytical summary mode.
+- `/credit-cards/[id]` is the single-card dashboard. It reuses the statement/analytics views scoped to the route card id.
+- `CreditCardExpenseModal` is the canonical card-expense editor/launcher for statement rows. It follows the existing `EditTransactionModal` form pattern and always persists through the transactions resource.
 
 Core components:
 
-- `app/features/credit-cards/components/CreditCardsTable.vue`
-- `app/features/credit-cards/components/CreditCardDashboard.vue`
-- `app/features/credit-cards/components/CreditCardExpenseDrawer.vue`
+- `app/features/credit-cards/components/FaturasView.vue`
+- `app/features/credit-cards/components/AnaliticoView.vue`
+- `app/features/credit-cards/components/CreditCardExpenseModal.vue`
+- `app/features/credit-cards/model/credit-card-statement.ts`
+- `app/features/credit-cards/utils/transaction-billing.ts`
 - `app/features/credit-cards/utils/billing-cycle.ts`
 
-Transactions remain the canonical source of truth. Card screens consume card DTOs, bill/utilization endpoints and transaction creation APIs; they do not create a separate "card expense" model in the frontend.
+Transactions remain the canonical source of truth. A card expense is a `TransactionDto` with `credit_card_id` filled. Card statements list enriched transactions filtered by `credit_card_id` plus bill month; create, edit, duplicate and delete actions call the same transaction mutations used by the Transactions surface. The statement total and item count are derived from those transaction rows, not from a separate card-expense entity.
 
 ## Impact Policy Contract
 

--- a/DATAFLOW.md
+++ b/DATAFLOW.md
@@ -1,21 +1,17 @@
 # Data Flow - auraxis-web
 
-## Credit Card Launch
+## Credit Card Statement Expense Management
 
-1. User opens `CreditCardExpenseDrawer` from `/credit-cards` or `/credit-cards/[id]`.
-2. Drawer collects `Data da compra`, amount, card, category/account, installments and `impact_policy`.
-3. `billing-cycle.ts` computes the local preview:
-   - `Cai na fatura de ...`
-   - closing date
-   - due date
-   - cycle start/end
-4. Drawer submits `POST /transactions` with:
-   - `type: "expense"`
-   - `due_date` = purchase date
-   - `credit_card_id`
-   - `impact_policy`
-   - optional installment fields.
-5. On success, the page invalidates `credit-cards`, `transactions` and `dashboard` query families.
+1. `/credit-cards` and `/credit-cards/[id]` load card DTOs and the transaction list window used by `useCreditCardsStatement`.
+2. `transaction-billing.ts` enriches transactions that have `credit_card_id`, resolves the bill month through the card cycle and exposes the original `TransactionDto` on each statement row.
+3. `credit-card-statement.ts` filters enriched transactions by selected card and bill month. The statement `total`, `itemCount`, category groups and row list are derived from those transactions.
+4. User actions on statement rows use the transactions resource:
+   - `Ver detalhes / Editar` opens `CreditCardExpenseModal` with the row's source transaction.
+   - `Nova despesa` opens the same modal with the current statement card preselected.
+   - Saving creates or updates `POST/PATCH /transactions` with `type: "expense"` and `credit_card_id`.
+   - Duplicating calls `POST /transactions` with `buildDuplicatePayload`, preserving `credit_card_id` and suffixing the title with ` (cópia)`.
+   - Removing confirms that the item leaves both the bill and Transactions, then calls `DELETE /transactions/:id?scope=occurrence`.
+5. On success, the page invalidates `credit-cards`, `transactions` and `dashboard` query families and shows the statement-specific toast.
 
 ## Credit Card Dashboard
 
@@ -23,11 +19,8 @@
 2. It fetches:
    - `GET /credit-cards/:id/bill?month=YYYY-MM`
    - `GET /credit-cards/:id/utilization`
-3. `CreditCardDashboard` renders:
-   - KPIs from bill/utilization/card DTO.
-   - charts from bill totals and impact buckets.
-   - analytical blocks for real free limit, post-closing purchases and budget risk.
+3. `FaturasView` and `AnaliticoView` render statement and analytical data derived from synchronized transactions plus card DTOs.
 
 ## Known Data Gap
 
-The bill endpoint does not yet expose structured category/tag labels. The current categories tab starts with operational buckets by impact policy. Rich category analytics should be backed by API aggregates or `GET /transactions?credit_card_id=...` enrichment.
+The bill endpoint does not yet expose structured category/tag labels. The current statement categories are enriched on the client from synchronized transactions and tags. Richer cross-card analytics should eventually be backed by API aggregates or a first-class `GET /transactions?credit_card_id=...` aggregate endpoint.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ pnpm test
 pnpm test:coverage
 pnpm quality-check
 pnpm build
+bash scripts/run_ci_like_actions_local.sh --local --with-e2e
 ```
+
+O gate local com `--with-e2e` executa Playwright com `CI=true`, espelhando o
+workflow remoto: `chromium` e `mobile-chrome`.
 
 ## Notas importantes
 

--- a/app/features/credit-cards/components/CreditCardExpenseModal.spec.ts
+++ b/app/features/credit-cards/components/CreditCardExpenseModal.spec.ts
@@ -1,0 +1,294 @@
+import { mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+
+import CreditCardExpenseModal from "./CreditCardExpenseModal.vue";
+
+const createMutate = vi.hoisted(() => vi.fn());
+const updateMutate = vi.hoisted(() => vi.fn());
+
+vi.mock("~/features/transactions/queries/use-create-transaction-mutation", (): {
+  useCreateTransactionMutation: () => {
+    mutate: typeof createMutate;
+    isPending: { value: boolean };
+    isError: { value: boolean };
+    error: { value: null };
+  };
+} => ({
+  useCreateTransactionMutation: () => ({
+    mutate: createMutate,
+    isPending: { value: false },
+    isError: { value: false },
+    error: { value: null },
+  }),
+}));
+
+vi.mock("~/features/transactions/queries/use-update-transaction-mutation", (): {
+  useUpdateTransactionMutation: () => {
+    mutate: typeof updateMutate;
+    isPending: { value: boolean };
+    isError: { value: boolean };
+    error: { value: null };
+  };
+} => ({
+  useUpdateTransactionMutation: () => ({
+    mutate: updateMutate,
+    isPending: { value: false },
+    isError: { value: false },
+    error: { value: null },
+  }),
+}));
+
+vi.mock("~/features/tags/queries/use-tags-query", (): {
+  useTagsQuery: () => { data: { value: Array<{ id: string; name: string }> } };
+} => ({
+  useTagsQuery: () => ({ data: { value: [{ id: "tag-1", name: "Eletrônicos" }] } }),
+}));
+
+vi.mock("~/features/accounts/queries/use-accounts-query", (): {
+  useAccountsQuery: () => { data: { value: Array<{ id: string; name: string }> } };
+} => ({
+  useAccountsQuery: () => ({ data: { value: [{ id: "acc-1", name: "Conta Inter" }] } }),
+}));
+
+vi.mock("~/features/credit-cards/queries/use-credit-cards-query", (): {
+  useCreditCardsQuery: () => { data: { value: Array<{ id: string; name: string }> } };
+} => ({
+  useCreditCardsQuery: () => ({ data: { value: [{ id: "cc-1", name: "Cartão Inter" }] } }),
+}));
+
+vi.mock("~/features/budgets/queries/use-budgets-query", (): {
+  useBudgetsQuery: () => { data: { value: [] } };
+} => ({
+  useBudgetsQuery: () => ({ data: { value: [] } }),
+}));
+
+vi.mock("~/components/ui/UiIcon/UiIcon.vue", () => ({
+  default: { props: ["name", "size"], template: "<span data-testid='ui-icon' />" },
+}));
+
+vi.mock("~/components/ui/UiMoneyInput/UiMoneyInput.vue", () => ({
+  default: {
+    props: ["value"],
+    emits: ["update:value"],
+    setup(_props: unknown, { emit }: { emit: (event: "update:value", value: number) => void }): {
+      onInput: (event: Event) => void;
+    } {
+      return {
+        onInput(event: Event): void {
+          emit("update:value", Number((event.target as HTMLInputElement).value));
+        },
+      };
+    },
+    template: "<input data-testid='money-input' :value='value' @input='onInput' />",
+  },
+}));
+
+vi.mock("naive-ui", () => ({
+  NAlert: { props: ["type", "title"], template: "<div><slot />{{ title }}</div>" },
+  NButton: {
+    props: ["loading", "disabled", "type"],
+    emits: ["click"],
+    template: "<button :disabled='disabled || loading' @click='$emit(\"click\", $event)'><slot name='icon' /><slot /></button>",
+  },
+  NDatePicker: {
+    props: ["value"],
+    emits: ["update:value"],
+    setup(_props: unknown, { emit }: { emit: (event: "update:value", value: number) => void }): {
+      onInput: (event: Event) => void;
+    } {
+      return {
+        onInput(event: Event): void {
+          emit("update:value", Number((event.target as HTMLInputElement).value));
+        },
+      };
+    },
+    template: "<input data-testid='date-input' :value='value' @input='onInput' />",
+  },
+  NForm: { template: "<form><slot /></form>" },
+  NFormItem: { props: ["label"], template: "<label><span>{{ label }}</span><slot /></label>" },
+  NInput: {
+    props: ["value"],
+    emits: ["update:value"],
+    setup(_props: unknown, { emit }: { emit: (event: "update:value", value: string) => void }): {
+      onInput: (event: Event) => void;
+    } {
+      return {
+        onInput(event: Event): void {
+          emit("update:value", (event.target as HTMLInputElement).value);
+        },
+      };
+    },
+    template: "<input :value='value' @input='onInput' />",
+  },
+  NModal: {
+    props: ["show", "title"],
+    emits: ["update:show"],
+    template: `
+      <section v-if="show" data-testid="cc-expense-modal">
+        <h2>{{ title }}</h2>
+        <slot />
+        <footer><slot name="footer" /></footer>
+      </section>
+    `,
+  },
+  NSelect: {
+    props: ["value", "options"],
+    emits: ["update:value"],
+    setup(_props: unknown, { emit }: { emit: (event: "update:value", value: string | null) => void }): {
+      onChange: (event: Event) => void;
+    } {
+      return {
+        onChange(event: Event): void {
+          emit("update:value", (event.target as HTMLSelectElement).value || null);
+        },
+      };
+    },
+    template: "<select :value='value ?? \"\"' @change='onChange'><option v-for='option in options' :key='option.value' :value='option.value'>{{ option.label }}</option></select>",
+  },
+  NSpace: { template: "<div><slot /></div>" },
+  NSwitch: {
+    props: ["value"],
+    emits: ["update:value"],
+    setup(_props: unknown, { emit }: { emit: (event: "update:value", value: boolean) => void }): {
+      onChange: (event: Event) => void;
+    } {
+      return {
+        onChange(event: Event): void {
+          emit("update:value", (event.target as HTMLInputElement).checked);
+        },
+      };
+    },
+    template: "<input type='checkbox' :checked='value' @change='onChange' />",
+  },
+}));
+
+/**
+ * Builds a transaction fixture for the expense modal.
+ *
+ * @param overrides Fields to override.
+ * @returns Transaction fixture.
+ */
+const transactionFixture = (overrides: Partial<TransactionDto> = {}): TransactionDto => ({
+  id: "tx-1",
+  title: "Notebook Dell Inspiron",
+  amount: "899.90",
+  type: "expense",
+  due_date: "2026-06-13",
+  description: "Garantia estendida",
+  observation: null,
+  is_recurring: false,
+  is_installment: false,
+  installment_count: null,
+  recurrence_interval: 1,
+  recurrence_unit: "month",
+  currency: "BRL",
+  status: "pending",
+  start_date: null,
+  end_date: null,
+  tag_id: "tag-1",
+  account_id: "acc-1",
+  credit_card_id: "cc-1",
+  impact_policy: "full",
+  installment_group_id: null,
+  paid_at: null,
+  created_at: null,
+  updated_at: null,
+  ...overrides,
+});
+
+describe("CreditCardExpenseModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the linked-transactions banner in edit mode", () => {
+    const wrapper = mount(CreditCardExpenseModal, {
+      props: {
+        visible: true,
+        transaction: transactionFixture(),
+        presetCreditCardId: "cc-1",
+      },
+    });
+
+    expect(wrapper.text()).toContain("Detalhes da despesa");
+    expect(wrapper.text()).toContain("Vinculada às Transações");
+    expect(wrapper.text()).toContain("Cartão Inter");
+  });
+
+  it("updates the source transaction when saving an existing card expense", async () => {
+    const wrapper = mount(CreditCardExpenseModal, {
+      props: {
+        visible: true,
+        transaction: transactionFixture(),
+        presetCreditCardId: "cc-1",
+      },
+    });
+
+    await wrapper.get("[data-testid='cc-expense-modal-submit']").trigger("click");
+
+    expect(updateMutate).toHaveBeenCalledWith(
+      {
+        id: "tx-1",
+        payload: expect.objectContaining({
+          title: "Notebook Dell Inspiron",
+          amount: "899.90",
+          type: "expense",
+          due_date: "2026-06-13",
+          credit_card_id: "cc-1",
+        }),
+      },
+      expect.any(Object),
+    );
+  });
+
+  it("creates a new expense transaction with the preset credit card", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-15T09:00:00"));
+
+    const wrapper = mount(CreditCardExpenseModal, {
+      props: {
+        visible: true,
+        transaction: null,
+        presetCreditCardId: "cc-1",
+      },
+    });
+
+    await wrapper.get("[data-testid='cc-expense-title']").setValue("Nova compra");
+    await wrapper.get("[data-testid='money-input']").setValue("55.5");
+    await wrapper.get("[data-testid='cc-expense-modal-submit']").trigger("click");
+
+    expect(createMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Nova compra",
+        amount: "55.50",
+        type: "expense",
+        due_date: "2026-06-15",
+        credit_card_id: "cc-1",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("exposes duplicate and remove actions for existing expenses", async () => {
+    const transaction = transactionFixture();
+    const wrapper = mount(CreditCardExpenseModal, {
+      props: {
+        visible: true,
+        transaction,
+        presetCreditCardId: "cc-1",
+      },
+    });
+
+    await wrapper.get("[data-testid='cc-expense-modal-duplicate']").trigger("click");
+    await wrapper.get("[data-testid='cc-expense-modal-remove']").trigger("click");
+
+    expect(wrapper.emitted("duplicate")?.[0]).toEqual([transaction]);
+    expect(wrapper.emitted("remove")?.[0]).toEqual([transaction]);
+  });
+});

--- a/app/features/credit-cards/components/CreditCardExpenseModal.vue
+++ b/app/features/credit-cards/components/CreditCardExpenseModal.vue
@@ -1,0 +1,513 @@
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from "vue";
+import {
+  NAlert,
+  NButton,
+  NDatePicker,
+  NForm,
+  NFormItem,
+  NInput,
+  NModal,
+  NSelect,
+  NSpace,
+  NSwitch,
+  type FormInst,
+  type FormRules,
+  type SelectOption,
+} from "naive-ui";
+
+import UiIcon from "~/components/ui/UiIcon/UiIcon.vue";
+import UiMoneyInput from "~/components/ui/UiMoneyInput/UiMoneyInput.vue";
+import type {
+  CreateTransactionPayload,
+  TransactionDto,
+  TransactionStatusDto,
+} from "~/features/transactions/contracts/transaction.dto";
+import { useCreateTransactionMutation } from "~/features/transactions/queries/use-create-transaction-mutation";
+import { useUpdateTransactionMutation } from "~/features/transactions/queries/use-update-transaction-mutation";
+import { useTagsQuery } from "~/features/tags/queries/use-tags-query";
+import { useAccountsQuery } from "~/features/accounts/queries/use-accounts-query";
+import { useCreditCardsQuery } from "~/features/credit-cards/queries/use-credit-cards-query";
+import type { CreditCardDto } from "~/features/credit-cards/contracts/credit-card.dto";
+import { resolveCardTheme } from "~/features/credit-cards/utils/card-brand-theme";
+import {
+  parseCurrencyAmount,
+  serializeCurrencyAmount,
+} from "~/utils/currencyInput";
+
+const props = defineProps<{
+  /** Controls the central card-expense modal. */
+  readonly visible: boolean;
+  /** Existing transaction in edit mode; null means "Nova despesa". */
+  readonly transaction: TransactionDto | null;
+  /** Credit card selected in the invoice, preselected for new expenses. */
+  readonly presetCreditCardId: string | null;
+}>();
+
+const emit = defineEmits<{
+  "update:visible": [value: boolean];
+  saved: [mode: "created" | "updated"];
+  duplicate: [transaction: TransactionDto];
+  remove: [transaction: TransactionDto];
+}>();
+
+interface ExpenseFormState {
+  title: string;
+  amount: number | null;
+  dueDate: number | null;
+  tagId: string | null;
+  accountId: string | null;
+  creditCardId: string | null;
+  status: TransactionStatusDto;
+  isRecurring: boolean;
+  description: string;
+}
+
+const formRef = ref<FormInst | null>(null);
+const form = reactive<ExpenseFormState>({
+  title: "",
+  amount: null,
+  dueDate: null,
+  tagId: null,
+  accountId: null,
+  creditCardId: null,
+  status: "pending",
+  isRecurring: false,
+  description: "",
+});
+
+const { data: tags } = useTagsQuery();
+const { data: accounts } = useAccountsQuery();
+const { data: creditCards } = useCreditCardsQuery();
+const createMutation = useCreateTransactionMutation();
+const updateMutation = useUpdateTransactionMutation();
+
+const tagOptions = computed<SelectOption[]>(() =>
+  (tags.value ?? []).map((tag) => ({ label: tag.name, value: tag.id })),
+);
+
+const accountOptions = computed<SelectOption[]>(() =>
+  (accounts.value ?? []).map((account) => ({ label: account.name, value: account.id })),
+);
+
+const creditCardOptions = computed<SelectOption[]>(() =>
+  (creditCards.value ?? []).map((card) => ({ label: card.name, value: card.id })),
+);
+
+const statusOptions: SelectOption[] = [
+  { label: "Pendente", value: "pending" },
+  { label: "Pago", value: "paid" },
+  { label: "Cancelado", value: "cancelled" },
+  { label: "Postergado", value: "postponed" },
+  { label: "Vencido", value: "overdue" },
+];
+
+const rules: FormRules = {
+  title: [{ required: true, message: "Informe o título da despesa.", trigger: "blur" }],
+  amount: [
+    {
+      required: true,
+      type: "number",
+      message: "Informe o valor da despesa.",
+      trigger: ["blur", "change"],
+    },
+  ],
+  dueDate: [
+    {
+      required: true,
+      type: "number",
+      message: "Informe a data da despesa.",
+      trigger: "change",
+    },
+  ],
+};
+
+const selectedCard = computed<CreditCardDto | null>(
+  () => (creditCards.value ?? []).find((entry) => entry.id === form.creditCardId) ?? null,
+);
+
+const selectedCardName = computed<string>(() => {
+  const card = selectedCard.value;
+  return card?.name ?? "Cartão";
+});
+
+const selectedCardColor = computed<string>(() =>
+  selectedCard.value ? resolveCardTheme(selectedCard.value).color : "var(--color-brand-500)",
+);
+
+const modalTitle = computed<string>(() =>
+  props.transaction ? "Detalhes da despesa" : "Nova despesa",
+);
+
+const subtitle = computed<string>(() =>
+  props.transaction
+    ? selectedCardName.value
+    : `Lançar no ${selectedCardName.value}`,
+);
+
+const primaryLabel = computed<string>(() =>
+  props.transaction ? "Salvar alterações" : "Lançar despesa",
+);
+
+const isSubmitting = computed<boolean>(() =>
+  createMutation.isPending.value || updateMutation.isPending.value,
+);
+
+/**
+ * Converts a YYYY-MM-DD string to a local DatePicker timestamp.
+ *
+ * @param isoDate Date-only ISO string.
+ * @returns Timestamp in milliseconds.
+ */
+const dateToTs = (isoDate: string | null | undefined): number | null => {
+  if (!isoDate) {
+    return null;
+  }
+  const timestamp = new Date(`${isoDate}T00:00:00`).getTime();
+  return Number.isNaN(timestamp) ? null : timestamp;
+};
+
+/**
+ * Converts a local DatePicker timestamp to YYYY-MM-DD.
+ *
+ * @param timestamp Milliseconds timestamp.
+ * @returns Date-only ISO string.
+ */
+const tsToDate = (timestamp: number): string => {
+  const date = new Date(timestamp);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+};
+
+/**
+ * Today's local midnight timestamp for new expenses.
+ *
+ * @returns Timestamp in milliseconds.
+ */
+const todayTs = (): number => {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+};
+
+/** Resets the form to the "new card expense" defaults. */
+const populateNewForm = (): void => {
+  form.title = "";
+  form.amount = null;
+  form.dueDate = todayTs();
+  form.tagId = null;
+  form.accountId = null;
+  form.creditCardId = props.presetCreditCardId;
+  form.status = "pending";
+  form.isRecurring = false;
+  form.description = "";
+};
+
+/**
+ * Populates the form from an existing transaction.
+ *
+ * @param transaction Source transaction.
+ */
+const populateEditForm = (transaction: TransactionDto): void => {
+  form.title = transaction.title;
+  form.amount = parseCurrencyAmount(transaction.amount);
+  form.dueDate = dateToTs(transaction.due_date);
+  form.tagId = transaction.tag_id;
+  form.accountId = transaction.account_id;
+  form.creditCardId = transaction.credit_card_id ?? props.presetCreditCardId;
+  form.status = transaction.status;
+  form.isRecurring = transaction.is_recurring;
+  form.description = transaction.description ?? "";
+};
+
+watch(
+  () => [props.visible, props.transaction, props.presetCreditCardId] as const,
+  ([visible, transaction]) => {
+    if (!visible) {
+      return;
+    }
+    if (transaction) {
+      populateEditForm(transaction);
+      return;
+    }
+    populateNewForm();
+  },
+  { immediate: true },
+);
+
+/** Closes the modal without persisting changes. */
+const close = (): void => {
+  emit("update:visible", false);
+};
+
+/**
+ * Builds the canonical transaction payload for a card expense.
+ *
+ * @returns Payload for POST/PATCH /transactions.
+ */
+const buildPayload = (): CreateTransactionPayload => ({
+  title: form.title.trim(),
+  amount: serializeCurrencyAmount(form.amount),
+  type: "expense",
+  due_date: form.dueDate ? tsToDate(form.dueDate) : "",
+  status: form.status,
+  tag_id: form.tagId,
+  account_id: form.accountId,
+  credit_card_id: form.creditCardId,
+  is_recurring: form.isRecurring,
+  ...(form.description.trim() ? { description: form.description.trim() } : {}),
+});
+
+/**
+ * Validates the required fields before delegating to the API mutation.
+ */
+const submit = async (): Promise<void> => {
+  try {
+    await formRef.value?.validate?.();
+  } catch {
+    return;
+  }
+
+  if (!form.title.trim() || form.amount === null || form.amount <= 0 || !form.dueDate) {
+    return;
+  }
+
+  if (props.transaction) {
+    updateMutation.mutate(
+      {
+        id: props.transaction.id,
+        payload: buildPayload(),
+      },
+      {
+        onSuccess: () => {
+          emit("saved", "updated");
+          close();
+        },
+      },
+    );
+    return;
+  }
+
+  createMutation.mutate(buildPayload(), {
+    onSuccess: () => {
+      emit("saved", "created");
+      close();
+    },
+  });
+};
+</script>
+
+<template>
+  <NModal
+    :show="props.visible"
+    preset="card"
+    :title="modalTitle"
+    class="cc-expense-modal"
+    :style="{ maxWidth: '560px', width: '100%' }"
+    @update:show="(value) => { if (!value) close(); }"
+  >
+    <div class="cc-expense-modal__subtitle">
+      <span class="cc-expense-modal__swatch" :style="{ background: selectedCardColor }" />
+      {{ subtitle }}
+    </div>
+
+    <NAlert
+      v-if="createMutation.isError.value || updateMutation.isError.value"
+      type="error"
+      title="Não foi possível salvar a despesa."
+      class="cc-expense-modal__alert"
+    />
+
+    <div class="cc-expense-modal__sync-banner">
+      <UiIcon name="transactions" :size="16" />
+      <p>
+        <strong>Vinculada às Transações.</strong>
+        Esta despesa também aparece em Transações, atrelada ao {{ selectedCardName }}.
+        Qualquer alteração aqui é refletida nos dois lugares.
+      </p>
+    </div>
+
+    <NForm ref="formRef" :model="form" :rules="rules" label-placement="top">
+      <NFormItem label="Título*" path="title">
+        <NInput
+          v-model:value="form.title"
+          placeholder="Ex: Notebook Dell"
+          data-testid="cc-expense-title"
+        />
+      </NFormItem>
+
+      <div class="cc-expense-modal__row">
+        <NFormItem label="Valor*" path="amount">
+          <UiMoneyInput
+            v-model:value="form.amount"
+            placeholder="0,00"
+            :min="0.01"
+          />
+        </NFormItem>
+
+        <NFormItem label="Data*" path="dueDate">
+          <NDatePicker
+            v-model:value="form.dueDate"
+            type="date"
+            format="dd/MM/yyyy"
+            style="width: 100%"
+          />
+        </NFormItem>
+      </div>
+
+      <div class="cc-expense-modal__row">
+        <NFormItem label="Categoria" path="tagId">
+          <NSelect v-model:value="form.tagId" :options="tagOptions" clearable />
+        </NFormItem>
+
+        <NFormItem label="Status" path="status">
+          <NSelect v-model:value="form.status" :options="statusOptions" />
+        </NFormItem>
+      </div>
+
+      <NFormItem label="Conta" path="accountId">
+        <NSelect v-model:value="form.accountId" :options="accountOptions" clearable />
+      </NFormItem>
+
+      <NFormItem label="Cartão de crédito" path="creditCardId">
+        <NSelect v-model:value="form.creditCardId" :options="creditCardOptions" clearable />
+      </NFormItem>
+
+      <NFormItem label="Recorrente?" path="isRecurring">
+        <div class="cc-expense-modal__switch-row">
+          <div>
+            <strong>Repete esta despesa</strong>
+            <span>Repete esta despesa nas próximas faturas</span>
+          </div>
+          <NSwitch v-model:value="form.isRecurring" />
+        </div>
+      </NFormItem>
+
+      <NFormItem label="Observações" path="description">
+        <NInput
+          v-model:value="form.description"
+          type="textarea"
+          placeholder="Notas sobre esta despesa"
+          :rows="3"
+        />
+      </NFormItem>
+    </NForm>
+
+    <template #footer>
+      <div class="cc-expense-modal__footer">
+        <div class="cc-expense-modal__footer-left">
+          <NButton
+            v-if="props.transaction"
+            :disabled="isSubmitting"
+            data-testid="cc-expense-modal-duplicate"
+            @click="emit('duplicate', props.transaction)"
+          >
+            <template #icon><UiIcon name="copy" :size="15" /></template>
+            Duplicar
+          </NButton>
+          <NButton
+            v-if="props.transaction"
+            type="error"
+            :disabled="isSubmitting"
+            data-testid="cc-expense-modal-remove"
+            @click="emit('remove', props.transaction)"
+          >
+            <template #icon><UiIcon name="trash" :size="15" /></template>
+            Remover
+          </NButton>
+        </div>
+        <NSpace>
+          <NButton :disabled="isSubmitting" @click="close">Cancelar</NButton>
+          <NButton
+            type="primary"
+            :loading="isSubmitting"
+            data-testid="cc-expense-modal-submit"
+            @click="submit"
+          >
+            {{ primaryLabel }}
+          </NButton>
+        </NSpace>
+      </div>
+    </template>
+  </NModal>
+</template>
+
+<style scoped>
+.cc-expense-modal {
+  color: var(--color-text-primary);
+}
+.cc-expense-modal__subtitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: -8px 0 var(--space-3);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+.cc-expense-modal__swatch {
+  width: 20px;
+  height: 14px;
+  border-radius: var(--radius-xs);
+}
+.cc-expense-modal__alert {
+  margin-bottom: var(--space-2);
+}
+.cc-expense-modal__sync-banner {
+  display: flex;
+  gap: var(--space-2);
+  align-items: flex-start;
+  padding: var(--space-2);
+  margin-bottom: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--color-brand-500) 24%, white);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-brand-500) 10%, white);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}
+.cc-expense-modal__sync-banner p {
+  margin: 0;
+}
+.cc-expense-modal__sync-banner strong {
+  color: var(--color-text-primary);
+}
+.cc-expense-modal__row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+.cc-expense-modal__switch-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+.cc-expense-modal__switch-row strong,
+.cc-expense-modal__switch-row span {
+  display: block;
+}
+.cc-expense-modal__switch-row span {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+.cc-expense-modal__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+.cc-expense-modal__footer-left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+@media (max-width: 640px) {
+  .cc-expense-modal__row,
+  .cc-expense-modal__footer {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+  .cc-expense-modal__footer-left {
+    justify-content: stretch;
+  }
+}
+</style>

--- a/app/features/credit-cards/components/FaturasView.spec.ts
+++ b/app/features/credit-cards/components/FaturasView.spec.ts
@@ -1,0 +1,168 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CreditCardDto } from "../contracts/credit-card.dto";
+import type { StatementViewModel } from "../model/credit-card-statement";
+import type { EnrichedTransaction } from "../utils/transaction-billing";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import FaturasView from "./FaturasView.vue";
+
+vi.mock("~/components/ui/UiIcon/UiIcon.vue", () => ({
+  default: { props: ["name", "size"], template: "<span data-testid='ui-icon' />" },
+}));
+
+vi.mock("~/components/ui/UiSurfaceCard/UiSurfaceCard.vue", () => ({
+  default: {
+    props: ["as"],
+    template: "<component :is='as || \"div\"'><slot /></component>",
+  },
+}));
+
+vi.mock("./charts/CreditCardBillsAreaTrend.vue", () => ({
+  default: { template: "<div data-testid='trend-chart' />" },
+}));
+
+vi.mock("./charts/CreditCardCategoryHBars.vue", () => ({
+  default: { template: "<div data-testid='category-chart' />" },
+}));
+
+vi.mock("./CreditCardMonthSwitcher.vue", () => ({
+  default: {
+    props: ["monthLabel"],
+    emits: ["shift"],
+    template: "<button data-testid='month-switcher' @click='$emit(\"shift\", 1)'>{{ monthLabel }}</button>",
+  },
+}));
+
+vi.mock("./CreditCardRailItem.vue", () => ({
+  default: {
+    props: ["label"],
+    emits: ["select"],
+    template: "<button data-testid='rail-item' @click='$emit(\"select\")'>{{ label }}</button>",
+  },
+}));
+
+vi.mock("naive-ui", () => ({
+  NButton: {
+    props: ["type", "tertiary", "size"],
+    emits: ["click"],
+    template: "<button @click='$emit(\"click\", $event)'><slot name='icon' /><slot /></button>",
+  },
+}));
+
+/**
+ * Builds a credit card fixture for the statement view.
+ *
+ * @param overrides Fields to override.
+ * @returns Credit card fixture.
+ */
+const cardFixture = (overrides: Partial<CreditCardDto> = {}): CreditCardDto => ({
+  id: "cc-1",
+  name: "Cartão Inter",
+  brand: "mastercard",
+  limit_amount: 5000,
+  closing_day: 5,
+  due_day: 10,
+  bank: "Inter",
+  description: null,
+  benefits: null,
+  created_at: null,
+  updated_at: null,
+  ...overrides,
+});
+
+/**
+ * Builds an enriched transaction fixture for the invoice row.
+ *
+ * @param overrides Fields to override.
+ * @returns Enriched transaction fixture.
+ */
+const txFixture = (overrides: Partial<EnrichedTransaction> = {}): EnrichedTransaction => ({
+  transaction: { id: overrides.id ?? "tx-1" } as TransactionDto,
+  id: "tx-1",
+  title: "Notebook Dell Inspiron",
+  amount: 899.9,
+  purchaseDate: "2026-06-13",
+  tagId: "tag-eletronicos",
+  creditCardId: "cc-1",
+  billMonth: "2026-06",
+  isInstallment: true,
+  installmentCount: 10,
+  installmentGroupId: "installment-1",
+  isRecurring: false,
+  status: "pending",
+  ...overrides,
+});
+
+/**
+ * Builds the minimal statement view-model consumed by FaturasView.
+ *
+ * @param item Invoice item to expose.
+ * @returns Statement view-model fixture.
+ */
+const statementFixture = (item: EnrichedTransaction): StatementViewModel => ({
+  month: "2026-06",
+  monthLabel: "junho de 2026",
+  cardId: "cc-1",
+  total: item.amount,
+  itemCount: 1,
+  status: { label: "Aberta", tone: "open" },
+  closingDate: "2026-06-05",
+  dueDate: "2026-06-10",
+  categories: [{
+    tagId: "tag-eletronicos",
+    name: "Eletrônicos",
+    color: "#594FC2",
+    total: item.amount,
+    count: 1,
+    items: [item],
+  }],
+  items: [item],
+  monthlyTrend: [],
+  utilizationPct: null,
+  limitAmount: 5000,
+  railTotals: [{ cardId: "cc-1", name: "Cartão Inter", total: item.amount }],
+  allCardsTotal: item.amount,
+});
+
+/**
+ * Mounts the statement view with one selected card and one invoice item.
+ *
+ * @returns Mounted component wrapper.
+ */
+const mountView = (): ReturnType<typeof mount> => mount(FaturasView, {
+  props: {
+    statement: statementFixture(txFixture()),
+    cards: [cardFixture()],
+    selectedCardId: "cc-1",
+  },
+});
+
+describe("FaturasView", () => {
+  it("renames card actions to clarify they act on the card", () => {
+    const wrapper = mountView();
+
+    expect(wrapper.text()).toContain("Editar cartão");
+    expect(wrapper.text()).toContain("Remover cartão");
+  });
+
+  it("emits expense actions from the bill item title and icon buttons", async () => {
+    const wrapper = mountView();
+
+    await wrapper.get("[data-testid='cc-bill-item-title-tx-1']").trigger("click");
+    await wrapper.get("[data-testid='cc-bill-item-edit-tx-1']").trigger("click");
+    await wrapper.get("[data-testid='cc-bill-item-duplicate-tx-1']").trigger("click");
+    await wrapper.get("[data-testid='cc-bill-item-delete-tx-1']").trigger("click");
+
+    expect(wrapper.emitted("edit-expense")?.map((args) => args[0])).toEqual([
+      expect.objectContaining({ id: "tx-1" }),
+      expect.objectContaining({ id: "tx-1" }),
+    ]);
+    expect(wrapper.emitted("duplicate-expense")?.[0]?.[0]).toEqual(
+      expect.objectContaining({ id: "tx-1" }),
+    );
+    expect(wrapper.emitted("delete-expense")?.[0]?.[0]).toEqual(
+      expect.objectContaining({ id: "tx-1" }),
+    );
+  });
+});

--- a/app/features/credit-cards/components/FaturasView.vue
+++ b/app/features/credit-cards/components/FaturasView.vue
@@ -8,6 +8,7 @@ import { formatCurrency } from "~/utils/currency";
 
 import type { CreditCardDto } from "../contracts/credit-card.dto";
 import type { StatementViewModel } from "../model/credit-card-statement";
+import type { EnrichedTransaction } from "../utils/transaction-billing";
 import { resolveCardTheme } from "../utils/card-brand-theme";
 import { formatDayMonth } from "../utils/format";
 import CreditCardBillsAreaTrend from "./charts/CreditCardBillsAreaTrend.vue";
@@ -30,6 +31,9 @@ const emit = defineEmits<{
   "add-card": [];
   "edit-card": [card: CreditCardDto];
   "delete-card": [card: CreditCardDto];
+  "edit-expense": [transaction: EnrichedTransaction];
+  "duplicate-expense": [transaction: EnrichedTransaction];
+  "delete-expense": [transaction: EnrichedTransaction];
 }>();
 
 const selectedCard = computed<CreditCardDto | null>(
@@ -57,6 +61,44 @@ const hbarItems = computed(() =>
     color: category.color,
   })),
 );
+
+const categoryByItemId = computed(() => {
+  const map = new Map<string, { name: string; color: string }>();
+  for (const category of props.statement.categories) {
+    for (const item of category.items) {
+      map.set(item.id, { name: category.name, color: category.color });
+    }
+  }
+  return map;
+});
+
+/**
+ * Resolve categoria visual de um lançamento da fatura.
+ *
+ * @param item Lançamento enriquecido.
+ * @returns Nome e cor já derivados da categoria/tag.
+ */
+const categoryForItem = (item: EnrichedTransaction): { name: string; color: string } =>
+  categoryByItemId.value.get(item.id) ?? { name: "Sem categoria", color: "var(--color-text-muted)" };
+
+/**
+ * Formata a data do lançamento como DD/MM/AAAA para a lista da fatura.
+ *
+ * @param isoDate Data ISO YYYY-MM-DD.
+ * @returns Data em formato brasileiro.
+ */
+const formatFullDate = (isoDate: string): string => {
+  const [year, month, day] = isoDate.split("-");
+  return `${day ?? "--"}/${month ?? "--"}/${year ?? "----"}`;
+};
+
+/**
+ * Formata despesa com sinal negativo, preservando a tipografia monetária local.
+ *
+ * @param amount Valor positivo da despesa.
+ * @returns Valor exibido na linha.
+ */
+const formatExpenseAmount = (amount: number): string => `- ${formatCurrency(amount)}`;
 
 const trendColor = computed<string>(() => {
   if (selectedCard.value) {
@@ -119,7 +161,7 @@ const trendColor = computed<string>(() => {
             data-testid="cc-edit-card"
             @click="emit('edit-card', selectedCard)"
           >
-            Editar
+            Editar cartão
           </NButton>
           <NButton
             v-if="selectedCard && !singleCard"
@@ -129,7 +171,7 @@ const trendColor = computed<string>(() => {
             data-testid="cc-delete-card"
             @click="emit('delete-card', selectedCard)"
           >
-            Remover
+            Remover cartão
           </NButton>
           <NButton size="small" type="primary" data-testid="cc-add-expense-faturas" @click="emit('add-expense')">
             <template #icon><UiIcon name="plus" :size="14" /></template>
@@ -162,30 +204,80 @@ const trendColor = computed<string>(() => {
         <CreditCardCategoryHBars :items="hbarItems" :limit="6" />
       </section>
 
-      <section v-if="statement.categories.length" class="fat__section">
+      <section v-if="statement.items.length" class="fat__section">
         <span class="fat__section-title">Itens da fatura</span>
-        <div class="fat__groups">
-          <div v-for="group in statement.categories" :key="group.tagId ?? 'none'" class="fat__group">
-            <div class="fat__group-head">
-              <span class="fat__dot" :style="{ background: group.color }" />
-              <span class="fat__group-name">{{ group.name }}</span>
-              <span class="fat__group-line" />
-              <span class="fat__group-total">{{ formatCurrency(group.total) }}</span>
-            </div>
-            <ul class="fat__items">
-              <li v-for="item in group.items" :key="item.id" class="fat__item">
-                <span class="fat__item-title">{{ item.title }}</span>
+        <ul class="fat__items" aria-label="Lançamentos da fatura">
+          <li v-for="item in statement.items" :key="item.id" class="fat__item">
+            <span class="fat__item-date">{{ formatFullDate(item.purchaseDate) }}</span>
+            <span class="fat__item-main">
+              <span class="fat__item-topline">
+                <button
+                  type="button"
+                  class="fat__item-title"
+                  :data-testid="`cc-bill-item-title-${item.id}`"
+                  @click="emit('edit-expense', item)"
+                >
+                  {{ item.title }}
+                </button>
+                <span
+                  class="fat__category-chip"
+                  :style="{ color: categoryForItem(item).color }"
+                >
+                  {{ categoryForItem(item).name }}
+                </span>
                 <span
                   v-if="item.isInstallment && item.installmentCount"
                   class="fat__badge"
-                >{{ item.installmentCount }}x</span>
-                <span class="fat__item-spacer" />
-                <span class="fat__item-date">{{ formatDayMonth(item.purchaseDate) }}</span>
-                <span class="fat__item-amount">{{ formatCurrency(item.amount) }}</span>
-              </li>
-            </ul>
-          </div>
-        </div>
+                >
+                  {{ item.installmentCount }}x
+                </span>
+                <span v-if="item.isRecurring" class="fat__recurring">
+                  Recorrente
+                </span>
+              </span>
+              <button
+                type="button"
+                class="fat__sync"
+                @click="emit('edit-expense', item)"
+              >
+                <UiIcon name="transactions" :size="12" /> Também em Transações
+              </button>
+            </span>
+            <span class="fat__item-amount">{{ formatExpenseAmount(item.amount) }}</span>
+            <span class="fat__item-actions" aria-label="Ações do lançamento">
+              <button
+                type="button"
+                class="fat__icon-button"
+                :data-testid="`cc-bill-item-edit-${item.id}`"
+                aria-label="Editar despesa"
+                title="Editar despesa"
+                @click="emit('edit-expense', item)"
+              >
+                <UiIcon name="edit" :size="15" />
+              </button>
+              <button
+                type="button"
+                class="fat__icon-button"
+                :data-testid="`cc-bill-item-duplicate-${item.id}`"
+                aria-label="Duplicar despesa"
+                title="Duplicar despesa"
+                @click="emit('duplicate-expense', item)"
+              >
+                <UiIcon name="copy" :size="15" />
+              </button>
+              <button
+                type="button"
+                class="fat__icon-button fat__icon-button--danger"
+                :data-testid="`cc-bill-item-delete-${item.id}`"
+                aria-label="Remover despesa"
+                title="Remover despesa"
+                @click="emit('delete-expense', item)"
+              >
+                <UiIcon name="trash" :size="15" />
+              </button>
+            </span>
+          </li>
+        </ul>
       </section>
 
       <p v-else class="fat__empty">Nenhum lançamento nesta fatura.</p>
@@ -311,8 +403,8 @@ const trendColor = computed<string>(() => {
   color: var(--color-brand-500);
 }
 .fat__status--closed {
-  background: rgba(22, 163, 74, 0.14);
-  color: #16a34a;
+  background: var(--color-positive-bg);
+  color: var(--color-positive);
 }
 .fat__meta {
   font-size: var(--font-size-sm);
@@ -330,38 +422,6 @@ const trendColor = computed<string>(() => {
   font-weight: var(--font-weight-bold);
   color: var(--color-text-primary);
 }
-.fat__groups {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-}
-.fat__group-head {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  margin-bottom: 4px;
-}
-.fat__dot {
-  width: 9px;
-  height: 9px;
-  border-radius: var(--radius-xs);
-  flex-shrink: 0;
-}
-.fat__group-name {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-}
-.fat__group-line {
-  flex: 1;
-  border-bottom: 1px dashed var(--color-outline-soft);
-}
-.fat__group-total {
-  font-family: var(--font-mono);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-text-primary);
-}
 .fat__items {
   display: flex;
   flex-direction: column;
@@ -373,32 +433,130 @@ const trendColor = computed<string>(() => {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: 7px 4px;
+  padding: 15px 6px;
+  border-bottom: 1px solid var(--color-outline-soft);
+}
+.fat__item:last-child {
+  border-bottom: 0;
 }
 .fat__item-title {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-body);
   font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-primary);
+  transition: color 0.15s ease, text-decoration-color 0.15s ease;
 }
-.fat__badge {
-  padding: 1px 7px;
+.fat__item-title:hover,
+.fat__item-title:focus-visible {
+  color: var(--color-brand-500);
+  text-decoration: underline;
+  outline: none;
+}
+.fat__item-main {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.fat__item-topline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.fat__category-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
   border-radius: var(--radius-full);
   background: var(--color-bg-elevated);
   font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+}
+.fat__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: var(--radius-full);
+  background: var(--color-bg-elevated);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-muted);
 }
-.fat__item-spacer {
-  flex: 1;
-}
 .fat__item-date {
+  width: 82px;
+  flex: none;
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 .fat__item-amount {
+  min-width: 126px;
+  text-align: right;
   font-family: var(--font-mono);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
+  color: var(--color-negative);
+  white-space: nowrap;
+}
+.fat__sync {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  align-self: flex-start;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--color-brand-500);
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+}
+.fat__sync:hover,
+.fat__sync:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+.fat__recurring {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+.fat__item-actions {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.fat__icon-button {
+  width: 34px;
+  height: 34px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid var(--color-outline-soft);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-surface);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+.fat__icon-button:hover,
+.fat__icon-button:focus-visible {
+  border-color: var(--color-brand-500);
+  background: var(--color-bg-elevated);
+  color: var(--color-brand-500);
+  outline: none;
+}
+.fat__icon-button--danger:hover,
+.fat__icon-button--danger:focus-visible {
+  border-color: var(--color-negative);
+  background: var(--color-negative-bg);
+  color: var(--color-negative);
 }
 .fat__empty {
   margin: 0;
@@ -409,6 +567,16 @@ const trendColor = computed<string>(() => {
 @media (max-width: 980px) {
   .fat {
     grid-template-columns: 1fr;
+  }
+  .fat__item {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+  .fat__item-date {
+    width: auto;
+  }
+  .fat__item-amount {
+    margin-left: auto;
   }
 }
 </style>

--- a/app/features/credit-cards/components/cc-story-fixtures.ts
+++ b/app/features/credit-cards/components/cc-story-fixtures.ts
@@ -1,5 +1,6 @@
 import type { CreditCardDto } from "../contracts/credit-card.dto";
 import type { TagDto } from "~/features/tags/contracts/tag.dto";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
 import type { EnrichedTransaction } from "../utils/transaction-billing";
 
 /** Cartões fictícios para stories. */
@@ -28,8 +29,10 @@ let sequence = 0;
  */
 const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => {
   sequence += 1;
+  const id = `tx-${sequence}`;
   return {
-    id: `tx-${sequence}`,
+    transaction: { id } as TransactionDto,
+    id,
     title: "Compra",
     amount: 100,
     purchaseDate: "2026-06-12",
@@ -39,6 +42,7 @@ const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => {
     isInstallment: false,
     installmentCount: null,
     installmentGroupId: null,
+    isRecurring: false,
     status: "pending",
     ...partial,
   };

--- a/app/features/credit-cards/model/credit-card-aggregation.spec.ts
+++ b/app/features/credit-cards/model/credit-card-aggregation.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { TagDto } from "~/features/tags/contracts/tag.dto";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
 
 import type { CreditCardDto } from "../contracts/credit-card.dto";
 import type { EnrichedTransaction } from "../utils/transaction-billing";
@@ -23,6 +24,7 @@ import {
  * @returns Complete EnrichedTransaction.
  */
 const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => ({
+  transaction: { id: partial.id ?? "tx-1" } as TransactionDto,
   id: "tx-1",
   title: "Compra",
   amount: 100,
@@ -33,6 +35,7 @@ const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => ({
   isInstallment: false,
   installmentCount: null,
   installmentGroupId: null,
+  isRecurring: false,
   status: "pending",
   ...partial,
 });

--- a/app/features/credit-cards/model/credit-card-analytics.spec.ts
+++ b/app/features/credit-cards/model/credit-card-analytics.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { TagDto } from "~/features/tags/contracts/tag.dto";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
 
 import type { CreditCardDto, CreditCardUtilization } from "../contracts/credit-card.dto";
 import type { EnrichedTransaction } from "../utils/transaction-billing";
@@ -13,6 +14,7 @@ import { buildAnalytics } from "./credit-card-analytics";
  * @returns Complete EnrichedTransaction.
  */
 const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => ({
+  transaction: { id: partial.id ?? "tx-1" } as TransactionDto,
   id: "tx-1",
   title: "Compra",
   amount: 100,
@@ -23,6 +25,7 @@ const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => ({
   isInstallment: false,
   installmentCount: null,
   installmentGroupId: null,
+  isRecurring: false,
   status: "pending",
   ...partial,
 });

--- a/app/features/credit-cards/model/credit-card-statement.spec.ts
+++ b/app/features/credit-cards/model/credit-card-statement.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { TagDto } from "~/features/tags/contracts/tag.dto";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
 
 import type { CreditCardBill, CreditCardDto, CreditCardUtilization } from "../contracts/credit-card.dto";
 import type { EnrichedTransaction } from "../utils/transaction-billing";
@@ -13,6 +14,7 @@ import { buildStatement } from "./credit-card-statement";
  * @returns Complete EnrichedTransaction.
  */
 const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => ({
+  transaction: { id: partial.id ?? "tx-1" } as TransactionDto,
   id: "tx-1",
   title: "Compra",
   amount: 100,
@@ -23,6 +25,7 @@ const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => ({
   isInstallment: false,
   installmentCount: null,
   installmentGroupId: null,
+  isRecurring: false,
   status: "pending",
   ...partial,
 });
@@ -46,9 +49,9 @@ const CARDS: CreditCardDto[] = [
 ];
 
 const TXS: EnrichedTransaction[] = [
-  etx({ id: "a", creditCardId: "cc-1", billMonth: "2026-06", tagId: "t-food", amount: 100 }),
-  etx({ id: "b", creditCardId: "cc-2", billMonth: "2026-06", tagId: "t-transport", amount: 50 }),
-  etx({ id: "c", creditCardId: "cc-1", billMonth: "2026-05", tagId: "t-food", amount: 30 }),
+  etx({ id: "a", creditCardId: "cc-1", billMonth: "2026-06", tagId: "t-food", amount: 100, purchaseDate: "2026-06-02" }),
+  etx({ id: "b", creditCardId: "cc-2", billMonth: "2026-06", tagId: "t-transport", amount: 50, purchaseDate: "2026-06-12" }),
+  etx({ id: "c", creditCardId: "cc-1", billMonth: "2026-05", tagId: "t-food", amount: 30, purchaseDate: "2026-05-20" }),
 ];
 
 describe("buildStatement — consolidated (all cards)", () => {
@@ -69,6 +72,10 @@ describe("buildStatement — consolidated (all cards)", () => {
       ["Alimentação", 100],
       ["Transporte", 50],
     ]);
+  });
+
+  it("exposes bill items sorted by purchase date descending", () => {
+    expect(vm.items.map((item) => item.id)).toEqual(["b", "a"]);
   });
 
   it("builds a 6-month trend marking the current month", () => {
@@ -116,9 +123,9 @@ describe("buildStatement — single card with official bill", () => {
     transactions: TXS, tags: TAGS, cards: CARDS, month: "2026-06", cardId: "cc-1", bill, utilization,
   });
 
-  it("prefers the official bill total and item count", () => {
-    expect(vm.total).toBe(999);
-    expect(vm.itemCount).toBe(2);
+  it("derives total and item count from synchronized transaction items", () => {
+    expect(vm.total).toBe(100);
+    expect(vm.itemCount).toBe(1);
   });
 
   it("uses the official cycle status and due date", () => {

--- a/app/features/credit-cards/model/credit-card-statement.ts
+++ b/app/features/credit-cards/model/credit-card-statement.ts
@@ -46,6 +46,8 @@ export interface StatementViewModel {
   readonly status: BillStatusVM | null;
   readonly closingDate: string | null;
   readonly dueDate: string | null;
+  /** Lançamentos da fatura no mês, ordenados para leitura operacional. */
+  readonly items: readonly EnrichedTransaction[];
   readonly categories: readonly CategoryGroup[];
   readonly monthlyTrend: readonly MonthlyTrendPoint[];
   readonly utilizationPct: number | null;
@@ -203,10 +205,29 @@ const resolveStatementUtilization = (
 };
 
 /**
+ * Ordena lançamentos da fatura do mais recente para o mais antigo, mantendo uma
+ * ordem estável por título quando datas empatam.
+ *
+ * @param transactions Transações já filtradas para o mês/escopo.
+ * @returns Nova lista ordenada para renderização.
+ */
+const sortStatementItems = (
+  transactions: readonly EnrichedTransaction[],
+): EnrichedTransaction[] =>
+  [...transactions].sort((a, b) => {
+    const dateOrder = b.purchaseDate.localeCompare(a.purchaseDate);
+    if (dateOrder !== 0) {
+      return dateOrder;
+    }
+    return a.title.localeCompare(b.title, "pt-BR");
+  });
+
+/**
  * Monta o view-model da visão Faturas a partir dos dados já carregados.
  *
- * Para cartão único usa os números oficiais da fatura/utilização do backend;
- * para o consolidado ("Todos") agrega as transações da janela.
+ * Totais, contagem e linhas são sempre derivados das transações sincronizadas.
+ * Para cartão único ainda reaproveita ciclo/status/utilização oficiais quando
+ * disponíveis; para o consolidado ("Todos") agrega as transações da janela.
  *
  * @param params Dados e seleção atuais.
  * @returns View-model da visão Faturas.
@@ -216,6 +237,7 @@ export const buildStatement = (params: StatementParams): StatementViewModel => {
   const scoped = filterByCard(params.transactions, params.cardId);
   const monthTxs = filterByBillMonth(scoped, params.month);
   const aggregatedTotal = sumAmount(monthTxs);
+  const statementItems = sortStatementItems(monthTxs);
 
   const isSingleCard = params.cardId !== null;
   const card = isSingleCard
@@ -238,11 +260,12 @@ export const buildStatement = (params: StatementParams): StatementViewModel => {
     month: params.month,
     monthLabel: monthKeyLabel(params.month),
     cardId: params.cardId,
-    total: bill ? bill.totalAmount : aggregatedTotal,
-    itemCount: bill ? bill.transactions.length : monthTxs.length,
+    total: aggregatedTotal,
+    itemCount: statementItems.length,
     status: cycle.status,
     closingDate: cycle.closingDate,
     dueDate: cycle.dueDate,
+    items: statementItems,
     categories: groupByCategory(monthTxs, params.tags),
     monthlyTrend,
     utilizationPct: resolveStatementUtilization(params, limitAmount, aggregatedTotal),

--- a/app/features/credit-cards/utils/transaction-billing.spec.ts
+++ b/app/features/credit-cards/utils/transaction-billing.spec.ts
@@ -80,6 +80,14 @@ describe("enrichCardTransactions", () => {
     expect(enriched?.amount).toBe(1234.56);
   });
 
+  it("preserves the source transaction and recurrence flag for shared card actions", () => {
+    const source = tx({ id: "tx-rec", is_recurring: true, description: "Mensal" });
+    const [enriched] = enrichCardTransactions([source], MOCK_CREDIT_CARDS);
+
+    expect(enriched?.transaction).toBe(source);
+    expect(enriched?.isRecurring).toBe(true);
+  });
+
   it("keeps the transaction but leaves billMonth null for an unknown card", () => {
     const [enriched] = enrichCardTransactions(
       [tx({ credit_card_id: "cc-unknown" })],

--- a/app/features/credit-cards/utils/transaction-billing.ts
+++ b/app/features/credit-cards/utils/transaction-billing.ts
@@ -20,6 +20,8 @@ const MONTH_ABBR_PT = [
  * coagido para number. Forma de domínio consumida pelas agregações e views.
  */
 export interface EnrichedTransaction {
+  /** Registro canônico de Transações usado para editar/duplicar/remover. */
+  readonly transaction: TransactionDto;
   readonly id: string;
   readonly title: string;
   readonly amount: number;
@@ -32,6 +34,7 @@ export interface EnrichedTransaction {
   readonly isInstallment: boolean;
   readonly installmentCount: number | null;
   readonly installmentGroupId: string | null;
+  readonly isRecurring: boolean;
   readonly status: string;
 }
 
@@ -78,6 +81,7 @@ export const enrichCardTransactions = (
       }
 
       return {
+        transaction: tx,
         id: tx.id,
         title: tx.title,
         amount: toAmount(tx.amount),
@@ -88,6 +92,7 @@ export const enrichCardTransactions = (
         isInstallment: tx.is_installment,
         installmentCount: tx.installment_count,
         installmentGroupId: tx.installment_group_id,
+        isRecurring: tx.is_recurring,
         status: tx.status,
       };
     });

--- a/app/pages/credit-cards/[id].spec.ts
+++ b/app/pages/credit-cards/[id].spec.ts
@@ -5,7 +5,7 @@ import type { App } from "vue";
 import type { CreditCardDto } from "~/features/credit-cards/contracts/credit-card.dto";
 import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
 
-import CreditCardsPage from "./index.vue";
+import CreditCardDetailPage from "./[id].vue";
 
 const navigateToMock = vi.hoisted(() => vi.fn());
 const queryClientHarness = vi.hoisted(() => ({ invalidateQueries: vi.fn() }));
@@ -13,17 +13,12 @@ const creditCardsHarness = vi.hoisted(() => ({
   data: { __v_isRef: true, value: [] as CreditCardDto[] },
   isLoading: { __v_isRef: true, value: false },
 }));
-const deleteMutationHarness = vi.hoisted(() => ({
-  isPending: { __v_isRef: true, value: false },
-  mutateAsync: vi.fn(),
-}));
-const createMutationHarness = vi.hoisted(() => ({
-  isPending: { __v_isRef: true, value: false },
-  mutateAsync: vi.fn(),
-}));
-const updateMutationHarness = vi.hoisted(() => ({
-  isPending: { __v_isRef: true, value: false },
-  mutateAsync: vi.fn(),
+const viewStateHarness = vi.hoisted(() => ({
+  view: { __v_isRef: true, value: "faturas" as const },
+  month: { __v_isRef: true, value: "2026-06" },
+  monthLabel: { __v_isRef: true, value: "junho de 2026" },
+  setView: vi.fn(),
+  shiftMonth: vi.fn(),
 }));
 const createTransactionMutationHarness = vi.hoisted(() => ({
   isPending: { __v_isRef: true, value: false },
@@ -44,16 +39,22 @@ vi.mock("#imports", () => ({
   definePageMeta: vi.fn(),
   navigateTo: navigateToMock,
   useHead: vi.fn(),
+  useRoute: (): { params: { id: string } } => ({ params: { id: "cc-1" } }),
 }));
 
 vi.mock("#app", () => ({
   definePageMeta: vi.fn(),
   navigateTo: navigateToMock,
   useHead: vi.fn(),
+  useRoute: (): { params: { id: string } } => ({ params: { id: "cc-1" } }),
 }));
 
 vi.mock("#app/composables/head", () => ({ useHead: vi.fn() }));
 vi.mock("#app/composables/pages", () => ({ definePageMeta: vi.fn() }));
+vi.mock("#app/composables/router", () => ({
+  useRoute: (): { params: { id: string } } => ({ params: { id: "cc-1" } }),
+  navigateTo: navigateToMock,
+}));
 
 vi.mock("vue-i18n", () => ({
   useI18n: (): { t: (key: string) => string } => ({ t: (key: string): string => key }),
@@ -66,14 +67,18 @@ vi.mock("@tanstack/vue-query", () => ({
 vi.mock("~/features/credit-cards/queries/use-credit-cards-query", () => ({
   useCreditCardsQuery: (): typeof creditCardsHarness => creditCardsHarness,
 }));
-vi.mock("~/features/credit-cards/queries/use-create-credit-card-mutation", () => ({
-  useCreateCreditCardMutation: (): typeof createMutationHarness => createMutationHarness,
+vi.mock("~/features/credit-cards/composables/useCreditCardsViewState", () => ({
+  useCreditCardsViewState: (): typeof viewStateHarness => viewStateHarness,
 }));
-vi.mock("~/features/credit-cards/queries/use-update-credit-card-mutation", () => ({
-  useUpdateCreditCardMutation: (): typeof updateMutationHarness => updateMutationHarness,
+vi.mock("~/features/credit-cards/composables/useCreditCardsStatement", () => ({
+  useCreditCardsStatement: (): { statement: { value: unknown } } => ({
+    statement: { value: { categories: [], monthlyTrend: [], railTotals: [], allCardsTotal: 0 } },
+  }),
 }));
-vi.mock("~/features/credit-cards/queries/use-delete-credit-card-mutation", () => ({
-  useDeleteCreditCardMutation: (): typeof deleteMutationHarness => deleteMutationHarness,
+vi.mock("~/features/credit-cards/composables/useCreditCardsAnalytics", () => ({
+  useCreditCardsAnalytics: (): { analytics: { value: unknown } } => ({
+    analytics: { value: { categories: [], cardTotals: [], topRows: [], monthlySeries: { months: [], series: [] }, kpis: {} } },
+  }),
 }));
 vi.mock("~/features/transactions/queries/use-create-transaction-mutation", () => ({
   useCreateTransactionMutation: (): typeof createTransactionMutationHarness => createTransactionMutationHarness,
@@ -85,33 +90,10 @@ vi.mock("~/composables/useToast", () => ({
   useToast: (): typeof toastHarness => toastHarness,
 }));
 
-// Composables de dados — mockados (lógica testada nos models). Retornam objetos
-// "ref-like" que a página apenas repassa às views mockadas.
-vi.mock("~/features/credit-cards/composables/useCreditCardsStatement", () => ({
-  useCreditCardsStatement: (): { statement: { value: unknown } } => ({
-    statement: { value: { categories: [], monthlyTrend: [], railTotals: [], allCardsTotal: 0 } },
-  }),
-}));
-vi.mock("~/features/credit-cards/composables/useCreditCardsAnalytics", () => ({
-  useCreditCardsAnalytics: (): { analytics: { value: unknown } } => ({
-    analytics: { value: { categories: [], cardTotals: [], topRows: [], monthlySeries: { months: [], series: [] }, kpis: {} } },
-  }),
-}));
-
 vi.mock("~/features/credit-cards/components/FaturasView.vue", () => ({
   default: {
-    props: ["statement", "cards", "selectedCardId"],
-    emits: [
-      "select-card",
-      "shift-month",
-      "add-expense",
-      "add-card",
-      "edit-card",
-      "delete-card",
-      "edit-expense",
-      "duplicate-expense",
-      "delete-expense",
-    ],
+    props: ["statement", "cards", "selectedCardId", "singleCard"],
+    emits: ["shift-month", "add-expense", "edit-expense", "duplicate-expense", "delete-expense"],
     data(): { invoiceItem: { creditCardId: string; transaction: Partial<TransactionDto> } } {
       return {
         invoiceItem: {
@@ -136,11 +118,7 @@ vi.mock("~/features/credit-cards/components/FaturasView.vue", () => ({
     },
     template: `
       <section data-testid="faturas-view">
-        <button data-testid="fv-select-cc-2" @click="$emit('select-card', 'cc-2')">select</button>
         <button data-testid="fv-add-expense" @click="$emit('add-expense')">expense</button>
-        <button data-testid="fv-add-card" @click="$emit('add-card')">add</button>
-        <button data-testid="fv-edit" @click="$emit('edit-card', { id: 'cc-1', name: 'Cartao Inter' })">edit</button>
-        <button data-testid="fv-delete" @click="$emit('delete-card', { id: 'cc-1', name: 'Cartao Inter' })">del</button>
         <button data-testid="fv-edit-expense" @click="$emit('edit-expense', invoiceItem)">edit expense</button>
         <button data-testid="fv-duplicate-expense" @click="$emit('duplicate-expense', invoiceItem)">duplicate expense</button>
         <button data-testid="fv-delete-expense" @click="$emit('delete-expense', invoiceItem)">delete expense</button>
@@ -151,17 +129,39 @@ vi.mock("~/features/credit-cards/components/FaturasView.vue", () => ({
 
 vi.mock("~/features/credit-cards/components/AnaliticoView.vue", () => ({
   default: {
-    props: ["analytics", "cards", "selectedCardId", "monthLabel"],
-    emits: ["select-card", "shift-month"],
+    props: ["analytics", "cards", "selectedCardId", "monthLabel", "singleCard"],
+    emits: ["shift-month"],
     template: "<section data-testid='analitico-view' />",
   },
 }));
-
-vi.mock("~/features/credit-cards/components/CreditCardForm.vue", () => ({
-  default: { template: "<form data-testid='credit-card-form' />" },
+vi.mock("~/features/credit-cards/components/CreditCardExpenseSheet.vue", () => ({
+  default: {
+    props: ["visible", "presetCreditCardId"],
+    emits: ["update:visible", "success"],
+    template: `
+      <section v-if="visible" data-testid="credit-card-expense-drawer" :data-card-id="presetCreditCardId ?? ''">
+        <button data-testid="drawer-success" @click="$emit('success')">success</button>
+      </section>
+    `,
+  },
 }));
-vi.mock("~/features/ai-insights/components/AiInsightSurface.vue", () => ({
-  default: { template: "<aside data-testid='ai-insight' />" },
+vi.mock("~/features/credit-cards/components/CreditCardExpenseModal.vue", () => ({
+  default: {
+    props: ["visible", "transaction", "presetCreditCardId"],
+    emits: ["update:visible", "saved", "duplicate", "remove"],
+    template: `
+      <section
+        v-if="visible"
+        data-testid="credit-card-expense-modal"
+        :data-card-id="presetCreditCardId ?? ''"
+        :data-transaction-id="transaction?.id ?? ''"
+      >
+        <button data-testid="expense-modal-saved-updated" @click="$emit('saved', 'updated')">updated</button>
+        <button v-if="transaction" data-testid="expense-modal-duplicate" @click="$emit('duplicate', transaction)">duplicate</button>
+        <button v-if="transaction" data-testid="expense-modal-remove" @click="$emit('remove', transaction)">remove</button>
+      </section>
+    `,
+  },
 }));
 vi.mock("~/components/ui/UiIcon/UiIcon.vue", () => ({
   default: { props: ["name", "size"], template: "<i />" },
@@ -174,46 +174,13 @@ vi.mock("~/components/ui/UiSegmentedControl/UiSegmentedControl.vue", () => ({
   },
 }));
 
-vi.mock("~/features/credit-cards/components/CreditCardExpenseSheet.vue", () => ({
-  default: {
-    props: ["visible", "presetCreditCardId"],
-    emits: ["update:visible", "success"],
-    template: `
-      <section v-if="visible" data-testid="credit-card-expense-drawer" :data-card-id="presetCreditCardId ?? ''">
-        <button data-testid="drawer-success" @click="$emit('success')">success</button>
-      </section>
-    `,
-  },
-}));
-
-vi.mock("~/features/credit-cards/components/CreditCardExpenseModal.vue", () => ({
-  default: {
-    props: ["visible", "transaction", "presetCreditCardId"],
-    emits: ["update:visible", "saved", "duplicate", "remove"],
-    template: `
-      <section
-        v-if="visible"
-        data-testid="credit-card-expense-modal"
-        :data-card-id="presetCreditCardId ?? ''"
-        :data-transaction-id="transaction?.id ?? ''"
-      >
-        <button data-testid="expense-modal-saved-created" @click="$emit('saved', 'created')">created</button>
-        <button data-testid="expense-modal-saved-updated" @click="$emit('saved', 'updated')">updated</button>
-        <button v-if="transaction" data-testid="expense-modal-duplicate" @click="$emit('duplicate', transaction)">duplicate</button>
-        <button v-if="transaction" data-testid="expense-modal-remove" @click="$emit('remove', transaction)">remove</button>
-      </section>
-    `,
-  },
-}));
-
 vi.mock("naive-ui", () => ({
   NButton: {
-    props: ["disabled", "loading", "type"],
+    props: ["disabled", "loading", "type", "text"],
     emits: ["click"],
     template: "<button :disabled='disabled || loading' @click='$emit(\"click\", $event)'><slot /></button>",
   },
-  NButtonGroup: { template: "<div><slot /></div>" },
-  NEmpty: { props: ["description"], template: "<div data-testid='empty'>{{ description }}<slot name='extra' /></div>" },
+  NEmpty: { props: ["description"], template: "<div data-testid='empty'>{{ description }}</div>" },
   NModal: {
     props: ["show", "title"],
     emits: ["update:show", "close"],
@@ -229,7 +196,7 @@ vi.mock("naive-ui", () => ({
 }));
 
 /**
- * Builds a credit card fixture.
+ * Builds a credit card fixture for the route card.
  *
  * @param overrides Fields to override.
  * @returns Credit card fixture.
@@ -250,13 +217,13 @@ const cardFixture = (overrides: Partial<CreditCardDto> = {}): CreditCardDto => (
 });
 
 /**
- * Installs the minimal Nuxt app context for page-level auto-imports.
+ * Installs the minimal Nuxt app context used by page tests.
  *
  * @param app Vue test app instance.
  */
 function nuxtContextPlugin(app: App): void {
   Reflect.set(app, "$nuxt", {
-    _route: { path: "/credit-cards", meta: {}, params: {}, query: {} },
+    _route: { path: "/credit-cards/cc-1", meta: {}, params: { id: "cc-1" }, query: {} },
     $config: { public: {} },
     payload: { serverRendered: false },
     ssrContext: { head: { push: vi.fn(() => ({ patch: vi.fn(), dispose: vi.fn() })) } },
@@ -271,21 +238,19 @@ function nuxtContextPlugin(app: App): void {
 }
 
 /**
- * Mounts the credit cards page with the mocked Nuxt context.
+ * Mounts the credit card detail page with the mocked Nuxt context.
  *
  * @returns Mounted page wrapper.
  */
 const mountPage = (): ReturnType<typeof mount> =>
-  mount(CreditCardsPage, { global: { plugins: [{ install: nuxtContextPlugin }] } });
+  mount(CreditCardDetailPage, { global: { plugins: [{ install: nuxtContextPlugin }] } });
 
-describe("CreditCardsPage", () => {
+describe("CreditCardDetailPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    creditCardsHarness.data.value = [cardFixture(), cardFixture({ id: "cc-2", name: "Cartao Azul", bank: "Itau" })];
+    creditCardsHarness.data.value = [cardFixture()];
     creditCardsHarness.isLoading.value = false;
-    deleteMutationHarness.isPending.value = false;
-    deleteMutationHarness.mutateAsync.mockResolvedValue(undefined);
-    createTransactionMutationHarness.isPending.value = false;
+    viewStateHarness.view.value = "faturas";
     createTransactionMutationHarness.mutate.mockImplementation(
       (_payload: unknown, options?: { onSuccess?: () => void }) => options?.onSuccess?.(),
     );
@@ -295,45 +260,14 @@ describe("CreditCardsPage", () => {
     );
   });
 
-  it("renders the view selector and the Faturas view by default", () => {
-    const wrapper = mountPage();
-    expect(wrapper.find("[data-testid='view-seg']").exists()).toBe(true);
-    expect(wrapper.find("[data-testid='faturas-view']").exists()).toBe(true);
-  });
-
-  it("opens the delete confirmation from the Faturas view without mutating", async () => {
-    const wrapper = mountPage();
-    await wrapper.get("[data-testid='fv-delete']").trigger("click");
-
-    expect(deleteMutationHarness.mutateAsync).not.toHaveBeenCalled();
-    expect(wrapper.get("[data-testid='delete-modal']").text()).toContain("Remover cartão?");
-    expect(wrapper.get("[data-testid='delete-modal']").text()).toContain("Cartao Inter");
-  });
-
-  it("confirms removal calling the mutation with the card id", async () => {
-    const wrapper = mountPage();
-    await wrapper.get("[data-testid='fv-delete']").trigger("click");
-    await wrapper.get("[data-testid='cc-delete-confirm']").trigger("click");
-    await flushPromises();
-
-    expect(deleteMutationHarness.mutateAsync).toHaveBeenCalledWith("cc-1");
-  });
-
-  it("opens the expense modal preset with the selected card and invalidates on create", async () => {
+  it("opens the expense modal in new mode with the route card preselected", async () => {
     const wrapper = mountPage();
 
-    await wrapper.get("[data-testid='fv-select-cc-2']").trigger("click");
-    await wrapper.get("[data-testid='cc-add-expense']").trigger("click");
+    await wrapper.get("[data-testid='cc-detail-add-expense']").trigger("click");
 
     const modal = wrapper.get("[data-testid='credit-card-expense-modal']");
-    expect(modal.attributes("data-card-id")).toBe("cc-2");
+    expect(modal.attributes("data-card-id")).toBe("cc-1");
     expect(modal.attributes("data-transaction-id")).toBe("");
-
-    await wrapper.get("[data-testid='expense-modal-saved-created']").trigger("click");
-    expect(queryClientHarness.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["credit-cards"] });
-    expect(queryClientHarness.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["transactions"] });
-    expect(queryClientHarness.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["dashboard"] });
-    expect(toastHarness.success).toHaveBeenCalledWith("Despesa lançada e sincronizada com Transações");
   });
 
   it("opens the expense modal from an invoice row using the source transaction", async () => {
@@ -374,7 +308,6 @@ describe("CreditCardsPage", () => {
 
     expect(deleteTransactionMutationHarness.mutate).not.toHaveBeenCalled();
     expect(wrapper.get("[data-testid='delete-modal']").text()).toContain("Remover despesa?");
-    expect(wrapper.get("[data-testid='delete-modal']").text()).toContain("Notebook Dell Inspiron");
     expect(wrapper.get("[data-testid='delete-modal']").text()).toContain("desta fatura e das Transações");
 
     await wrapper.get("[data-testid='cc-expense-delete-confirm']").trigger("click");

--- a/app/pages/credit-cards/[id].vue
+++ b/app/pages/credit-cards/[id].vue
@@ -2,21 +2,27 @@
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useQueryClient } from "@tanstack/vue-query";
-import { NButton, NEmpty, NSpin } from "naive-ui";
+import { NButton, NEmpty, NModal, NSpin } from "naive-ui";
 
 import UiIcon from "~/components/ui/UiIcon/UiIcon.vue";
 import UiSegmentedControl from "~/components/ui/UiSegmentedControl/UiSegmentedControl.vue";
 import type { CreditCardDto } from "~/features/credit-cards/contracts/credit-card.dto";
 import { useCreditCardsQuery } from "~/features/credit-cards/queries/use-credit-cards-query";
+import { useCreateTransactionMutation } from "~/features/transactions/queries/use-create-transaction-mutation";
+import { useDeleteTransactionMutation } from "~/features/transactions/queries/use-delete-transaction-mutation";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import { buildDuplicatePayload } from "~/features/transactions/composables/useTransactionActions";
 import {
   type CreditCardsView,
   useCreditCardsViewState,
 } from "~/features/credit-cards/composables/useCreditCardsViewState";
 import { useCreditCardsStatement } from "~/features/credit-cards/composables/useCreditCardsStatement";
 import { useCreditCardsAnalytics } from "~/features/credit-cards/composables/useCreditCardsAnalytics";
+import type { EnrichedTransaction } from "~/features/credit-cards/utils/transaction-billing";
 import FaturasView from "~/features/credit-cards/components/FaturasView.vue";
 import AnaliticoView from "~/features/credit-cards/components/AnaliticoView.vue";
-import CreditCardExpenseSheet from "~/features/credit-cards/components/CreditCardExpenseSheet.vue";
+import CreditCardExpenseModal from "~/features/credit-cards/components/CreditCardExpenseModal.vue";
+import { useToast } from "~/composables/useToast";
 
 definePageMeta({ middleware: ["authenticated", "coming-soon"] });
 
@@ -25,10 +31,13 @@ useHead({ title: "Cartão | Auraxis" });
 const { t } = useI18n();
 const route = useRoute();
 const queryClient = useQueryClient();
+const toast = useToast();
 
 const cardId = computed<string>(() => String(route.params.id ?? ""));
 
 const { data: creditCards, isLoading: cardsLoading } = useCreditCardsQuery();
+const duplicateTransactionMutation = useCreateTransactionMutation();
+const deleteTransactionMutation = useDeleteTransactionMutation();
 const card = computed<CreditCardDto | null>(
   () => (creditCards.value ?? []).find((entry) => entry.id === cardId.value) ?? null,
 );
@@ -46,13 +55,110 @@ const viewOptions: { value: CreditCardsView; label: string }[] = [
   { value: "analitico", label: "Analítico" },
 ];
 
-const showExpenseForm = ref(false);
+const expenseModalVisible = ref(false);
+const expenseModalTransaction = ref<TransactionDto | null>(null);
+const expenseDeleteTarget = ref<TransactionDto | null>(null);
 
-/** Refresca fatura/utilização do cartão após lançar uma despesa. */
-const onExpenseCreated = (): void => {
+type ExpenseActionTarget = EnrichedTransaction | TransactionDto;
+
+/**
+ * Normaliza um alvo de ação vindo da fatura ou do modal para a transação canônica.
+ *
+ * @param target Item enriquecido da fatura ou DTO de transação.
+ * @returns Transação fonte.
+ */
+const transactionFromExpenseTarget = (target: ExpenseActionTarget): TransactionDto =>
+  "transaction" in target ? target.transaction : target;
+
+/** Abre o modal de nova despesa com o cartão da rota pré-selecionado. */
+const openExpense = (): void => {
+  expenseModalTransaction.value = null;
+  expenseModalVisible.value = true;
+};
+
+/**
+ * Abre o modal de detalhes/edição de um lançamento da fatura.
+ *
+ * @param item Lançamento enriquecido com a transação fonte.
+ */
+const openExpenseEdit = (item: EnrichedTransaction): void => {
+  expenseModalTransaction.value = item.transaction;
+  expenseModalVisible.value = true;
+};
+
+/** Refresca fatura/utilização do cartão após mutações de despesa/transação. */
+const invalidateTransactionSurfaces = (): void => {
   void queryClient.invalidateQueries({ queryKey: ["credit-cards"] });
   void queryClient.invalidateQueries({ queryKey: ["transactions"] });
   void queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+};
+
+/**
+ * Trata salvamento feito pelo modal de despesa.
+ *
+ * @param mode Modo salvo pelo modal.
+ */
+const onExpenseSaved = (mode: "created" | "updated"): void => {
+  invalidateTransactionSurfaces();
+  toast.success(
+    mode === "created"
+      ? "Despesa lançada e sincronizada com Transações"
+      : "Despesa atualizada em Cartões e Transações",
+  );
+};
+
+/**
+ * Duplica uma despesa criando uma nova transação.
+ *
+ * @param target Item da fatura ou transação do modal.
+ */
+const duplicateExpense = (target: ExpenseActionTarget): void => {
+  const transaction = transactionFromExpenseTarget(target);
+  duplicateTransactionMutation.mutate(buildDuplicatePayload(transaction), {
+    onSuccess: () => {
+      expenseModalVisible.value = false;
+      invalidateTransactionSurfaces();
+      toast.success("Despesa duplicada");
+    },
+  });
+};
+
+/**
+ * Abre a confirmação de remoção de uma despesa.
+ *
+ * @param target Item da fatura ou transação do modal.
+ */
+const requestRemoveExpense = (target: ExpenseActionTarget): void => {
+  expenseDeleteTarget.value = transactionFromExpenseTarget(target);
+};
+
+/** Fecha a confirmação de remoção quando não há mutação pendente. */
+const cancelExpenseDelete = (): void => {
+  if (!deleteTransactionMutation.isPending.value) {
+    expenseDeleteTarget.value = null;
+  }
+};
+
+/** Remove a despesa confirmada da fatura e de Transações. */
+const confirmExpenseDelete = (): void => {
+  if (!expenseDeleteTarget.value) {
+    return;
+  }
+  const deletedTransactionId = expenseDeleteTarget.value.id;
+  deleteTransactionMutation.mutate(
+    { id: deletedTransactionId, scope: "occurrence" },
+    {
+      onSuccess: () => {
+        expenseDeleteTarget.value = null;
+        if (expenseModalTransaction.value?.id === deletedTransactionId) {
+          expenseModalVisible.value = false;
+          expenseModalTransaction.value = null;
+        }
+        invalidateTransactionSurfaces();
+        toast.success("Despesa removida de Cartões e Transações");
+      },
+    },
+  );
 };
 </script>
 
@@ -77,7 +183,7 @@ const onExpenseCreated = (): void => {
           aria-label="Selecionar visão do cartão"
           @update:model-value="setView"
         />
-        <NButton v-if="card" type="primary" data-testid="cc-detail-add-expense" @click="showExpenseForm = true">
+        <NButton v-if="card" type="primary" data-testid="cc-detail-add-expense" @click="openExpense">
           <template #icon><UiIcon name="plus" :size="16" /></template>
           Lançar despesa
         </NButton>
@@ -96,7 +202,10 @@ const onExpenseCreated = (): void => {
         :selected-card-id="cardId"
         single-card
         @shift-month="shiftMonth"
-        @add-expense="showExpenseForm = true"
+        @add-expense="openExpense"
+        @edit-expense="openExpenseEdit"
+        @duplicate-expense="duplicateExpense"
+        @delete-expense="requestRemoveExpense"
       />
       <AnaliticoView
         v-else
@@ -111,10 +220,47 @@ const onExpenseCreated = (): void => {
 
     <NEmpty v-else :description="t('pages.settings.creditCards.empty')" />
 
-    <CreditCardExpenseSheet
-      v-model:visible="showExpenseForm"
+    <NModal
+      :show="expenseDeleteTarget !== null"
+      preset="dialog"
+      type="error"
+      title="Remover despesa?"
+      style="width: min(420px, calc(100vw - 32px))"
+      :mask-closable="!deleteTransactionMutation.isPending.value"
+      :close-on-esc="!deleteTransactionMutation.isPending.value"
+      @close="cancelExpenseDelete"
+    >
+      <p class="cc-detail__delete-copy">
+        <strong>{{ expenseDeleteTarget?.title }}</strong> será removida desta fatura
+        e das Transações. Esta ação não pode ser desfeita.
+      </p>
+      <template #action>
+        <NButton
+          tertiary
+          data-testid="cc-expense-delete-cancel"
+          :disabled="deleteTransactionMutation.isPending.value"
+          @click="cancelExpenseDelete"
+        >
+          Cancelar
+        </NButton>
+        <NButton
+          type="error"
+          data-testid="cc-expense-delete-confirm"
+          :loading="deleteTransactionMutation.isPending.value"
+          @click="confirmExpenseDelete"
+        >
+          Remover
+        </NButton>
+      </template>
+    </NModal>
+
+    <CreditCardExpenseModal
+      v-model:visible="expenseModalVisible"
+      :transaction="expenseModalTransaction"
       :preset-credit-card-id="cardId"
-      @success="onExpenseCreated"
+      @saved="onExpenseSaved"
+      @duplicate="duplicateExpense"
+      @remove="requestRemoveExpense"
     />
   </div>
 </template>
@@ -157,6 +303,14 @@ const onExpenseCreated = (): void => {
   display: flex;
   justify-content: center;
   padding: var(--space-5);
+}
+.cc-detail__delete-copy {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.55;
+}
+.cc-detail__delete-copy strong {
+  color: var(--color-text-primary);
 }
 @media (max-width: 760px) {
   .cc-detail__actions {

--- a/app/pages/credit-cards/index.vue
+++ b/app/pages/credit-cards/index.vue
@@ -14,20 +14,27 @@ import { useCreditCardsQuery } from "~/features/credit-cards/queries/use-credit-
 import { useCreateCreditCardMutation } from "~/features/credit-cards/queries/use-create-credit-card-mutation";
 import { useUpdateCreditCardMutation } from "~/features/credit-cards/queries/use-update-credit-card-mutation";
 import { useDeleteCreditCardMutation } from "~/features/credit-cards/queries/use-delete-credit-card-mutation";
+import { useCreateTransactionMutation } from "~/features/transactions/queries/use-create-transaction-mutation";
+import { useDeleteTransactionMutation } from "~/features/transactions/queries/use-delete-transaction-mutation";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import { buildDuplicatePayload } from "~/features/transactions/composables/useTransactionActions";
 import {
   type CreditCardsView,
   useCreditCardsViewState,
 } from "~/features/credit-cards/composables/useCreditCardsViewState";
 import { useCreditCardsStatement } from "~/features/credit-cards/composables/useCreditCardsStatement";
 import { useCreditCardsAnalytics } from "~/features/credit-cards/composables/useCreditCardsAnalytics";
+import type { EnrichedTransaction } from "~/features/credit-cards/utils/transaction-billing";
 import FaturasView from "~/features/credit-cards/components/FaturasView.vue";
 import AnaliticoView from "~/features/credit-cards/components/AnaliticoView.vue";
-import CreditCardExpenseSheet from "~/features/credit-cards/components/CreditCardExpenseSheet.vue";
+import CreditCardExpenseModal from "~/features/credit-cards/components/CreditCardExpenseModal.vue";
 import CreditCardForm from "~/features/credit-cards/components/CreditCardForm.vue";
 import AiInsightSurface from "~/features/ai-insights/components/AiInsightSurface.vue";
+import { useToast } from "~/composables/useToast";
 
 const { t } = useI18n();
 const queryClient = useQueryClient();
+const toast = useToast();
 
 definePageMeta({
   middleware: ["authenticated", "coming-soon"],
@@ -41,6 +48,8 @@ const { data: creditCards, isLoading } = useCreditCardsQuery();
 const createMutation = useCreateCreditCardMutation();
 const updateMutation = useUpdateCreditCardMutation();
 const deleteMutation = useDeleteCreditCardMutation();
+const duplicateTransactionMutation = useCreateTransactionMutation();
+const deleteTransactionMutation = useDeleteTransactionMutation();
 
 const cards = computed<CreditCardDto[]>(() => creditCards.value ?? []);
 
@@ -63,8 +72,10 @@ const selectedCard = computed<CreditCardDto | null>(
 const showModal = ref(false);
 const editingCard = ref<CreditCardDto | null>(null);
 const deleteTarget = ref<CreditCardDto | null>(null);
-const expenseDrawerVisible = ref(false);
+const expenseModalVisible = ref(false);
+const expenseModalTransaction = ref<TransactionDto | null>(null);
 const expensePresetCardId = ref<string | null>(null);
+const expenseDeleteTarget = ref<TransactionDto | null>(null);
 
 const submitting = computed<boolean>(
   () => createMutation.isPending.value || updateMutation.isPending.value,
@@ -131,19 +142,123 @@ const confirmDelete = async (): Promise<void> => {
   deleteTarget.value = null;
 };
 
+type ExpenseActionTarget = EnrichedTransaction | TransactionDto;
+
+/**
+ * Normaliza um alvo de ação vindo da fatura ou do modal para a transação canônica.
+ *
+ * @param target Item enriquecido da fatura ou DTO de transação.
+ * @returns Transação fonte.
+ */
+const transactionFromExpenseTarget = (target: ExpenseActionTarget): TransactionDto =>
+  "transaction" in target ? target.transaction : target;
+
+/**
+ * Resolve o cartão associado a um alvo de despesa.
+ *
+ * @param target Item enriquecido da fatura ou DTO de transação.
+ * @returns Id do cartão, quando houver.
+ */
+const cardIdFromExpenseTarget = (target: ExpenseActionTarget): string | null =>
+  "transaction" in target
+    ? target.creditCardId ?? target.transaction.credit_card_id
+    : target.credit_card_id;
+
 /**
  * Abre o lançador de despesa, pré-selecionando o cartão atual quando houver.
  */
 const openExpense = (): void => {
+  expenseModalTransaction.value = null;
   expensePresetCardId.value = selectedCard.value?.id ?? selectedCardId.value ?? null;
-  expenseDrawerVisible.value = true;
+  expenseModalVisible.value = true;
 };
 
-/** Invalida as queries adjacentes após lançar uma despesa. */
-const onExpenseCreated = (): void => {
+/**
+ * Abre o modal de detalhes/edição para um lançamento da fatura.
+ *
+ * @param item Lançamento enriquecido com a transação fonte.
+ */
+const openExpenseEdit = (item: EnrichedTransaction): void => {
+  expenseModalTransaction.value = item.transaction;
+  expensePresetCardId.value = item.creditCardId ?? item.transaction.credit_card_id;
+  expenseModalVisible.value = true;
+};
+
+/** Invalida as queries adjacentes após mutações de despesa/transação. */
+const invalidateTransactionSurfaces = (): void => {
   void queryClient.invalidateQueries({ queryKey: ["credit-cards"] });
   void queryClient.invalidateQueries({ queryKey: ["transactions"] });
   void queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+};
+
+/**
+ * Trata salvamento feito pelo modal de despesa.
+ *
+ * @param mode Modo salvo pelo modal.
+ */
+const onExpenseSaved = (mode: "created" | "updated"): void => {
+  invalidateTransactionSurfaces();
+  toast.success(
+    mode === "created"
+      ? "Despesa lançada e sincronizada com Transações"
+      : "Despesa atualizada em Cartões e Transações",
+  );
+};
+
+/**
+ * Duplica uma despesa criando uma nova transação com sufixo "(cópia)".
+ *
+ * @param target Item da fatura ou transação do modal.
+ */
+const duplicateExpense = (target: ExpenseActionTarget): void => {
+  const transaction = transactionFromExpenseTarget(target);
+  duplicateTransactionMutation.mutate(buildDuplicatePayload(transaction), {
+    onSuccess: () => {
+      expenseModalVisible.value = false;
+      invalidateTransactionSurfaces();
+      toast.success("Despesa duplicada");
+    },
+  });
+};
+
+/**
+ * Abre a confirmação de remoção de uma despesa/transação.
+ *
+ * @param target Item da fatura ou transação do modal.
+ */
+const requestRemoveExpense = (target: ExpenseActionTarget): void => {
+  const transaction = transactionFromExpenseTarget(target);
+  expensePresetCardId.value = cardIdFromExpenseTarget(target);
+  expenseDeleteTarget.value = transaction;
+};
+
+/** Fecha a confirmação de remoção da despesa quando não há mutação pendente. */
+const cancelExpenseDelete = (): void => {
+  if (!deleteTransactionMutation.isPending.value) {
+    expenseDeleteTarget.value = null;
+  }
+};
+
+/** Remove a despesa confirmada da fatura e de Transações. */
+const confirmExpenseDelete = (): void => {
+  if (!expenseDeleteTarget.value) {
+    return;
+  }
+  const deletedTransactionId = expenseDeleteTarget.value.id;
+  deleteTransactionMutation.mutate(
+    { id: deletedTransactionId, scope: "occurrence" },
+    {
+      onSuccess: () => {
+        expenseDeleteTarget.value = null;
+        if (expenseModalTransaction.value?.id === deletedTransactionId) {
+          expenseModalVisible.value = false;
+          expenseModalTransaction.value = null;
+        }
+        invalidateTransactionSurfaces();
+        toast.success("Despesa removida de Cartões e Transações");
+      },
+    },
+  );
 };
 </script>
 
@@ -202,6 +317,9 @@ const onExpenseCreated = (): void => {
         @add-card="openCreate"
         @edit-card="openEdit"
         @delete-card="openDeleteConfirm"
+        @edit-expense="openExpenseEdit"
+        @duplicate-expense="duplicateExpense"
+        @delete-expense="requestRemoveExpense"
       />
       <AnaliticoView
         v-else
@@ -265,10 +383,47 @@ const onExpenseCreated = (): void => {
       </template>
     </NModal>
 
-    <CreditCardExpenseSheet
-      v-model:visible="expenseDrawerVisible"
+    <NModal
+      :show="expenseDeleteTarget !== null"
+      preset="dialog"
+      type="error"
+      title="Remover despesa?"
+      style="width: min(420px, calc(100vw - 32px))"
+      :mask-closable="!deleteTransactionMutation.isPending.value"
+      :close-on-esc="!deleteTransactionMutation.isPending.value"
+      @close="cancelExpenseDelete"
+    >
+      <p class="cc-delete-copy">
+        <strong>{{ expenseDeleteTarget?.title }}</strong> será removida desta fatura
+        e das Transações. Esta ação não pode ser desfeita.
+      </p>
+      <template #action>
+        <NButton
+          tertiary
+          data-testid="cc-expense-delete-cancel"
+          :disabled="deleteTransactionMutation.isPending.value"
+          @click="cancelExpenseDelete"
+        >
+          Cancelar
+        </NButton>
+        <NButton
+          type="error"
+          data-testid="cc-expense-delete-confirm"
+          :loading="deleteTransactionMutation.isPending.value"
+          @click="confirmExpenseDelete"
+        >
+          Remover
+        </NButton>
+      </template>
+    </NModal>
+
+    <CreditCardExpenseModal
+      v-model:visible="expenseModalVisible"
+      :transaction="expenseModalTransaction"
       :preset-credit-card-id="expensePresetCardId"
-      @success="onExpenseCreated"
+      @saved="onExpenseSaved"
+      @duplicate="duplicateExpense"
+      @remove="requestRemoveExpense"
     />
   </div>
 </template>

--- a/app/pages/insights.spec.ts
+++ b/app/pages/insights.spec.ts
@@ -9,6 +9,8 @@ describe("Insights page — deep link and source surface", () => {
     expect(source).toContain("useRoute()");
     expect(source).toContain("route.query.open");
     expect(source).toContain("selectedInsightId");
+    expect(source).toContain("showFluidaReading");
+    expect(source).toContain("!requestedOpenInsightId.value");
     expect(source).toContain("Relatório global");
     expect(source).toContain("Histórico de insights gerados");
   });

--- a/app/pages/insights.vue
+++ b/app/pages/insights.vue
@@ -73,6 +73,9 @@ const requestedOpenInsightId = computed(() => {
   const open = route.query.open;
   return Array.isArray(open) ? open[0] : open;
 });
+const showFluidaReading = computed(() =>
+  isFluidaEnabled.value && !requestedOpenInsightId.value,
+);
 const selectedInsightId = ref<string | null>(null);
 const selectedInsight = computed<AIInsight | null>(() =>
   sortedInsights.value.find((item) => item.id === selectedInsightId.value) ?? null,
@@ -168,7 +171,7 @@ watch(
 </script>
 
 <template>
-  <InsightsFluida v-if="isFluidaEnabled" />
+  <InsightsFluida v-if="showFluidaReading" />
 
   <div v-else class="insights-page">
     <section class="insights-page__hero">

--- a/app/shared/utils/icons/__tests__/iconMap.spec.ts
+++ b/app/shared/utils/icons/__tests__/iconMap.spec.ts
@@ -9,6 +9,7 @@ const ALL_ICON_NAMES: AuraxisIconName[] = [
   "close", "chevronRight", "chevronDown", "trendingUp", "trendingDown",
   "eye", "eyeOff", "check", "warning", "info", "upload", "download",
   "filter", "calendar", "calendarCheck", "menu", "pieChart", "chartLine", "target",
+  "layers", "chevronLeft", "creditCard", "clock", "edit", "copy", "trash", "sync",
 ];
 
 describe("ICON_MAP", () => {

--- a/app/shared/utils/icons/iconMap.ts
+++ b/app/shared/utils/icons/iconMap.ts
@@ -6,6 +6,7 @@ import {
   Eye, EyeOff, Check, AlertTriangle, Info,
   Upload, Download, Filter, Calendar, CalendarCheck,
   Menu, PieChart, ChartLine, Layers, CreditCard, Clock,
+  Pencil, Copy, Trash2, RefreshCw,
 } from "lucide-vue-next";
 import type { IconMap } from "./icons.types";
 
@@ -51,4 +52,8 @@ export const ICON_MAP: IconMap = {
   chevronLeft:   ChevronLeft,
   creditCard:    CreditCard,
   clock:         Clock,
+  edit:          Pencil,
+  copy:          Copy,
+  trash:         Trash2,
+  sync:          RefreshCw,
 };

--- a/app/shared/utils/icons/icons.types.ts
+++ b/app/shared/utils/icons/icons.types.ts
@@ -38,5 +38,9 @@ export type AuraxisIconName =
   | "chevronLeft"
   | "creditCard"
   | "clock"
+  | "edit"
+  | "copy"
+  | "trash"
+  | "sync"
 
 export type IconMap = Record<AuraxisIconName, LucideIcon>

--- a/docs/web/ai-insights.md
+++ b/docs/web/ai-insights.md
@@ -1,0 +1,10 @@
+# AI Insights
+
+## Insights Hub
+
+`/insights` renders the Fluida editorial reading when `web.insights.fluida` is enabled.
+Historical deep links remain backward compatible: `/insights?open=<insight-id>` bypasses Fluida
+and opens the canonical history report for the requested insight.
+
+This keeps shared monthly-report links stable while allowing the default hub experience to evolve
+behind the release flag.

--- a/docs/web/credit-cards-hybrid.md
+++ b/docs/web/credit-cards-hybrid.md
@@ -8,14 +8,16 @@ Credit cards are now a first-class private workspace. The web implementation fol
 - optional detailed card grid;
 - analytical summary mode;
 - less dense single-card dashboard;
-- wide card expense drawer.
+- statement rows managed through the canonical transaction modal.
 
 ## UX Rules
 
-- The card list defaults to `Tabela`.
-- The user can launch a card expense globally; selecting a card first is helpful, not required.
-- The card-specific launch flow labels the date as `Data da compra`, not due date.
-- The drawer must show the predicted bill cycle before submit when the selected card has closing and due days.
+- The card workspace defaults to `Faturas`.
+- The user can launch a card expense globally; the current statement card is preselected when available.
+- A card expense is not a separate frontend entity. It is a transaction with `credit_card_id`.
+- Statement rows expose edit, duplicate and remove actions. Clicking the row title opens the same modal as the edit icon.
+- Removing a statement row must warn that the transaction disappears from both the bill and Transactions.
+- Statement total and item count are derived from synchronized transaction rows.
 - The dashboard should avoid packing all metrics into one viewport. KPIs, charts and analytics are split into large sections/tabs.
 
 ## Task Breakdown
@@ -24,15 +26,16 @@ Completed in this implementation:
 
 - Add frontend billing-cycle helper and tests.
 - Add transaction `impact_policy` and `credit_card_id` filter typing.
-- Add `CreditCardExpenseDrawer`.
+- Add `CreditCardExpenseModal` for new/edit statement expenses.
 - Add `CreditCardsTable`.
 - Add `CreditCardDashboard`.
 - Replace `/credit-cards` grid default with hybrid workspace.
 - Replace `/credit-cards/[id]` simple bill view with tabbed dashboard.
+- Make statement rows actionable and route create/edit/duplicate/delete through transaction mutations.
 
 Follow-up tasks:
 
 - Add API-backed card analytics endpoint for category/time-series data.
 - Add full authenticated Playwright flow for global launch, card launch, installments and impact-policy switching.
-- Enrich bill transaction payload with tag/category names.
+- Move category/time-series card analytics to backend aggregates once the API exposes them.
 - Add empty-state actions for users without cards.

--- a/docs/web/seo-public-architecture.md
+++ b/docs/web/seo-public-architecture.md
@@ -74,6 +74,7 @@ Regras editoriais:
 - Rotas autenticadas continuam `ssr: false` e fora do sitemap para evitar HTML estatico de superficie privada.
 - `/privacy` e `/terms` sao as rotas canonicas legais. `/privacy-policy` e `/terms-of-service` continuam como compatibilidade, com canonical apontando para as novas rotas.
 - Slugs comerciais antigos (`/controle-de-financas`, `/controle-de-gastos`, `/planejador-financeiro`, `/analises-financeiras`) redirecionam para o novo cluster canonico equivalente.
+- A folha XSL decorativa do sitemap fica desativada (`sitemap.xsl=false`). O XML continua publicado em `/sitemap.xml`; a rota XSL era apenas visual e conflitava com versões transitivas diferentes de `nuxt-site-config`.
 
 ## Search Console E Bing
 

--- a/e2e/specs/ai-insights.spec.ts
+++ b/e2e/specs/ai-insights.spec.ts
@@ -192,23 +192,6 @@ const login = async (page: Page): Promise<void> => {
 	await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 });
 };
 
-/**
- * Opens the insights hub through the registered app link.
- *
- * Mobile keeps sidebar links outside the viewport until the menu is expanded, so
- * the test activates the route through the anchor element without depending on
- * the sidebar's visual state.
- *
- * @param page Playwright page.
- */
-const openInsightsHub = async (page: Page): Promise<void> => {
-	await page.locator("a[href=\"/insights\"]").first().evaluate((element) => {
-		if (element instanceof HTMLElement) {
-			element.click();
-		}
-	});
-};
-
 test.describe("AI Insights — surface slices", () => {
 	test("transactions generates a global insight request and shows only transaction slice", async ({ page }) => {
 		await login(page);
@@ -263,12 +246,7 @@ test.describe("AI Insights — surface slices", () => {
 
 	test("insights hub opens a monthly report from the deep link", async ({ page }) => {
 		await login(page);
-		await openInsightsHub(page);
-		await expect(page).toHaveURL(/\/insights/, { timeout: 10_000 });
-		await page.evaluate(() => {
-			window.history.replaceState({}, "", "/insights?open=ai-1");
-			window.dispatchEvent(new PopStateEvent("popstate"));
-		});
+		await page.goto("/insights?open=ai-1");
 		await waitForHydration(page);
 
 		await expect(page.getByRole("heading", { name: "Insight de maio de 2026" })).toBeVisible({ timeout: 10_000 });

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -391,6 +391,10 @@ export default defineNuxtConfig({
   // Only public SSG routes are included — private SPA routes are excluded.
   // Locale alternates are injected automatically by @nuxtjs/i18n integration.
   sitemap: {
+    // Disable the decorative XSL route. The XML sitemap remains intact, and
+    // this avoids a transitive @nuxtjs/seo mismatch where sitemap v7 imports a
+    // nuxt-site-config v3 server composable while og-image pulls v4.
+    xsl: false,
     // Explicitly exclude private SPA routes (ssr: false in routeRules).
     // @nuxtjs/sitemap normally skips them, but listing is belt-and-suspenders.
     exclude: [

--- a/scripts/run_ci_like_actions_local.sh
+++ b/scripts/run_ci_like_actions_local.sh
@@ -85,7 +85,7 @@ run_core_pipeline() {
   if [[ "$RUN_E2E" -eq 1 ]]; then
     echo "[ci-like-local] step=e2e"
     pnpm exec playwright install --with-deps chromium
-    pnpm test:e2e
+    CI=true BASE_URL="${BASE_URL:-http://localhost:3000}" pnpm test:e2e
   else
     echo "[ci-like-local] step=e2e skipped (use --with-e2e)"
   fi


### PR DESCRIPTION
## Summary

- Make credit card bill rows actionable with edit, duplicate and remove actions.
- Add the central `CreditCardExpenseModal` for new/edit card expenses, backed by the existing transactions resource.
- Wire `/credit-cards` and `/credit-cards/[id]` so card expenses are canonical transactions with `credit_card_id`, including confirmation copy and success toasts.
- Derive statement totals and item counts from synchronized transaction rows and document the data flow.
- Preserve AI Insights historical deep links when the Fluida reading flag is enabled.
- Keep the local CI-like E2E gate aligned with GitHub Actions browser selection.

Closes #1078

## Validation

- `pnpm exec vitest run app/pages/insights.spec.ts`
- `pnpm build`
- `CI=true BASE_URL=http://localhost:3000 pnpm exec playwright test e2e/specs/ai-insights.spec.ts --project=chromium --project=mobile-chrome --grep "insights hub opens a monthly report from the deep link"`
- `CI=true BASE_URL=http://localhost:3000 pnpm exec playwright test e2e/specs/ai-insights.spec.ts --project=chromium --project=mobile-chrome`
- `bash scripts/run_ci_like_actions_local.sh --local --with-e2e` (exit 0; includes install, lint, typecheck, Vitest coverage 444 files / 3996 tests, feature flags, governance, contracts, production build, audit gate, and Playwright E2E with 242 passed / 10 skipped / 2 flaky recovered by retry)

## Notes

- Build emits existing i18n fallback warnings for unrelated tool pages.
- The full local E2E run uses `CI=true`, matching GitHub Actions projects (`chromium` and `mobile-chrome`).
