### PR TITLE
fix(credit-cards): janela completa corrige gráfico "Faturas anteriores" zerado (#1083)

### DIFF
--- a/app/features/credit-cards/composables/useCardTransactionsWindow.ts
+++ b/app/features/credit-cards/composables/useCardTransactionsWindow.ts
@@ -2,7 +2,7 @@ import { type ComputedRef, type MaybeRefOrGetter, computed, toValue } from "vue"
 
 import type { TagDto } from "~/features/tags/contracts/tag.dto";
 import { useTagsQuery } from "~/features/tags/queries/use-tags-query";
-import { useListTransactionsQuery } from "~/features/transactions/queries/use-list-transactions-query";
+import { useListAllTransactionsQuery } from "~/features/transactions/queries/use-list-all-transactions-query";
 
 import type { CreditCardDto } from "../contracts/credit-card.dto";
 import { useCreditCardsQuery } from "../queries/use-credit-cards-query";
@@ -32,6 +32,11 @@ export interface CardTransactionsWindow {
  * de fatura. Compartilhado por Faturas e Analítico — a mesma queryKey é deduzida
  * pelo Vue Query, evitando refetch ao alternar de visão.
  *
+ * Usa `useListAllTransactionsQuery` (todas as páginas), não a versão paginada:
+ * o gráfico de tendência, o rail de totais e o consolidado "Todos" precisam do
+ * conjunto COMPLETO da janela. Carregar só a 1ª página zera cartões cujas
+ * transações de fatura caem em páginas posteriores (issue #1083).
+ *
  * @param month Mês selecionado (YYYY-MM), reativo.
  * @returns Dados reativos da janela.
  */
@@ -46,7 +51,7 @@ export const useCardTransactionsWindow = (
     start_date: billWindowStartDate(toValue(month), CREDIT_CARDS_WINDOW_MONTHS),
     end_date: monthEndDate(toValue(month)),
   }));
-  const transactionsQuery = useListTransactionsQuery(filters);
+  const transactionsQuery = useListAllTransactionsQuery(filters);
 
   const cards = computed<CreditCardDto[]>(() => cardsQuery.data.value ?? []);
   const tags = computed<TagDto[]>(() => tagsQuery.data.value ?? []);

--- a/app/features/transactions/queries/use-list-all-transactions-query.spec.ts
+++ b/app/features/transactions/queries/use-list-all-transactions-query.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useListAllTransactionsQuery } from "./use-list-all-transactions-query";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+
+const useQueryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/vue-query", () => ({
+  useQuery: useQueryMock,
+}));
+
+describe("useListAllTransactionsQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useQueryMock.mockImplementation((opts: unknown) => opts);
+  });
+
+  it("calls client.listAllTransactions without filters by default", async () => {
+    const client = { listAllTransactions: vi.fn().mockResolvedValue([]) };
+
+    const query = useListAllTransactionsQuery(undefined, client as never) as unknown as {
+      queryFn: () => Promise<TransactionDto[]>;
+    };
+
+    await query.queryFn();
+
+    expect(client.listAllTransactions).toHaveBeenCalledWith(undefined);
+  });
+
+  it("passes filters to client.listAllTransactions", async () => {
+    const client = { listAllTransactions: vi.fn().mockResolvedValue([]) };
+    const filters = { type: "expense" as const, start_date: "2026-01-01", end_date: "2026-06-30" };
+
+    const query = useListAllTransactionsQuery(filters, client as never) as unknown as {
+      queryFn: () => Promise<TransactionDto[]>;
+    };
+
+    await query.queryFn();
+
+    expect(client.listAllTransactions).toHaveBeenCalledWith(filters);
+  });
+
+  it("isolates the cache from the paginated list under a distinct queryKey", () => {
+    const client = { listAllTransactions: vi.fn().mockResolvedValue([]) };
+    const filters = { type: "expense" as const };
+
+    const query = useListAllTransactionsQuery(filters, client as never) as unknown as {
+      queryKey: readonly unknown[];
+    };
+
+    expect(query.queryKey).toEqual(["transactions", "list-all", filters]);
+  });
+
+  it("propagates errors from client.listAllTransactions without catching", async () => {
+    const client = {
+      listAllTransactions: vi.fn().mockRejectedValue(new Error("network error")),
+    };
+
+    const query = useListAllTransactionsQuery(undefined, client as never) as unknown as {
+      queryFn: () => Promise<TransactionDto[]>;
+    };
+
+    await expect(query.queryFn()).rejects.toThrow("network error");
+  });
+});

