### PR TITLE
feat(payments-assistant): assistente de pagamentos (modal Premium)

### DIFF
--- a/app/features/payments-assistant/components/PaymentAssistantModal/PaymentAssistantModal.vue
+++ b/app/features/payments-assistant/components/PaymentAssistantModal/PaymentAssistantModal.vue
@@ -1,0 +1,325 @@
+<script setup lang="ts">
+/**
+ * Payments Assistant modal.
+ *
+ * Surfaces overdue open transactions one card at a time so the user can mark
+ * them paid/received, discard them, or skip — with a one-tap undo. Auto-opens
+ * once per session for Premium users when there is a backlog and no
+ * higher-priority modal is holding the surface.
+ *
+ * "Marcar como pago/recebido" only updates the status inside Auraxis; it does
+ * not move real money.
+ */
+import { computed, watch } from "vue";
+
+import { useToast } from "~/composables/useToast";
+import { usePaymentAssistant } from "~/features/payments-assistant/composables/use-payment-assistant";
+
+const props = withDefaults(
+  defineProps<{
+    /** When true, a higher-priority modal (email gate, onboarding) holds the surface. */
+    hold?: boolean;
+  }>(),
+  { hold: false },
+);
+
+const { t, n } = useI18n();
+const toast = useToast();
+
+const assistant = usePaymentAssistant();
+const { isOpen, current, progress, isDone, lastAction, close } = assistant;
+
+/** Whether the last action can still be undone (pay/delete, not skip). */
+const canUndo = computed(
+  () => lastAction.value?.kind === "paid" || lastAction.value?.kind === "deleted",
+);
+
+/** Action label depends on whether the current entry is income or expense. */
+const payLabel = computed(() =>
+  current.value?.type === "income"
+    ? t("paymentsAssistant.actions.payIncome")
+    : t("paymentsAssistant.actions.payExpense"),
+);
+
+/**
+ * Formats a `YYYY-MM-DD` or ISO datetime as `dd/mm/yyyy` without timezone drift.
+ *
+ * @param value Date string to format, or null.
+ * @returns Localised `dd/mm/yyyy`, or an em dash when empty.
+ */
+const formatDate = (value: string | null): string => {
+  if (!value) {
+    return "—";
+  }
+  const [year, month, day] = value.slice(0, 10).split("-");
+  return `${day}/${month}/${year}`;
+};
+
+/**
+ * Formats a decimal-string amount as BRL currency.
+ *
+ * @param amount Decimal string (e.g. "150.50").
+ * @returns Amount formatted as BRL.
+ */
+const formatAmount = (amount: string): string => n(Number(amount), "currency");
+
+watch(
+  [current, (): boolean => assistant.isPremium.value, (): boolean => props.hold],
+  (): void => {
+    if (!isOpen.value) {
+      assistant.maybeAutoOpen(props.hold);
+    }
+  },
+  { immediate: true },
+);
+
+/** Marks the current card paid/received and toasts the result. */
+const onPay = async (): Promise<void> => {
+  const isIncome = current.value?.type === "income";
+  await assistant.pay();
+  toast.success(
+    isIncome ? t("paymentsAssistant.toast.received") : t("paymentsAssistant.toast.paid"),
+  );
+};
+
+/** Soft-deletes the current card and toasts the result. */
+const onDelete = async (): Promise<void> => {
+  await assistant.discard();
+  toast.success(t("paymentsAssistant.toast.deleted"));
+};
+
+/** Skips the current card. */
+const onSkip = (): void => {
+  assistant.skipCard();
+};
+
+/** Marks every remaining card paid and toasts the result. */
+const onMarkAll = async (): Promise<void> => {
+  await assistant.markAllPaid();
+  toast.success(t("paymentsAssistant.toast.allPaid"));
+};
+
+/** Reverts the last pay/delete action. */
+const onUndo = async (): Promise<void> => {
+  const undone = await assistant.undo();
+  if (undone) {
+    toast.info(t("paymentsAssistant.toast.undone"));
+  }
+};
+
+/** Closes the assistant. */
+const onClose = (): void => {
+  close();
+};
+</script>
+
+<template>
+  <NModal
+    :show="isOpen"
+    preset="card"
+    :title="t('paymentsAssistant.title')"
+    :style="{ maxWidth: '480px' }"
+    :bordered="false"
+    :mask-closable="true"
+    aria-label="Assistente de pagamentos"
+    @update:show="(value: boolean) => { if (!value) { onClose(); } }"
+  >
+    <div v-if="!isDone && current" class="payments-assistant">
+      <p class="payments-assistant__progress">
+        {{ t("paymentsAssistant.progress", { current: progress.current, total: progress.total }) }}
+      </p>
+
+      <article class="payments-assistant__card" data-testid="payment-assistant-card">
+        <header class="payments-assistant__card-head">
+          <NTag :type="current.type === 'income' ? 'success' : 'warning'" size="small" round>
+            {{
+              current.type === "income"
+                ? t("paymentsAssistant.type.income")
+                : t("paymentsAssistant.type.expense")
+            }}
+          </NTag>
+          <strong class="payments-assistant__amount">{{ formatAmount(current.amount) }}</strong>
+        </header>
+
+        <h3 class="payments-assistant__card-title">{{ current.title }}</h3>
+        <p v-if="current.description" class="payments-assistant__card-desc">
+          {{ current.description }}
+        </p>
+
+        <dl class="payments-assistant__meta">
+          <div>
+            <dt>{{ t("paymentsAssistant.fields.createdAt") }}</dt>
+            <dd>{{ formatDate(current.created_at) }}</dd>
+          </div>
+          <div>
+            <dt>{{ t("paymentsAssistant.fields.dueDate") }}</dt>
+            <dd>{{ formatDate(current.due_date) }}</dd>
+          </div>
+        </dl>
+
+        <p v-if="current.observation" class="payments-assistant__obs">
+          <span class="payments-assistant__obs-label">
+            {{ t("paymentsAssistant.fields.observation") }}:
+          </span>
+          {{ current.observation }}
+        </p>
+      </article>
+
+      <p class="payments-assistant__hint">{{ t("paymentsAssistant.statusHint") }}</p>
+
+      <div class="payments-assistant__actions">
+        <NButton type="primary" block @click="onPay">{{ payLabel }}</NButton>
+        <NPopconfirm @positive-click="onDelete">
+          <template #trigger>
+            <NButton tertiary type="error" block>
+              {{ t("paymentsAssistant.actions.delete") }}
+            </NButton>
+          </template>
+          {{ t("paymentsAssistant.confirmDelete") }}
+        </NPopconfirm>
+        <NButton quaternary block @click="onSkip">
+          {{ t("paymentsAssistant.actions.skip") }}
+        </NButton>
+      </div>
+    </div>
+
+    <div v-else class="payments-assistant payments-assistant--done">
+      <p class="payments-assistant__done-title">{{ t("paymentsAssistant.emptyTitle") }}</p>
+      <p class="payments-assistant__done-body">{{ t("paymentsAssistant.emptyBody") }}</p>
+    </div>
+
+    <template #footer>
+      <div class="payments-assistant__footer">
+        <NButton v-if="canUndo" text type="primary" @click="onUndo">
+          {{ t("paymentsAssistant.actions.undo") }}
+        </NButton>
+        <span v-else />
+        <div class="payments-assistant__footer-right">
+          <NButton
+            v-if="!isDone && progress.total > 1"
+            tertiary
+            @click="onMarkAll"
+          >
+            {{ t("paymentsAssistant.actions.markAllPaid") }}
+          </NButton>
+          <NButton @click="onClose">{{ t("paymentsAssistant.actions.close") }}</NButton>
+        </div>
+      </div>
+    </template>
+  </NModal>
+</template>
+
+<style scoped>
+.payments-assistant {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.payments-assistant__progress {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--text-color-3, #8a8a8a);
+}
+
+.payments-assistant__card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: var(--card-color, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+}
+
+.payments-assistant__card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.payments-assistant__amount {
+  font-size: var(--font-size-lg);
+  font-variant-numeric: tabular-nums;
+}
+
+.payments-assistant__card-title {
+  margin: 0;
+  font-size: var(--font-size-md);
+}
+
+.payments-assistant__card-desc {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--text-color-2, #b5b5b5);
+}
+
+.payments-assistant__meta {
+  display: flex;
+  gap: 24px;
+  margin: 4px 0 0;
+}
+
+.payments-assistant__meta dt {
+  font-size: var(--font-size-xs);
+  color: var(--text-color-3, #8a8a8a);
+}
+
+.payments-assistant__meta dd {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.payments-assistant__obs {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--text-color-2, #b5b5b5);
+}
+
+.payments-assistant__obs-label {
+  font-weight: var(--font-weight-semibold);
+}
+
+.payments-assistant__hint {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--text-color-3, #8a8a8a);
+}
+
+.payments-assistant__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.payments-assistant--done {
+  align-items: center;
+  text-align: center;
+  padding: 16px 8px;
+}
+
+.payments-assistant__done-title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+}
+
+.payments-assistant__done-body {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--text-color-2, #b5b5b5);
+}
+
+.payments-assistant__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.payments-assistant__footer-right {
+  display: flex;
+  gap: 8px;
+}
+</style>

--- a/app/features/payments-assistant/composables/use-assistant-actions.ts
+++ b/app/features/payments-assistant/composables/use-assistant-actions.ts
@@ -1,0 +1,172 @@
+/**
+ * Action handlers for the Payments Assistant deck.
+ *
+ * Extracted from {@link usePaymentAssistant} so the orchestrator stays small and
+ * each concern (open/close/auto-open, pay/discard/skip, undo) is easy to read.
+ * All side effects (mutations) flow through here; the pure deck reducer drives
+ * navigation.
+ */
+
+import type { ComputedRef, Ref } from "vue";
+
+import type { TransactionDto, UpdateTransactionPayload } from "~/features/transactions/contracts/transaction.dto";
+
+import { shouldAutoOpenAssistant, markAssistantShown, wasAssistantShown } from "../services/payment-assistant.session";
+import {
+  type DeckAction,
+  type DeckState,
+  advanceDeck,
+  createDeck,
+  currentCard,
+  undoDeck,
+} from "../services/payment-assistant.deck";
+
+/** A mutation surface exposing only the `mutateAsync` used by the assistant. */
+interface MutateAsync<TArgs> {
+  readonly mutateAsync: (args: TArgs) => Promise<unknown>;
+}
+
+/** The four transaction mutations the assistant drives. */
+export interface AssistantMutations {
+  readonly markPaid: MutateAsync<{ id: string; paidAt: string }>;
+  readonly remove: MutateAsync<{ id: string; scope: "occurrence" | "series" }>;
+  readonly update: MutateAsync<{ id: string; payload: UpdateTransactionPayload }>;
+  readonly restore: { readonly mutateAsync: (id: string) => Promise<unknown> };
+}
+
+/** Reactive dependencies the action handlers operate on. */
+export interface AssistantActionsDeps {
+  readonly deck: Ref<DeckState>;
+  readonly current: ComputedRef<TransactionDto | null>;
+  readonly candidates: ComputedRef<TransactionDto[]>;
+  readonly isOpen: Ref<boolean>;
+  readonly lastAction: Ref<DeckAction | null>;
+  readonly flagEnabled: Readonly<Ref<boolean>>;
+  readonly isPremium: ComputedRef<boolean>;
+  readonly mutations: AssistantMutations;
+  readonly now: () => Date;
+}
+
+/** The handler surface returned to the composable. */
+export interface AssistantActions {
+  open: () => void;
+  close: () => void;
+  maybeAutoOpen: (heldByOtherModals: boolean) => boolean;
+  pay: () => Promise<void>;
+  discard: () => Promise<void>;
+  skipCard: () => void;
+  markAllPaid: () => Promise<void>;
+  undo: () => Promise<DeckAction | null>;
+}
+
+/**
+ * Builds the assistant's action handlers over the given reactive dependencies.
+ *
+ * @param deps Reactive state and mutation surfaces.
+ * @returns The handler functions wiring user intents to mutations + deck moves.
+ */
+export const useAssistantActions = (deps: AssistantActionsDeps): AssistantActions => {
+  const { deck, current, candidates, isOpen, lastAction, flagEnabled, isPremium, mutations, now } =
+    deps;
+
+  /** Opens the assistant with the current candidate set and marks the session. */
+  const open = (): void => {
+    deck.value = createDeck(candidates.value);
+    lastAction.value = null;
+    isOpen.value = true;
+    markAssistantShown();
+  };
+
+  /** Closes the assistant. */
+  const close = (): void => {
+    isOpen.value = false;
+  };
+
+  /**
+   * Opens the assistant automatically when all gating conditions are satisfied.
+   *
+   * @param heldByOtherModals Whether a higher-priority modal holds the surface.
+   * @returns True when it opened.
+   */
+  const maybeAutoOpen = (heldByOtherModals: boolean): boolean => {
+    const should = shouldAutoOpenAssistant({
+      flagEnabled: flagEnabled.value,
+      isPremium: isPremium.value,
+      shownThisSession: wasAssistantShown(),
+      candidateCount: candidates.value.length,
+      heldByOtherModals,
+    });
+    if (should) {
+      open();
+    }
+    return should;
+  };
+
+  /** Marks the current card as paid and advances. */
+  const pay = async (): Promise<void> => {
+    const card = current.value;
+    if (!card) {
+      return;
+    }
+    await mutations.markPaid.mutateAsync({ id: card.id, paidAt: now().toISOString() });
+    deck.value = advanceDeck(deck.value, "paid");
+    lastAction.value = { kind: "paid", card };
+  };
+
+  /** Soft-deletes the current card and advances. */
+  const discard = async (): Promise<void> => {
+    const card = current.value;
+    if (!card) {
+      return;
+    }
+    await mutations.remove.mutateAsync({ id: card.id, scope: "occurrence" });
+    deck.value = advanceDeck(deck.value, "deleted");
+    lastAction.value = { kind: "deleted", card };
+  };
+
+  /** Skips the current card without mutating it. */
+  const skipCard = (): void => {
+    const card = current.value;
+    if (!card) {
+      return;
+    }
+    deck.value = advanceDeck(deck.value, "skipped");
+    lastAction.value = { kind: "skipped", card };
+  };
+
+  /** Marks every remaining card as paid in order. */
+  const markAllPaid = async (): Promise<void> => {
+    let card = currentCard(deck.value);
+    while (card) {
+      await mutations.markPaid.mutateAsync({ id: card.id, paidAt: now().toISOString() });
+      deck.value = advanceDeck(deck.value, "paid");
+      lastAction.value = { kind: "paid", card };
+      card = currentCard(deck.value);
+    }
+  };
+
+  /**
+   * Reverts the last action: paid → back to pending, deleted → restored.
+   *
+   * @returns The reverted action, or null when there was nothing to undo.
+   */
+  const undo = async (): Promise<DeckAction | null> => {
+    const { deck: previous, undone } = undoDeck(deck.value);
+    if (!undone) {
+      return null;
+    }
+    deck.value = previous;
+    lastAction.value = null;
+    if (undone.kind === "paid") {
+      await mutations.update.mutateAsync({
+        id: undone.card.id,
+        payload: { status: "pending", paid_at: null },
+      });
+    } else if (undone.kind === "deleted") {
+      await mutations.restore.mutateAsync(undone.card.id);
+    }
+    return undone;
+  };
+
+  return { open, close, maybeAutoOpen, pay, discard, skipCard, markAllPaid, undo };
+};

--- a/app/features/payments-assistant/composables/use-payment-assistant.spec.ts
+++ b/app/features/payments-assistant/composables/use-payment-assistant.spec.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+
+import { usePaymentAssistant } from "./use-payment-assistant";
+
+const h = vi.hoisted(() => ({
+  flag: { value: true },
+  subData: { value: null as unknown },
+  txData: { value: [] as unknown[] },
+  markPaid: vi.fn(),
+  del: vi.fn(),
+  update: vi.fn(),
+  restore: vi.fn(),
+  useFeatureFlag: vi.fn(),
+  useSubscriptionQuery: vi.fn(),
+  useListAll: vi.fn(),
+  useMarkPaid: vi.fn(),
+  useDelete: vi.fn(),
+  useUpdate: vi.fn(),
+  useRestore: vi.fn(),
+}));
+
+vi.mock("~/shared/feature-flags/use-feature-flag", () => ({ useFeatureFlag: h.useFeatureFlag }));
+vi.mock("~/features/subscription/queries/use-subscription-query", () => ({
+  useSubscriptionQuery: h.useSubscriptionQuery,
+}));
+vi.mock("~/features/transactions/queries/use-list-all-transactions-query", () => ({
+  useListAllTransactionsQuery: h.useListAll,
+}));
+vi.mock("~/features/transactions/queries/use-mark-transaction-paid-mutation", () => ({
+  useMarkTransactionPaidMutation: h.useMarkPaid,
+}));
+vi.mock("~/features/transactions/queries/use-delete-transaction-mutation", () => ({
+  useDeleteTransactionMutation: h.useDelete,
+}));
+vi.mock("~/features/transactions/queries/use-update-transaction-mutation", () => ({
+  useUpdateTransactionMutation: h.useUpdate,
+}));
+vi.mock("~/features/transactions/queries/use-restore-transaction-mutation", () => ({
+  useRestoreTransactionMutation: h.useRestore,
+}));
+
+/**
+ * Fixed clock for deterministic eligibility math.
+ *
+ * @returns 2026-06-29 (local).
+ */
+const NOW = (): Date => new Date(2026, 5, 29);
+
+/**
+ * Builds a TransactionDto with overdue-expense defaults.
+ *
+ * @param overrides Fields to override.
+ * @returns A transaction fixture.
+ */
+const tx = (overrides: Partial<TransactionDto> = {}): TransactionDto =>
+  ({
+    id: "tx",
+    title: "Conta",
+    amount: "100.00",
+    type: "expense",
+    due_date: "2026-04-01",
+    status: "pending",
+    description: null,
+    observation: null,
+    paid_at: null,
+    created_at: "2026-03-01T00:00:00Z",
+    ...overrides,
+  }) as TransactionDto;
+
+const premiumSub = {
+  id: "s",
+  planSlug: "premium",
+  status: "active",
+  trialEndsAt: null,
+  currentPeriodEnd: null,
+  provider: null,
+  providerSubscriptionId: null,
+};
+
+describe("usePaymentAssistant", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.flag.value = true;
+    h.subData.value = premiumSub;
+    h.txData.value = [
+      tx({ id: "a", due_date: "2026-02-01" }),
+      tx({ id: "b", due_date: "2026-03-01" }),
+      tx({ id: "recent", due_date: "2026-06-25" }),
+      tx({ id: "settled", status: "paid", due_date: "2026-01-01" }),
+    ];
+    h.markPaid.mockResolvedValue(undefined);
+    h.del.mockResolvedValue(undefined);
+    h.update.mockResolvedValue(undefined);
+    h.restore.mockResolvedValue(undefined);
+    h.useFeatureFlag.mockReturnValue(h.flag);
+    h.useSubscriptionQuery.mockReturnValue({ data: h.subData });
+    h.useListAll.mockReturnValue({ data: h.txData });
+    h.useMarkPaid.mockReturnValue({ mutateAsync: h.markPaid });
+    h.useDelete.mockReturnValue({ mutateAsync: h.del });
+    h.useUpdate.mockReturnValue({ mutateAsync: h.update });
+    h.useRestore.mockReturnValue({ mutateAsync: h.restore });
+    sessionStorage.clear();
+  });
+
+  it("derives Premium from the subscription query", () => {
+    expect(usePaymentAssistant(NOW).isPremium.value).toBe(true);
+    h.subData.value = { ...premiumSub, planSlug: "free" };
+    expect(usePaymentAssistant(NOW).isPremium.value).toBe(false);
+  });
+
+  it("selects only overdue open candidates, oldest first", () => {
+    const a = usePaymentAssistant(NOW);
+    expect(a.candidates.value.map((t) => t.id)).toEqual(["a", "b"]);
+  });
+
+  it("auto-opens for a Premium user with candidates and marks the session", () => {
+    const a = usePaymentAssistant(NOW);
+    expect(a.maybeAutoOpen(false)).toBe(true);
+    expect(a.isOpen.value).toBe(true);
+    // Second instance must not auto-open again in the same session.
+    expect(usePaymentAssistant(NOW).maybeAutoOpen(false)).toBe(false);
+  });
+
+  it("does not auto-open while held by another modal", () => {
+    const a = usePaymentAssistant(NOW);
+    expect(a.maybeAutoOpen(true)).toBe(false);
+    expect(a.isOpen.value).toBe(false);
+  });
+
+  it("pays the current card and advances", async () => {
+    const a = usePaymentAssistant(NOW);
+    a.open();
+    expect(a.current.value?.id).toBe("a");
+    await a.pay();
+    expect(h.markPaid).toHaveBeenCalledWith({ id: "a", paidAt: expect.any(String) });
+    expect(a.current.value?.id).toBe("b");
+    expect(a.progress.value).toEqual({ current: 2, total: 2 });
+  });
+
+  it("discards the current card via soft-delete and advances", async () => {
+    const a = usePaymentAssistant(NOW);
+    a.open();
+    await a.discard();
+    expect(h.del).toHaveBeenCalledWith({ id: "a", scope: "occurrence" });
+    expect(a.current.value?.id).toBe("b");
+  });
+
+  it("skips without mutating", () => {
+    const a = usePaymentAssistant(NOW);
+    a.open();
+    a.skipCard();
+    expect(h.markPaid).not.toHaveBeenCalled();
+    expect(h.del).not.toHaveBeenCalled();
+    expect(a.current.value?.id).toBe("b");
+  });
+
+  it("marks all remaining cards as paid", async () => {
+    const a = usePaymentAssistant(NOW);
+    a.open();
+    await a.markAllPaid();
+    expect(h.markPaid).toHaveBeenCalledTimes(2);
+    expect(a.isDone.value).toBe(true);
+  });
+
+  it("undo of a payment reverts the status back to pending", async () => {
+    const a = usePaymentAssistant(NOW);
+    a.open();
+    await a.pay();
+    const undone = await a.undo();
+    expect(undone?.kind).toBe("paid");
+    expect(h.update).toHaveBeenCalledWith({
+      id: "a",
+      payload: { status: "pending", paid_at: null },
+    });
+    expect(a.current.value?.id).toBe("a");
+  });
+
+  it("undo of a delete restores the transaction", async () => {
+    const a = usePaymentAssistant(NOW);
+    a.open();
+    await a.discard();
+    await a.undo();
+    expect(h.restore).toHaveBeenCalledWith("a");
+  });
+
+  it("undo is a no-op when nothing was done", async () => {
+    const a = usePaymentAssistant(NOW);
+    a.open();
+    expect(await a.undo()).toBeNull();
+    expect(h.update).not.toHaveBeenCalled();
+    expect(h.restore).not.toHaveBeenCalled();
+  });
+});

