### PR TITLE
fix(checkout): pagar com a conta certa e respeitar o plano do link

### DIFF
--- a/app/core/http/__tests__/auth-interceptor.spec.ts
+++ b/app/core/http/__tests__/auth-interceptor.spec.ts
@@ -1,0 +1,68 @@
+import type { InternalAxiosRequestConfig } from "axios";
+import { describe, expect, it } from "vitest";
+
+import { createHttpClient } from "../http-client";
+
+/**
+ * Runs every registered request interceptor over a bare config, the same way
+ * Axios does before a request leaves.
+ *
+ * @param client Axios instance under test.
+ * @param headers Headers the caller set on the request itself.
+ * @returns The config as it would go on the wire.
+ */
+const runRequestInterceptors = async (
+  client: ReturnType<typeof createHttpClient>,
+  headers: Record<string, string> = {},
+): Promise<InternalAxiosRequestConfig> => {
+  let config = {
+    headers: { ...headers },
+    method: "post",
+    url: "/subscriptions/checkout",
+  } as unknown as InternalAxiosRequestConfig;
+
+  const handlers = (
+    client.interceptors.request as unknown as {
+      handlers: { fulfilled?: (c: InternalAxiosRequestConfig) => InternalAxiosRequestConfig }[];
+    }
+  ).handlers;
+
+  for (const handler of handlers) {
+    if (handler.fulfilled) {
+      config = await handler.fulfilled(config);
+    }
+  }
+
+  return config;
+};
+
+describe("auth request interceptor", () => {
+  it("injects the session token when the caller did not set one", async () => {
+    const client = createHttpClient("https://api.example", () => "session-token");
+
+    const config = await runRequestInterceptors(client);
+
+    expect(config.headers.Authorization).toBe("Bearer session-token");
+  });
+
+  it("leaves the request untouched when there is no session", async () => {
+    const client = createHttpClient("https://api.example", () => null);
+
+    const config = await runRequestInterceptors(client);
+
+    expect(config.headers.Authorization).toBeUndefined();
+  });
+
+  it("keeps the caller's own token instead of the restored session's (#1202)", async () => {
+    // The public checkout signs a brand-new account in and pays with that
+    // token, while the browser may still hold a session for someone else.
+    // Overwriting it here charged the wrong account in production.
+    const client = createHttpClient("https://api.example", () => "other-users-token");
+
+    const config = await runRequestInterceptors(client, {
+      Authorization: "Bearer just-registered-token",
+    });
+
+    expect(config.headers.Authorization).toBe("Bearer just-registered-token");
+  });
+});