--- a/app/features/transactions/queries/use-list-all-transactions-query.ts
+++ b/app/features/transactions/queries/use-list-all-transactions-query.ts
@@ -1,0 +1,38 @@
+import { type MaybeRef, unref } from "vue";
+import { type UseQueryReturnType, useQuery } from "@tanstack/vue-query";
+
+import { STALE_TIME } from "~/core/query/stale-time";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import {
+  type ListTransactionsFilters,
+  type TransactionsClient,
+  useTransactionsClient,
+} from "~/features/transactions/services/transactions.client";
+
+/**
+ * Vue Query hook for listing the COMPLETE set of transactions matching the
+ * filters, following server-side pagination.
+ *
+ * Unlike `useListTransactionsQuery` (first page only), this hook returns every
+ * record in the range. Use it where aggregations must see all transactions
+ * (e.g. the credit-cards billing window). Cached under a distinct `list-all`
+ * key so it never collides with the paginated list.
+ *
+ * @param filters Optional reactive filters (type, status, date range).
+ * @param providedClient Optional injected client for unit tests.
+ * @returns Vue Query state with the full typed TransactionDto array.
+ */
+export const useListAllTransactionsQuery = (
+  filters?: MaybeRef<ListTransactionsFilters | undefined>,
+  providedClient?: TransactionsClient,
+): UseQueryReturnType<TransactionDto[], Error> => {
+  const client = providedClient ?? useTransactionsClient();
+
+  return useQuery({
+    queryKey: ["transactions", "list-all", filters] as const,
+    queryFn: (): Promise<TransactionDto[]> => {
+      return client.listAllTransactions(unref(filters));
+    },
+    staleTime: STALE_TIME.ACTIVE,
+  });
+};

--- a/app/features/transactions/services/transactions.client.list-all.spec.ts
+++ b/app/features/transactions/services/transactions.client.list-all.spec.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
+
+import { TransactionsClient } from "./transactions.client";
+import type { TransactionDto } from "../contracts/transaction.dto";
+
+vi.mock("axios");
+
+const mockedAxiosCreate = vi.mocked(axios.create) as ReturnType<typeof vi.fn>;
+
+/**
+ * Builds a minimal TransactionDto fixture.
+ *
+ * @param overrides Partial overrides applied to the default fixture.
+ * @returns A TransactionDto with sensible defaults.
+ */
+const makeTransaction = (overrides: Partial<TransactionDto> = {}): TransactionDto => ({
+  id: "txn-001",
+  title: "Test",
+  amount: "150.00",
+  type: "expense",
+  due_date: "2026-06-01",
+  description: null,
+  observation: null,
+  is_recurring: false,
+  is_installment: false,
+  installment_count: null,
+  recurrence_interval: 1,
+  recurrence_unit: "month",
+  currency: "BRL",
+  status: "pending",
+  start_date: null,
+  end_date: null,
+  tag_id: null,
+  account_id: null,
+  credit_card_id: null,
+  impact_policy: "full",
+  installment_group_id: null,
+  paid_at: null,
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: null,
+  ...overrides,
+});
+
+describe("TransactionsClient.listAllTransactions", () => {
+  let httpGetMock: ReturnType<typeof vi.fn>;
+  let client: TransactionsClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    httpGetMock = vi.fn();
+    mockedAxiosCreate.mockReturnValue({ get: httpGetMock } as never);
+    client = new TransactionsClient(axios.create());
+  });
+
+  it("requests the first page with a large per_page and returns its items when single-page", async () => {
+    const txn = makeTransaction();
+    httpGetMock.mockResolvedValueOnce({
+      data: {
+        data: { transactions: [txn] },
+        meta: { pagination: { page: 1, pages: 1, per_page: 100, total: 1 } },
+      },
+    });
+
+    const result = await client.listAllTransactions({ type: "expense" });
+
+    expect(httpGetMock).toHaveBeenCalledTimes(1);
+    expect(httpGetMock).toHaveBeenCalledWith("/transactions", {
+      params: { type: "expense", page: 1, per_page: 100 },
+    });
+    expect(result).toEqual([txn]);
+  });
+
+  it("follows pagination and concatenates every page in order", async () => {
+    const page1 = [makeTransaction({ id: "p1-a" }), makeTransaction({ id: "p1-b" })];
+    const page2 = [makeTransaction({ id: "p2-a" })];
+    const page3 = [makeTransaction({ id: "p3-a" })];
+    httpGetMock
+      .mockResolvedValueOnce({
+        data: {
+          data: { transactions: page1 },
+          meta: { pagination: { page: 1, pages: 3, per_page: 100, total: 4 } },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: { transactions: page2 },
+          meta: { pagination: { page: 2, pages: 3, per_page: 100, total: 4 } },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: { transactions: page3 },
+          meta: { pagination: { page: 3, pages: 3, per_page: 100, total: 4 } },
+        },
+      });
+
+    const result = await client.listAllTransactions({
+      type: "expense",
+      start_date: "2025-12-01",
+      end_date: "2026-06-30",
+    });
+
+    expect(httpGetMock).toHaveBeenCalledTimes(3);
+    expect(httpGetMock).toHaveBeenNthCalledWith(2, "/transactions", {
+      params: {
+        type: "expense",
+        start_date: "2025-12-01",
+        end_date: "2026-06-30",
+        page: 2,
+        per_page: 100,
+      },
+    });
+    expect(httpGetMock).toHaveBeenNthCalledWith(3, "/transactions", {
+      params: {
+        type: "expense",
+        start_date: "2025-12-01",
+        end_date: "2026-06-30",
+        page: 3,
+        per_page: 100,
+      },
+    });
+    expect(result.map((tx) => tx.id)).toEqual(["p1-a", "p1-b", "p2-a", "p3-a"]);
+  });
+
+  it("treats a response without pagination meta as a single complete page", async () => {
+    const txn = makeTransaction();
+    httpGetMock.mockResolvedValueOnce({ data: { data: { transactions: [txn] } } });
+
+    const result = await client.listAllTransactions();
+
+    expect(httpGetMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([txn]);
+  });
+
+  it("handles a bare array response as a single page", async () => {
+    const txn = makeTransaction();
+    httpGetMock.mockResolvedValueOnce({ data: [txn] });
+
+    const result = await client.listAllTransactions();
+
+    expect(httpGetMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([txn]);
+  });
+
+  it("propagates network errors without catching them", async () => {
+    httpGetMock.mockRejectedValueOnce(new Error("network error"));
+
+    await expect(client.listAllTransactions()).rejects.toThrow("network error");
+  });
+});

