### PR TITLE
feat(transactions): coluna Observações na tabela de Transações

### DIFF
--- a/app/features/transactions/composables/__tests__/useTransactionTable.spec.ts
+++ b/app/features/transactions/composables/__tests__/useTransactionTable.spec.ts
@@ -7,6 +7,7 @@ import {
   buildPaidStatusFeedback,
   isTransactionNearDue,
   isTransactionOverdue,
+  renderNotes,
   renderTagBadge,
   resolveSwipeGestureAction,
   useTransactionTable,
@@ -128,6 +129,49 @@ describe("renderTagBadge", () => {
     expect(JSON.stringify(result)).toContain("Urgent");
     // Style string includes the background colour + 20 alpha suffix
     expect(JSON.stringify(result)).toContain("#FF6B6B20");
+  });
+});
+
+describe("renderNotes", () => {
+  /**
+   * Builds a minimal transaction fixture for notes-cell tests.
+   *
+   * @param description - Free-text observation ("Observações") field value.
+   * @returns A TransactionDto with the given description.
+   */
+  function buildTx(description: string | null): TransactionDto {
+    return {
+      id: "tx-1",
+      title: "Payment",
+      amount: "10.00",
+      type: "expense",
+      status: "pending",
+      due_date: "2026-01-01",
+      description,
+    } as unknown as TransactionDto;
+  }
+
+  it("returns em-dash placeholder when there is no observation", () => {
+    expect(renderNotes(buildTx(null))).toBe("—");
+  });
+
+  it("returns em-dash placeholder when the observation is blank whitespace", () => {
+    expect(renderNotes(buildTx("   "))).toBe("—");
+  });
+
+  it("returns a truncating VNode carrying the full text as tooltip", () => {
+    const text = "Pagar antes do dia 10 — combinado com o financeiro";
+    const result = renderNotes(buildTx(text));
+    expect(typeof result).toBe("object");
+    // VNode renders the observation text...
+    expect(JSON.stringify(result)).toContain(text);
+    // ...and exposes the full text via the title attribute for hover tooltip.
+    expect((result as { props?: Record<string, unknown> }).props?.title).toBe(text);
+  });
+
+  it("trims surrounding whitespace before rendering", () => {
+    const result = renderNotes(buildTx("  nota com espaços  "));
+    expect((result as { props?: Record<string, unknown> }).props?.title).toBe("nota com espaços");
   });
 });
 