--- a/app/features/payments-assistant/composables/use-payment-assistant.ts
+++ b/app/features/payments-assistant/composables/use-payment-assistant.ts
@@ -1,0 +1,122 @@
+/**
+ * Orchestrates the Payments Assistant: which overdue transactions to review,
+ * deck navigation, and the pay/delete/skip/undo actions backed by the existing
+ * transaction mutations.
+ *
+ * This composable deliberately owns NO presentation concern (no i18n, no toast).
+ * It exposes reactive state and async actions; the modal component renders them
+ * and surfaces toasts/undo affordances. Decision logic lives in the pure
+ * `services/payment-assistant.*` modules and the action handlers in
+ * `use-assistant-actions`, so this stays a thin, testable façade.
+ */
+
+import { type ComputedRef, type Ref, computed, ref } from "vue";
+
+import { useFeatureFlag } from "~/shared/feature-flags/use-feature-flag";
+import { useSubscriptionQuery } from "~/features/subscription/queries/use-subscription-query";
+import { useListAllTransactionsQuery } from "~/features/transactions/queries/use-list-all-transactions-query";
+import { useMarkTransactionPaidMutation } from "~/features/transactions/queries/use-mark-transaction-paid-mutation";
+import { useDeleteTransactionMutation } from "~/features/transactions/queries/use-delete-transaction-mutation";
+import { useUpdateTransactionMutation } from "~/features/transactions/queries/use-update-transaction-mutation";
+import { useRestoreTransactionMutation } from "~/features/transactions/queries/use-restore-transaction-mutation";
+import type { ListTransactionsFilters } from "~/features/transactions/services/transactions.client";
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+
+import {
+  OVERDUE_THRESHOLD_DAYS,
+  isPremiumSubscription,
+  selectOverdueCandidates,
+} from "../services/payment-assistant.eligibility";
+import {
+  type DeckAction,
+  type DeckProgress,
+  type DeckState,
+  createDeck,
+  currentCard,
+  deckProgress,
+  isDeckDone,
+} from "../services/payment-assistant.deck";
+import { type AssistantActions, useAssistantActions } from "./use-assistant-actions";
+
+/** Feature flag gating the assistant (kill-switch / staged rollout). */
+export const PAYMENTS_ASSISTANT_FLAG = "web.features.payments-assistant";
+
+/** Reactive surface returned by {@link usePaymentAssistant}. */
+export interface UsePaymentAssistantReturn extends AssistantActions {
+  readonly isOpen: Ref<boolean>;
+  readonly isPremium: ComputedRef<boolean>;
+  readonly candidates: ComputedRef<TransactionDto[]>;
+  readonly current: ComputedRef<TransactionDto | null>;
+  readonly progress: ComputedRef<DeckProgress>;
+  readonly isDone: ComputedRef<boolean>;
+  readonly lastAction: Ref<DeckAction | null>;
+}
+
+/**
+ * Formats a Date as a local `YYYY-MM-DD` calendar date.
+ *
+ * @param date Date to format.
+ * @returns ISO calendar-date string.
+ */
+const toIsoDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+/**
+ * Payments Assistant composable.
+ *
+ * @param now Clock injector (defaults to `() => new Date()`), overridable in tests.
+ * @returns Reactive state and actions for the assistant.
+ */
+export const usePaymentAssistant = (
+  now: () => Date = () => new Date(),
+): UsePaymentAssistantReturn => {
+  const flag = useFeatureFlag(PAYMENTS_ASSISTANT_FLAG);
+
+  const subscriptionQuery = useSubscriptionQuery();
+  const isPremium = computed(() => isPremiumSubscription(subscriptionQuery.data.value ?? null));
+
+  // Cap the fetch to entries already past the overdue threshold; the precise
+  // status/threshold filtering happens client-side via selectOverdueCandidates.
+  const listFilters = computed<ListTransactionsFilters>(() => {
+    const cutoff = now();
+    cutoff.setDate(cutoff.getDate() - OVERDUE_THRESHOLD_DAYS);
+    return { end_date: toIsoDate(cutoff) };
+  });
+  const transactionsQuery = useListAllTransactionsQuery(listFilters);
+  const candidates = computed(() =>
+    selectOverdueCandidates(transactionsQuery.data.value ?? [], now()),
+  );
+
+  const mutations = {
+    markPaid: useMarkTransactionPaidMutation(),
+    remove: useDeleteTransactionMutation(),
+    update: useUpdateTransactionMutation(),
+    restore: useRestoreTransactionMutation(),
+  };
+
+  const isOpen = ref(false);
+  const deck = ref<DeckState>(createDeck([]));
+  const lastAction = ref<DeckAction | null>(null);
+
+  const current = computed(() => currentCard(deck.value));
+  const progress = computed(() => deckProgress(deck.value));
+  const isDone = computed(() => isDeckDone(deck.value));
+
+  const actions = useAssistantActions({
+    deck,
+    current,
+    candidates,
+    isOpen,
+    lastAction,
+    flagEnabled: flag,
+    isPremium,
+    mutations,
+    now,
+  });
+
+  return { isOpen, isPremium, candidates, current, progress, isDone, lastAction, ...actions };
+};

