### PR TITLE
feat(lint): guard de paginação segura em agregações + fix truncamento do calendário (#1104)

### DIFF
--- a/app/features/transactions/composables/__tests__/useFinancialCalendar.spec.ts
+++ b/app/features/transactions/composables/__tests__/useFinancialCalendar.spec.ts
@@ -45,8 +45,8 @@ function makeTx(overrides: Partial<TransactionDto> = {}): TransactionDto {
 }
 
 /**
- * Builds a stub TransactionsClient that resolves listTransactions with the
- * provided array.
+ * Builds a stub TransactionsClient that resolves both the paginated and the
+ * full-range listing with the provided array.
  *
  * @param txs - Array of TransactionDto to return.
  * @returns Partial TransactionsClient stub.
@@ -54,6 +54,7 @@ function makeTx(overrides: Partial<TransactionDto> = {}): TransactionDto {
 function makeStubClient(txs: TransactionDto[]): TransactionsClient {
   return {
     listTransactions: vi.fn().mockResolvedValue(txs),
+    listAllTransactions: vi.fn().mockResolvedValue(txs),
   } as unknown as TransactionsClient;
 }
 
@@ -191,6 +192,24 @@ describe("useFinancialCalendar", () => {
     const { result } = mountComposable(makeStubClient([]));
     const todaySlot = result.calendarDays.value.find((d) => d.isToday);
     expect(todaySlot).toBeDefined();
+  });
+
+  // Regression (#1104): the calendar aggregates every transaction of the month
+  // across day cells, so it MUST fetch the complete result set. Using the
+  // page-1 paginated query silently dropped transactions once a month held more
+  // than one page — days beyond the first 10 records rendered empty.
+  it("loads the COMPLETE month via listAllTransactions, never the paginated page-1 query", async () => {
+    const listPaginated = vi.fn().mockResolvedValue([]);
+    const listAll = vi.fn().mockResolvedValue([]);
+    const client = {
+      listTransactions: listPaginated,
+      listAllTransactions: listAll,
+    } as unknown as TransactionsClient;
+
+    mountComposable(client);
+
+    await vi.waitFor(() => expect(listAll).toHaveBeenCalled());
+    expect(listPaginated).not.toHaveBeenCalled();
   });
 });
 

--- a/app/features/transactions/composables/useFinancialCalendar.ts
+++ b/app/features/transactions/composables/useFinancialCalendar.ts
@@ -1,7 +1,7 @@
 import { computed, type ComputedRef, ref, type Ref } from "vue";
 import type { TransactionDto } from "~/features/transactions/contracts/transaction.dto";
 import type { TransactionsClient } from "~/features/transactions/services/transactions.client";
-import { useListTransactionsQuery } from "~/features/transactions/queries/use-list-transactions-query";
+import { useListAllTransactionsQuery } from "~/features/transactions/queries/use-list-all-transactions-query";
 import { parseCurrencyAmount } from "~/utils/currencyInput";
 import type { CalendarDay } from "~/components/financial-calendar/FinancialCalendar/FinancialCalendar.types";
 
@@ -269,7 +269,10 @@ export function useFinancialCalendar(
     end_date: endDate.value,
   }));
 
-  const { data: transactions, isLoading, isError } = useListTransactionsQuery(
+  // #1104: the calendar distributes EVERY transaction of the month across day
+  // cells, so it must follow pagination to the end — the page-1 query would
+  // silently drop records past the first page.
+  const { data: transactions, isLoading, isError } = useListAllTransactionsQuery(
     filters,
     providedClient,
   );

--- a/app/features/transactions/queries/use-list-transactions-query.spec.ts
+++ b/app/features/transactions/queries/use-list-transactions-query.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- Definitional test for the paginated `useListTransactionsQuery` hook: it exercises the hook under test (and mocks useQuery), so the PAGE-SAFE aggregation guard does not apply here (#1104). */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useListTransactionsQuery } from "./use-list-transactions-query";

