### PR TITLE
feat(auth): rate-based mass-logout metric on refresh 401 cluster

### DIFF
--- a/app/composables/useHttp/useHttp.spec.ts
+++ b/app/composables/useHttp/useHttp.spec.ts
@@ -29,9 +29,11 @@ const dialogStub = vi.hoisted(() => ({ warning: vi.fn() }));
 const verificationGateStub = vi.hoisted(() => ({ open: vi.fn() }));
 const navigateToMock = vi.hoisted(() => vi.fn());
 const captureExceptionMock = vi.hoisted(() => vi.fn());
+const captureMessageMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@sentry/nuxt", () => ({
   captureException: captureExceptionMock,
+  captureMessage: captureMessageMock,
 }));
 
 vi.mock("~/stores/session", () => ({
@@ -279,6 +281,56 @@ describe("refreshAccessToken (SEC-GAP-01 — cookie-based)", () => {
 
     expect(captureExceptionMock).not.toHaveBeenCalled();
     expect(sessionStore.signOut).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT emit a mass-logout event for a lone refresh 401 (W1.4 #1102)", async () => {
+    __resetHttpClientForTests();
+    const sessionStore = {
+      signOut: vi.fn(),
+      updateTokens: vi.fn(),
+    } as unknown as Parameters<typeof refreshAccessToken>[1];
+
+    const axiosError = Object.assign(new Error("Unauthorized"), {
+      isAxiosError: true,
+      response: { status: 401 },
+    });
+    vi.spyOn(axios, "post").mockRejectedValueOnce(axiosError);
+
+    await refreshAccessToken("http://api", sessionStore);
+
+    expect(captureMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("emits exactly ONE mass-logout Sentry event when refresh 401s cluster (W1.4 #1102)", async () => {
+    __resetHttpClientForTests();
+    const sessionStore = {
+      signOut: vi.fn(),
+      updateTokens: vi.fn(),
+    } as unknown as Parameters<typeof refreshAccessToken>[1];
+
+    const axiosError = Object.assign(new Error("Unauthorized"), {
+      isAxiosError: true,
+      response: { status: 401 },
+    });
+    // Persistent rejection: every sequential refresh yields a 401. Single-flight
+    // resets between awaited calls, so each fires its own POST → its own 401.
+    vi.spyOn(axios, "post").mockRejectedValue(axiosError);
+
+    for (let i = 0; i < 5; i += 1) {
+      await refreshAccessToken("http://api", sessionStore);
+    }
+
+    // Individual 401s stay filtered from captureException…
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+    // …but the burst surfaces exactly ONE aggregate mass-logout event.
+    expect(captureMessageMock).toHaveBeenCalledOnce();
+    expect(captureMessageMock).toHaveBeenCalledWith(
+      expect.stringContaining("Mass refresh-401"),
+      expect.objectContaining({
+        level: "warning",
+        tags: { feature: "auth", flow: "mass-logout" },
+      }),
+    );
   });
 
   it("is single-flight: N concurrent callers share ONE POST /auth/refresh", async () => {

--- a/app/composables/useHttp/useHttp.ts
+++ b/app/composables/useHttp/useHttp.ts
@@ -48,6 +48,70 @@ interface RefreshEnvelope {
 }
 
 /**
+ * Sliding window for the mass-logout rate detector (W1.4 / #1102).
+ * A cluster of refresh 401s inside this window signals a regression that
+ * logs everyone out (e.g. the 2026-07-03 broken-F5 incident), as opposed to
+ * a lone expired cookie.
+ */
+const MASS_LOGOUT_WINDOW_MS = 10_000;
+
+/** Number of refresh 401s within the window that trips the mass-logout alarm. */
+const MASS_LOGOUT_THRESHOLD = 5;
+
+/**
+ * Timestamps (ms epoch) of recent refresh 401s, pruned to the sliding window
+ * on every record. Module-scoped so it spans every `useHttp` caller/tab-less
+ * navigation in the same client session.
+ */
+let refresh401Timestamps: number[] = [];
+
+/**
+ * Debounce guard so a single sustained burst reports at most ONE Sentry event
+ * (we want a regression signal, not a flood). Resets once the burst subsides
+ * back under the threshold so a genuinely new cluster can surface again.
+ */
+let massLogoutReported = false;
+
+/**
+ * Records a refresh 401 into the sliding window and, when they cluster
+ * (>= {@link MASS_LOGOUT_THRESHOLD} within {@link MASS_LOGOUT_WINDOW_MS}),
+ * emits a single Sentry event tagged `flow:mass-logout`.
+ *
+ * Individual 401s stay OUT of Sentry — an expired cookie is an expected
+ * sign-out (see {@link performRefreshRequest}). Only the RATE is an incident:
+ * a spike of refresh failures means auth is broken for everyone, which the
+ * per-401 filter would otherwise hide.
+ *
+ * @param now Current time in ms (injectable for deterministic tests).
+ */
+const recordRefresh401 = (now: number = Date.now()): void => {
+  const windowStart = now - MASS_LOGOUT_WINDOW_MS;
+  refresh401Timestamps = refresh401Timestamps.filter((ts) => ts > windowStart);
+  refresh401Timestamps.push(now);
+
+  if (refresh401Timestamps.length < MASS_LOGOUT_THRESHOLD) {
+    // Burst subsided — re-arm so the next real cluster can report.
+    massLogoutReported = false;
+    return;
+  }
+
+  if (massLogoutReported) {
+    return;
+  }
+
+  massLogoutReported = true;
+  Sentry.captureMessage("Mass refresh-401 burst detected (possible auth regression)", {
+    level: "warning",
+    tags: { feature: "auth", flow: "mass-logout" },
+    extra: {
+      count: refresh401Timestamps.length,
+      windowMs: MASS_LOGOUT_WINDOW_MS,
+      threshold: MASS_LOGOUT_THRESHOLD,
+    },
+  });
+};
+
+/**
  * Reads a cookie value from `document.cookie` by exact name match.
  *
  * Returns null on the server (no document) and when the cookie is absent
@@ -140,6 +204,11 @@ const performRefreshRequest = async (
         tags: { feature: "auth", flow: "session-refresh" },
         extra: { apiBase, httpStatus: status ?? null },
       });
+    } else {
+      // A lone 401 stays out of Sentry (expected expiry), but a CLUSTER of them
+      // in a short window is a mass-logout regression — surface exactly one
+      // aggregate event instead (W1.4 / #1102).
+      recordRefresh401();
     }
     sessionStore.signOut();
     return null;
@@ -226,6 +295,8 @@ let isSessionDialogOpen = false;
 export const __resetHttpClientForTests = (): void => {
   cachedClient = null;
   isSessionDialogOpen = false;
+  refresh401Timestamps = [];
+  massLogoutReported = false;
 };
 
 /**


### PR DESCRIPTION
## What

Adds a **rate-based mass-logout detector** to the token-refresh path in `app/composables/useHttp/useHttp.ts`.

Individual refresh `401`s stay filtered from Sentry (an expired refresh cookie is an expected sign-out — keeps Sentry clean on normal session expiry). But a **cluster** of refresh 401s in a short window is a different signal: auth is broken for everyone, like the 2026-07-03 broken-F5 incident. The per-401 filter would otherwise hide exactly that regression.

## How

- Module-scoped sliding window: if **≥5 refresh 401s land within 10s**, emit **one** aggregate Sentry event.
  - `Sentry.captureMessage(..., { level: "warning", tags: { feature: "auth", flow: "mass-logout" }, extra: { count, windowMs, threshold } })`
- Single-report debounce: a sustained burst reports at most once; re-arms when it subsides.
- Window/debounce state reset wired into `__resetHttpClientForTests` for test isolation.

## Tests

- Lone refresh 401 → **no** mass-logout event (still filtered).
- Five sequential refresh 401s → **exactly one** `captureMessage` with `flow:mass-logout`; `captureException` never called.

`pnpm quality-check` green locally (lint, typecheck, coverage, policy, contracts, codegen, build). `useHttp.ts` coverage 97%.

Closes #1102