--- a/app/features/payments-assistant/services/payment-assistant.deck.spec.ts
+++ b/app/features/payments-assistant/services/payment-assistant.deck.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+
+import {
+  advanceDeck,
+  createDeck,
+  currentCard,
+  deckProgress,
+  isDeckDone,
+  undoDeck,
+} from "./payment-assistant.deck";
+
+/**
+ * Builds a minimal transaction card fixture.
+ *
+ * @param id Card id (also used as the title).
+ * @returns A transaction fixture.
+ */
+const card = (id: string): TransactionDto =>
+  ({ id, title: id, due_date: "2026-01-01", status: "pending" }) as TransactionDto;
+
+const cards = [card("a"), card("b"), card("c")];
+
+describe("payment-assistant deck reducer", () => {
+  it("starts at the first card", () => {
+    const deck = createDeck(cards);
+    expect(currentCard(deck)?.id).toBe("a");
+    expect(deckProgress(deck)).toEqual({ current: 1, total: 3 });
+    expect(isDeckDone(deck)).toBe(false);
+  });
+
+  it("advances through cards recording the action", () => {
+    const deck = advanceDeck(createDeck(cards), "paid");
+    expect(currentCard(deck)?.id).toBe("b");
+    expect(deckProgress(deck)).toEqual({ current: 2, total: 3 });
+  });
+
+  it("is done after the last card is processed", () => {
+    let deck = createDeck(cards);
+    deck = advanceDeck(deck, "paid");
+    deck = advanceDeck(deck, "deleted");
+    deck = advanceDeck(deck, "skipped");
+    expect(isDeckDone(deck)).toBe(true);
+    expect(currentCard(deck)).toBeNull();
+    expect(deckProgress(deck)).toEqual({ current: 3, total: 3 });
+  });
+
+  it("undo steps back and returns the reverted action and card", () => {
+    const advanced = advanceDeck(createDeck(cards), "paid");
+    const { deck, undone } = undoDeck(advanced);
+    expect(currentCard(deck)?.id).toBe("a");
+    expect(undone).toEqual({ kind: "paid", card: cards[0] });
+  });
+
+  it("undo is a no-op at the start", () => {
+    const deck = createDeck(cards);
+    const result = undoDeck(deck);
+    expect(result.deck).toEqual(deck);
+    expect(result.undone).toBeNull();
+  });
+
+  it("treats an empty deck as immediately done", () => {
+    const deck = createDeck([]);
+    expect(isDeckDone(deck)).toBe(true);
+    expect(currentCard(deck)).toBeNull();
+    expect(deckProgress(deck)).toEqual({ current: 0, total: 0 });
+  });
+});

