### PR TITLE
fix(billing): enviar Idempotency-Key no checkout e no cancelamento

### DIFF
--- a/app/core/http/idempotency.spec.ts
+++ b/app/core/http/idempotency.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createIdempotencyKey,
+  idempotencyHeaders,
+  IDEMPOTENCY_KEY_HEADER,
+} from "./idempotency";
+
+describe("createIdempotencyKey", () => {
+  it("prefixes the key with the calling scope so charges are traceable in API logs", () => {
+    expect(createIdempotencyKey("landing-checkout")).toMatch(
+      /^landing-checkout-[0-9a-f-]{36}$/,
+    );
+  });
+
+  it("never repeats a key across intents", () => {
+    const keys = new Set(
+      Array.from({ length: 50 }, () => createIdempotencyKey("checkout")),
+    );
+
+    expect(keys.size).toBe(50);
+  });
+});
+
+describe("idempotencyHeaders", () => {
+  it("returns the header name the API middleware expects", () => {
+    const headers = idempotencyHeaders("checkout");
+
+    expect(Object.keys(headers)).toEqual([IDEMPOTENCY_KEY_HEADER]);
+    expect(headers[IDEMPOTENCY_KEY_HEADER]).toMatch(/^checkout-/);
+  });
+});

--- a/app/core/http/idempotency.ts
+++ b/app/core/http/idempotency.ts
@@ -1,0 +1,40 @@
+/**
+ * Idempotency keys for the POST endpoints that require them.
+ *
+ * The API rejects `POST /subscriptions/checkout` and `/subscriptions/cancel`
+ * with 400 `IDEMPOTENCY_KEY_REQUIRED` when the `Idempotency-Key` header is
+ * absent (api#946), and replays the stored response when the same key comes
+ * back with the same body.
+ *
+ * A key stands for **one user intent**, not one request: generate it once when
+ * the user submits and let the automatic retries (see `retry-config.ts`) reuse
+ * it, so a checkout that is retried after a network blip settles as a single
+ * charge. A new click means a new intent — and a new key.
+ */
+
+/** Header name expected by the API middleware. */
+export const IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+
+/**
+ * Builds an idempotency key scoped to the flow that issues it.
+ *
+ * The scope prefix is only there to make keys readable in API logs when
+ * tracing a charge back to the surface that started it.
+ *
+ * @param scope Short slug identifying the caller, e.g. `landing-checkout`.
+ * @returns Key such as `landing-checkout-3f1c…`.
+ */
+export const createIdempotencyKey = (scope: string): string =>
+  `${scope}-${globalThis.crypto.randomUUID()}`;
+
+/**
+ * Builds the request headers carrying a fresh idempotency key.
+ *
+ * @param scope Short slug identifying the caller.
+ * @returns Headers object ready to spread into an Axios request config.
+ */
+export const idempotencyHeaders = (
+  scope: string,
+): Record<string, string> => ({
+  [IDEMPOTENCY_KEY_HEADER]: createIdempotencyKey(scope),
+});

--- a/app/features/subscription/services/subscription.client.spec.ts
+++ b/app/features/subscription/services/subscription.client.spec.ts
@@ -93,9 +93,24 @@ describe("SubscriptionClient", () => {
     await expect(client.createCheckout("premium", "annual")).resolves.toBe(
       "https://billing.example/checkout",
     );
-    expect(post).toHaveBeenCalledWith("/subscriptions/checkout", {
-      plan_slug: "premium",
-      billing_cycle: "annual",
+    expect(post).toHaveBeenCalledWith(
+      "/subscriptions/checkout",
+      {
+        plan_slug: "premium",
+        billing_cycle: "annual",
+      },
+      { headers: { "Idempotency-Key": expect.stringMatching(/^web-checkout-/) } },
+    );
+  });
+
+  it("sends an idempotency key when cancelling, which the API also requires", async () => {
+    const { client, post } = makeClient();
+    post.mockResolvedValue({ data: { success: true } });
+
+    await client.cancelSubscription();
+
+    expect(post).toHaveBeenCalledWith("/subscriptions/cancel", undefined, {
+      headers: { "Idempotency-Key": expect.stringMatching(/^web-cancel-/) },
     });
   });
 });

--- a/app/features/subscription/services/subscription.client.ts
+++ b/app/features/subscription/services/subscription.client.ts
@@ -1,6 +1,7 @@
 import type { AxiosInstance } from "axios";
 
 import { useHttp } from "~/composables/useHttp";
+import { idempotencyHeaders } from "~/core/http/idempotency";
 import type {
   BillingCycle,
   CheckoutResponseDto,
@@ -110,10 +111,17 @@ export class SubscriptionClient {
    * @returns Checkout URL to redirect the user to.
    */
   async createCheckout(planSlug: string, billingCycle: BillingCycle = "monthly"): Promise<string> {
-    const response = await this.#http.post<CheckoutResponseBodyDto>("/subscriptions/checkout", {
-      plan_slug: planSlug,
-      billing_cycle: billingCycle,
-    });
+    const response = await this.#http.post<CheckoutResponseBodyDto>(
+      "/subscriptions/checkout",
+      {
+        plan_slug: planSlug,
+        billing_cycle: billingCycle,
+      },
+      // The API requires this header on checkout/cancel and answers 400
+      // without it (#1200). One key per user intent — the automatic retries
+      // reuse it, so a retried checkout settles as a single charge.
+      { headers: idempotencyHeaders("web-checkout") },
+    );
     return unwrapCheckout(response.data).checkout_url;
   }
 