--- a/app/features/transactions/composables/useTransactionTable.ts
+++ b/app/features/transactions/composables/useTransactionTable.ts
@@ -415,6 +415,21 @@ export function renderTagBadge(
 }
 
 /**
+ * Renders the "Observações" (notes) cell with the transaction's free-text
+ * observation, truncated to two lines and exposing the full text as a hover
+ * tooltip. Empty observations fall back to the same em-dash placeholder used by
+ * the category/account columns.
+ *
+ * @param row - Transaction row data (observation lives in `description`).
+ * @returns VNode with the truncated note, or the em-dash placeholder string.
+ */
+export function renderNotes(row: TransactionDto): ReturnType<typeof h> | string {
+  const note = row.description?.trim();
+  if (!note) { return "—"; }
+  return h("span", { class: "tx-notes-cell", title: note }, note);
+}
+
+/**
  * Manages table columns, drag-and-drop reorder, touch swipe gestures,
  * row props, pagination and summary totals for the transactions page.
  *
@@ -479,6 +494,7 @@ export function useTransactionTable(opts: UseTransactionTableOptions): UseTransa
       { key: "status" as DataTableRowKey, title: t("transactions.table.status"), width: 64, render: (row: TransactionDto) => renderStatusIcon(row, t) },
       { key: "due_date" as DataTableRowKey, title: t("transactions.table.date"), width: 108, defaultSortOrder: "descend" as const, sorter: withSort ? (a: TransactionDto, b: TransactionDto): number => a.due_date.localeCompare(b.due_date) : undefined, render: (row: TransactionDto): string => formatTransactionDate(row.due_date) },
       { key: "title" as DataTableRowKey, title: t("transactions.table.description"), ellipsis: { tooltip: true }, sorter: withSort ? (a: TransactionDto, b: TransactionDto): number => a.title.localeCompare(b.title, "pt-BR") : undefined, render: (row: TransactionDto) => renderTitle(row, t, billCtx) },
+      { key: "description" as DataTableRowKey, title: t("transactions.table.notes"), width: 180, render: (row: TransactionDto) => renderNotes(row) },
       { key: "tag_id" as DataTableRowKey, title: t("transactions.table.category"), width: 150, ellipsis: { tooltip: true }, render: (row: TransactionDto) => renderTagBadge(row, opts.tagDetailMap) },
       { key: "account_id" as DataTableRowKey, title: t("transactions.table.account"), width: 120, ellipsis: { tooltip: true }, render: (row: TransactionDto): string => opts.accountMap.value.get(row.account_id ?? "") ?? "—" },
       { key: "amount" as DataTableRowKey, title: t("transactions.table.amount"), width: 138, sorter: withSort ? (a: TransactionDto, b: TransactionDto): number => parseCurrencyAmount(a.amount) - parseCurrencyAmount(b.amount) : undefined, render: (row: TransactionDto) => renderAmount(row) },

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -1965,6 +1965,7 @@
       "status": "Status",
       "date": "Data",
       "description": "Descrição",
+      "notes": "Observações",
       "category": "Categoria",
       "account": "Conta",
       "amount": "Valor",

--- a/app/pages/transactions/index.vue
+++ b/app/pages/transactions/index.vue
@@ -237,7 +237,7 @@ const totalBalance = computed(() => totalIncome.value - totalExpense.value);
     </UiEmptyState>
 
     <!-- ── Data table ──────────────────────────────────────────────────────── -->
-    <NDataTable v-else-if="viewMode === 'list'" :columns="columns" :data="tableData" :loading="isLoading" :pagination="pagination" :row-key="rowKey" :row-props="rowProps" :scroll-x="780" size="small" class="transactions-page__table" />
+    <NDataTable v-else-if="viewMode === 'list'" :columns="columns" :data="tableData" :loading="isLoading" :pagination="pagination" :row-key="rowKey" :row-props="rowProps" :scroll-x="960" size="small" class="transactions-page__table" />
 
     <!-- ── Financial calendar ──────────────────────────────────────────────── -->
     <FinancialCalendar v-else-if="viewMode === 'calendar'" class="transactions-page__calendar" @day-click="onDayClick" />
@@ -405,6 +405,15 @@ const totalBalance = computed(() => totalIncome.value - totalExpense.value);
 :deep(.tx-title-cell__heading) { display: inline-flex; align-items: center; gap: var(--space-2); min-width: 0; }
 :deep(.tx-title-cell__name) { font-size: var(--font-size-sm); color: var(--color-text-primary); }
 :deep(.tx-badge) { display: inline-flex; align-items: center; gap: 3px; font-size: var(--font-size-xs); color: var(--color-text-muted); }
+:deep(.tx-notes-cell) {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+  color: var(--color-text-muted);
+}
 :deep(.tx-paid-chip) {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Closes #1079

## O que muda
Adiciona a coluna **Observações** na tabela de Transações (desktop), entre **Descrição** e **Categoria**, conforme o handoff `design_handoff_transacoes_coluna_observacoes` (Proposta A — Ledger refinado).

A ordem passa a ser: `Status · Data · Descrição · Observações · Categoria · Conta · Valor · Ações`.

## Detalhes
- Nova função pura `renderNotes(row)` exibe `description` (o "Observações" do modal de editar/criar) truncado em **2 linhas** (`-webkit-line-clamp:2`), com `title` (tooltip) do texto completo.
- Quando não há observação, mostra o placeholder `—` (mesmo das colunas Categoria/Conta).
- Célula estilizada com tokens do DS (`--color-text-muted` = #5d6f89, `--font-size-sm`) — sem cores/tamanhos hardcoded.
- i18n `transactions.table.notes` adicionada ao `pt.json` (EN deferido per DEC-186 freeze — só WARN no parity check).
- `scroll-x` da tabela ajustado para acomodar a nova coluna.
- Nenhuma outra parte da tela foi alterada.

## Testes
- 4 novos casos para `renderNotes` (vazio → `—`, whitespace → `—`, texto com tooltip, trim). Suíte do composable: 27/27 verdes.
- `pnpm quality-check` completo verde localmente (flags, i18n, lint, typecheck, test:coverage ≥85%, policy, contracts, codegen, build).

## Critérios de aceite
- [x] Coluna "Observações" entre Descrição e Categoria
- [x] Texto truncado em 2 linhas com tooltip do conteúdo completo
- [x] Linhas sem observação mostram `—`
- [x] Nenhuma outra parte da tela alterada