--- a/app/features/payments-assistant/services/payment-assistant.deck.ts
+++ b/app/features/payments-assistant/services/payment-assistant.deck.ts
@@ -1,0 +1,123 @@
+/**
+ * Pure reducer for the Payments Assistant card deck.
+ *
+ * The deck is an immutable ordered list with a cursor. Paying, deleting or
+ * skipping a card advances the cursor and records the action; undo steps the
+ * cursor back and reports the action to revert. Keeping this pure isolates the
+ * navigation/undo logic from Vue and the API mutations, which the composable
+ * layers on top as side effects.
+ */
+
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+
+/** The kind of action taken on a card. */
+export type DeckActionKind = "paid" | "deleted" | "skipped";
+
+/** A recorded action against a specific card. */
+export interface DeckAction {
+  readonly kind: DeckActionKind;
+  readonly card: TransactionDto;
+}
+
+/** Immutable deck state: the cards, the cursor, and the action history. */
+export interface DeckState {
+  readonly cards: readonly TransactionDto[];
+  readonly index: number;
+  readonly history: readonly DeckAction[];
+}
+
+/** Progress through the deck, 1-based for display. */
+export interface DeckProgress {
+  readonly current: number;
+  readonly total: number;
+}
+
+/**
+ * Creates a fresh deck positioned at the first card.
+ *
+ * @param cards Ordered cards to review.
+ * @returns Initial deck state.
+ */
+export const createDeck = (cards: readonly TransactionDto[]): DeckState => ({
+  cards,
+  index: 0,
+  history: [],
+});
+
+/**
+ * Returns the card under the cursor, or null when the deck is done.
+ *
+ * @param state Deck state.
+ * @returns Current card or null.
+ */
+export const currentCard = (state: DeckState): TransactionDto | null =>
+  state.cards[state.index] ?? null;
+
+/**
+ * Whether every card has been processed.
+ *
+ * @param state Deck state.
+ * @returns True when the cursor is past the last card.
+ */
+export const isDeckDone = (state: DeckState): boolean => state.index >= state.cards.length;
+
+/**
+ * Computes 1-based progress, clamped to the deck size.
+ *
+ * @param state Deck state.
+ * @returns Progress `{ current, total }`.
+ */
+export const deckProgress = (state: DeckState): DeckProgress => ({
+  current: Math.min(state.index + (state.cards.length > 0 ? 1 : 0), state.cards.length),
+  total: state.cards.length,
+});
+
+/**
+ * Advances the cursor, recording the action taken on the current card.
+ *
+ * No-op (returns the same state) when the deck is already done.
+ *
+ * @param state Deck state.
+ * @param kind Action taken on the current card.
+ * @returns Next deck state.
+ */
+export const advanceDeck = (state: DeckState, kind: DeckActionKind): DeckState => {
+  const card = currentCard(state);
+  if (!card) {
+    return state;
+  }
+  return {
+    cards: state.cards,
+    index: state.index + 1,
+    history: [...state.history, { kind, card }],
+  };
+};
+
+/** Result of an undo: the new state and the action that was reverted (if any). */
+export interface UndoResult {
+  readonly deck: DeckState;
+  readonly undone: DeckAction | null;
+}
+
+/**
+ * Steps the cursor back one card, returning the action to revert.
+ *
+ * No-op at the start of the deck.
+ *
+ * @param state Deck state.
+ * @returns The previous state and the reverted action, or the same state + null.
+ */
+export const undoDeck = (state: DeckState): UndoResult => {
+  if (state.index <= 0 || state.history.length === 0) {
+    return { deck: state, undone: null };
+  }
+  const undone = state.history[state.history.length - 1] ?? null;
+  return {
+    deck: {
+      cards: state.cards,
+      index: state.index - 1,
+      history: state.history.slice(0, -1),
+    },
+    undone,
+  };
+};

