### PR TITLE
feat(landing): pricing section with subscription CTA [#1180]

### DIFF
--- a/app/features/landing/components/LandingPricing.vue
+++ b/app/features/landing/components/LandingPricing.vue
@@ -1,0 +1,264 @@
+<script setup lang="ts">
+import { ArrowRight } from "lucide-vue-next";
+import {
+  LANDING_PLANS,
+  LANDING_REGISTER_URL,
+  LANDING_SUBSCRIBE_URL,
+} from "../model/landing-content";
+</script>
+
+<template>
+  <section
+    class="landing-pricing"
+    aria-labelledby="landing-pricing-title"
+    data-testid="landing-pricing"
+  >
+    <div class="landing-pricing__inner">
+      <p class="landing-pricing__kicker">Planos</p>
+      <h2 id="landing-pricing-title" class="landing-pricing__title">
+        Um preço justo para ter o controle de volta.
+      </h2>
+      <p class="landing-pricing__lead">
+        Comece com 7 dias grátis. Depois, escolha o plano que cabe no seu mês —
+        IA, metas, orçamentos e carteira, tudo incluído.
+      </p>
+
+      <ul class="landing-pricing__plans" role="list">
+        <li
+          v-for="plan in LANDING_PLANS"
+          :key="plan.key"
+          class="landing-pricing__plan"
+          :class="{ 'landing-pricing__plan--featured': plan.featured }"
+        >
+          <span v-if="plan.featured" class="landing-pricing__badge">
+            Recomendado
+          </span>
+          <h3 class="landing-pricing__plan-name">{{ plan.name }}</h3>
+          <p class="landing-pricing__price">
+            <span class="landing-pricing__amount">{{ plan.price }}</span>
+            <span class="landing-pricing__period">{{ plan.period }}</span>
+          </p>
+          <p class="landing-pricing__note">{{ plan.note }}</p>
+        </li>
+      </ul>
+
+      <div class="landing-pricing__actions">
+        <a
+          :href="LANDING_SUBSCRIBE_URL"
+          class="landing-pricing__button"
+          data-testid="landing-pricing-subscribe"
+        >
+          Assinar Premium
+          <ArrowRight :size="17" aria-hidden="true" />
+        </a>
+        <p class="landing-pricing__free">
+          7 dias grátis para experimentar.
+          <a :href="LANDING_REGISTER_URL">Começar grátis</a>
+        </p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.landing-pricing {
+  position: relative;
+  overflow: hidden;
+  padding-block: clamp(var(--space-8), 9vw, 112px);
+  border-top: 1px solid var(--landing-line-soft);
+  background:
+    radial-gradient(52% 62% at 50% -8%, rgba(68, 212, 255, 0.14), transparent 70%),
+    var(--landing-bg);
+}
+
+.landing-pricing__inner {
+  display: grid;
+  justify-items: center;
+  gap: var(--space-4);
+  width: min(920px, calc(100% - 40px));
+  margin-inline: auto;
+  text-align: center;
+}
+
+.landing-pricing__kicker {
+  margin: 0;
+  color: var(--landing-cyan);
+  font-size: var(--landing-size-kicker);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--landing-tracking-kicker);
+  text-transform: uppercase;
+}
+
+.landing-pricing__title {
+  margin: 0;
+  max-width: 18ch;
+  color: var(--landing-ink);
+  font-family: var(--landing-font-display);
+  font-size: var(--landing-size-h2);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--landing-leading-h2);
+  letter-spacing: -0.01em;
+  text-wrap: balance;
+}
+
+.landing-pricing__lead {
+  margin: 0;
+  max-width: 56ch;
+  color: var(--landing-body);
+  font-size: var(--landing-size-lead);
+  line-height: var(--landing-leading-body);
+}
+
+.landing-pricing__plans {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+  width: 100%;
+  margin: var(--space-4) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.landing-pricing__plan {
+  position: relative;
+  display: grid;
+  gap: var(--space-2);
+  align-content: start;
+  padding: var(--space-6) var(--space-5);
+  border: 1px solid var(--landing-line);
+  border-radius: var(--landing-radius-card);
+  background: var(--landing-surface);
+  text-align: left;
+}
+
+.landing-pricing__plan--featured {
+  border-color: var(--landing-cyan);
+  box-shadow: var(--landing-shadow-frame);
+}
+
+.landing-pricing__badge {
+  position: absolute;
+  top: calc(var(--space-3) * -1);
+  right: var(--space-5);
+  padding: 4px var(--space-3);
+  border-radius: var(--landing-radius-pill);
+  background: var(--landing-grad);
+  color: var(--landing-cyan-ink);
+  font-size: var(--landing-size-fine);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.landing-pricing__plan-name {
+  margin: 0;
+  color: var(--landing-ink);
+  font-size: var(--landing-size-h3);
+  font-weight: var(--font-weight-semibold);
+}
+
+.landing-pricing__price {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-1) var(--space-2);
+  margin: 0;
+}
+
+.landing-pricing__amount {
+  color: var(--landing-ink);
+  font-family: var(--landing-font-display);
+  font-size: var(--landing-size-h2);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.05;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.landing-pricing__period {
+  color: var(--landing-muted);
+  font-size: var(--landing-size-sm);
+  white-space: nowrap;
+}
+
+.landing-pricing__note {
+  margin: 0;
+  color: var(--landing-body);
+  font-size: var(--landing-size-sm);
+  line-height: var(--landing-leading-body);
+}
+
+.landing-pricing__actions {
+  display: grid;
+  justify-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.landing-pricing__button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 52px;
+  padding-inline: var(--space-6);
+  border-radius: var(--landing-radius-pill);
+  background: var(--landing-grad);
+  color: var(--landing-cyan-ink);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  text-decoration: none;
+  box-shadow: var(--landing-shadow-cta);
+  transition:
+    transform var(--motion-fast),
+    filter var(--motion-fast);
+}
+
+.landing-pricing__button:hover {
+  transform: translateY(-2px);
+  filter: brightness(1.06);
+}
+
+.landing-pricing__button:focus-visible {
+  outline: 3px solid var(--landing-glow-cyan);
+  outline-offset: 3px;
+}
+
+.landing-pricing__free {
+  margin: 0;
+  color: var(--landing-muted);
+  font-size: var(--landing-size-sm);
+}
+
+.landing-pricing__free a {
+  color: var(--landing-cyan);
+  font-weight: var(--font-weight-semibold);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.landing-pricing__free a:focus-visible {
+  outline: 3px solid var(--landing-glow-cyan);
+  outline-offset: 3px;
+  border-radius: var(--radius-xs);
+}
+
+@media (max-width: 640px) {
+  .landing-pricing__inner {
+    width: min(920px, calc(100% - 24px));
+  }
+
+  .landing-pricing__plans {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landing-pricing__button {
+    transition: none;
+  }
+
+  .landing-pricing__button:hover {
+    transform: none;
+  }
+}
+</style>

--- a/app/features/landing/components/LandingRoot.vue
+++ b/app/features/landing/components/LandingRoot.vue
@@ -4,6 +4,7 @@ import LandingCta from "./LandingCta.vue";
 import LandingFooter from "./LandingFooter.vue";
 import LandingHeader from "./LandingHeader.vue";
 import LandingHero from "./LandingHero.vue";
+import LandingPricing from "./LandingPricing.vue";
 import LandingShowcase from "./LandingShowcase.vue";
 
 /**
@@ -48,6 +49,7 @@ useSeoMeta({
     <LandingHero />
     <LandingShowcase />
     <LandingAi />
+    <LandingPricing />
     <LandingCta />
     <LandingFooter />
   </div>

--- a/app/features/landing/model/landing-content.spec.ts
+++ b/app/features/landing/model/landing-content.spec.ts
@@ -7,7 +7,9 @@ import {
   LANDING_FOOTER_LINKS,
   LANDING_LOGIN_URL,
   LANDING_PAIN_POINTS,
+  LANDING_PLANS,
   LANDING_REGISTER_URL,
+  LANDING_SUBSCRIBE_URL,
 } from "./landing-content";
 
 describe("buildAppUrl", () => {
@@ -31,6 +33,10 @@ describe("landing CTA urls", () => {
 
   it("points the discreet login link at the app login page", () => {
     expect(LANDING_LOGIN_URL).toBe("https://app.auraxis.com.br/login");
+  });
+
+  it("points the subscribe CTA at the app subscription flow", () => {
+    expect(LANDING_SUBSCRIBE_URL).toBe("https://app.auraxis.com.br/subscription");
   });
 });
 
@@ -57,6 +63,16 @@ describe("landing content catalog", () => {
       "chat",
       "briefing",
     ]);
+  });
+
+  it("exposes the monthly and annual Premium plans with canonical pricing", () => {
+    expect(LANDING_PLANS.map((plan) => plan.key)).toEqual(["monthly", "annual"]);
+    const monthly = LANDING_PLANS.find((plan) => plan.key === "monthly");
+    const annual = LANDING_PLANS.find((plan) => plan.key === "annual");
+    expect(monthly?.price).toBe("R$ 29,90");
+    expect(annual?.price).toBe("R$ 287,04");
+    expect(monthly?.featured).toBe(false);
+    expect(annual?.featured).toBe(true);
   });
 
   it("lists three concrete pain points for the problem section", () => {

--- a/app/features/landing/model/landing-content.ts
+++ b/app/features/landing/model/landing-content.ts
@@ -30,6 +30,12 @@ export const LANDING_REGISTER_URL = buildAppUrl("/register");
 /** Discreet secondary action — login on the product app. */
 export const LANDING_LOGIN_URL = buildAppUrl("/login");
 
+/**
+ * Subscription-flow destination on the product app. Unauthenticated visitors
+ * are routed through login/register and returned here afterwards (web#1172).
+ */
+export const LANDING_SUBSCRIBE_URL = buildAppUrl("/subscription");
+
 /** Identifier keys for the four v1 product features, in display order. */
 export type LandingFeatureKey = "transactions" | "goals" | "budgets" | "wallet";
 
@@ -51,6 +57,17 @@ export interface LandingAiHighlight {
 export interface LandingFooterLink {
   readonly label: string;
   readonly href: string;
+}
+
+/** A Premium plan card shown in the pricing section. */
+export interface LandingPlan {
+  readonly key: "monthly" | "annual";
+  readonly name: string;
+  readonly price: string;
+  readonly period: string;
+  readonly note: string;
+  /** The recommended plan gets the highlighted treatment. */
+  readonly featured: boolean;
 }
 
 /** Pain points that open the problem → solution narrative. */
@@ -107,6 +124,29 @@ export const LANDING_AI_HIGHLIGHTS: readonly LandingAiHighlight[] = [
     title: "Briefing semanal",
     description:
       "Um resumo editorial do que aconteceu com o seu dinheiro — direto, sem jargão e com o que merece atenção.",
+  },
+] as const;
+
+/**
+ * Premium plans shown in the pricing section — canonical pricing from ADR
+ * platform#669 (R$29,90/mês · R$287,04/ano). Both include a 7-day free trial.
+ */
+export const LANDING_PLANS: readonly LandingPlan[] = [
+  {
+    key: "monthly",
+    name: "Premium mensal",
+    price: "R$ 29,90",
+    period: "por mês",
+    note: "Flexível — cancele quando quiser.",
+    featured: false,
+  },
+  {
+    key: "annual",
+    name: "Premium anual",
+    price: "R$ 287,04",
+    period: "por ano",
+    note: "R$ 23,92/mês, 20% de desconto.",
+    featured: true,
   },
 ] as const;
 

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -71,6 +71,23 @@ test.describe("Landing de captação — auraxis.com.br", () => {
     await expect(aiSection.getByRole("heading", { name: "Briefing semanal" })).toBeVisible();
   });
 
+  test("renders the pricing section with plans and the subscribe CTA", async ({ page }) => {
+    const pricing = page.getByTestId("landing-pricing");
+    await pricing.scrollIntoViewIfNeeded();
+    await expect(pricing).toBeVisible();
+    await expect(pricing.getByRole("heading", { name: "Premium mensal" })).toBeVisible();
+    await expect(pricing.getByRole("heading", { name: "Premium anual" })).toBeVisible();
+    await expect(pricing.getByText("R$ 29,90")).toBeVisible();
+    await expect(pricing.getByText("R$ 287,04")).toBeVisible();
+
+    const subscribe = page.getByTestId("landing-pricing-subscribe");
+    await expect(subscribe).toBeVisible();
+    await expect(subscribe).toHaveAttribute(
+      "href",
+      "https://app.auraxis.com.br/subscription",
+    );
+  });
+
   test("shows the landing footer with legal links on the app origin", async ({ page }) => {
     const footer = page.getByTestId("landing-footer");
     await footer.scrollIntoViewIfNeeded();


### PR DESCRIPTION
## Contexto
A landing (auraxis.com.br) só tinha CTAs para register/login — nenhuma seção que levasse o usuário à **assinatura** (pedido do Italo).

## Mudança
Nova seção **LandingPricing** (entre AI e o CTA final):
- Planos Premium com preço canônico (**R$ 29,90/mês** · **R$ 287,04/ano**, ADR platform#669), card anual destacado ('Recomendado').
- CTA primário **'Assinar Premium'** → `app.auraxis.com.br/subscription` (fluxo de assinatura; visitante não-autenticado passa por login/registro e volta — web#1172).
- CTA secundário **'Começar grátis'** → /register (trial de 7 dias).
- Conteúdo tipado em `landing-content.ts` (testado); prosa inline como as demais seções `Landing*`; tokens `--landing-*`, dark-first, responsivo, reduced-motion.

## Validação
- Unit `landing-content.spec.ts` → **13 passed** (novos: URL de assinatura + planos com preço canônico).
- `nuxt typecheck` → 0 erros · `eslint` → limpo.
- e2e novo: seção + CTA de assinatura (href = /subscription).
- Build `NUXT_PUBLIC_SITE_SURFACE=landing pnpm generate` OK; markup prerenderizado confirmado.
- **Screenshots capturadas em 3 resoluções** (desktop 1440, tablet 834, mobile 390) — anexadas na conversa; seção renderiza corretamente, preços em uma linha, cards empilham no mobile.

## Risco
Baixo — seção estática nova na landing; nenhum fluxo existente alterado.

Closes #1180