### PR TITLE
fix(landing): alinhar o E2E do CTA de assinatura ao checkout próprio

### DIFF
--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -80,12 +80,11 @@ test.describe("Landing de captação — auraxis.com.br", () => {
     await expect(pricing.getByText("R$ 29,90")).toBeVisible();
     await expect(pricing.getByText("R$ 287,04")).toBeVisible();
 
+    // #1187: buying happens on the landing itself — the CTA must NOT hand the
+    // visitor to another origin before they can pay.
     const subscribe = page.getByTestId("landing-pricing-subscribe");
     await expect(subscribe).toBeVisible();
-    await expect(subscribe).toHaveAttribute(
-      "href",
-      "https://app.auraxis.com.br/subscription",
-    );
+    await expect(subscribe).toHaveAttribute("href", "/checkout?plano=anual");
   });
 
   test("shows the landing footer with legal links on the app origin", async ({ page }) => {


### PR DESCRIPTION
## Summary

O merge de #1187 moveu o CTA de assinatura para `/checkout?plano=anual`, mas `e2e/landing.spec.ts` continuava afirmando `https://app.auraxis.com.br/subscription`. O **deploy da landing falhou** por isso (run 30273848611).

A quebra passou despercebida porque o gate E2E vive no `deploy-landing.yml` e o `pnpm quality-check` não roda E2E — o teste só executa no caminho de deploy.

## Validation

`LANDING_E2E=1 pnpm test:e2e e2e/landing.spec.ts --project=chromium` contra a build real da surface landing: **8 passed**.

## Residual risk

Nenhum — ajuste de asserção para o comportamento já mergeado e validado.

## Refs

Closes #1195