--- a/app/features/payments-assistant/services/payment-assistant.eligibility.spec.ts
+++ b/app/features/payments-assistant/services/payment-assistant.eligibility.spec.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
+import type { Subscription } from "~/features/subscription/model/subscription";
+
+import {
+  OVERDUE_THRESHOLD_DAYS,
+  isOverdueByAtLeastDays,
+  isPremiumSubscription,
+  selectOverdueCandidates,
+} from "./payment-assistant.eligibility";
+
+/**
+ * Builds a TransactionDto with sensible defaults, overridable per test.
+ *
+ * @param overrides Fields to override.
+ * @returns A transaction fixture.
+ */
+const makeTransaction = (overrides: Partial<TransactionDto> = {}): TransactionDto => ({
+  id: "tx-1",
+  title: "Aluguel",
+  amount: "1200.00",
+  type: "expense",
+  due_date: "2026-05-01",
+  description: null,
+  observation: null,
+  is_recurring: false,
+  is_installment: false,
+  installment_count: null,
+  recurrence_interval: 1,
+  recurrence_unit: "month",
+  currency: "BRL",
+  status: "pending",
+  start_date: null,
+  end_date: null,
+  tag_id: null,
+  account_id: null,
+  credit_card_id: null,
+  installment_group_id: null,
+  paid_at: null,
+  created_at: "2026-04-01T00:00:00Z",
+  updated_at: null,
+  ...overrides,
+});
+
+const TODAY = new Date(2026, 5, 29); // 2026-06-29 (local)
+
+describe("isOverdueByAtLeastDays", () => {
+  it("is true for a due date older than the threshold", () => {
+    expect(isOverdueByAtLeastDays("2026-04-01", 30, TODAY)).toBe(true);
+  });
+
+  it("is true exactly on the cutoff boundary (today - days)", () => {
+    expect(isOverdueByAtLeastDays("2026-05-30", 30, TODAY)).toBe(true);
+  });
+
+  it("is false one day inside the threshold window", () => {
+    expect(isOverdueByAtLeastDays("2026-05-31", 30, TODAY)).toBe(false);
+  });
+
+  it("is false for a future due date", () => {
+    expect(isOverdueByAtLeastDays("2026-07-15", 30, TODAY)).toBe(false);
+  });
+});
+
+describe("selectOverdueCandidates", () => {
+  it("keeps only pending/postponed transactions overdue beyond the threshold", () => {
+    const transactions = [
+      makeTransaction({ id: "pending-old", status: "pending", due_date: "2026-04-10" }),
+      makeTransaction({ id: "postponed-old", status: "postponed", due_date: "2026-03-20" }),
+      makeTransaction({ id: "paid-old", status: "paid", due_date: "2026-04-10" }),
+      makeTransaction({ id: "cancelled-old", status: "cancelled", due_date: "2026-04-10" }),
+      makeTransaction({ id: "pending-recent", status: "pending", due_date: "2026-06-20" }),
+    ];
+
+    const result = selectOverdueCandidates(transactions, TODAY);
+
+    expect(result.map((t) => t.id)).toEqual(["postponed-old", "pending-old"]);
+  });
+
+  it("sorts by due date ascending (oldest first)", () => {
+    const transactions = [
+      makeTransaction({ id: "b", status: "pending", due_date: "2026-04-15" }),
+      makeTransaction({ id: "a", status: "pending", due_date: "2026-02-01" }),
+      makeTransaction({ id: "c", status: "pending", due_date: "2026-05-01" }),
+    ];
+
+    const result = selectOverdueCandidates(transactions, TODAY);
+
+    expect(result.map((t) => t.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns an empty array when nothing qualifies", () => {
+    const transactions = [
+      makeTransaction({ status: "paid", due_date: "2026-01-01" }),
+      makeTransaction({ status: "pending", due_date: "2026-06-28" }),
+    ];
+
+    expect(selectOverdueCandidates(transactions, TODAY)).toEqual([]);
+  });
+
+  it("exposes a 30-day default threshold", () => {
+    expect(OVERDUE_THRESHOLD_DAYS).toBe(30);
+  });
+});
+
+describe("isPremiumSubscription", () => {
+  /**
+   * Builds a Subscription fixture, overridable per test.
+   *
+   * @param overrides Fields to override.
+   * @returns A subscription fixture.
+   */
+  const makeSubscription = (overrides: Partial<Subscription> = {}): Subscription => ({
+    id: "sub-1",
+    planSlug: "premium",
+    status: "active",
+    trialEndsAt: null,
+    currentPeriodEnd: null,
+    provider: null,
+    providerSubscriptionId: null,
+    ...overrides,
+  });
+
+  it("is true for an active paid plan", () => {
+    expect(isPremiumSubscription(makeSubscription({ status: "active" }))).toBe(true);
+  });
+
+  it("is true while trialing a paid plan", () => {
+    expect(isPremiumSubscription(makeSubscription({ status: "trialing", planSlug: "pro" }))).toBe(
+      true,
+    );
+  });
+
+  it("is false for the free plan even when active", () => {
+    expect(isPremiumSubscription(makeSubscription({ planSlug: "free" }))).toBe(false);
+  });
+
+  it("is false for past_due or canceled status", () => {
+    expect(isPremiumSubscription(makeSubscription({ status: "past_due" }))).toBe(false);
+    expect(isPremiumSubscription(makeSubscription({ status: "canceled" }))).toBe(false);
+  });
+
+  it("is false for null/undefined subscription", () => {
+    expect(isPremiumSubscription(null)).toBe(false);
+    expect(isPremiumSubscription(undefined)).toBe(false);
+  });
+});

--- a/app/features/payments-assistant/services/payment-assistant.eligibility.ts
+++ b/app/features/payments-assistant/services/payment-assistant.eligibility.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure eligibility rules for the Payments Assistant.
+ *
+ * The assistant surfaces transactions that are still "open" (pending or
+ * postponed) and overdue by at least {@link OVERDUE_THRESHOLD_DAYS} days, so the
+ * user can clear or discard the backlog of stale entries. Keeping these rules
+ * pure (no Vue, no fetch) makes them trivially testable and reusable across the
+ * composable and any future surface.
+ */
+
+import type { TransactionDto, TransactionStatusDto } from "~/features/transactions/contracts/transaction.dto";
+import type { Subscription } from "~/features/subscription/model/subscription";
+
+/** A transaction must be overdue by at least this many days to qualify. */
+export const OVERDUE_THRESHOLD_DAYS = 30;
+
+/** Statuses considered "open" (still actionable) by the assistant. */
+const ELIGIBLE_STATUSES: ReadonlySet<TransactionStatusDto> = new Set<TransactionStatusDto>([
+  "pending",
+  "postponed",
+]);
+
+/** Subscription statuses that grant access to Premium-only surfaces. */
+const PREMIUM_STATUSES: ReadonlySet<Subscription["status"]> = new Set<Subscription["status"]>([
+  "active",
+  "trialing",
+]);
+
+/**
+ * Formats a Date as a local `YYYY-MM-DD` calendar date.
+ *
+ * Uses local components (not UTC) so comparisons line up with the calendar the
+ * user sees, avoiding timezone off-by-one around midnight.
+ *
+ * @param date Date to format.
+ * @returns ISO calendar-date string.
+ */
+const toIsoDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+/**
+ * Whether a `due_date` is overdue by at least `days` days relative to `today`.
+ *
+ * The comparison is calendar-date only (lexicographic on `YYYY-MM-DD`, which is
+ * chronologically correct for that format). A due date exactly on the cutoff
+ * (`today - days`) counts as overdue.
+ *
+ * @param dueDate Due date as `YYYY-MM-DD`.
+ * @param days Minimum number of days overdue.
+ * @param today Reference "now" date.
+ * @returns True when `dueDate <= today - days`.
+ */
+export const isOverdueByAtLeastDays = (dueDate: string, days: number, today: Date): boolean => {
+  const cutoff = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  cutoff.setDate(cutoff.getDate() - days);
+  return dueDate <= toIsoDate(cutoff);
+};
+
+/**
+ * Selects the transactions the assistant should present, oldest due date first.
+ *
+ * Keeps only open (pending/postponed) entries overdue beyond the threshold and
+ * sorts them ascending by due date so the most stale item is reviewed first.
+ *
+ * @param transactions Full set of candidate transactions.
+ * @param today Reference "now" date.
+ * @param thresholdDays Overdue threshold (defaults to {@link OVERDUE_THRESHOLD_DAYS}).
+ * @returns Filtered, sorted list of overdue open transactions.
+ */
+export const selectOverdueCandidates = (
+  transactions: readonly TransactionDto[],
+  today: Date,
+  thresholdDays: number = OVERDUE_THRESHOLD_DAYS,
+): TransactionDto[] =>
+  transactions
+    .filter(
+      (transaction) =>
+        ELIGIBLE_STATUSES.has(transaction.status) &&
+        isOverdueByAtLeastDays(transaction.due_date, thresholdDays, today),
+    )
+    .slice()
+    .sort((a, b) => a.due_date.localeCompare(b.due_date));
+
+/**
+ * Whether a subscription grants access to Premium-only features.
+ *
+ * Premium requires an active or trialing subscription on a paid (non-free) plan.
+ *
+ * @param subscription Current subscription, if any.
+ * @returns True when the user is entitled to Premium surfaces.
+ */
+export const isPremiumSubscription = (
+  subscription: Subscription | null | undefined,
+): boolean => {
+  if (!subscription) {
+    return false;
+  }
+  if (!PREMIUM_STATUSES.has(subscription.status)) {
+    return false;
+  }
+  return subscription.planSlug !== "free" && subscription.planSlug.length > 0;
+};

--- a/app/features/payments-assistant/services/payment-assistant.session.spec.ts
+++ b/app/features/payments-assistant/services/payment-assistant.session.spec.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ASSISTANT_SESSION_KEY,
+  markAssistantShown,
+  shouldAutoOpenAssistant,
+  wasAssistantShown,
+} from "./payment-assistant.session";
+
+/**
+ * Builds a minimal in-memory Storage stub for deterministic session tests.
+ *
+ * @returns A Storage-compatible stub backed by a Map.
+ */
+const makeStorage = (): Storage => {
+  const map = new Map<string, string>();
+  return {
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => void map.set(key, value),
+    removeItem: (key) => void map.delete(key),
+    clear: () => map.clear(),
+    key: (index) => Array.from(map.keys())[index] ?? null,
+    get length() {
+      return map.size;
+    },
+  } as Storage;
+};
+
+describe("shouldAutoOpenAssistant", () => {
+  const base = {
+    flagEnabled: true,
+    isPremium: true,
+    shownThisSession: false,
+    candidateCount: 3,
+    heldByOtherModals: false,
+  };
+
+  it("opens when all conditions are met", () => {
+    expect(shouldAutoOpenAssistant(base)).toBe(true);
+  });
+
+  it("stays closed when the feature flag is off", () => {
+    expect(shouldAutoOpenAssistant({ ...base, flagEnabled: false })).toBe(false);
+  });
+
+  it("stays closed for non-Premium users", () => {
+    expect(shouldAutoOpenAssistant({ ...base, isPremium: false })).toBe(false);
+  });
+
+  it("stays closed when already shown this session", () => {
+    expect(shouldAutoOpenAssistant({ ...base, shownThisSession: true })).toBe(false);
+  });
+
+  it("stays closed when other modals hold the surface", () => {
+    expect(shouldAutoOpenAssistant({ ...base, heldByOtherModals: true })).toBe(false);
+  });
+
+  it("stays closed when there are no candidates", () => {
+    expect(shouldAutoOpenAssistant({ ...base, candidateCount: 0 })).toBe(false);
+  });
+});
+
+describe("session-shown flag", () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = makeStorage();
+  });
+
+  it("reports not shown before being marked", () => {
+    expect(wasAssistantShown(storage)).toBe(false);
+  });
+
+  it("persists the shown flag under the session key", () => {
+    markAssistantShown(storage);
+    expect(storage.getItem(ASSISTANT_SESSION_KEY)).toBe("1");
+    expect(wasAssistantShown(storage)).toBe(true);
+  });
+});

