### PR TITLE
fix(checkout): resolver o plano pela URL de navegação, não só pela query

### DIFF
--- a/app/features/landing/model/landing-checkout.spec.ts
+++ b/app/features/landing/model/landing-checkout.spec.ts
@@ -44,6 +44,34 @@ describe("resolveLandingCheckoutPlanFromSources", () => {
     );
   });
 
+  it("falls through to the navigation URL when route and search are both empty", () => {
+    // Measured in production: at `onMounted` both are empty because Nuxt
+    // strips the query while normalising the route (#1203).
+    expect(
+      resolveLandingCheckoutPlanFromSources(
+        undefined,
+        "",
+        "https://auraxis.com.br/checkout?plano=mensal",
+      ),
+    ).toBe("monthly");
+  });
+
+  it("takes the first source that names a known plan", () => {
+    expect(
+      resolveLandingCheckoutPlanFromSources(
+        undefined,
+        "?plano=mensal",
+        "https://auraxis.com.br/checkout?plano=anual",
+      ),
+    ).toBe("monthly");
+  });
+
+  it("survives a malformed URL source", () => {
+    expect(
+      resolveLandingCheckoutPlanFromSources(undefined, "://quebrado", "?plano=mensal"),
+    ).toBe("monthly");
+  });
+
   it("accepts a query string without the leading question mark", () => {
     expect(resolveLandingCheckoutPlanFromSources(undefined, "plano=mensal")).toBe(
       "monthly",

--- a/app/features/landing/model/landing-checkout.ts
+++ b/app/features/landing/model/landing-checkout.ts
@@ -86,36 +86,57 @@ export const resolveLandingCheckoutPlan = (
   matchLandingCheckoutPlan(raw) ?? DEFAULT_LANDING_CHECKOUT_PLAN;
 
 /**
- * Resolves the plan from the Nuxt route, falling back to the query string the
- * browser itself holds.
+ * Reads the `plano` param out of a query string or a full URL.
  *
- * The checkout page is prerendered, and on that path the hydrated `route.query`
- * can come back empty. Since an unrecognised value silently falls back to the
- * recommended plan, a `?plano=mensal` link opened — and charged — the annual
- * plan (#1203). Same hydration gap already handled in `pages/confirm-email.vue`.
+ * @param source `?plano=mensal`, `plano=mensal`, or `https://…/checkout?plano=mensal`.
+ * @returns The raw param value, or null when absent or unparseable.
+ */
+const readPlanParam = (source: string | null | undefined): string | null => {
+  if (!source) {
+    return null;
+  }
+  try {
+    if (source.includes("://")) {
+      return new URL(source).searchParams.get("plano");
+    }
+    const search = source.startsWith("?") ? source : `?${source}`;
+    return new URLSearchParams(search).get("plano");
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Resolves the plan from the Nuxt route, falling back to URL sources owned by
+ * the browser.
+ *
+ * The checkout page is prerendered and, measured in a production build, at the
+ * moment `onMounted` runs BOTH `route.query` and `window.location.search` are
+ * empty — Nuxt strips the query while it normalises the route during hydration.
+ * Since an unrecognised value silently falls back to the recommended plan, a
+ * `?plano=mensal` link opened — and charged — the annual plan (#1203). The
+ * navigation entry keeps the original URL and survives that window, which is
+ * the same reason `pages/confirm-email.vue` reads it.
  *
  * @param routeValue Value read from the Nuxt route query.
- * @param browserSearch `window.location.search`, with or without the leading `?`.
+ * @param urlSources URL-ish fallbacks, in priority order.
  * @returns The resolved plan key.
  */
 export const resolveLandingCheckoutPlanFromSources = (
   routeValue: unknown,
-  browserSearch: string | null | undefined,
+  ...urlSources: (string | null | undefined)[]
 ): LandingCheckoutPlanKey => {
   const fromRoute = matchLandingCheckoutPlan(routeValue);
   if (fromRoute) {
     return fromRoute;
   }
-  if (!browserSearch) {
-    return DEFAULT_LANDING_CHECKOUT_PLAN;
+  for (const source of urlSources) {
+    const fromUrl = matchLandingCheckoutPlan(readPlanParam(source));
+    if (fromUrl) {
+      return fromUrl;
+    }
   }
-  const search = browserSearch.startsWith("?")
-    ? browserSearch
-    : `?${browserSearch}`;
-  return (
-    matchLandingCheckoutPlan(new URLSearchParams(search).get("plano")) ??
-    DEFAULT_LANDING_CHECKOUT_PLAN
-  );
+  return DEFAULT_LANDING_CHECKOUT_PLAN;
 };
 
 /**

--- a/app/pages/checkout/index.spec.ts
+++ b/app/pages/checkout/index.spec.ts
@@ -276,6 +276,33 @@ describe("landing checkout page", () => {
     });
   });
 
+  it("falls back to the navigation URL when Nuxt has stripped the query entirely", async () => {
+    // What actually happens in production: at `onMounted` the route query AND
+    // `location.search` are both empty, and only the navigation entry still
+    // carries the plan the visitor clicked (#1203).
+    stubLocation("");
+    const navigationSpy = vi
+      .spyOn(window.performance, "getEntriesByType")
+      .mockReturnValue([
+        { name: "https://auraxis.com.br/checkout?plano=mensal" } as PerformanceNavigationTiming,
+      ]);
+    startLandingCheckoutMock.mockResolvedValue({
+      status: "account-exists",
+    } satisfies LandingCheckoutOutcome);
+
+    try {
+      const wrapper = await mountFilledPage();
+      await flushPromises();
+      await submitForm(wrapper);
+
+      expect(startLandingCheckoutMock.mock.calls[0]?.[0]).toMatchObject({
+        plan: "monthly",
+      });
+    } finally {
+      navigationSpy.mockRestore();
+    }
+  });
+
   it("hands the app surface over to the in-app subscription screen", async () => {
     siteSurface.current = "app";
 

--- a/app/pages/checkout/index.vue
+++ b/app/pages/checkout/index.vue
@@ -52,13 +52,26 @@ const route = useRoute();
 const selectedPlan = ref<LandingCheckoutPlanKey>(
   resolveLandingCheckoutPlan(route.query["plano"]),
 );
+/**
+ * URL the browser actually navigated to.
+ *
+ * Measured on a production build: when `onMounted` runs, `route.query` AND
+ * `window.location.search` are both empty because Nuxt strips the query while
+ * normalising the route during hydration. This entry keeps the original URL
+ * (#1203) — same reason `pages/confirm-email.vue` reads it.
+ *
+ * @returns The navigation URL, or null when unavailable.
+ */
+const readNavigationUrl = (): string | null => {
+  const entry = performance.getEntriesByType("navigation")[0];
+  return entry && "name" in entry ? entry.name : null;
+};
+
 onMounted((): void => {
-  // `route.query` can hydrate empty on the prerendered page, and an unmatched
-  // value falls back to the annual plan — so a ?plano=mensal link used to open
-  // the annual charge (#1203). The browser's own query string is the tiebreak.
   selectedPlan.value = resolveLandingCheckoutPlanFromSources(
     route.query["plano"],
     window.location.search,
+    readNavigationUrl(),
   );
   if (!isLandingSurface.value) {
     void navigateTo("/subscription");


### PR DESCRIPTION
## Por que um segundo PR para o #1203

O fix que foi no #1204 **não resolveu**. Validado em produção depois do deploy, `?plano=mensal` continuou enviando:

```json
{"plan_slug":"premium_annual","return_surface":"landing"}
```

Os testes passavam porque eu tinha testado a hipótese errada.

## O que realmente acontece

Instrumentei um build de produção com log no `onMounted`:

```
[DEBUG-1203] {"routeQuery":{},"search":"","resolvido":"annual"}
```

`route.query` **e** `window.location.search` estão os **dois vazios** no instante do mount — o Nuxt tira a query enquanto normaliza a rota durante a hidratação. Medindo em `script-start`, `DOMContentLoaded`, `load` e `setTimeout(0)`, a query aparece preenchida em todos: a janela em que ela some é justamente a do mount, e foi por isso que o primeiro fix pareceu correto.

`pages/confirm-email.vue` já convivia com isso e por isso lê a navigation entry — eu tinha visto esse código e implementei só metade do padrão.

## O que mudou

`resolveLandingCheckoutPlanFromSources` passa a aceitar várias fontes de URL em ordem de prioridade, e a página consulta: rota → `location.search` → `performance.getEntriesByType("navigation")[0].name`, que preserva o link original.

## Validação

Build estático da landing (`NUXT_PUBLIC_SITE_SURFACE=landing pnpm generate`) servido localmente:

| URL | Plano ativo | Preço |
|---|---|---|
| `/checkout?plano=mensal` | Premium mensal | R$ 29,90 |
| `/checkout?plano=anual` | Premium anual | R$ 287,04 |
| `/checkout` | Premium anual | R$ 287,04 |

`pnpm quality-check` verde — 4239 testes, cobertura 92,47% stmts / 85,27% branches, build ok.

Testes novos cobrem a navigation entry como fonte, a ordem de prioridade entre fontes e uma URL malformada. O caso da página reproduz o cenário real: `location.search` vazio e só a navigation entry com o plano.

Validação em produção depois do merge + deploy, repetindo o link que expôs o defeito.

## Risco residual

- O `?plano=` é resolvido uma vez, no mount. Uma navegação client-side para outro plano continua passando pelo `selectPlan`, que já cuida do estado — mas não há watcher na query, então um `router.push` externo com outro `?plano=` não seria refletido. Fora do escopo.

Closes #1203