### PR TITLE
fix(credit-cards): /bill como fonte de verdade da fatura (corrige R$ 0,00)

### DIFF
--- a/app/features/credit-cards/contracts/credit-card.dto.spec.ts
+++ b/app/features/credit-cards/contracts/credit-card.dto.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+
 import {
   toCreditCardBill,
   toCreditCardUtilization,
@@ -23,7 +25,7 @@ describe("toCreditCardBill", () => {
         due_date: "2026-06-10",
         status: "paid",
         type: "expense",
-      },
+      } as unknown as TransactionDto,
     ],
     total_amount: "3250.00",
     paid_amount: "1000.00",
@@ -35,7 +37,9 @@ describe("toCreditCardBill", () => {
     expect(bill.totalAmount).toBe(3250);
     expect(bill.paidAmount).toBe(1000);
     expect(bill.pendingAmount).toBe(2250);
-    expect(bill.transactions[0]!.amount).toBe(150.5);
+    // Bill items preserve the full TransactionDto shape (amount stays a string),
+    // so the bill view renders category/notes and edits from /bill alone.
+    expect(bill.transactions[0]!.amount).toBe("150.50");
     expect(bill.cycle.status).toBe("open");
   });
 

--- a/app/features/credit-cards/contracts/credit-card.dto.ts
+++ b/app/features/credit-cards/contracts/credit-card.dto.ts
@@ -1,3 +1,5 @@
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+
 export type CreditCardBrand = "visa" | "mastercard" | "elo" | "hipercard" | "amex" | "other";
 
 export type CreditCardDto = {
@@ -43,20 +45,15 @@ export interface BillCycle {
   readonly status: string;
 }
 
-export interface BillTransaction {
-  readonly id: string;
-  readonly title: string;
-  readonly amount: number;
-  readonly dueDate: string | null;
-  readonly status: string;
-  readonly type: string;
-  readonly impactPolicy: "full" | "cards_only" | "planned_until_bill";
-}
-
 /** View-model de domínio da fatura (valores já coagidos para number). */
 export interface CreditCardBill {
   readonly cycle: BillCycle;
-  readonly transactions: readonly BillTransaction[];
+  /**
+   * Lançamentos da fatura, no mesmo shape de `GET /transactions` (payload
+   * completo). É a fonte de verdade dos itens da fatura — server-side já aplica
+   * o ciclo de fechamento e não sofre do truncamento de paginação do client.
+   */
+  readonly transactions: readonly TransactionDto[];
   readonly totalAmount: number;
   readonly paidAmount: number;
   readonly pendingAmount: number;
@@ -81,19 +78,9 @@ interface BillCycleRaw {
   readonly status: string;
 }
 
-interface BillTransactionRaw {
-  readonly id: string;
-  readonly title: string;
-  readonly amount: string;
-  readonly due_date: string | null;
-  readonly status: string;
-  readonly type: string;
-  readonly impact_policy?: "full" | "cards_only" | "planned_until_bill";
-}
-
 interface CreditCardBillRaw {
   readonly cycle: BillCycleRaw;
-  readonly transactions: readonly BillTransactionRaw[];
+  readonly transactions: readonly TransactionDto[];
   readonly total_amount: string;
   readonly paid_amount: string;
   readonly pending_amount: string;
@@ -172,15 +159,10 @@ export const toCreditCardBill = (
   const raw = unwrap(payload);
   return {
     cycle: toCycle(raw!.cycle),
-    transactions: (raw?.transactions ?? []).map((tx) => ({
-      id: tx.id,
-      title: tx.title,
-      amount: toNumber(tx.amount),
-      dueDate: tx.due_date,
-      status: tx.status,
-      type: tx.type,
-      impactPolicy: tx.impact_policy ?? "full",
-    })),
+    // Itens já vêm no shape de TransactionDto (igual a /transactions); repassa
+    // sem remapear para preservar o payload completo (categoria, observações,
+    // e os campos que as ações editar/duplicar/remover precisam).
+    transactions: [...(raw?.transactions ?? [])],
     totalAmount: toNumber(raw?.total_amount),
     paidAmount: toNumber(raw?.paid_amount),
     pendingAmount: toNumber(raw?.pending_amount),

--- a/app/features/credit-cards/model/credit-card-statement.spec.ts
+++ b/app/features/credit-cards/model/credit-card-statement.spec.ts
@@ -101,11 +101,26 @@ describe("buildStatement — consolidated (all cards)", () => {
 });
 
 describe("buildStatement — single card with official bill", () => {
+  // Bill items now carry the full TransactionDto payload (server is the source of
+  // truth, immune to the client pagination truncation that left bills at R$ 0,00).
+  /**
+   * Builds a bill TransactionDto fixture with sensible defaults.
+   *
+   * @param partial Fields to override.
+   * @returns A TransactionDto-shaped bill item.
+   */
+  const billTx = (partial: Partial<TransactionDto>): TransactionDto =>
+    ({
+      id: "x", title: "A", amount: "0", type: "expense", due_date: "2026-05-20",
+      status: "pending", tag_id: null, credit_card_id: "cc-1",
+      ...partial,
+    }) as unknown as TransactionDto;
+
   const bill: CreditCardBill = {
     cycle: { startDate: "2026-05-04", endDate: "2026-06-03", dueDate: "2026-06-10", status: "closed" },
     transactions: [
-      { id: "x", title: "A", amount: 600, dueDate: "2026-05-20", status: "paid", type: "expense", impactPolicy: "full" },
-      { id: "y", title: "B", amount: 399, dueDate: "2026-05-22", status: "pending", type: "expense", impactPolicy: "full" },
+      billTx({ id: "x", title: "A", amount: "600.00", status: "paid", tag_id: "t-food", due_date: "2026-05-20" }),
+      billTx({ id: "y", title: "B", amount: "399.00", status: "pending", tag_id: "t-food", due_date: "2026-05-22" }),
     ],
     totalAmount: 999,
     paidAmount: 600,
@@ -123,9 +138,9 @@ describe("buildStatement — single card with official bill", () => {
     transactions: TXS, tags: TAGS, cards: CARDS, month: "2026-06", cardId: "cc-1", bill, utilization,
   });
 
-  it("derives total and item count from synchronized transaction items", () => {
-    expect(vm.total).toBe(100);
-    expect(vm.itemCount).toBe(1);
+  it("derives total from the official bill and item count from its transactions", () => {
+    expect(vm.total).toBe(999);
+    expect(vm.itemCount).toBe(2);
   });
 
   it("uses the official cycle status and due date", () => {
@@ -138,7 +153,7 @@ describe("buildStatement — single card with official bill", () => {
     expect(vm.limitAmount).toBe(5000);
   });
 
-  it("still groups categories from real transactions (bill lacks category)", () => {
+  it("groups categories from the official bill transactions", () => {
     expect(vm.categories.map((c) => c.name)).toEqual(["Alimentação"]);
   });
 });

--- a/app/features/credit-cards/model/credit-card-statement.ts
+++ b/app/features/credit-cards/model/credit-card-statement.ts
@@ -8,6 +8,7 @@ import type {
 import {
   type EnrichedTransaction,
   billMonthsWindow,
+  enrichCardTransactions,
   monthKeyLabel,
   monthKeyShort,
   resolveCardCycleForMonth,
@@ -235,15 +236,20 @@ const sortStatementItems = (
 export const buildStatement = (params: StatementParams): StatementViewModel => {
   const trendMonths = params.trendMonths ?? 6;
   const scoped = filterByCard(params.transactions, params.cardId);
-  const monthTxs = filterByBillMonth(scoped, params.month);
-  const aggregatedTotal = sumAmount(monthTxs);
-  const statementItems = sortStatementItems(monthTxs);
 
   const isSingleCard = params.cardId !== null;
   const card = isSingleCard
     ? params.cards.find((entry) => entry.id === params.cardId) ?? null
     : null;
   const bill = isSingleCard ? params.bill ?? null : null;
+
+  // Cartão único com fatura oficial: itens e total vêm da /bill (fonte de verdade,
+  // imune ao truncamento de paginação da lista client-side). Sem bill (consolidado
+  // ou fatura ainda carregando), deriva da janela sincronizada.
+  const billItems = bill ? enrichCardTransactions(bill.transactions, params.cards) : null;
+  const monthTxs = billItems ?? filterByBillMonth(scoped, params.month);
+  const aggregatedTotal = bill ? bill.totalAmount : sumAmount(monthTxs);
+  const statementItems = sortStatementItems(monthTxs);
 
   const cycle = resolveStatementCycle(params, card, bill);
   const limitAmount = isSingleCard ? card?.limit_amount ?? null : sumLimits(params.cards);


### PR DESCRIPTION
Closes #1081

## Problema
A fatura de um cartão aparecia **R$ 0,00 / 0 itens** mesmo quando a `/credit-cards/{id}/bill` retornava o valor correto. Causa raiz: `buildStatement` derivava total/itens da lista `/transactions` carregada client-side, que é **paginada** (`listTransactions` retorna só a página 1 = 10 de N). A transação que compunha a fatura ficava numa página não carregada → fatura = 0.

## Mudança
No modo **cartão único**, os itens e o total da fatura passam a vir da `/bill` (fonte de verdade — o servidor aplica o ciclo de fechamento e não trunca por paginação):
- itens ← `enrichCardTransactions(bill.transactions, cards)`
- total ← `bill.totalAmount`

O contrato `CreditCardBill.transactions` passou de um shape magro (`BillTransaction`) para o `TransactionDto` completo (a `/bill` agora envia o payload completo — auraxis-api #1509), preservando categoria, observações e os campos que as ações editar/duplicar/remover precisam.

Visão consolidada ("Todos os cartões"), trend de meses anteriores e `railTotals` da sidebar permanecem client-side por ora — **follow-up** (não há `/bill` consolidada; exigiria somar /bill por cartão ou corrigir a paginação de `listTransactions`).

## Degradação graciosa
Se a `/bill` ainda vier no shape antigo (backend #1509 não deployado), o total correto já aparece (o backend atual já calcula `total_amount`); os itens detalhados completam após o deploy.

## Testes
- `credit-card-statement.spec.ts`: fatura de cartão único deriva total de `bill.totalAmount`, itemCount de `bill.transactions`, e categorias dos itens da bill.
- `credit-card.dto.spec.ts`: mapper preserva o payload completo (amount permanece string).
- Suíte de credit-cards: 138/138. `pnpm quality-check` completo verde.

## Ordem de deploy
Depende de **auraxis-api #1510** (payload completo na /bill) em produção para os itens virem completos. O valor já corrige antes disso.