--- a/app/core/http/http-client.ts
+++ b/app/core/http/http-client.ts
@@ -25,7 +25,13 @@ export const normalizeBaseUrl = (rawUrl: string): string => {
 };
 
 /**
- * Creates an authorization interceptor that injects a bearer token when available.
+ * Creates an authorization interceptor that injects the session bearer token
+ * into requests that do not already carry one.
+ *
+ * A caller that sets `Authorization` itself always wins: the public checkout
+ * signs a brand-new account in and pays with *that* token, while the browser
+ * may still hold a restored session for a different user. Overwriting the
+ * explicit header there billed the wrong account (#1202).
  *
  * @param getAccessToken Lazy token resolver.
  * @returns Axios request interceptor.
@@ -34,6 +40,10 @@ const createAuthInterceptor = (
   getAccessToken: () => string | null,
 ): ((config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig) => {
   return (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
+    if (config.headers.Authorization) {
+      return config;
+    }
+
     const token = getAccessToken();
 
     if (token) {

--- a/app/features/landing/model/landing-checkout.spec.ts
+++ b/app/features/landing/model/landing-checkout.spec.ts
@@ -4,6 +4,7 @@ import {
   buildLandingCheckoutPath,
   LANDING_CHECKOUT_PLANS,
   resolveLandingCheckoutPlan,
+  resolveLandingCheckoutPlanFromSources,
   startLandingCheckout,
   type LandingCheckoutDeps,
 } from "./landing-checkout";
@@ -30,6 +31,41 @@ describe("resolveLandingCheckoutPlan", () => {
     "falls back to the recommended plan for %p",
     (raw) => {
       expect(resolveLandingCheckoutPlan(raw)).toBe("annual");
+    },
+  );
+});
+
+describe("resolveLandingCheckoutPlanFromSources", () => {
+  it("reads the browser query string when the hydrated route comes back empty", () => {
+    // The prerendered page hydrates with no query, and the silent fallback to
+    // the recommended plan charged the annual price on a monthly link (#1203).
+    expect(resolveLandingCheckoutPlanFromSources(undefined, "?plano=mensal")).toBe(
+      "monthly",
+    );
+  });
+
+  it("accepts a query string without the leading question mark", () => {
+    expect(resolveLandingCheckoutPlanFromSources(undefined, "plano=mensal")).toBe(
+      "monthly",
+    );
+  });
+
+  it("prefers the route value over the browser query string", () => {
+    expect(resolveLandingCheckoutPlanFromSources("anual", "?plano=mensal")).toBe(
+      "annual",
+    );
+  });
+
+  it("ignores the browser query string when it carries no known plan", () => {
+    expect(
+      resolveLandingCheckoutPlanFromSources(undefined, "?utm_source=x&plano=premium"),
+    ).toBe("annual");
+  });
+
+  it.each([undefined, null, ""])(
+    "falls back to the recommended plan when both sources are %p",
+    (search) => {
+      expect(resolveLandingCheckoutPlanFromSources(undefined, search)).toBe("annual");
     },
   );
 });

--- a/app/features/landing/model/landing-checkout.ts
+++ b/app/features/landing/model/landing-checkout.ts
@@ -50,6 +50,28 @@ export const LANDING_CHECKOUT_PLANS: Readonly<
 } as const;
 
 /**
+ * Matches a raw `?plano=` value against the sellable plans.
+ *
+ * @param raw Raw value — a string, an array (repeated param), or absent.
+ * @returns The plan key, or null when nothing matches.
+ */
+const matchLandingCheckoutPlan = (
+  raw: unknown,
+): LandingCheckoutPlanKey | null => {
+  const candidate = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof candidate !== "string") {
+    return null;
+  }
+  const normalized = candidate.trim().toLowerCase();
+  for (const plan of Object.values(LANDING_CHECKOUT_PLANS)) {
+    if (normalized === plan.querySlug || normalized === plan.key) {
+      return plan.key;
+    }
+  }
+  return null;
+};
+
+/**
  * Resolves the plan a visitor asked for in the URL.
  *
  * Anything unrecognised falls back to the recommended plan instead of erroring:
@@ -60,18 +82,40 @@ export const LANDING_CHECKOUT_PLANS: Readonly<
  */
 export const resolveLandingCheckoutPlan = (
   raw: unknown,
+): LandingCheckoutPlanKey =>
+  matchLandingCheckoutPlan(raw) ?? DEFAULT_LANDING_CHECKOUT_PLAN;
+
+/**
+ * Resolves the plan from the Nuxt route, falling back to the query string the
+ * browser itself holds.
+ *
+ * The checkout page is prerendered, and on that path the hydrated `route.query`
+ * can come back empty. Since an unrecognised value silently falls back to the
+ * recommended plan, a `?plano=mensal` link opened — and charged — the annual
+ * plan (#1203). Same hydration gap already handled in `pages/confirm-email.vue`.
+ *
+ * @param routeValue Value read from the Nuxt route query.
+ * @param browserSearch `window.location.search`, with or without the leading `?`.
+ * @returns The resolved plan key.
+ */
+export const resolveLandingCheckoutPlanFromSources = (
+  routeValue: unknown,
+  browserSearch: string | null | undefined,
 ): LandingCheckoutPlanKey => {
-  const candidate = Array.isArray(raw) ? raw[0] : raw;
-  if (typeof candidate !== "string") {
+  const fromRoute = matchLandingCheckoutPlan(routeValue);
+  if (fromRoute) {
+    return fromRoute;
+  }
+  if (!browserSearch) {
     return DEFAULT_LANDING_CHECKOUT_PLAN;
   }
-  const normalized = candidate.trim().toLowerCase();
-  for (const plan of Object.values(LANDING_CHECKOUT_PLANS)) {
-    if (normalized === plan.querySlug || normalized === plan.key) {
-      return plan.key;
-    }
-  }
-  return DEFAULT_LANDING_CHECKOUT_PLAN;
+  const search = browserSearch.startsWith("?")
+    ? browserSearch
+    : `?${browserSearch}`;
+  return (
+    matchLandingCheckoutPlan(new URLSearchParams(search).get("plano")) ??
+    DEFAULT_LANDING_CHECKOUT_PLAN
+  );
 };
 
 /**

--- a/app/pages/checkout/index.spec.ts
+++ b/app/pages/checkout/index.spec.ts
@@ -94,10 +94,11 @@ vi.mock("lucide-vue-next", () => ({
  * Replaces `window.location` with a plain object so the redirect assignment is
  * observable instead of triggering a real navigation in happy-dom.
  *
+ * @param search Query string the page should read on mount, e.g. `?plano=mensal`.
  * @returns The stub whose `href` the page writes to.
  */
-function stubLocation(): { href: string } {
-  const stub = { href: "" };
+function stubLocation(search = ""): { href: string; search: string } {
+  const stub = { href: "", search };
   Object.defineProperty(window, "location", {
     configurable: true,
     writable: true,
@@ -256,6 +257,23 @@ describe("landing checkout page", () => {
 
     expect(wrapper.text()).not.toContain("Preparando…");
     expect(wrapper.find("[data-testid='landing-checkout-error']").exists()).toBe(true);
+  });
+
+  it("honours ?plano=mensal from the browser URL when the hydrated route is empty", async () => {
+    // The page is prerendered: `route.query` hydrates empty and the silent
+    // fallback used to send the annual plan on a monthly link (#1203).
+    stubLocation("?plano=mensal");
+    startLandingCheckoutMock.mockResolvedValue({
+      status: "account-exists",
+    } satisfies LandingCheckoutOutcome);
+
+    const wrapper = await mountFilledPage();
+    await flushPromises();
+    await submitForm(wrapper);
+
+    expect(startLandingCheckoutMock.mock.calls[0]?.[0]).toMatchObject({
+      plan: "monthly",
+    });
   });
 
   it("hands the app surface over to the in-app subscription screen", async () => {

--- a/app/pages/checkout/index.vue
+++ b/app/pages/checkout/index.vue
@@ -9,6 +9,7 @@ import {
   LANDING_CHECKOUT_GENERIC_ERROR,
   LANDING_CHECKOUT_PLANS,
   resolveLandingCheckoutPlan,
+  resolveLandingCheckoutPlanFromSources,
   startLandingCheckout,
   type LandingCheckoutPlanKey,
 } from "~/features/landing/model/landing-checkout";
@@ -52,7 +53,13 @@ const selectedPlan = ref<LandingCheckoutPlanKey>(
   resolveLandingCheckoutPlan(route.query["plano"]),
 );
 onMounted((): void => {
-  selectedPlan.value = resolveLandingCheckoutPlan(route.query["plano"]);
+  // `route.query` can hydrate empty on the prerendered page, and an unmatched
+  // value falls back to the annual plan — so a ?plano=mensal link used to open
+  // the annual charge (#1203). The browser's own query string is the tiebreak.
+  selectedPlan.value = resolveLandingCheckoutPlanFromSources(
+    route.query["plano"],
+    window.location.search,
+  );
   if (!isLandingSurface.value) {
     void navigateTo("/subscription");
   }


### PR DESCRIPTION
Dois defeitos que só apareceram testando a compra real em produção, depois que #1198, platform#928 e #1200 destravaram o fluxo até o fim.

## 1. A assinatura ia para a conta errada (#1202)

Criei uma conta nova pela landing e o checkout foi cobrado em **outra conta**:

| | |
|---|---|
| `POST /auth/register` + `/auth/login` | `qa-checkout-1200@auraxis.com.br` → `sub becc9a9b-936c-…` |
| `Authorization` enviado no `POST /subscriptions/checkout` | JWT com `sub 65eda270-53ae-…` |

O hosted checkout do AbacatePay abriu preenchido com o nome e o email do **usuário antigo**.

`createAuthInterceptor` sobrescrevia o `Authorization` que a página já tinha definido:

```ts
const token = getAccessToken();
if (token) {
  config.headers.Authorization = `Bearer ${token}`;   // ← por cima do header da request
}
```

Na landing isso acontece com facilidade: o boot roda `POST /auth/refresh` e, com o cookie httpOnly de uma sessão anterior, restaura a sessão de outra pessoa antes de o visitante tocar no formulário.

Agora um `Authorization` definido na própria request vence o da sessão.

## 2. `?plano=mensal` cobrava o anual (#1203)

`https://auraxis.com.br/checkout?plano=mensal` enviava `{"plan_slug":"premium_annual"}` e abria a cobrança de R$ 287,04/ano.

A página é prerenderizada e o `route.query` hidrata vazio; como um valor não reconhecido cai silenciosamente no plano recomendado (anual), o link do mensal virava o anual. O bug ficava invisível porque o CTA da home aponta justamente para `?plano=anual`.

Passa a cair para a query string do browser — mesmo tratamento que `pages/confirm-email.vue` já fazia para o token.

## Validação

`pnpm quality-check` verde — 4235 testes, cobertura 92,47% stmts / 85,27% branches, build ok.

Os testes foram escritos antes do fix e falham sem ele:

```
FAIL | keeps the caller's own token instead of the restored session's (#1202)
```

Cobertura nova: precedência do `Authorization` (com e sem sessão), resolução do plano por query do browser (com/sem `?`, route ganhando do browser, valor desconhecido) e o caminho de página completo com `?plano=mensal`.

Validação em produção logo após o merge + deploy, repetindo o cenário que expôs cada um.

## Risco residual

- **O retry de 401 tem a mesma sobrescrita** (`app/core/api/interceptors.ts:177`): se a chamada do checkout tomasse 401, ela seria repetida com o token da sessão. Não mexi — um token recém-emitido não deve expirar no meio do fluxo, e ali a sobrescrita é intencional para o app autenticado. Fica registrado.
- **A landing não deveria restaurar sessão nenhuma.** O checkout público não precisa do refresh de boot; desligá-lo nessa surface removeria a origem do #1202 em vez de só neutralizá-la. Fora do escopo deste PR.
- Contas de teste criadas em produção durante a investigação: `qa-checkout-1198@auraxis.com.br` e `qa-checkout-1200@auraxis.com.br` — a segunda com uma bill sandbox no AbacatePay ligada à conta errada.

Closes #1202
Closes #1203