@@ -123,7 +131,9 @@ export class SubscriptionClient {
    * @returns Void on success.
    */
   async cancelSubscription(): Promise<void> {
-    await this.#http.post("/subscriptions/cancel");
+    await this.#http.post("/subscriptions/cancel", undefined, {
+      headers: idempotencyHeaders("web-cancel"),
+    });
   }
 }
 

--- a/app/pages/checkout/index.spec.ts
+++ b/app/pages/checkout/index.spec.ts
@@ -209,7 +209,13 @@ describe("landing checkout page", () => {
     expect(postMock).toHaveBeenCalledWith(
       "/subscriptions/checkout",
       { plan_slug: "premium_annual", return_surface: "landing" },
-      { headers: { Authorization: "Bearer jwt-token" } },
+      {
+        headers: {
+          Authorization: "Bearer jwt-token",
+          // The API answers 400 without it (#1200).
+          "Idempotency-Key": expect.stringMatching(/^landing-checkout-/),
+        },
+      },
     );
   });
 

--- a/app/pages/checkout/index.vue
+++ b/app/pages/checkout/index.vue
@@ -3,6 +3,7 @@ import { ArrowRight } from "lucide-vue-next";
 
 import { useHttp } from "~/composables/useHttp";
 import { createAuthApi } from "~/composables/useAuth";
+import { idempotencyHeaders } from "~/core/http/idempotency";
 import {
   buildLandingCheckoutPath,
   LANDING_CHECKOUT_GENERIC_ERROR,
@@ -137,7 +138,14 @@ const submit = async (): Promise<void> => {
           }>(
             "/subscriptions/checkout",
             { plan_slug: planSlug, return_surface: "landing" },
-            { headers: { Authorization: `Bearer ${token}` } },
+            {
+              headers: {
+                Authorization: `Bearer ${token}`,
+                // Required by the API on this endpoint — without it the
+                // purchase dies on a 400 (#1200).
+                ...idempotencyHeaders("landing-checkout"),
+              },
+            },
           );
           const body = response.data;
           return {


### PR DESCRIPTION
## O que estava quebrado

Validando o #1198 em produção, a compra em `auraxis.com.br/checkout` chegou até o último passo e morreu:

```
POST https://api.auraxis.com.br/auth/register          → 201
POST https://api.auraxis.com.br/auth/login             → 200
POST https://api.auraxis.com.br/subscriptions/checkout → 400
```

```json
{"error":{"code":"IDEMPOTENCY_KEY_REQUIRED"},
 "message":"Header Idempotency-Key obrigatório para este endpoint.","success":false}
```

O middleware da API (`app/middleware/idempotency_key.py`, api#946) exige o header em todo POST para `/subscriptions/checkout` e `/subscriptions/cancel`. Nenhum dos clientes do web mandava:

- `app/pages/checkout/index.vue` — a landing;
- `app/features/subscription/services/subscription.client.ts` — `createCheckout()` **e** `cancelSubscription()`, usados por `pages/subscription.vue` e `pages/plans.vue`.

Ou seja, o problema não era só da landing: **assinar e cancelar pelo app web estavam quebrados do mesmo jeito.**

## O que mudou

`app/core/http/idempotency.ts` — helper único que gera a chave com um prefixo de escopo (`landing-checkout-…`, `web-checkout-…`, `web-cancel-…`), para dar de rastrear uma cobrança até a superfície que a iniciou nos logs da API. Os três POSTs passam a mandar o header.

A chave representa **uma intenção do usuário**, não um request: os retries automáticos (`core/http/retry-config.ts`, 2× em erro de rede) reenviam a mesma config e portanto a mesma chave — é isso que faz um checkout retentado virar uma cobrança só. Clique novo gera chave nova.

## Validação

`pnpm quality-check` verde — 4224 testes, cobertura 92,47% stmts / 85,27% branches, build ok.

Testes novos: geração e unicidade da chave, header no `createCheckout`, header no `cancelSubscription`, e o wiring da landing (`app/pages/checkout/index.spec.ts`) agora exige `Idempotency-Key` além do `Authorization`.

Validação em produção vem logo após o merge + deploy da landing — o mesmo caminho que expôs o defeito.

## Risco residual

- **Não achei chamada equivalente no app mobile** (`repos/auraxis-app`): há mock e catálogo de contratos para `POST /subscriptions/checkout`, mas nenhuma chamada real no código. Se a assinatura no app passar por outro caminho, ele precisa da mesma correção — vale confirmar antes do próximo release mobile.
- O helper novo não foi aplicado ao `admin-users.client.ts`, que já tinha a sua própria função local e continua correto. Unificar fica para uma limpeza à parte.

Closes #1200