### PR TITLE
feat(navigation): link-map público por surface — pré-requisito da migração para o apex

### DIFF
--- a/app/components/tool/ToolGuestCta/ToolGuestCta.spec.ts
+++ b/app/components/tool/ToolGuestCta/ToolGuestCta.spec.ts
@@ -5,8 +5,9 @@ import ToolGuestCta from "./ToolGuestCta.vue";
 
 /* ── Module mocks ──────────────────────────────────────────────────────────── */
 
-const pushMock = vi.fn();
+const navigateToMock = vi.fn();
 const showCtaRef = ref(true);
+let mockedSurface: string | undefined;
 
 vi.mock("~/features/tools/composables/useToolCta", () => ({
   useToolCta: (): { showCta: Ref<boolean> } => ({
@@ -15,7 +16,8 @@ vi.mock("~/features/tools/composables/useToolCta", () => ({
 }));
 
 vi.mock("#app", () => ({
-  useRouter: (): { push: typeof pushMock } => ({ push: pushMock }),
+  navigateTo: (...args: unknown[]): unknown => navigateToMock(...args),
+  tryUseNuxtApp: (): unknown => ({ $config: { public: { siteSurface: mockedSurface } } }),
 }));
 
 vi.mock("vue-i18n", () => ({
@@ -47,6 +49,7 @@ const stubs = {
 
 beforeEach(() => {
   showCtaRef.value = true;
+  mockedSurface = "marketing";
   vi.clearAllMocks();
 });
 
@@ -90,26 +93,44 @@ describe("ToolGuestCta", () => {
     expect(wrapper.findAll(".n-button")).toHaveLength(2);
   });
 
-  it("navigates to /auth/register when primary CTA is clicked", async () => {
-    pushMock.mockResolvedValue(undefined);
+  it("navigates to /register when primary CTA is clicked", async () => {
+    navigateToMock.mockResolvedValue(undefined);
 
     const wrapper = mount(ToolGuestCta, { global: { stubs } });
 
     const buttons = wrapper.findAll(".n-button");
     await buttons[0]!.trigger("click");
 
-    expect(pushMock).toHaveBeenCalledWith("/auth/register");
+    expect(navigateToMock).toHaveBeenCalledWith("/register", undefined);
   });
 
-  it("navigates to /auth/login when secondary CTA is clicked", async () => {
-    pushMock.mockResolvedValue(undefined);
+  it("navigates to /login when secondary CTA is clicked", async () => {
+    navigateToMock.mockResolvedValue(undefined);
 
     const wrapper = mount(ToolGuestCta, { global: { stubs } });
 
     const buttons = wrapper.findAll(".n-button");
     await buttons[1]!.trigger("click");
 
-    expect(pushMock).toHaveBeenCalledWith("/auth/login");
+    expect(navigateToMock).toHaveBeenCalledWith("/login", undefined);
+  });
+
+  it("crosses to the app host with an external navigation on the landing surface", async () => {
+    mockedSurface = "landing";
+    navigateToMock.mockResolvedValue(undefined);
+
+    const wrapper = mount(ToolGuestCta, { global: { stubs } });
+
+    const buttons = wrapper.findAll(".n-button");
+    await buttons[0]!.trigger("click");
+    expect(navigateToMock).toHaveBeenCalledWith("https://app.auraxis.com.br/register", {
+      external: true,
+    });
+
+    await buttons[1]!.trigger("click");
+    expect(navigateToMock).toHaveBeenCalledWith("https://app.auraxis.com.br/login", {
+      external: true,
+    });
   });
 
   it("renders all four color variant icon wrappers", () => {

--- a/app/components/tool/ToolGuestCta/ToolGuestCta.stories.ts
+++ b/app/components/tool/ToolGuestCta/ToolGuestCta.stories.ts
@@ -58,7 +58,7 @@ const meta: Meta<typeof ToolGuestCta> = {
 - Rendered only when the user has **no active session** (via \`useToolCta()\`)
 - Invisible to authenticated users of any plan
 - Replaces the inline CTAs previously hardcoded in each tool page
-- Routes to \`/auth/register\` and \`/auth/login\`
+- Routes to \`/register\` and \`/login\` (absolutos para o app na surface landing)
 
 **Usage:**
 \`\`\`vue

--- a/app/components/tool/ToolGuestCta/ToolGuestCta.vue
+++ b/app/components/tool/ToolGuestCta/ToolGuestCta.vue
@@ -2,9 +2,10 @@
 import type { Component } from "vue";
 import { BarChart3, Target, ShieldCheck, Zap, Sparkles, ArrowRight } from "lucide-vue-next";
 import { NButton } from "naive-ui";
-import { useRouter } from "#app";
+import { navigateTo } from "#app";
 import { useI18n } from "vue-i18n";
 import { useToolCta } from "~/features/tools/composables/useToolCta";
+import { usePublicNav } from "~/shared/navigation/public-links";
 
 /**
  * A feature highlight shown inside the guest CTA panel.
@@ -30,17 +31,30 @@ const CTA_FEATURES: readonly CtaFeature[] = [
 ] as const;
 
 const { showCta } = useToolCta();
-const router = useRouter();
+const { productHref } = usePublicNav();
 const { t } = useI18n();
+
+// No apex a conta vive em outro host — a navegação precisa ser external.
+const registerHref = productHref("/register");
+const loginHref = productHref("/login");
+
+/**
+ * Navigates to a product destination, crossing hosts when the href is absolute.
+ *
+ * @param target - Href already resolved for the active surface.
+ */
+const goToProduct = (target: string): void => {
+  void navigateTo(target, target.startsWith("http") ? { external: true } : undefined);
+};
 
 /** Navigates the visitor to the registration page. */
 const goToRegister = (): void => {
-  void router.push("/auth/register");
+  goToProduct(registerHref);
 };
 
 /** Navigates the visitor to the login page. */
 const goToLogin = (): void => {
-  void router.push("/auth/login");
+  goToProduct(loginHref);
 };
 </script>
 

--- a/app/components/ui/UiPublicFooter/UiPublicFooter.types.ts
+++ b/app/components/ui/UiPublicFooter/UiPublicFooter.types.ts
@@ -1,4 +1,8 @@
+import type { PublicSurface } from "~/shared/navigation/public-links";
+
 export interface UiPublicFooterProps {
   /** Ano exibido no copyright. Padrão: ano atual. */
   year?: number
+  /** Superfície pública ativa — decide quais links atravessam para o host do app. Padrão: runtimeConfig. */
+  surface?: PublicSurface
 }

--- a/app/components/ui/UiPublicFooter/UiPublicFooter.vue
+++ b/app/components/ui/UiPublicFooter/UiPublicFooter.vue
@@ -1,15 +1,28 @@
 <script setup lang="ts">
+import {
+  resolveProductHref,
+  resolveSiteSurface,
+  type PublicSurface,
+} from "~/shared/navigation/public-links";
 import type { UiPublicFooterProps } from "./UiPublicFooter.types";
 
 const props = withDefaults(defineProps<UiPublicFooterProps>(), {
   year: undefined,
+  surface: undefined,
 });
 
 const { t } = useI18n();
+const runtimeSurface = resolveSiteSurface();
 
 const copyrightYear = computed<number>(() =>
   props.year !== undefined ? props.year : new Date().getFullYear(),
 );
+const surface = computed<PublicSurface>(() => props.surface ?? runtimeSurface);
+
+// Institucionais vivem no host do app; conteúdo e legais são servidos pela
+// própria surface (o apex passa a servi-los na expansão da landing, #1211).
+const aboutHref = computed<string>(() => resolveProductHref(surface.value, "/about-us"));
+const supportHref = computed<string>(() => resolveProductHref(surface.value, "/support"));
 </script>
 
 <template>
@@ -23,8 +36,8 @@ const copyrightYear = computed<number>(() =>
         class="ui-public-footer__links"
         :aria-label="t('components.publicFooter.columns.legal.title')"
       >
-        <NuxtLink to="/about-us" class="ui-public-footer__link"> Sobre nós </NuxtLink>
-        <NuxtLink to="/support" class="ui-public-footer__link"> Suporte </NuxtLink>
+        <NuxtLink :to="aboutHref" class="ui-public-footer__link"> Sobre nós </NuxtLink>
+        <NuxtLink :to="supportHref" class="ui-public-footer__link"> Suporte </NuxtLink>
         <NuxtLink to="/blog" class="ui-public-footer__link"> Blog </NuxtLink>
         <NuxtLink to="/privacy" class="ui-public-footer__link">
           {{ t("components.publicFooter.columns.legal.links.privacy") }}

--- a/app/components/ui/UiPublicFooter/__tests__/UiPublicFooter.spec.ts
+++ b/app/components/ui/UiPublicFooter/__tests__/UiPublicFooter.spec.ts
@@ -79,4 +79,41 @@ describe("UiPublicFooter", () => {
 
     expect(wrapper.find("nav").attributes("aria-label")).toBe("Legal");
   });
+
+  describe("landing surface", () => {
+    it("points product/institutional links at the app host", () => {
+      const wrapper = renderWithProviders(UiPublicFooter, {
+        props: { surface: "landing" },
+        global: { stubs },
+      });
+
+      expect(wrapper.find("a[href=\"https://app.auraxis.com.br/about-us\"]").exists()).toBe(true);
+      expect(wrapper.find("a[href=\"https://app.auraxis.com.br/support\"]").exists()).toBe(true);
+      expect(wrapper.find("a[href=\"/about-us\"]").exists()).toBe(false);
+      expect(wrapper.find("a[href=\"/support\"]").exists()).toBe(false);
+    });
+
+    it("keeps content and legal links relative to the apex", () => {
+      const wrapper = renderWithProviders(UiPublicFooter, {
+        props: { surface: "landing" },
+        global: { stubs },
+      });
+
+      expect(wrapper.find("a[href=\"/blog\"]").exists()).toBe(true);
+      expect(wrapper.find("a[href=\"/privacy\"]").exists()).toBe(true);
+      expect(wrapper.find("a[href=\"/terms\"]").exists()).toBe(true);
+      expect(wrapper.find("a[href=\"/cookies\"]").exists()).toBe(true);
+    });
+  });
+
+  it("keeps every link relative on the marketing surface", () => {
+    const wrapper = renderWithProviders(UiPublicFooter, {
+      props: { surface: "marketing" },
+      global: { stubs },
+    });
+
+    expect(wrapper.find("a[href=\"/about-us\"]").exists()).toBe(true);
+    expect(wrapper.find("a[href=\"/support\"]").exists()).toBe(true);
+    expect(wrapper.find("a[href^=\"https://app.auraxis.com.br\"]").exists()).toBe(false);
+  });
 });

--- a/app/components/ui/UiPublicHeader/UiPublicHeader.types.ts
+++ b/app/components/ui/UiPublicHeader/UiPublicHeader.types.ts
@@ -1,6 +1,8 @@
+import type { PublicSurface } from "~/shared/navigation/public-links";
+
 export interface UiPublicHeaderProps {
   /** Força o estado de autenticação (útil em Storybook/testes). Padrão: lido do sessionStore. */
   authenticated?: boolean
-  /** Superfície pública: marketing mostra nav; app foca ações de auth. */
-  surface?: "app" | "marketing"
+  /** Superfície pública: marketing/landing mostram nav; app foca ações de auth. Padrão: runtimeConfig. */
+  surface?: PublicSurface
 }

--- a/app/components/ui/UiPublicHeader/UiPublicHeader.vue
+++ b/app/components/ui/UiPublicHeader/UiPublicHeader.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { tryUseNuxtApp } from "#app";
 import { useSessionStore } from "~/stores/session";
+import {
+  resolveProductHref,
+  resolveSiteSurface,
+  type PublicSurface,
+} from "~/shared/navigation/public-links";
 import type { UiPublicHeaderProps } from "./UiPublicHeader.types";
 
 const props = withDefaults(defineProps<UiPublicHeaderProps>(), {
@@ -10,18 +14,45 @@ const props = withDefaults(defineProps<UiPublicHeaderProps>(), {
 
 const { t } = useI18n();
 const sessionStore = useSessionStore();
-const nuxtApp = tryUseNuxtApp();
+const runtimeSurface = resolveSiteSurface();
 
 /** Whether the current visitor has an active session. */
 const isAuthenticated = computed<boolean>(() =>
   props.authenticated !== undefined ? props.authenticated : sessionStore.isAuthenticated,
 );
-const runtimeSurface = computed(
-  (): unknown => (nuxtApp?.$config.public as Record<string, unknown> | undefined)?.siteSurface,
+const surface = computed<PublicSurface>(() => props.surface ?? runtimeSurface);
+const showNav = computed<boolean>(() => surface.value !== "app");
+
+interface PublicNavLink {
+  label: string;
+  to: string;
+}
+
+/**
+ * Marketing navega a home por âncoras próprias; a landing (apex) navega o
+ * conteúdo real que ela mesma serve — as âncoras de marketing não existem lá.
+ */
+const navLinks = computed<readonly PublicNavLink[]>(() =>
+  surface.value === "landing"
+    ? [
+        { label: "Ferramentas", to: "/tools" },
+        { label: "Soluções", to: "/controle-financeiro" },
+        { label: "Planos", to: "/#planos" },
+        { label: "Blog", to: "/blog" },
+      ]
+    : [
+        { label: "Produto", to: "/#produto" },
+        { label: "Soluções", to: "/controle-financeiro" },
+        { label: "Analytics", to: "/#analytics" },
+        { label: "Planos", to: "/#planos" },
+        { label: "FAQ", to: "/#faq" },
+        { label: "Blog", to: "/blog" },
+      ],
 );
-const isMarketingSurface = computed<boolean>(() =>
-  props.surface !== undefined ? props.surface === "marketing" : runtimeSurface.value !== "app",
-);
+
+const loginHref = computed<string>(() => resolveProductHref(surface.value, "/login"));
+const registerHref = computed<string>(() => resolveProductHref(surface.value, "/register"));
+const dashboardHref = computed<string>(() => resolveProductHref(surface.value, "/dashboard"));
 
 const menuOpen = ref(false);
 
@@ -52,66 +83,33 @@ const closeMenu = (): void => {
 
       <!-- Desktop navigation -->
       <nav
-        v-if="isMarketingSurface"
+        v-if="showNav"
         class="ui-public-header__nav"
         :aria-label="t('components.publicHeader.navAriaLabel')"
       >
         <NuxtLink
-          to="/#produto"
+          v-for="link in navLinks"
+          :key="link.to"
+          :to="link.to"
           class="ui-public-header__nav-link"
           active-class="ui-public-header__nav-link--active"
         >
-          Produto
-        </NuxtLink>
-        <NuxtLink
-          to="/controle-financeiro"
-          class="ui-public-header__nav-link"
-          active-class="ui-public-header__nav-link--active"
-        >
-          Soluções
-        </NuxtLink>
-        <NuxtLink
-          to="/#analytics"
-          class="ui-public-header__nav-link"
-          active-class="ui-public-header__nav-link--active"
-        >
-          Analytics
-        </NuxtLink>
-        <NuxtLink
-          to="/#planos"
-          class="ui-public-header__nav-link"
-          active-class="ui-public-header__nav-link--active"
-        >
-          Planos
-        </NuxtLink>
-        <NuxtLink
-          to="/#faq"
-          class="ui-public-header__nav-link"
-          active-class="ui-public-header__nav-link--active"
-        >
-          FAQ
-        </NuxtLink>
-        <NuxtLink
-          to="/blog"
-          class="ui-public-header__nav-link"
-          active-class="ui-public-header__nav-link--active"
-        >
-          Blog
+          {{ link.label }}
         </NuxtLink>
       </nav>
 
       <!-- Desktop CTAs -->
       <div class="ui-public-header__actions">
         <template v-if="isAuthenticated">
-          <NuxtLink to="/dashboard" class="ui-public-header__btn ui-public-header__btn--ghost">
+          <NuxtLink :to="dashboardHref" class="ui-public-header__btn ui-public-header__btn--ghost">
             {{ t("components.publicHeader.cta.dashboard") }}
           </NuxtLink>
         </template>
         <template v-else>
-          <NuxtLink to="/login" class="ui-public-header__btn ui-public-header__btn--ghost">
+          <NuxtLink :to="loginHref" class="ui-public-header__btn ui-public-header__btn--ghost">
             {{ t("components.publicHeader.cta.login") }}
           </NuxtLink>
-          <NuxtLink to="/register" class="ui-public-header__btn ui-public-header__btn--primary">
+          <NuxtLink :to="registerHref" class="ui-public-header__btn ui-public-header__btn--primary">
             {{ t("components.publicHeader.cta.register") }}
           </NuxtLink>
         </template>
@@ -143,64 +141,26 @@ const closeMenu = (): void => {
       :aria-label="t('components.publicHeader.mobileMenuAriaLabel')"
     >
       <nav
-        v-if="isMarketingSurface"
+        v-if="showNav"
         class="ui-public-header__mobile-nav"
         :aria-label="t('components.publicHeader.navAriaLabel')"
       >
         <NuxtLink
-          to="/#produto"
+          v-for="link in navLinks"
+          :key="link.to"
+          :to="link.to"
           class="ui-public-header__mobile-link"
           active-class="ui-public-header__mobile-link--active"
           @click="closeMenu"
         >
-          Produto
-        </NuxtLink>
-        <NuxtLink
-          to="/controle-financeiro"
-          class="ui-public-header__mobile-link"
-          active-class="ui-public-header__mobile-link--active"
-          @click="closeMenu"
-        >
-          Soluções
-        </NuxtLink>
-        <NuxtLink
-          to="/#analytics"
-          class="ui-public-header__mobile-link"
-          active-class="ui-public-header__mobile-link--active"
-          @click="closeMenu"
-        >
-          Analytics
-        </NuxtLink>
-        <NuxtLink
-          to="/#planos"
-          class="ui-public-header__mobile-link"
-          active-class="ui-public-header__mobile-link--active"
-          @click="closeMenu"
-        >
-          Planos
-        </NuxtLink>
-        <NuxtLink
-          to="/#faq"
-          class="ui-public-header__mobile-link"
-          active-class="ui-public-header__mobile-link--active"
-          @click="closeMenu"
-        >
-          FAQ
-        </NuxtLink>
-        <NuxtLink
-          to="/blog"
-          class="ui-public-header__mobile-link"
-          active-class="ui-public-header__mobile-link--active"
-          @click="closeMenu"
-        >
-          Blog
+          {{ link.label }}
         </NuxtLink>
       </nav>
 
       <div class="ui-public-header__mobile-actions">
         <template v-if="isAuthenticated">
           <NuxtLink
-            to="/dashboard"
+            :to="dashboardHref"
             class="ui-public-header__btn ui-public-header__btn--primary ui-public-header__btn--full"
             @click="closeMenu"
           >
@@ -209,14 +169,14 @@ const closeMenu = (): void => {
         </template>
         <template v-else>
           <NuxtLink
-            to="/login"
+            :to="loginHref"
             class="ui-public-header__btn ui-public-header__btn--ghost ui-public-header__btn--full"
             @click="closeMenu"
           >
             {{ t("components.publicHeader.cta.login") }}
           </NuxtLink>
           <NuxtLink
-            to="/register"
+            :to="registerHref"
             class="ui-public-header__btn ui-public-header__btn--primary ui-public-header__btn--full"
             @click="closeMenu"
           >

--- a/app/components/ui/UiPublicHeader/__tests__/UiPublicHeader.spec.ts
+++ b/app/components/ui/UiPublicHeader/__tests__/UiPublicHeader.spec.ts
@@ -56,9 +56,9 @@ describe("UiPublicHeader", () => {
     expect(wrapper.text()).toContain("Auraxis");
   });
 
-  it("renders landing navigation links", () => {
+  it("renders marketing navigation links on the marketing surface", () => {
     const wrapper = renderWithProviders(UiPublicHeader, {
-      props: { authenticated: false },
+      props: { authenticated: false, surface: "marketing" },
       global: { stubs },
     });
 
@@ -80,6 +80,71 @@ describe("UiPublicHeader", () => {
     expect(wrapper.text()).not.toContain("Blog");
     expect(wrapper.text()).toContain("Entrar");
     expect(wrapper.text()).toContain("Criar conta");
+  });
+
+  it("keeps auth CTAs relative on the marketing surface", () => {
+    const wrapper = renderWithProviders(UiPublicHeader, {
+      props: { authenticated: false, surface: "marketing" },
+      global: { stubs },
+    });
+
+    const hrefs = wrapper.findAll("a").map((a) => a.attributes("href"));
+    expect(hrefs).toContain("/login");
+    expect(hrefs).toContain("/register");
+    expect(hrefs).not.toContain("https://app.auraxis.com.br/login");
+  });
+
+  describe("landing surface", () => {
+    it("shows content navigation instead of marketing anchors", () => {
+      const wrapper = renderWithProviders(UiPublicHeader, {
+        props: { authenticated: false, surface: "landing" },
+        global: { stubs },
+      });
+
+      expect(wrapper.text()).toContain("Ferramentas");
+      expect(wrapper.text()).toContain("Soluções");
+      expect(wrapper.text()).toContain("Planos");
+      expect(wrapper.text()).toContain("Blog");
+      expect(wrapper.text()).not.toContain("Produto");
+      expect(wrapper.text()).not.toContain("Analytics");
+      expect(wrapper.text()).not.toContain("FAQ");
+    });
+
+    it("keeps content navigation relative to the apex", () => {
+      const wrapper = renderWithProviders(UiPublicHeader, {
+        props: { authenticated: false, surface: "landing" },
+        global: { stubs },
+      });
+
+      const hrefs = wrapper.findAll("a").map((a) => a.attributes("href"));
+      expect(hrefs).toContain("/tools");
+      expect(hrefs).toContain("/controle-financeiro");
+      expect(hrefs).toContain("/#planos");
+      expect(hrefs).toContain("/blog");
+    });
+
+    it("points auth CTAs at the app host", () => {
+      const wrapper = renderWithProviders(UiPublicHeader, {
+        props: { authenticated: false, surface: "landing" },
+        global: { stubs },
+      });
+
+      const hrefs = wrapper.findAll("a").map((a) => a.attributes("href"));
+      expect(hrefs).toContain("https://app.auraxis.com.br/login");
+      expect(hrefs).toContain("https://app.auraxis.com.br/register");
+      expect(hrefs).not.toContain("/login");
+      expect(hrefs).not.toContain("/register");
+    });
+
+    it("points the dashboard CTA at the app host when authenticated", () => {
+      const wrapper = renderWithProviders(UiPublicHeader, {
+        props: { authenticated: true, surface: "landing" },
+        global: { stubs },
+      });
+
+      const hrefs = wrapper.findAll("a").map((a) => a.attributes("href"));
+      expect(hrefs).toContain("https://app.auraxis.com.br/dashboard");
+    });
   });
 
   it("shows login and register when not authenticated", () => {
@@ -142,7 +207,7 @@ describe("UiPublicHeader", () => {
 
   it("closes mobile menu when a mobile nav link is clicked", async () => {
     const wrapper = renderWithProviders(UiPublicHeader, {
-      props: { authenticated: false },
+      props: { authenticated: false, surface: "marketing" },
       global: { stubs },
     });
 

--- a/app/features/landing/components/LandingPricing.vue
+++ b/app/features/landing/components/LandingPricing.vue
@@ -12,6 +12,7 @@ const { trackCta } = useLandingCtaTracking();
 
 <template>
   <section
+    id="planos"
     class="landing-pricing"
     aria-labelledby="landing-pricing-title"
     data-testid="landing-pricing"

--- a/app/pages/[seoLanding].vue
+++ b/app/pages/[seoLanding].vue
@@ -9,11 +9,13 @@ import {
   WalletCards,
 } from "lucide-vue-next";
 import { getSeoLanding } from "~/data/seoLandings";
+import { usePublicNav } from "~/shared/navigation/public-links";
 
 definePageMeta({ layout: "public" });
 
 const route = useRoute();
 const config = useRuntimeConfig();
+const { productHref, publicHref } = usePublicNav();
 
 const slugParam = Array.isArray(route.params.seoLanding)
   ? route.params.seoLanding[0]
@@ -107,7 +109,7 @@ useHead({
           <p class="seo-hero__lead">{{ landing.lead }}</p>
 
           <div class="seo-hero__actions">
-            <NuxtLink to="/register" class="seo-button seo-button--primary">
+            <NuxtLink :to="productHref('/register')" class="seo-button seo-button--primary">
               Começar gratuitamente
               <ArrowRight :size="16" aria-hidden="true" />
             </NuxtLink>
@@ -203,7 +205,7 @@ useHead({
           <h2 id="seo-links-title">Outras formas de organizar suas finanças</h2>
         </div>
         <nav class="seo-links__nav" aria-label="Páginas relacionadas">
-          <NuxtLink v-for="link in landing.relatedLinks" :key="link.to" :to="link.to">
+          <NuxtLink v-for="link in landing.relatedLinks" :key="link.to" :to="publicHref(link.to)">
             {{ link.label }}
             <ArrowRight :size="14" aria-hidden="true" />
           </NuxtLink>
@@ -235,7 +237,7 @@ useHead({
           Crie sua conta gratuita e use o Auraxis para transformar movimentações em uma rotina
           financeira mais clara.
         </p>
-        <NuxtLink to="/register" class="seo-button seo-button--primary">
+        <NuxtLink :to="productHref('/register')" class="seo-button seo-button--primary">
           Criar conta gratuita
           <ArrowRight :size="16" aria-hidden="true" />
         </NuxtLink>

--- a/app/pages/blog/[slug]/index.vue
+++ b/app/pages/blog/[slug]/index.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { ArrowLeft, ArrowRight, BookOpen, CalendarDays, Clock3 } from "lucide-vue-next";
 import { getBlogPost, getRelatedBlogPosts, resolveBlogRobots } from "~/data/blogPosts";
+import { usePublicNav } from "~/shared/navigation/public-links";
 
 definePageMeta({ layout: "public" });
 
 const route = useRoute();
 const config = useRuntimeConfig();
+const { publicHref } = usePublicNav();
 const slugParam = Array.isArray(route.params.slug) ? route.params.slug[0] : route.params.slug;
 const slug = typeof slugParam === "string" ? slugParam : "";
 const post = getBlogPost(slug);
@@ -141,7 +143,7 @@ useHead({
             <h2 id="blog-post-links-title">Próximos passos úteis</h2>
           </div>
           <nav aria-label="Links relacionados ao artigo">
-            <NuxtLink v-for="link in post.relatedLinks" :key="link.to" :to="link.to">
+            <NuxtLink v-for="link in post.relatedLinks" :key="link.to" :to="publicHref(link.to)">
               {{ link.label }}
               <ArrowRight :size="14" aria-hidden="true" />
             </NuxtLink>

--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ArrowRight, CheckCircle2, Sparkles } from "lucide-vue-next";
 import { BLOG_POSTS, resolveBlogRobots } from "~/data/blogPosts";
+import { usePublicNav } from "~/shared/navigation/public-links";
 
 definePageMeta({ layout: "public" });
 
 const config = useRuntimeConfig();
+const { productHref } = usePublicNav();
 const route = useRoute();
 const siteUrl = String(config.public.siteUrl ?? "https://www.auraxis.com.br").replace(/\/$/, "");
 const isMarketingSurface = config.public.siteSurface === "marketing";
@@ -69,7 +71,7 @@ useHead({
             financeira, planejamento, metas e insights com contexto.
           </p>
           <div class="blog-actions">
-            <NuxtLink to="/register" class="blog-button blog-button--primary">
+            <NuxtLink :to="productHref('/register')" class="blog-button blog-button--primary">
               Criar conta gratuita
               <ArrowRight :size="16" aria-hidden="true" />
             </NuxtLink>

--- a/app/pages/tools/installment-vs-cash.spec.ts
+++ b/app/pages/tools/installment-vs-cash.spec.ts
@@ -30,6 +30,8 @@ vi.mock("#imports", () => ({
   useSeoMeta: vi.fn(),
   useI18n: (): { t: (key: string) => string } => ({ t: (key: string) => key }),
   useRouter: (): { push: typeof mockPush } => ({ push: mockPush }),
+  navigateTo: (...args: unknown[]): unknown => mockPush(args[0]),
+  tryUseNuxtApp: (): unknown => ({ $config: { public: { siteSurface: "marketing" } } }),
 }));
 
 vi.mock("naive-ui", () => ({
@@ -112,6 +114,8 @@ vi.mock("~/stores/session", () => ({
 
 vi.mock("#app", () => ({
   useRouter: (): { push: typeof mockPush } => ({ push: mockPush }),
+  navigateTo: (...args: unknown[]): unknown => mockPush(args[0]),
+  tryUseNuxtApp: (): unknown => ({ $config: { public: { siteSurface: "marketing" } } }),
 }));
 
 vi.mock("~/features/tools/composables/useToolCta", () => ({

--- a/app/shared/navigation/public-links.spec.ts
+++ b/app/shared/navigation/public-links.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  isProductPath,
+  resolveProductHref,
+  resolvePublicHref,
+  resolveSiteSurface,
+  usePublicNav,
+} from "./public-links";
+
+/* ── Module mocks ──────────────────────────────────────────────────────────── */
+
+const tryUseNuxtAppMock = vi.fn();
+
+vi.mock("#app", () => ({
+  tryUseNuxtApp: (): unknown => tryUseNuxtAppMock(),
+}));
+
+/**
+ * Points the mocked nuxt app at a given runtime surface.
+ *
+ * @param siteSurface - Value exposed as `$config.public.siteSurface`.
+ */
+const withSurface = (siteSurface: unknown): void => {
+  tryUseNuxtAppMock.mockReturnValue({ $config: { public: { siteSurface } } });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  withSurface(undefined);
+});
+
+/* ── Tests ─────────────────────────────────────────────────────────────────── */
+
+describe("isProductPath", () => {
+  it.each(["/login", "/register", "/dashboard", "/plans", "/about-us", "/support"])(
+    "treats %s as a product path",
+    (path) => {
+      expect(isProductPath(path)).toBe(true);
+    },
+  );
+
+  it("treats nested and query variants of product paths as product", () => {
+    expect(isProductPath("/dashboard/settings")).toBe(true);
+    expect(isProductPath("/register?plan=annual")).toBe(true);
+  });
+
+  it.each(["/", "/tools", "/tools/juros-compostos", "/blog", "/controle-financeiro", "/checkout"])(
+    "treats %s as content (non-product)",
+    (path) => {
+      expect(isProductPath(path)).toBe(false);
+    },
+  );
+
+  it("does not confuse SEO slugs that share a product prefix substring", () => {
+    expect(isProductPath("/planejamento-financeiro")).toBe(false);
+    expect(isProductPath("/supporte-falso")).toBe(false);
+  });
+});
+
+describe("resolveProductHref", () => {
+  it("keeps product paths relative on the app surface", () => {
+    expect(resolveProductHref("app", "/login")).toBe("/login");
+  });
+
+  it("keeps product paths relative on the marketing surface", () => {
+    expect(resolveProductHref("marketing", "/register")).toBe("/register");
+  });
+
+  it("makes product paths absolute to the app host on the landing surface", () => {
+    expect(resolveProductHref("landing", "/register")).toBe(
+      "https://app.auraxis.com.br/register",
+    );
+    expect(resolveProductHref("landing", "/dashboard")).toBe(
+      "https://app.auraxis.com.br/dashboard",
+    );
+  });
+});
+
+describe("resolvePublicHref", () => {
+  it("routes product paths through the product resolver on the landing surface", () => {
+    expect(resolvePublicHref("landing", "/register")).toBe(
+      "https://app.auraxis.com.br/register",
+    );
+  });
+
+  it("keeps content paths relative on every surface", () => {
+    expect(resolvePublicHref("landing", "/tools")).toBe("/tools");
+    expect(resolvePublicHref("landing", "/controle-financeiro")).toBe("/controle-financeiro");
+    expect(resolvePublicHref("marketing", "/blog")).toBe("/blog");
+  });
+});
+
+describe("resolveSiteSurface", () => {
+  it.each(["app", "marketing", "landing"] as const)("returns %s from runtimeConfig", (surface) => {
+    withSurface(surface);
+    expect(resolveSiteSurface()).toBe(surface);
+  });
+
+  it("falls back to app when the surface is missing", () => {
+    withSurface(undefined);
+    expect(resolveSiteSurface()).toBe("app");
+  });
+
+  it("falls back to app when the surface is unknown", () => {
+    withSurface("preview");
+    expect(resolveSiteSurface()).toBe("app");
+  });
+
+  it("falls back to app when there is no nuxt app instance", () => {
+    tryUseNuxtAppMock.mockReturnValue(undefined);
+    expect(resolveSiteSurface()).toBe("app");
+  });
+});
+
+describe("usePublicNav", () => {
+  it("resolves the surface once at setup and exposes landing-aware helpers", () => {
+    withSurface("landing");
+
+    const nav = usePublicNav();
+
+    expect(nav.surface).toBe("landing");
+    expect(nav.isLanding).toBe(true);
+    expect(nav.productHref("/login")).toBe("https://app.auraxis.com.br/login");
+    expect(nav.publicHref("/tools")).toBe("/tools");
+  });
+
+  it("keeps product links relative outside the landing", () => {
+    withSurface("marketing");
+
+    const nav = usePublicNav();
+
+    expect(nav.isLanding).toBe(false);
+    expect(nav.productHref("/register")).toBe("/register");
+    expect(nav.publicHref("/register")).toBe("/register");
+  });
+});

--- a/app/shared/navigation/public-links.ts
+++ b/app/shared/navigation/public-links.ts
@@ -1,0 +1,95 @@
+import { tryUseNuxtApp } from "#app";
+import { buildAppUrl } from "~/features/landing/model/landing-content";
+
+/**
+ * Superfícies públicas do build multi-surface (espelha `SITE_SURFACES` do
+ * `nuxt.config.ts`). A landing (apex `auraxis.com.br`) serve conteúdo público
+ * mas NÃO serve o produto — links de produto precisam atravessar hosts.
+ */
+export type PublicSurface = "app" | "marketing" | "landing";
+
+const KNOWN_SURFACES: readonly PublicSurface[] = ["app", "marketing", "landing"];
+
+/**
+ * Rotas que pertencem ao produto (host `app.auraxis.com.br`) e nunca são
+ * servidas pelo apex — todo o resto é conteúdo público (tools, SEO landings,
+ * blog, páginas legais) e permanece relativo em qualquer surface.
+ */
+const PRODUCT_PATH_PREFIXES = [
+  "/login",
+  "/register",
+  "/dashboard",
+  "/plans",
+  "/about-us",
+  "/support",
+] as const;
+
+/**
+ * Um caminho de produto casa exato ou com sub-rota/query — nunca por substring.
+ *
+ * @param path - Caminho relativo a classificar (ex.: `/register?plan=annual`).
+ * @returns `true` quando o destino pertence ao produto (host do app).
+ */
+export const isProductPath = (path: string): boolean =>
+  PRODUCT_PATH_PREFIXES.some(
+    (prefix) =>
+      path === prefix || path.startsWith(`${prefix}/`) || path.startsWith(`${prefix}?`),
+  );
+
+/**
+ * Na landing (apex), destinos de produto viram absolutos para o host do app.
+ *
+ * @param surface - Surface pública ativa.
+ * @param path - Caminho relativo de produto (ex.: `/login`).
+ * @returns Href pronto para o `NuxtLink` da surface.
+ */
+export const resolveProductHref = (surface: PublicSurface, path: string): string =>
+  surface === "landing" ? buildAppUrl(path) : path;
+
+/**
+ * Resolve qualquer link público: produto atravessa hosts na landing; conteúdo fica relativo.
+ *
+ * @param surface - Surface pública ativa.
+ * @param path - Caminho relativo vindo de dados/conteúdo.
+ * @returns Href pronto para o `NuxtLink` da surface.
+ */
+export const resolvePublicHref = (surface: PublicSurface, path: string): string =>
+  isProductPath(path) ? resolveProductHref(surface, path) : path;
+
+/**
+ * Lê a surface ativa do runtimeConfig; fallback `app` (mesma semântica do nuxt.config).
+ *
+ * @returns Surface pública ativa do build corrente.
+ */
+export const resolveSiteSurface = (): PublicSurface => {
+  const raw = (tryUseNuxtApp()?.$config.public as Record<string, unknown> | undefined)
+    ?.siteSurface;
+  return KNOWN_SURFACES.includes(raw as PublicSurface) ? (raw as PublicSurface) : "app";
+};
+
+interface PublicNav {
+  /** Surface efetiva resolvida no setup. */
+  surface: PublicSurface;
+  /** Conveniência para condicionais de template. */
+  isLanding: boolean;
+  /** Href para destinos de produto (login/register/dashboard/…). */
+  productHref: (path: string) => string;
+  /** Href para qualquer link público (decide produto × conteúdo). */
+  publicHref: (path: string) => string;
+}
+
+/**
+ * Fachada de navegação pública por surface. Resolver no SETUP do componente,
+ * nunca dentro de handlers (composables fora do setup lançam — regra #1198).
+ *
+ * @returns Helpers de href com a surface resolvida uma única vez.
+ */
+export const usePublicNav = (): PublicNav => {
+  const surface = resolveSiteSurface();
+  return {
+    surface,
+    isLanding: surface === "landing",
+    productHref: (path: string): string => resolveProductHref(surface, path),
+    publicHref: (path: string): string => resolvePublicHref(surface, path),
+  };
+};


### PR DESCRIPTION
## Resumo

PR **C1** da Onda 2 (épico italofelipe/auraxis-platform#860): cria o **link-map por surface** que permite o apex `auraxis.com.br` servir o conteúdo público (#1211) sem quebrar navegação — destinos de **produto** (login/register/dashboard/plans/about-us/support) atravessam para `https://app.auraxis.com.br` quando a surface é `landing`; **conteúdo** (tools, SEO landings, blog, legais) fica relativo em qualquer surface.

- **Novo** `app/shared/navigation/public-links.ts`: `isProductPath` / `resolveProductHref` / `resolvePublicHref` / `resolveSiteSurface` / `usePublicNav()` (resolvido no setup — regra PAGE-SAFE #1198). 100% de cobertura no módulo.
- **UiPublicHeader**: nav por surface (landing navega o conteúdo real — Ferramentas/Soluções/Planos/Blog — em vez das âncoras de marketing, que não existem na home do apex); CTAs de auth via link-map; prop `surface` agora aceita `landing`; fallback de surface desconhecida passa de "marketing" para **"app"** (mesma semântica do nuxt.config — em runtime real o `siteSurface` sempre existe).
- **UiPublicFooter**: `about-us`/`support` (institucionais do app) via link-map; legais/blog relativos.
- **ToolGuestCta**: 🐛 corrige `router.push("/auth/register")` e `"/auth/login"` — **rotas que não existem** (as reais são `/register`/`/login`); navegação agora via `navigateTo` com `external` quando cruza hosts.
- **SEO landings + blog**: CTAs `/register` (incl. o relatedLink injetado em todos os posts) resolvem pela surface.
- **LandingPricing**: âncora `id="planos"` (destino do nav "Planos" no apex).

## Segurança de deploy

Este PR sozinho **não muda nada visível na landing em prod**: o chrome público continua escondido pelo `layouts/public.vue` até #1211, e as rotas de tools/blog não são servidas pelo apex ainda. No host do app, a única mudança de comportamento é o fix do ToolGuestCta (que hoje leva a uma rota 404-like). Por isso **sem screenshots**: não há delta visual nesta entrega — os prints virão no C2 (#1211), quando o chrome novo aparecer no apex.

## Validação

- `pnpm quality-check` completo verde (**4288 testes**, lint/typecheck/policy/contracts/build).
- Specs novos/atualizados: `public-links.spec.ts` (23 casos), header (surface landing: hrefs absolutos + nav de conteúdo; regressão marketing relativa), footer, ToolGuestCta (destinos corrigidos + external na landing).

## Refs

Closes #1176