### PR TITLE
ci(landing): wire Sentry + PostHog build envs into deploy-landing

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -70,6 +70,16 @@ jobs:
           NUXT_PUBLIC_API_BASE: https://api.auraxis.com.br
           NUXT_PUBLIC_API_V2_BASE: https://v2.auraxis.com.br
           NUXT_PUBLIC_BUILD_ID: "${{ github.run_id }}-${{ github.sha }}"
+          # Error monitoring on the apex landing. Active as soon as this ships:
+          # the DSN secret already exists and Sentry is not consent-gated.
+          NUXT_PUBLIC_SENTRY_DSN: ${{ secrets.NUXT_PUBLIC_SENTRY_DSN }}
+          # PostHog product analytics — mirrors deploy.yml (#1125). Wired so the
+          # landing is ready, but it stays a no-op on this surface until BOTH:
+          #   1. the shared NUXT_PUBLIC_POSTHOG_API_KEY secret exists (#1125), and
+          #   2. a consent path exists for the landing — today app.vue hides the
+          #      CookieConsentBanner when surface === "landing" and analytics
+          #      consent defaults to opt-out, so the plugin never initializes.
+          NUXT_PUBLIC_POSTHOG_API_KEY: ${{ secrets.NUXT_PUBLIC_POSTHOG_API_KEY }}
         run: pnpm generate
 
       - name: Validate output


### PR DESCRIPTION
## Resumo
Injeta `NUXT_PUBLIC_SENTRY_DSN` e `NUXT_PUBLIC_POSTHOG_API_KEY` no build da landing (`deploy-landing.yml`), espelhando o padrão do `deploy.yml` do app. A landing subiu ontem (auraxis.com.br) sem instrumentação.

## O que acende agora vs. depois
- ✅ **Sentry**: ativa imediatamente no merge — o DSN já existe como secret e o Sentry **não** é consent-gated. Passa a monitorar erros JS na landing de produção.
- ⏳ **PostHog**: fica **inerte de propósito** até dois pré-requisitos, e o comentário no YAML documenta isso:
  1. secret compartilhado `NUXT_PUBLIC_POSTHOG_API_KEY` (não existe hoje — **#1125**, ação do Italo);
  2. caminho de consentimento para a landing — hoje o `app.vue` esconde o `CookieConsentBanner` na surface landing e o consentimento de analytics é opt-out, então o plugin nunca inicializa (**#1177**, decisão de produto/legal).

Ou seja: este PR entrega o wiring e o monitoramento de erros; o **funil** de captação (pageview + clique de CTA no PostHog) depende de #1125 + #1177.

## Validação
- `actionlint .github/workflows/deploy-landing.yml` ✅
- Mudança aditiva (só envs de build); nenhum arquivo de `app/` tocado, então o build/typecheck não são afetados. O próprio workflow tem gate de build + e2e da landing antes do deploy.
- Merge nesta branch dispara o `deploy-landing.yml` (paths incluem o workflow) → rebuild + redeploy da landing com Sentry ativo.

## Risco residual
Baixo — reusa o mesmo pipeline OIDC que publicou a landing ontem; Sentry client é DSN-gated e testado. PostHog permanece no-op até #1125/#1177.

Closes #1175