### PR TITLE
ci(web): release auto-merge + quality-check:full

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,8 +16,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Release Please
+        id: release
         uses: googleapis/release-please-action@c3fc4de07084f75a2b61a5b933069bda6edf3d5c # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Habilita auto-merge no PR "chore(main): release ..." para ele não ficar
+      # parado (o crash P0 do app ficou ~1 mês sem lançar — issue platform #854).
+      # O auto-merge só efetiva quando os checks obrigatórios ficam verdes.
+      - name: Enable auto-merge on the release PR
+        if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PR_JSON: ${{ steps.release.outputs.pr }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pr_number="$(printf '%s' "${RELEASE_PR_JSON:-}" | jq -r '.number // empty' 2>/dev/null || true)"
+          if [ -z "${pr_number}" ]; then
+            pr_number="$(gh pr list --repo "${REPO}" --state open \
+              --label 'autorelease: pending' --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          fi
+          if [ -z "${pr_number}" ] || [ "${pr_number}" = "null" ]; then
+            echo "Nenhum PR de release aberto — nada a habilitar."
+            exit 0
+          fi
+          echo "Habilitando auto-merge (squash) no PR de release #${pr_number}"
+          gh pr merge "${pr_number}" --repo "${REPO}" --auto --squash

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "codegen": "graphql-codegen --config codegen.ts",
     "codegen:check": "graphql-codegen --config codegen.ts && git diff --exit-code app/shared/types/generated/graphql.ts",
     "quality-check": "pnpm flags:check && pnpm i18n:check && pnpm lint && pnpm typecheck && pnpm test:coverage && pnpm policy:check && pnpm contracts:check && pnpm codegen:check && pnpm build",
+    "quality-check:full": "pnpm quality-check && pnpm test:e2e",
     "mutation": "stryker run",
     "mutation:quick": "stryker run --mutate 'app/schemas/validators.ts'",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Onda 2/3 (web)
- **W2.1 (Refs #854):** auto-merge do PR de release-please — não fica parado.
- **W3.7 (Closes #1105):** script `quality-check:full` (= `quality-check` + `test:e2e`, que inclui a11y). O `quality-check` continua sendo o **fast-lane** local; o `:full` é o gate pré-release.

Só workflow + script — sem código de app (YAML+JSON validados).

**Deferido: W3.4 lint de paginação (#1104)** — `listTransactions` é usado legitimamente no query hook (view single-page), então um lint hard quebraria o CI. Precisa de regra ESLint custom com detecção de contexto.

Closes #1105