--- a/app/pages/budgets.vue
+++ b/app/pages/budgets.vue
@@ -220,6 +220,7 @@ const {
   data: transactionPreview,
   isError: isTransactionPreviewError,
   isLoading: isTransactionPreviewLoading,
+  // eslint-disable-next-line no-restricted-syntax -- budget detail preview: filters to committed expenses then slices to 5; page-1 is intentional, not a full aggregation (#1104)
 } = useListTransactionsQuery(selectedTransactionFilters);
 
 const previewTransactions = computed<TransactionDto[]>(() => {

--- a/app/pages/goals/[id]/index.vue
+++ b/app/pages/goals/[id]/index.vue
@@ -85,6 +85,7 @@ const recentTransactionFilters = computed(() => ({
   end_date: endDate.value,
 }));
 
+// eslint-disable-next-line no-restricted-syntax -- goal detail shows a "recent transactions" preview widget; page-1 is the intended scope, not an aggregation (#1104)
 const transactionsQuery = useListTransactionsQuery(recentTransactionFilters);
 
 const selectedGoal = computed<GoalDto | null>(() => {

--- a/app/pages/transactions/index.vue
+++ b/app/pages/transactions/index.vue
@@ -41,6 +41,7 @@ const showExportModal = ref(false);
 
 // ── Query ─────────────────────────────────────────────────────────────────────
 
+// eslint-disable-next-line no-restricted-syntax -- transactions list page: page-1 pagination is the intended UX (paginated list UI), not an aggregation (#1104)
 const { data, isLoading, isError, refetch } = useListTransactionsQuery(filters);
 
 // ── Actions ───────────────────────────────────────────────────────────────────

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -160,6 +160,14 @@ export default withNuxt(
           message:
             "Vue Query calls must set an explicit `staleTime` — import `STALE_TIME` from `~/core/query` (PERF-7).",
         },
+        // PAGE-SAFE (#1104): aggregations must never rely on the paginated
+        // page-1 query — it silently truncates once a range holds more than one
+        // page. Charts, summaries, calendars and exports must load every page.
+        {
+          selector: "CallExpression[callee.name='useListTransactionsQuery']",
+          message:
+            "Aggregations (charts, summaries, calendars, exports) must load ALL pages — use `useListAllTransactionsQuery` from `~/features/transactions/queries/use-list-all-transactions-query`. The paginated `useListTransactionsQuery` returns only page 1 and silently truncates. If page-1 pagination is genuinely intended (a paginated list UI or a small preview), add `// eslint-disable-next-line no-restricted-syntax -- <reason>` at the call site (PAGE-SAFE / #1104).",
+        },
       ],
     },
   },


### PR DESCRIPTION
## Contexto

`useListTransactionsQuery()` devolve **só a página 1** (10 registros). Usá-la em
contexto de **agregação** (gráficos, resumos, calendário, exports) trunca os
dados silenciosamente assim que o intervalo tem mais de uma página. O fix
(`useListAllTransactionsQuery` / `listAllTransactions`, que segue a paginação
até o fim) já existia (#1083, cartões), mas **não era enforced** — nada impedia
uma nova agregação de cair na versão paginada.

Fecha #1104 (Faxina — Onda 3) e, no caminho, corrige um **bug real de
truncamento no Calendário Financeiro**.

## O que muda

### 1. Regra ESLint (PAGE-SAFE) — enforcement
- Novo seletor em `no-restricted-syntax` (mesmo mecanismo do guard PERF-7 de
  `staleTime`) que **erra** em qualquer chamada de `useListTransactionsQuery`.
- Mensagem aponta o caminho correto (`useListAllTransactionsQuery`) e o escape
  hatch explícito (`// eslint-disable-next-line ... -- <motivo>`) para os casos
  em que a página 1 é intencional.

### 2. Bug fix — Calendário Financeiro truncava o mês
- `useFinancialCalendar` distribui **todas** as transações do mês pelas células
  de dia, mas usava a query paginada → meses com > 10 transações perdiam
  lançamentos (dias além dos 10 primeiros registros vinham vazios).
- Trocado para `useListAllTransactionsQuery`. Teste de regressão adicionado
  assertando que o composable usa a variante completa e **nunca** a paginada.

### 3. Call sites classificados (a regra passa sem falso-positivo)
| Site | Decisão | Motivo |
|------|---------|--------|
| `useFinancialCalendar.ts` | **corrigido → All** | agregação real (bug) |
| `pages/transactions/index.vue` | exempt | lista paginada — página 1 é o UX pretendido |
| `pages/goals/[id]/index.vue` | exempt | widget "transações recentes" (preview) |
| `pages/budgets.vue` | exempt | preview: filtra despesas comprometidas e `slice(0,5)` |
| `queries/use-list-transactions-query.spec.ts` | exempt (arquivo) | teste definicional do próprio hook |

## Validação

- `pnpm quality-check` — **verde** (flags → lint → typecheck → test:coverage →
  policy → contracts → build), CI parity local, Node 25.
- Teste de regressão do calendário: **red → green** (TDD).
- Controle positivo: uma violação nova (`useListTransactionsQuery()` em arquivo
  de produção) é capturada pela regra; os 4 call sites legítimos passam limpos.

### Screenshots
Sem mudança visual/layout: a regra é de lint e o fix do calendário altera
**completude de dados** (dias movimentados passam a mostrar todos os
lançamentos), não o desenho. A diferença só aparece com um mês de > 10
transações num ambiente semeado — sem sinal de design a capturar. Correção
coberta por teste unitário de regressão.

Closes #1104
