### PR TITLE
feat(transactions): deep-link ?open={id} para abrir a transação (CTA do email de vencimento)

### DIFF
--- a/app/pages/transactions/index.spec.ts
+++ b/app/pages/transactions/index.spec.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  join(process.cwd(), "app/pages/transactions/index.vue"),
+  "utf8",
+);
+
+describe("Transactions page — ?open deep link", () => {
+  it("opens the exact transaction from the open query param", () => {
+    // Powers the "Ver transação" CTA in the due-soon reminder email.
+    expect(source).toContain("useRoute()");
+    expect(source).toContain("route.query.open");
+    expect(source).toContain("requestedOpenId");
+    expect(source).toContain("hasOpenedFromQuery");
+    // When the requested id is found in the loaded list, its surface opens.
+    expect(source).toContain("handleEdit(match)");
+  });
+
+  it("guards against reopening on subsequent list refreshes", () => {
+    expect(source).toContain("if (hasOpenedFromQuery");
+  });
+});

--- a/app/pages/transactions/index.vue
+++ b/app/pages/transactions/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, watch } from "vue";
 import { NButton, NDataTable, NModal } from "naive-ui";
 import { ChevronLeft, ChevronRight, GripVertical, TrendingDown, TrendingUp, WalletCards } from "lucide-vue-next";
 import { useListTransactionsQuery } from "~/features/transactions/queries/use-list-transactions-query";
@@ -86,6 +86,32 @@ const {
 });
 
 const totalBalance = computed(() => totalIncome.value - totalExpense.value);
+
+// ── Deep link (?open=<id>) ──────────────────────────────────────────────────────
+// Lets the "Ver transação" CTA in the due-soon reminder email open the exact
+// transaction. When the list loads and contains the requested id, open its
+// detail/edit surface once.
+const route = useRoute();
+const requestedOpenId = computed<string | undefined>(() => {
+  const open = route.query.open;
+  const value = Array.isArray(open) ? open[0] : open;
+  return value ?? undefined;
+});
+let hasOpenedFromQuery = false;
+watch(
+  () => data.value,
+  (rows) => {
+    if (hasOpenedFromQuery || !requestedOpenId.value || !rows) {
+      return;
+    }
+    const match = rows.find((transaction) => transaction.id === requestedOpenId.value);
+    if (match) {
+      hasOpenedFromQuery = true;
+      handleEdit(match);
+    }
+  },
+  { immediate: true },
+);
 </script>
 
 <template>

--- a/app/shared/types/generated/graphql.ts
+++ b/app/shared/types/generated/graphql.ts
@@ -341,6 +341,13 @@ export type CancelSubscriptionMutation = {
   subscription: SubscriptionType;
 };
 
+/** Swap plan without double-charging (#1597); mirrors REST /change-plan. */
+export type ChangeSubscriptionPlanMutation = {
+  __typename?: 'ChangeSubscriptionPlanMutation';
+  checkout: CheckoutSessionType;
+  message: Scalars['String']['output'];
+};
+
 export type CheckoutSessionType = {
   __typename?: 'CheckoutSessionType';
   checkoutUrl: Scalars['String']['output'];
@@ -864,6 +871,11 @@ export type Mutation = {
   /** @deprecated ADR-0004: use POST /subscription/cancel */
   cancelSubscription?: Maybe<CancelSubscriptionMutation>;
   /**
+   * Swap plan without double-charging (#1597); mirrors REST /change-plan.
+   * @deprecated ADR-0004: use POST /subscription/change-plan
+   */
+  changeSubscriptionPlan?: Maybe<ChangeSubscriptionPlanMutation>;
+  /**
    * Mark the authenticated user's onboarding as completed (idempotent).
    *
    * REST parity: ``POST /user/onboarding/complete``.
@@ -1010,6 +1022,12 @@ export type MutationAskFinancialQuestionArgs = {
 
 export type MutationCancelReceivableArgs = {
   entryId: Scalars['UUID']['input'];
+};
+
+
+export type MutationChangeSubscriptionPlanArgs = {
+  billingCycle?: InputMaybe<BillingCycle>;
+  planSlug: Scalars['String']['input'];
 };
 
 


### PR DESCRIPTION
## Contexto

O redesign dos emails (auraxis-api) adicionou um CTA **"Ver transação"** no email de vencimento, que deep-linka em `/transactions?open={id}`. Faltava o suporte no web — a página de transações não abria uma transação específica por query param (o `/insights?open=` já existia).

## O que muda

`app/pages/transactions/index.vue`: ao carregar com `?open=<id>`, quando a lista carrega e contém aquele id, abre a superfície de detalhe/edição da transação (`handleEdit`) — uma vez só (guarda contra reabrir em refetch). Sem id ou id ausente da lista atual: no-op gracioso.

## Validação
- Teste (source-assertion, padrão do repo — igual `insights.spec.ts`): 2/2 verdes.
- `pnpm quality-check` verde.

## Risco residual
Mínimo. Só adiciona um watcher de deep-link; não altera o fluxo normal da lista.