--- a/app/features/payments-assistant/services/payment-assistant.session.ts
+++ b/app/features/payments-assistant/services/payment-assistant.session.ts
@@ -1,0 +1,56 @@
+/**
+ * Session-scoped gating + auto-open decision for the Payments Assistant.
+ *
+ * The assistant must appear at most once per browser session and only after the
+ * higher-priority gates (email verification, onboarding) have resolved. These
+ * helpers keep that decision pure (and the persistence injectable) so it is
+ * fully unit-testable without a real browser.
+ */
+
+/** `sessionStorage` key marking that the assistant was already shown this session. */
+export const ASSISTANT_SESSION_KEY = "auraxis:payments_assistant_shown";
+
+/** Inputs that decide whether the assistant should auto-open on entry. */
+export interface AutoOpenParams {
+  /** Whether the `payments_assistant` feature flag is enabled. */
+  readonly flagEnabled: boolean;
+  /** Whether the current user is entitled to Premium surfaces. */
+  readonly isPremium: boolean;
+  /** Whether the assistant was already shown in this session. */
+  readonly shownThisSession: boolean;
+  /** Number of overdue open transactions available to review. */
+  readonly candidateCount: number;
+  /** Whether a higher-priority modal (email gate, onboarding) is holding the surface. */
+  readonly heldByOtherModals: boolean;
+}
+
+/**
+ * Decides whether the assistant should auto-open for the current entry.
+ *
+ * @param params Gating inputs.
+ * @returns True only when every condition is satisfied.
+ */
+export const shouldAutoOpenAssistant = (params: AutoOpenParams): boolean =>
+  params.flagEnabled &&
+  params.isPremium &&
+  !params.shownThisSession &&
+  !params.heldByOtherModals &&
+  params.candidateCount > 0;
+
+/**
+ * Reads whether the assistant has already been shown this session.
+ *
+ * @param storage Storage backend (defaults to `sessionStorage`).
+ * @returns True when the shown flag is set.
+ */
+export const wasAssistantShown = (storage: Storage = sessionStorage): boolean =>
+  storage.getItem(ASSISTANT_SESSION_KEY) === "1";
+
+/**
+ * Marks the assistant as shown for the remainder of this session.
+ *
+ * @param storage Storage backend (defaults to `sessionStorage`).
+ */
+export const markAssistantShown = (storage: Storage = sessionStorage): void => {
+  storage.setItem(ASSISTANT_SESSION_KEY, "1");
+};

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -4232,5 +4232,38 @@
         }
       ]
     }
