### PR TITLE
docs(legal): substituir Asaas por AbacatePay nos documentos legais

### DIFF
--- a/app/features/legal/legal-documents.ts
+++ b/app/features/legal/legal-documents.ts
@@ -28,15 +28,15 @@ export interface LegalDocument {
 const supportEmail = "suporte@auraxis.com.br";
 
 /** Versão vigente da Política de Privacidade — gravada no aceite (#1118). */
-export const PRIVACY_POLICY_VERSION = "2.1.0";
+export const PRIVACY_POLICY_VERSION = "2.2.0";
 
 /** Versão vigente dos Termos de Uso — gravada no aceite (#1118). */
-export const TERMS_OF_USE_VERSION = "2.1.0";
+export const TERMS_OF_USE_VERSION = "2.2.0";
 
 export const privacyPolicyDocument: LegalDocument = {
   title: "Política de Privacidade",
   versionLabel: `Versão ${PRIVACY_POLICY_VERSION}`,
-  updatedAtLabel: "Atualizado em 2026-05-20",
+  updatedAtLabel: "Atualizado em 2026-07-19",
   contactEmail: supportEmail,
   navLinks: [
     { label: "Termos de Uso", to: "/terms" },
@@ -128,16 +128,16 @@ export const privacyPolicyDocument: LegalDocument = {
         "BRAPI — cotações e dados de mercado;",
         "PostHog Cloud — analytics de produto, eventos minimizados, sob consentimento;",
         "OpenAI — geração de insights financeiros com IA (apenas para usuários que utilizam o recurso, com dados minimizados);",
-        "Asaas — processamento de cobrança recorrente do plano Premium (compartilhados: nome, email, CPF ou CNPJ, valor, plano contratado);",
+        "AbacatePay (Abacatepay Tecnologia LTDA, CNPJ 58.271.413/0001-90) — processamento de cobrança recorrente do plano Premium (compartilhados: nome, email, CPF ou CNPJ, valor, plano contratado);",
         "Resend — envio de emails transacionais (cadastro, recibos, lembretes).",
       ],
     },
     {
       title: "7.1 Dados financeiros não armazenados pelo Auraxis",
       paragraphs: [
-        "O Auraxis NÃO armazena número de cartão de crédito, CVV, senha de cartão ou qualquer credencial bancária. O processamento desses dados ocorre exclusivamente no provedor de pagamento (Asaas) durante o checkout hospedado.",
+        "O Auraxis NÃO armazena número de cartão de crédito, CVV, senha de cartão ou qualquer credencial bancária. O processamento desses dados ocorre exclusivamente no provedor de pagamento (AbacatePay) durante o checkout hospedado.",
         "O Auraxis armazena apenas: identificador de assinatura, identificador de transação, status (active/canceled/past_due), histórico de cobranças com valor e data, plano vigente e período de validade.",
-        "Detalhes específicos do tratamento por Asaas: https://www.asaas.com/politica-de-privacidade.",
+        "O tratamento de dados pelo provedor de pagamento é regido pela política de privacidade da Abacatepay Tecnologia LTDA (CNPJ 58.271.413/0001-90), disponível em seu site.",
       ],
     },
     {
@@ -188,7 +188,7 @@ export const privacyPolicyDocument: LegalDocument = {
 export const termsOfUseDocument: LegalDocument = {
   title: "Termos de Uso",
   versionLabel: `Versão ${TERMS_OF_USE_VERSION}`,
-  updatedAtLabel: "Atualizado em 2026-05-20",
+  updatedAtLabel: "Atualizado em 2026-07-19",
   contactEmail: supportEmail,
   navLinks: [
     { label: "Política de Privacidade", to: "/privacy" },
@@ -268,7 +268,7 @@ export const termsOfUseDocument: LegalDocument = {
     {
       title: "9.1 Processamento de pagamento",
       paragraphs: [
-        "O processamento de cobrança é realizado pela Asaas, provedor de pagamento brasileiro regulado. O Auraxis não armazena dados de cartão de crédito. Tributos eventualmente aplicáveis seguem a legislação vigente.",
+        "O processamento de cobrança é realizado pela AbacatePay (Abacatepay Tecnologia LTDA, CNPJ 58.271.413/0001-90), provedor de pagamento brasileiro. O Auraxis não armazena dados de cartão de crédito. Tributos eventualmente aplicáveis seguem a legislação vigente.",
         "Preços podem ser alterados mediante aviso prévio razoável e atualização desta seção. Renovações em andamento permanecem com o preço vigente no momento da contratação até o término do ciclo.",
       ],
     },
@@ -287,7 +287,7 @@ export const termsOfUseDocument: LegalDocument = {
         "Em caso de falha na cobrança automática (cartão expirado, saldo insuficiente, etc.), o provedor de pagamento pode tentar a cobrança novamente conforme regras próprias.",
         "Após confirmação de falha definitiva, o usuário será notificado por email e poderá atualizar o método de pagamento ou cancelar o plano. Durante o período de carência (3 dias), o acesso Premium continua ativo.",
         "Após a carência sem regularização, o plano é rebaixado para Free e funcionalidades Premium ficam indisponíveis. Os dados do usuário permanecem preservados.",
-        "Para disputas envolvendo cobranças, o usuário deve entrar em contato pelo canal oficial de suporte. O Auraxis colabora com a Asaas para investigação e resolução conforme normas do setor.",
+        "Para disputas envolvendo cobranças, o usuário deve entrar em contato pelo canal oficial de suporte. O Auraxis colabora com a AbacatePay para investigação e resolução conforme normas do setor.",
       ],
     },
     {

--- a/app/pages/checkout/success.vue
+++ b/app/pages/checkout/success.vue
@@ -21,7 +21,7 @@ useSeoMeta({
 // plan without requiring a manual page refresh.
 const queryClient = useQueryClient();
 onMounted(async () => {
-  // #524 — Asaas redirects to this page after a confirmed payment. The
+  // #524 — the payment provider redirects to this page after a confirmed payment. The
   // webhook is the source-of-truth for entitlement state on the server;
   // this client event mirrors that success so funnel time-to-conversion
   // is computable from PostHog alone (without joining server logs).

--- a/app/pages/privacy-policy.spec.ts
+++ b/app/pages/privacy-policy.spec.ts
@@ -28,8 +28,8 @@ describe("PrivacyPolicyPage (/privacy-policy)", () => {
 
   it("displays document version and effective date", () => {
     const wrapper = mountPage();
-    expect(wrapper.text()).toContain("2.1.0");
-    expect(wrapper.text()).toContain("2026-05-20");
+    expect(wrapper.text()).toContain("2.2.0");
+    expect(wrapper.text()).toContain("2026-07-19");
   });
 
   it("displays the support email", () => {

--- a/app/pages/support.vue
+++ b/app/pages/support.vue
@@ -54,7 +54,7 @@ const faqItems = [
   {
     question: "O Auraxis guarda os dados do meu cartão?",
     answer:
-      "Não. O pagamento é processado pela Asaas (provedor brasileiro regulado) em checkout hospedado — número de cartão, CVV e credenciais bancárias nunca passam pelos servidores do Auraxis.",
+      "Não. O pagamento é processado pela AbacatePay (provedor brasileiro) em checkout hospedado — número de cartão, CVV e credenciais bancárias nunca passam pelos servidores do Auraxis.",
   },
   {
     question: "Quanto custa o Premium?",

--- a/app/pages/terms-of-service.spec.ts
+++ b/app/pages/terms-of-service.spec.ts
@@ -28,8 +28,8 @@ describe("TermsOfServicePage (/terms-of-service)", () => {
 
   it("displays document version and effective date", () => {
     const wrapper = mountPage();
-    expect(wrapper.text()).toContain("2.1.0");
-    expect(wrapper.text()).toContain("2026-05-20");
+    expect(wrapper.text()).toContain("2.2.0");
+    expect(wrapper.text()).toContain("2026-07-19");
   });
 
   it("displays the support email", () => {


### PR DESCRIPTION
## Summary

Decisão do PO (2026-07-19): o gateway de pagamento passa a ser **AbacatePay**.

"Asaas" estava publicado como **subprocessador de dados** na política de privacidade e citado nos
termos de uso e no FAQ público. Manter o nome errado deixaria a política divergente do tratamento
real — risco de LGPD, não cosmético.

### Mudanças

- Subprocessador → **Abacatepay Tecnologia LTDA (CNPJ 58.271.413/0001-90)**
- Termos §9.1 (processamento de pagamento) e §9.3 (disputas)
- FAQ de `/support` e um comentário em `checkout/success.vue`
- `PRIVACY_POLICY_VERSION` e `TERMS_OF_USE_VERSION` → **2.2.0**; vigência → **2026-07-19**

### Decisão registrada

O texto anterior linkava `https://www.asaas.com/politica-de-privacidade`. **Não consegui verificar
uma URL pública de política de privacidade da AbacatePay** (não há link visível no site), então o
controlador é identificado por razão social + CNPJ em vez de um link inventado. Vale preencher a URL
quando confirmada.

## Validation

- `pnpm quality-check` verde (lint, typecheck, coverage, policy, contracts, build)
- Suíte completa: **4108 testes passando, 463 arquivos**

**Screenshots:** não anexadas — a mudança é substituição de texto em documentos legais, sem
alteração de layout, componente ou estilo. Nenhum impacto visual além do conteúdo textual.

## Residual risk

Bump de versão dos documentos significa que novos cadastros passam a registrar aceite de `2.2.0`
(`POST /me/consents`) — comportamento correto e esperado, já que o subprocessador de pagamento mudou.
Usuários que aceitaram 2.1.0 seguem com o registro histórico.

## Refs

Closes #1139