### PR TITLE
feat(transactions): toggle auto-settle no form de transação (F4)

### DIFF
--- a/app/components/transactions/EditTransactionModal/EditTransactionModal.vue
+++ b/app/components/transactions/EditTransactionModal/EditTransactionModal.vue
@@ -82,6 +82,7 @@ const form = reactive({
   description: "",
   is_recurring: false,
   end_date: null as number | null,
+  auto_settle: false,
 });
 
 // ── Computed field visibility ──────────────────────────────────────────────────
@@ -162,6 +163,7 @@ const populateForm = (tx: TransactionDto): void => {
   form.description = tx.description ?? "";
   form.is_recurring = tx.is_recurring;
   form.end_date = dateToTs(tx.end_date);
+  form.auto_settle = tx.auto_settle ?? false;
 };
 
 // Re-populate whenever the modal opens with a new transaction.
@@ -242,6 +244,7 @@ const handleSubmit = async (): Promise<void> => {
       credit_card_id: form.credit_card_id ?? null,
       description: form.description.trim() || null,
       is_recurring: form.is_recurring,
+      auto_settle: form.auto_settle,
       ...(form.is_recurring && form.end_date
         ? { end_date: tsToDate(form.end_date) }
         : { end_date: null }),
@@ -381,6 +384,12 @@ const handleClose = (): void => {
         />
       </NFormItem>
 
+      <!-- Auto-settle toggle -->
+      <NFormItem :label="$t('transaction.form.autoSettle.label')" path="auto_settle">
+        <NSwitch v-model:value="form.auto_settle" />
+        <div class="edit-transaction-modal__hint">{{ $t('transaction.form.autoSettle.hint') }}</div>
+      </NFormItem>
+
       <!-- Description / notes -->
       <NFormItem :label="$t('transaction.form.description.label')" path="description">
         <NInput
@@ -423,6 +432,13 @@ const handleClose = (): void => {
   background: var(--color-bg-subtle);
   color: var(--color-text-secondary);
   font-size: var(--font-size-xs);
+  line-height: 1.45;
+}
+
+.edit-transaction-modal__hint {
+  margin-top: 4px;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
   line-height: 1.45;
 }
 

--- a/app/components/transactions/QuickTransactionForm/QuickTransactionFormFields.vue
+++ b/app/components/transactions/QuickTransactionForm/QuickTransactionFormFields.vue
@@ -182,6 +182,11 @@ const installmentPreview = computed<InstallmentPreview | null>(() => {
       <NDatePicker v-model:value="form.end_date" type="date" format="dd/MM/yyyy" style="width: 100%" clearable />
     </NFormItem>
 
+    <NFormItem :label="$t('transaction.form.autoSettle.label')" path="auto_settle">
+      <NSwitch v-model:value="form.auto_settle" />
+      <div class="quick-transaction-form__hint">{{ $t('transaction.form.autoSettle.hint') }}</div>
+    </NFormItem>
+
     <NFormItem :label="$t('transaction.form.description.label')" path="description">
       <NInput
         v-model:value="form.description"
@@ -204,6 +209,13 @@ const installmentPreview = computed<InstallmentPreview | null>(() => {
 
 .quick-transaction-form__settings-link:hover {
   text-decoration: underline;
+}
+
+.quick-transaction-form__hint {
+  margin-top: 4px;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  line-height: 1.45;
 }
 
 .quick-transaction-form__budget-preview {

--- a/app/components/transactions/QuickTransactionForm/useQuickTransactionForm.ts
+++ b/app/components/transactions/QuickTransactionForm/useQuickTransactionForm.ts
@@ -42,6 +42,7 @@ export interface QuickTransactionFormState {
   recurrence_interval: number;
   recurrence_unit: RecurrenceUnitDto;
   end_date: number | null;
+  auto_settle: boolean;
 }
 
 /**
@@ -82,6 +83,7 @@ function createDefaultFormState(
     recurrence_interval: 1,
     recurrence_unit: "month",
     end_date: null,
+    auto_settle: false,
   };
 }
 
@@ -211,6 +213,7 @@ export function useQuickTransactionForm(opts: UseQuickTransactionFormOptions) {
       status: form.status,
       tag_id: form.tag_id ?? null,
       account_id: form.account_id ?? null,
+      auto_settle: form.auto_settle,
       ...(form.description.trim() ? { description: form.description } : {}),
       ...buildInstallmentFields(),
       ...buildRecurringFields(),

--- a/app/features/transactions/contracts/transaction.dto.ts
+++ b/app/features/transactions/contracts/transaction.dto.ts
@@ -81,6 +81,9 @@ export interface CreateTransactionPayload {
 
   /** Integration policy between credit cards and other financial surfaces. */
   readonly impact_policy?: TransactionImpactPolicyDto;
+
+  /** Opt-in: auto-mark as paid/received when it comes due. Defaults to false. */
+  readonly auto_settle?: boolean;
 }
 
 /**
@@ -125,6 +128,9 @@ export interface UpdateTransactionPayload {
 
   /** Integration policy between credit cards and other financial surfaces. */
   readonly impact_policy?: TransactionImpactPolicyDto;
+
+  /** Opt-in: auto-mark as paid/received when it comes due. */
+  readonly auto_settle?: boolean;
 }
 
 /**
@@ -156,6 +162,8 @@ export interface TransactionDto {
   readonly credit_card_id: string | null;
   /** Integration policy. Legacy fixtures/responses may omit it; clients default to "full". */
   readonly impact_policy?: TransactionImpactPolicyDto;
+  /** Opt-in: auto-mark as paid/received when it comes due. */
+  readonly auto_settle?: boolean;
   readonly installment_group_id: string | null;
   readonly paid_at: string | null;
   readonly created_at: string | null;

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -1315,6 +1315,10 @@
       "endDate": {
         "label": "Repetir até (opcional)"
       },
+      "autoSettle": {
+        "label": "Marcar como pago/recebido automaticamente",
+        "hint": "No vencimento, o Auraxis marca esta transação como paga/recebida automaticamente. Você pode desfazer quando quiser."
+      },
       "description": {
         "label": "Observações",
         "placeholder": "Notas adicionais sobre este lançamento"

--- a/app/shared/types/generated/graphql.ts
+++ b/app/shared/types/generated/graphql.ts
@@ -1094,6 +1094,7 @@ export type MutationCreateTagArgs = {
 export type MutationCreateTransactionArgs = {
   accountId?: InputMaybe<Scalars['UUID']['input']>;
   amount: Scalars['String']['input'];
+  autoSettle?: InputMaybe<Scalars['Boolean']['input']>;
   category?: InputMaybe<Scalars['String']['input']>;
   creditCardId?: InputMaybe<Scalars['UUID']['input']>;
   currency?: InputMaybe<Scalars['String']['input']>;
@@ -1316,6 +1317,7 @@ export type MutationUpdateTagArgs = {
 export type MutationUpdateTransactionArgs = {
   accountId?: InputMaybe<Scalars['UUID']['input']>;
   amount?: InputMaybe<Scalars['String']['input']>;
+  autoSettle?: InputMaybe<Scalars['Boolean']['input']>;
   category?: InputMaybe<Scalars['String']['input']>;
   creditCardId?: InputMaybe<Scalars['UUID']['input']>;
   currency?: InputMaybe<Scalars['String']['input']>;
@@ -1970,6 +1972,7 @@ export type TransactionTypeObject = {
   __typename?: 'TransactionTypeObject';
   accountId?: Maybe<Scalars['String']['output']>;
   amount: Scalars['String']['output'];
+  autoSettle?: Maybe<Scalars['Boolean']['output']>;
   bankName?: Maybe<Scalars['String']['output']>;
   category?: Maybe<Scalars['String']['output']>;
   createdAt?: Maybe<Scalars['String']['output']>;


### PR DESCRIPTION
## O que muda

Adiciona o toggle **"Marcar como pago/recebido automaticamente"** (campo `auto_settle`, opt-in,
default OFF) no form de **criar** (`QuickTransactionForm`) e **editar** (`EditTransactionModal`)
transação. Liga o piloto automático da F4: no vencimento, o backend marca a transação como
paga/recebida (job diário). Reversível.

- `auto_settle` adicionado a `CreateTransactionPayload`/`UpdateTransactionPayload`/`TransactionDto`.
- Enviado no create/update; seedado ao editar; tipos GraphQL regenerados (codegen).
- i18n PT (label + hint).

## Contexto

Closes #1095
Frontend da F4 (backend: auraxis-api #1519). REST é o caminho usado pelo form.

> **Dependência de CI:** `codegen:check` puxa o schema de `auraxis-api/master`
> (`GRAPHQL_SCHEMA_PATH`). O `graphql.ts` regenerado inclui `autoSettle`, que só existe no schema
> após **auraxis-api #1519** entrar em master. Até lá, o `codegen:check` fica vermelho aqui;
> depois do merge do api, re-rodar o CID deixa verde. Localmente `pnpm quality-check` passa
> (schema local já tem o campo).

## Screenshots

> Toggle adicionado a um form autenticado (criar/editar transação). Captura ao vivo requer login;
> posso anexar screenshots em 3 resoluções como follow-up se preferir.

## Quality gates (local)

- [x] eslint/typecheck: PASS
- [x] testes: 4053 (forms 76/76); policy/contracts: PASS
- [x] `pnpm quality-check` local verde (codegen contra schema local com autoSettle)

## Risco

LOW — campo aditivo opt-in (default OFF); sem mudança de fluxo existente.