+  },
+  "paymentsAssistant": {
+    "title": "Pendências em aberto",
+    "progress": "{current} de {total}",
+    "emptyTitle": "Tudo em dia ✓",
+    "emptyBody": "Você não tem contas em aberto vencidas há mais de um mês.",
+    "statusHint": "Marcar aqui só atualiza o status no Auraxis — não move dinheiro de verdade.",
+    "type": {
+      "income": "Receita",
+      "expense": "Despesa"
+    },
+    "fields": {
+      "createdAt": "Criada em",
+      "dueDate": "Vencimento",
+      "observation": "Observações"
+    },
+    "actions": {
+      "payExpense": "Marcar como pago",
+      "payIncome": "Marcar como recebido",
+      "delete": "Excluir",
+      "skip": "Pular",
+      "markAllPaid": "Marcar todas como pagas",
+      "undo": "Desfazer",
+      "close": "Fechar"
+    },
+    "confirmDelete": "Excluir esta transação? Você pode desfazer logo em seguida.",
+    "toast": {
+      "paid": "Transação marcada como paga.",
+      "received": "Transação marcada como recebida.",
+      "deleted": "Transação excluída.",
+      "allPaid": "Todas as pendências foram quitadas.",
+      "undone": "Ação desfeita."
+    }
   }
 }

