### PR TITLE
feat(dashboard): fluxo de caixa como três linhas de tendência (design Apple) — #1182

### DIFF
--- a/app/features/dashboard/components/DashboardMarketPulseWorkspace.vue
+++ b/app/features/dashboard/components/DashboardMarketPulseWorkspace.vue
@@ -418,50 +418,66 @@ function buildCashflowYAxis(tokens: ChartThemeTokens): EChartsOption["yAxis"] {
  * @returns ECharts series option.
  */
 function buildCashflowSeries(points: CashflowPoint[], tokens: ChartThemeTokens): EChartsOption["series"] {
+  // Sober, Apple-like reading: three thin trend lines instead of stacked bars —
+  // the bars collapsed into a single block whenever only one period was present.
+  // Subtle point markers when the series is sparse (monthly view) so a lone
+  // point is still visible; hidden on dense series to keep the line clean.
+  const sparse = points.length <= 12;
+  const symbolSize = sparse ? 4 : 0;
+  const baseLine = {
+    type: "line" as const,
+    smooth: 0.3,
+    symbol: "circle" as const,
+    symbolSize,
+    showSymbol: sparse,
+    emphasis: { focus: "series" as const },
+  };
   return [
     {
+      ...baseLine,
       name: "Receitas",
-      type: "bar",
-      stack: "cashflow",
-      barMaxWidth: 34,
       data: points.map((point) => point.income),
-      itemStyle: {
-        color: tokens.income,
-        borderRadius: [6, 6, 0, 0],
-        opacity: 0.86,
-      },
+      lineStyle: { color: tokens.income, width: 2 },
+      itemStyle: { color: tokens.income },
     },
     {
+      ...baseLine,
       name: "Despesas",
-      type: "bar",
-      stack: "cashflow",
-      barMaxWidth: 34,
-      data: points.map((point) => -point.expense),
-      itemStyle: {
-        color: tokens.expense,
-        borderRadius: [0, 0, 6, 6],
-        opacity: 0.86,
-      },
+      data: points.map((point) => point.expense),
+      lineStyle: { color: tokens.expense, width: 2 },
+      itemStyle: { color: tokens.expense },
     },
     {
+      ...baseLine,
       name: "Saldo",
-      type: "line",
       data: points.map((point) => point.balance),
-      smooth: true,
-      symbol: "circle",
-      symbolSize: 7,
-      lineStyle: {
-        color: tokens.balance,
-        width: 3,
-      },
-      itemStyle: {
-        color: tokens.balance,
-      },
-      areaStyle: {
-        color: withAlpha(tokens.balance, 0.12),
-      },
+      z: 3,
+      lineStyle: { color: tokens.balance, width: 2.5 },
+      itemStyle: { color: tokens.balance },
+      areaStyle: { color: withAlpha(tokens.balance, 0.05) },
     },
   ];
+}
+
+/**
+ * Formats a multi-series axis tooltip as a compact currency list.
+ *
+ * @param params ECharts axis-trigger params (one entry per series).
+ * @returns HTML string with the period label and one currency row per series.
+ */
+function formatCashflowTooltip(params: unknown): string {
+  const items = Array.isArray(params) ? params : [params];
+  if (items.length === 0) {
+    return "";
+  }
+  const rows = items
+    .map((entry) => {
+      const point = entry as { marker?: string; seriesName?: string; value?: number };
+      return `${point.marker ?? ""} ${point.seriesName ?? ""}: ${formatCurrency(Number(point.value ?? 0))}`;
+    })
+    .join("<br/>");
+  const header = (items[0] as { axisValueLabel?: string }).axisValueLabel ?? "";
+  return header ? `<strong>${header}</strong><br/>${rows}` : rows;
 }
 
 /**
@@ -469,7 +485,7 @@ function buildCashflowSeries(points: CashflowPoint[], tokens: ChartThemeTokens):
  *
  * @param points Normalized cashflow points.
  * @param tokens Theme-aware chart tokens.
- * @returns ECharts option for bars and accumulated balance line.
+ * @returns ECharts option for the three-line cashflow trend.
  */
 function buildCashflowOption(points: CashflowPoint[], tokens: ChartThemeTokens): EChartsOption {
   return {
@@ -477,9 +493,16 @@ function buildCashflowOption(points: CashflowPoint[], tokens: ChartThemeTokens):
     color: [tokens.income, tokens.expense, tokens.balance],
     tooltip: {
       trigger: "axis",
+      axisPointer: {
+        type: "line",
+        lineStyle: { color: tokens.grid, width: 1, type: "dashed" },
+      },
       backgroundColor: tokens.tooltipBackground,
       borderColor: tokens.tooltipBorder,
-      textStyle: { color: tokens.tooltipText },
+      borderWidth: 1,
+      padding: [8, 12],
+      textStyle: { color: tokens.tooltipText, fontSize: 12 },
+      formatter: formatCashflowTooltip,
     },
     legend: {
       show: false,

--- a/app/features/dashboard/components/__tests__/DashboardMarketPulseWorkspace.spec.ts
+++ b/app/features/dashboard/components/__tests__/DashboardMarketPulseWorkspace.spec.ts
@@ -119,6 +119,26 @@ describe("DashboardMarketPulseWorkspace", () => {
     expect(wrapper.text()).not.toContain("Ainda não há movimentações");
   });
 
+  it("renders the cashflow chart as three clean trend lines (no stacked bars)", () => {
+    const wrapper = mountWorkspace();
+
+    const charts = wrapper.findAllComponents(UiChartStub);
+    const cashflow = charts.find((chart) => {
+      const option = chart.props("option") as { series?: Array<{ name?: string }> };
+      return Array.isArray(option?.series) && option.series.some((serie) => serie.name === "Saldo");
+    });
+    expect(cashflow).toBeTruthy();
+
+    const series = (
+      cashflow!.props("option") as { series: Array<{ type?: string; name?: string }> }
+    ).series;
+    expect(series).toHaveLength(3);
+    expect(series.map((serie) => serie.name)).toEqual(["Receitas", "Despesas", "Saldo"]);
+    for (const serie of series) {
+      expect(serie.type).toBe("line");
+    }
+  });
+
   it("surfaces category drilldown from dashboard data", () => {
     const wrapper = mountWorkspace();
 


### PR DESCRIPTION
## Contexto

O widget **Fluxo de Caixa (mensal)** do dashboard aparecia como uma **barra gorda** verde/vermelha pouco informativa. A causa não era só design: o gráfico montava Receitas e Despesas como **barras empilhadas** (`type: "bar"`, `stack: "cashflow"`) e, sempre que havia **um só período** (o fallback de 1 ponto, quando a série de tendência mensal e a timeseries diária vêm vazias), as barras colapsavam num bloco único.

## O que muda

Converte o gráfico para **três linhas de tendência** sóbrias e minimalistas (estilo Apple) — Receitas, Despesas e Saldo — como o usuário pediu:

- **Linhas finas** (2px; Saldo 2.5px) com `smooth` suave.
- **Marcadores discretos** (4px) só quando a série é esparsa (visão mensal); somem em séries densas para manter a linha limpa.
- **Área quase imperceptível** só no Saldo (alpha 0.05) para ancorá-lo sem poluir — nada de preenchimento pesado.
- **Tooltip axis** com formatter de moeda (pt-BR) + `axisPointer` tracejado discreto.
- **Um único período** agora renderiza como pontos limpos, **nunca um bloco**.

Nenhuma mudança de dados: a página já busca `/dashboard/trends?months=12` e passa ao workspace. Este PR é a camada visual. A investigação de por que a série de tendência chega vazia em algumas contas (fazendo cair no fallback de 1 ponto) segue como follow-up em #1182.

## Validação

- `pnpm lint` (arquivos tocados) — OK
- `pnpm typecheck` — OK
- Spec do workspace — **6/6 verde**, incluindo o novo caso que trava o redesign (assere 3 séries `type: "line"`, sem `bar`/`stack`).
- Preview renderizado com a **option real do ECharts** + as **cores reais dos tokens** (`income #087F5B`, `expense #C2414D`, `balance #087FA7`), em 3 resoluções (desktop/tablet/mobile) — antes (barra) × depois (3 linhas + fallback gracioso). Screenshots entregues na sessão.

## Risco residual

Baixo. Muda só a montagem de série/option de um componente (`DashboardMarketPulseWorkspace.vue`); não toca contrato, dados nem outras superfícies. O teste de regressão fixa o formato de linha.

Closes #1182
