### PR TITLE
ci(landing): trocar a allowlist de paths do deploy por lista de exclusão

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -14,15 +14,29 @@ name: Deploy Landing (auraxis.com.br)
 on:
   push:
     branches: [main]
-    paths:
-      - "app/features/landing/**"
-      - "app/pages/index.vue"
-      - "app/layouts/public.vue"
-      - "app/app.vue"
-      - "app/assets/css/main.css"
-      - "public/landing/**"
-      - "nuxt.config.ts"
-      - ".github/workflows/deploy-landing.yml"
+    # Lista de EXCLUSÃO, não de inclusão (#1197).
+    #
+    # A allowlist anterior tentava enumerar o que a landing embarca e, na
+    # prática, sempre ficava desatualizada: quando o checkout próprio entrou
+    # (#1187), `app/pages/checkout/**` ficou de fora e o fix de pagamento do
+    # #1200 foi para a main sem nunca chegar em produção — silenciosamente,
+    # sem erro nenhum. Três deploys deste dia dependeram de dispatch manual.
+    #
+    # O grafo real de imports da landing passa por `core/http`, `composables/*`,
+    # `features/subscription`, `schemas/*` e cresce a cada feature; manter isso
+    # sincronizado à mão é garantia de repetir o bug. Invertendo, o pior caso
+    # vira um deploy à toa em vez de uma mudança que não sobe.
+    #
+    # Custo do pior caso: repositório público → minutos de Actions ilimitados;
+    # a invalidação usa `--paths "/*"`, que conta como 1 path, contra 1.000
+    # gratuitos por mês na AWS. No ritmo atual (unidades de push por dia) fica
+    # dentro do free tier com folga.
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".context/**"
+      - ".vscode/**"
+      - ".idea/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## O problema

O `deploy-landing.yml` dispara por uma **allowlist** de caminhos. Ela tenta enumerar o que o artefato da landing embarca — e sempre fica para trás.

Quando o checkout próprio entrou (#1187), `app/pages/checkout/**` não foi adicionado. Resultado: o fix de pagamento do #1200 foi mergeado na main e **nunca chegou em produção**, sem erro nenhum. Três deploys de hoje precisaram de `workflow_dispatch` manual:

| PR | Disparou sozinho? | Por quê |
|---|---|---|
| #1201 | não | só tocou `pages/checkout`, `features/subscription`, `core/http` |
| #1204 | sim | por acaso encostou em `features/landing` |
| #1205 | sim | idem |

## Por que não é o caso de só acrescentar os paths que faltam

Foi minha primeira ideia, e ela repete o bug daqui a duas features. Os imports diretos das páginas da landing e do checkout já são:

```
~/composables/useApiError      ~/composables/useAuth
~/composables/useAuthRedirectContext  ~/composables/useHttp
~/composables/useToast         ~/core/http/idempotency
~/features/auth/composables/useCaptcha
~/features/landing/model/*     ~/schemas/auth
```

E isso é só o primeiro nível — o grafo transitivo passa por naive-ui, stores, interceptors. Manter essa lista sincronizada à mão não é sustentável.

## A mudança

Inverte para `paths-ignore`, listando só o que comprovadamente não afeta o artefato (`**/*.md`, `docs/**`, `.context/**`, configs de editor). Qualquer mudança de código passa a disparar o deploy.

O pior caso deixa de ser "mudança não sobe silenciosamente" e passa a ser "um deploy à toa".

## Custo (verificado, não estimado)

- **GitHub Actions**: repositório é público → minutos ilimitados, US$ 0.
- **CloudFront**: o step usa `--paths "/*"`, que conta como **1 path** por invalidação. O free tier da AWS é **1.000 paths/mês**. No ritmo atual (unidades de push por dia) sobra folga; mesmo a 30 pushes/dia seriam ~900/mês, ainda dentro do gratuito.

## Validação

Sintaxe do YAML conferida com parser (`triggers: ['push', 'workflow_dispatch']`, `paths-ignore` aplicado). A prova real vem no próximo merge que tocar só código de checkout — deve disparar sozinho, sem dispatch.

## Risco residual

- Um push que mexa **apenas** em documentação não deploya — correto e desejado.
- Se o volume de pushes crescer muito (>1.000/mês), a invalidação começa a custar US$ 0,005 por deploy. Nesse cenário vale trocar `/*` por invalidação seletiva, não voltar para a allowlist.

Closes #1197