--- a/app/layouts/default.spec.ts
+++ b/app/layouts/default.spec.ts
@@ -104,6 +104,7 @@ const globalStubs = {
   EmailConfirmationModal: true,
   EmailVerificationGate: true,
   AdminImpersonationBanner: true,
+  PaymentAssistantModal: true,
 };
 
 describe("DefaultLayout", () => {

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -31,6 +31,7 @@ import AdminImpersonationBanner from "~/features/admin/impersonation/components/
 import EmailVerificationGate from "~/features/auth/components/EmailVerificationGate.vue";
 import OnboardingWizard from "~/features/onboarding/components/OnboardingWizard.vue";
 import OnboardingTriggerButton from "~/features/onboarding/components/OnboardingTriggerButton.vue";
+import PaymentAssistantModal from "~/features/payments-assistant/components/PaymentAssistantModal/PaymentAssistantModal.vue";
 
 const { t } = useI18n();
 const route = useRoute();
@@ -92,6 +93,14 @@ const { shouldShow: showOnboardingWizard } = onboarding;
 
 const showProfileModal = ref(false);
 const shouldHoldSecondaryModals = computed(() => sessionStore.emailConfirmed === false);
+
+/**
+ * The Payments Assistant must wait for higher-priority modals (email gate,
+ * onboarding, profile completion) to resolve before auto-opening.
+ */
+const paymentsAssistantHold = computed(
+  () => shouldHoldSecondaryModals.value || showOnboardingWizard.value || showProfileModal.value,
+);
 
 const _profileModalFlagKey = computed((): string => {
   const uid = userStore.profile?.id ?? sessionStore.userEmail ?? "guest";
@@ -171,5 +180,6 @@ function onReplayOnboarding(): void {
   </UiAppShell>
   <OnboardingWizard />
   <OnboardingTriggerButton />
+  <PaymentAssistantModal :hold="paymentsAssistantHold" />
   </div>
 </template>

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -509,6 +509,16 @@
       "status": "enabled-prod",
       "description": "Leitura editorial \"Fluida\" da tela de Insights de IA (masthead + lead + beats). Ativada em producao apos o backend (auraxis-api #1502) entregar paragraphs/retro/series/highlights.",
       "repositories": ["auraxis-web"]
+    },
+    {
+      "key": "web.features.payments-assistant",
+      "owner": "growth",
+      "createdAt": "2026-06-29",
+      "removeBy": "2027-12-31",
+      "type": "release",
+      "status": "enabled-prod",
+      "description": "Assistente de Pagamentos: modal 1x/sessao (Premium) que lista transacoes em aberto vencidas ha mais de 30 dias para marcar como paga/recebida ou excluir, com desfazer. Kill-switch da feature.",
+      "repositories": ["auraxis-web"]
     }
   ]
 }


### PR DESCRIPTION
## O que muda

Adiciona o **Assistente de Pagamentos** no web: um modal que aparece 1×/sessão para usuários
Premium e lista as transações **em aberto vencidas há mais de 30 dias** (`pending`/`postponed`),
permitindo marcar como pago/recebido, excluir (com confirmação) ou pular — com **desfazer** após
cada ação. Inclui "Marcar todas como pagas" e progresso ("X de Y").

Semântica importante: "marcar como pago/recebido" apenas atualiza o status no Auraxis — **não
move dinheiro real**.

Arquitetura:
- Serviços puros (100% testados): `eligibility` (filtro vencidas+abertas, derivação de Premium),
  `session` (decisão de auto-abertura + flag 1×/sessão), `deck` (reducer de navegação/undo).
- Composable `usePaymentAssistant` + `useAssistantActions` (estado + mutations + undo), sem
  acoplar i18n/toast.
- `PaymentAssistantModal.vue` (Naive UI `NModal`), montado no `default.vue` após os gates de
  maior prioridade (email/onboarding/perfil).
- Reuso total do backend existente: `GET /transactions/due-range` (+ filtro client-side),
  `use-mark-transaction-paid-mutation`, `use-delete-transaction-mutation`,
  `use-update-transaction-mutation` (undo de pago→pendente) e `use-restore-transaction-mutation`
  (undo de exclusão). **Sem mudança de contrato.**
- Feature flag `web.features.payments-assistant` (kill-switch).

## Contexto

Closes #1093
Task no GitHub Projects: [WEB] Assistente de Pagamentos.

Auraxis é um tracker de **entrada manual**; o assistente ataca a dor central de pendências
acumuladas. Parte da sequência F3 → F4 → F1 → F2 acordada na sessão de design (2026-06-29).

## Como testar

- [ ] Como usuário Premium com transações `pending`/`postponed` vencidas há +30d: ao entrar no
      app, o modal abre 1×/sessão.
- [ ] Marcar como pago dispara `PATCH {status:"paid", paid_at:now}` e avança o card; "Desfazer"
      reverte para `pending`.
- [ ] Excluir pede confirmação (soft-delete); "Desfazer" restaura.
- [ ] "Marcar todas como pagas" quita o restante; estado vazio "Tudo em dia ✓".
- [ ] Sem pendências, sem Premium, ou com a flag desligada → o modal não abre.

## Screenshots

> O modal é gated (Premium + transações vencidas há +30d), então a captura ao vivo exige estado
> semeado. Posso adicionar um **Storybook story** do `PaymentAssistantModal` (3 resoluções) como
> follow-up rápido se preferir embutir aqui antes do merge.

## Quality gates

- [x] eslint: PASS
- [x] typecheck: PASS
- [x] testes: PASS (4053, sendo 38 novos da feature)
- [x] cobertura ≥ thresholds: PASS
- [x] policy/contracts/flags: PASS
- [x] build: PASS (`pnpm quality-check` completo verde)

## Impacto de contrato

Nenhum — reusa endpoints e mutations existentes.

## Risco

LOW — feature aditiva atrás de feature flag (kill-switch) e gate Premium; sem mudança de schema
ou de contrato; ações reversíveis (undo + soft-delete).