--- a/app/features/transactions/services/transactions.client.ts
+++ b/app/features/transactions/services/transactions.client.ts
@@ -27,6 +27,14 @@ interface TransactionCreateResponseEnvelope {
   readonly transactions?: TransactionDto | TransactionDto[];
 }
 
+/** Bloco de paginação retornado em `meta.pagination` pela API v2. */
+interface PaginationMeta {
+  readonly page: number;
+  readonly pages: number;
+  readonly per_page: number;
+  readonly total: number;
+}
+
 /**
  * Raw envelope returned by GET /transactions.
  *
@@ -38,7 +46,13 @@ interface TransactionListResponseEnvelope {
     readonly transactions?: TransactionDto[];
   };
   readonly transactions?: TransactionDto[];
+  readonly meta?: {
+    readonly pagination?: PaginationMeta;
+  };
 }
+
+/** Tamanho de página usado ao varrer todas as páginas (`listAllTransactions`). */
+const LIST_ALL_PER_PAGE = 100;
 
 /** Optional filters accepted by GET /transactions. */
 export interface ListTransactionsFilters {
@@ -54,6 +68,10 @@ export interface ListTransactionsFilters {
   readonly tag_id?: string;
   /** Filter by credit card UUID. */
   readonly credit_card_id?: string;
+  /** 1-based page index (server-side pagination). */
+  readonly page?: number;
+  /** Page size (server-side pagination). */
+  readonly per_page?: number;
 }
 
 /**
@@ -211,6 +229,58 @@ export class TransactionsClient {
    * @returns Array of TransactionDto records.
    */
   async listTransactions(filters?: ListTransactionsFilters): Promise<TransactionDto[]> {
+    const { items } = await this.#fetchTransactionsPage(filters);
+    return items;
+  }
+
+  /**
+   * Lists the COMPLETE set of transactions for the given filters by following
+   * server-side pagination.
+   *
+   * `listTransactions` only returns the first page (the backend defaults to
+   * `per_page: 10`), which silently truncates any aggregation that assumes it
+   * holds every record in the range. This method requests a large page and,
+   * if the response reports more pages, fetches the remainder and concatenates
+   * them in order. Use it whenever correctness depends on having all records
+   * (e.g. the credit-cards billing window).
+   *
+   * @param filters Optional query-parameter filters.
+   * @returns Every TransactionDto matching the filters, across all pages.
+   */
+  async listAllTransactions(filters?: ListTransactionsFilters): Promise<TransactionDto[]> {
+    const first = await this.#fetchTransactionsPage({
+      ...filters,
+      page: 1,
+      per_page: LIST_ALL_PER_PAGE,
+    });
+
+    if (first.pages <= 1) {
+      return first.items;
+    }
+
+    const remaining = await Promise.all(
+      Array.from({ length: first.pages - 1 }, (_unused, index) =>
+        this.#fetchTransactionsPage({
+          ...filters,
+          page: index + 2,
+          per_page: LIST_ALL_PER_PAGE,
+        }).then((page) => page.items),
+      ),
+    );
+
+    return [first.items, ...remaining].flat();
+  }
+
+  /**
+   * Fetches a single page of GET /transactions, normalising the envelope and
+   * extracting the pagination page count.
+   *
+   * @param filters Query-parameter filters (may include `page`/`per_page`).
+   * @returns The page's transactions and the total number of pages (>= 1).
+   */
+  async #fetchTransactionsPage(
+    filters?: ListTransactionsFilters,
+  ): Promise<{ items: TransactionDto[]; pages: number }> {
     const response = await this.#http.get<TransactionListResponseEnvelope | TransactionDto[]>(
       "/transactions",
       { params: filters },
@@ -219,12 +289,13 @@ export class TransactionsClient {
     const raw = response.data;
 
     if (Array.isArray(raw)) {
-      return raw;
+      return { items: raw, pages: 1 };
     }
 
-    return (raw as TransactionListResponseEnvelope).data?.transactions
-      ?? (raw as TransactionListResponseEnvelope).transactions
-      ?? [];
+    const envelope = raw as TransactionListResponseEnvelope;
+    const items = envelope.data?.transactions ?? envelope.transactions ?? [];
+    const pages = envelope.meta?.pagination?.pages ?? 1;
+    return { items, pages };
   }
 }
 


