### PR TITLE
chore(flags): promove web.features.ai-chat para enabled-prod — G2 go-live

### DIFF
--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -526,8 +526,8 @@
       "createdAt": "2026-06-30",
       "removeBy": "2027-12-31",
       "type": "release",
-      "status": "enabled-staging",
-      "description": "Ask Anything: barra/drawer de chat com IA (Premium) que responde perguntas sobre as finanças do usuario via POST /ai/chat, ancoradas no snapshot financeiro. Kill-switch da feature; enabled-staging ate validacao em prod.",
+      "status": "enabled-prod",
+      "description": "Ask Anything: barra/drawer de chat com IA (Premium) que responde perguntas sobre as finanças do usuario via POST /ai/chat, ancoradas no snapshot financeiro. Kill-switch da feature; promovida a enabled-prod em 2026-07-12 (go-live G2, pós-deploy da Onda IA v3 na API).",
       "repositories": ["auraxis-web"]
     },
     {


### PR DESCRIPTION
## Summary

Item **G2** do catálogo de go-live (épico platform#860): promove a flag `web.features.ai-chat` de `enabled-staging` para **`enabled-prod`** no catálogo local. A flag segue funcionando como kill-switch da feature.

**Pré-condição (G1) cumprida em 2026-07-12** — platform#874 fechada com evidências:
- API prod no release **1.64.0** (`/healthz` reporta commit `48cac1a…` == master), incluindo a Onda IA v3 completa (chat month-aware + tools, POST /ai/chat).
- `AI_INSIGHTS_USER_BUDGET_PCT=0.167` presente no container (teto R$5/usuário/mês, ADR amendada em platform#859).
- `auraxis:verify-prod-state` todo verde (imagem por SHA, env crítico, preflight CORS com X-CSRF-TOKEN, readiness 200).

## Validation

- `pnpm quality-check` completo local: flags:check → lint → typecheck → test:coverage → policy:check → contracts:check → build — **verde** (exit 0).

## Screenshots

Sem screenshots: mudança é **um flip de status em `config/feature-flags.json`** (sem alteração de código/UI). A UI do chat foi validada visualmente no PR #1098 (3 resoluções) quando a feature entrou em staging.

## Residual risk

- Chat IA passa a aparecer para usuários Premium em prod. Reversão = flip da flag de volta (kill-switch) + deploy, ou runtime override via provider.
- Custo LLM limitado pelo teto de R$5/usuário/mês já ativo na API.

## Refs

Closes #1127
Ref platform#860 (épico go-live) · platform#874 (G1)