### PR TITLE
ci(web): wire PostHog key into the official deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,12 @@ jobs:
           # The smoke test reads this tag to confirm CloudFront is serving
           # the current build and not a stale cached snapshot.
           NUXT_PUBLIC_BUILD_ID: "${{ github.run_id }}-${{ github.sha }}"
+          # PostHog product analytics (#1125): with an empty key the client
+          # plugin installs a no-op $analytics — the funnel (signup →
+          # onboarding → paywall → upgrade, platform#524) stays dark. The env
+          # is wired here so analytics turn on automatically on the first
+          # deploy after the NUXT_PUBLIC_POSTHOG_API_KEY secret is created.
+          NUXT_PUBLIC_POSTHOG_API_KEY: ${{ secrets.NUXT_PUBLIC_POSTHOG_API_KEY }}
           # Brapi public market-data API key (wallet quotes, FII dividends,
           # currency conversion). Without it brapi.dev replies 401 and the
           # wallet + tools pages log Unauthorized errors in the browser.


### PR DESCRIPTION
## Resumo
Injeta `NUXT_PUBLIC_POSTHOG_API_KEY: ${{ secrets.NUXT_PUBLIC_POSTHOG_API_KEY }}` no bloco env do build do deploy oficial (evidência do gap: auditoria platform#898 — nenhuma env POSTHOG no workflow, `nuxt.config.ts:282` esperando).

**Comportamento**: com o secret ausente (estado atual), a env chega vazia e o plugin instala `$analytics` no-op — deploy idêntico ao de hoje, zero risco. Quando o Italo criar o secret `NUXT_PUBLIC_POSTHOG_API_KEY` no repo, o próximo deploy liga o funil (registro → onboarding → paywall → upgrade, platform#524) automaticamente.

**Não fecha** a web#1125 — restam os passos do Italo (criar projeto/key no PostHog + secret) e a validação do $pageview em prod. Refs #1125. Closes #1155

## Validação
Mudança de 1 env em workflow; pre-push completo verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCQunEjQs5YziwSwFKqJJr