### PR DESCRIPTION
## Problema

Após o #1082 (total do painel vindo de `/bill`), o gráfico **"Faturas anteriores"** e o **rail de totais por cartão** continuavam zerados para alguns cartões.

- **Nubank**: gráfico mostra junho corretamente (R$ 2.891,92).
- **Inter**: painel mostra **R$ 11.049,16** (via `/bill`), mas o gráfico fica **plano em zero** e o rail mostra **R$ 0,00**.

## Causa raiz

`useCardTransactionsWindow` carregava a janela de 6 meses via `useListTransactionsQuery` → `TransactionsClient.listTransactions`, que faz **uma única request sem paginação**. O backend pagina (`per_page: 10`); com 32 transações na janela, **só a 1ª página chega ao cliente**.

Todas as agregações client-side dos cartões (`monthlyTrend` do gráfico, `cardBreakdown`/rail, consolidado "Todos", categorias) operavam sobre esse conjunto truncado. As transações do Inter que fecham em junho (vencimento 31/05, `closing_day=5`) estão em páginas posteriores e nunca eram carregadas. O painel de cartão único escapa porque usa `/bill` (server-side).

**Verificado** com o dataset completo (`per_page=100`): junho do Inter = **R$ 11.049,16** (idêntico ao `/bill`); transações com vencimento 06-10/12/23 fecham corretamente em julho (fora da janela Jan–Jun).

## Correção

- `TransactionsClient.listAllTransactions(filters)`: busca o conjunto **completo** seguindo `meta.pagination.pages` (página grande + varredura do restante em paralelo).
- `useListAllTransactionsQuery`: hook Vue Query com `queryKey` própria (`list-all`), isolada do cache paginado.
- `useCardTransactionsWindow` passa a usar a versão completa — corrige **Faturas e Analítico** de uma vez.
- `listTransactions` segue inalterado para os demais consumidores (transações, budgets, goals, calendário).

## Testes

- `transactions.client.list-all.spec.ts`: página única, varredura multi-página com concatenação ordenada, ausência de `meta`, resposta array cru, propagação de erro.
- `use-list-all-transactions-query.spec.ts`: repasse de filtros, `queryKey` isolada, propagação de erro.
- `pnpm quality-check` verde (4009 testes, cobertura ≥ thresholds, build ok).

## Critérios de aceite

- [x] Gráfico "Faturas anteriores" reflete os valores de fatura por mês para todos os cartões.
- [x] Rail e consolidado "Todos" deixam de zerar por truncamento.
- [x] Junho do Inter no gráfico = R$ 11.049,16 (consistente com painel/`/bill`).
- [x] Cobertura mantida; testes unitários cobrindo o fetch paginado completo.

Closes #1083
