### PR TITLE
fix(deploy): sw.js e manifests de update sem cache immutable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -221,7 +221,42 @@ jobs:
           aws s3 sync .output/public/ "s3://${{ env.S3_BUCKET }}/" \
             --region "${{ env.AWS_REGION }}" \
             --exclude "*.html" \
+            --exclude "sw.js" \
+            --exclude "workbox-*.js" \
+            --exclude "manifest.webmanifest" \
+            --exclude "_nuxt/builds/*" \
             --cache-control "public, max-age=31536000, immutable"
+
+      # Mutable runtime files must NEVER be immutable (#1173): the browser
+      # revalidates the service-worker script (24h cap) and Nuxt polls
+      # _nuxt/builds/latest.json to detect new deploys — an immutable header on
+      # any of them pins clients to a stale app shell for up to a day after
+      # every deploy (root cause of the /admin fix appearing "not deployed").
+      - name: Upload mutable runtime files (no-cache)
+        run: |
+          BUCKET="s3://${{ env.S3_BUCKET }}"
+          NO_CACHE="no-cache, no-store, must-revalidate"
+          aws s3 cp .output/public/ "$BUCKET/" \
+            --region "${{ env.AWS_REGION }}" \
+            --recursive \
+            --exclude "*" \
+            --include "sw.js" \
+            --include "workbox-*.js" \
+            --cache-control "$NO_CACHE" \
+            --content-type "application/javascript"
+          if [ -f .output/public/manifest.webmanifest ]; then
+            aws s3 cp .output/public/manifest.webmanifest "$BUCKET/manifest.webmanifest" \
+              --region "${{ env.AWS_REGION }}" \
+              --cache-control "$NO_CACHE" \
+              --content-type "application/manifest+json"
+          fi
+          if [ -d .output/public/_nuxt/builds ]; then
+            aws s3 cp .output/public/_nuxt/builds/ "$BUCKET/_nuxt/builds/" \
+              --region "${{ env.AWS_REGION }}" \
+              --recursive \
+              --cache-control "$NO_CACHE" \
+              --content-type "application/json"
+          fi
 
       - name: Invalidate CloudFront cache
         run: |


### PR DESCRIPTION
## O que muda

O passo de sync do deploy carimbava `max-age=31536000, immutable` em TODO arquivo não-HTML — incluindo `sw.js`, `workbox-*.js`, `manifest.webmanifest` e `_nuxt/builds/*.json`. Consequência: o browser segurava o service worker antigo (e o app shell inteiro do precache) por até 24h após cada deploy, e o polling de update do Nuxt lia um `latest.json` congelado. Foi exatamente o que fez o fix do admin (#1172) parecer "não deployado" no browser do operador hoje.

Agora esses arquivos ficam fora do sync immutable e sobem num passo próprio com `no-cache, no-store, must-revalidate` (com content-types corretos). Assets hasheados de `/_nuxt/**` continuam immutable.

## Contexto

Closes #1173

Diagnóstico ao vivo no browser do operador (sessão claude-in-chrome): runtimeBuildId da página vs build da CDN, SW ativo e headers do `sw.js` em prod.

## Como testar

- [ ] Após o merge (o push na main dispara o próprio deploy alterado): `curl -sI https://app.auraxis.com.br/sw.js | grep -i cache-control` → `no-cache, no-store, must-revalidate`
- [ ] `curl -sI https://app.auraxis.com.br/_nuxt/builds/latest.json | grep -i cache-control` → idem
- [ ] Asset hasheado qualquer de `/_nuxt/` continua `immutable`

## Evidência visual

n/a — mudança de workflow de deploy (sem superfície de UI).

## Quality gates

- [x] YAML validado localmente
- [ ] CI (workflow-only; jobs de app não afetados)

## Impacto de contrato

Nenhum.

## Risco

LOW — só metadados de cache de 4 padrões de arquivo; rollback é reverter o commit.