### PR TITLE
fix(seo): app produto puro — sitemap e robots sem as rotas migradas

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -449,14 +449,23 @@ export default defineNuxtConfig({
     // Explicitly exclude private SPA routes (ssr: false in routeRules).
     // @nuxtjs/sitemap normally skips them, but listing is belt-and-suspenders.
     exclude: [
-      // App surface: the root serves the login home — keep it (and the SEO
-      // landings) out of the sitemap. Marketing and landing surfaces index "/".
-      ...(isMarketingSurface || isLandingSurface
+      // App surface: the root serves the login home — keep it out of the
+      // sitemap. Marketing and landing surfaces index "/".
+      ...(isMarketingSurface || isLandingSurface ? [] : ["/", "/en"]),
+      // #1212: conteúdo público migrado para o apex — fora da landing essas
+      // rotas respondem 301 (platform#934); listá-las viraria "Page with
+      // redirect" no GSC. Só o apex as anuncia (via urls explícitas acima).
+      ...(isLandingSurface
         ? []
-        : ["/", "/en", ...seoLandingSitemapExclusions]),
+        : [
+            "/tools",
+            "/tools/**",
+            "/en/tools",
+            "/en/tools/**",
+            ...seoLandingSitemapExclusions,
+            ...blogSitemapExclusions,
+          ]),
       ...localizedBlogSitemapExclusions,
-      // Blog indexa no marketing e no apex (#1211); só o host-app puro exclui.
-      ...(isMarketingSurface || isLandingSurface ? [] : blogSitemapExclusions),
       "/dashboard",
       "/portfolio",
       "/goals",

--- a/public/_robots.txt
+++ b/public/_robots.txt
@@ -30,4 +30,3 @@ Disallow: /en/investor-profile
 Disallow: /en/settings/
 Disallow: /en/checkout/success
 
-Sitemap: https://app.auraxis.com.br/sitemap.xml


### PR DESCRIPTION
## Resumo

PR **C4** (último da Onda 2 — épico italofelipe/auraxis-platform#860). Com o apex servindo o conteúdo público (#1220) e o app respondendo **301** nessas rotas (platform#934, aplicado hoje), o sitemap do host do app não pode continuar anunciando-as:

- **Sitemap (marketing/app)**: exclui `/tools`, `/tools/**`, `/en/tools/**`, as 8 SEO landings e o blog — no GSC essas URLs virariam "Page with redirect". Só a landing as anuncia (via `urls` explícitas).
- **`public/_robots.txt`**: remove a linha `Sitemap: …/sitemap.xml` — essa URL cai no fallback SPA (a CF function não reescreve URI com ponto) e **servia HTML** para crawlers. Fica só a `sitemap_index.xml` válida, injetada pelo módulo.

## Validação

- Build marketing local: sitemap `pt-BR.xml` com **19 URLs**, zero tools/SEO/blog; `robots.txt` do artefato com **uma única** linha `Sitemap` (a válida).
- `pnpm quality-check` verde (480 arquivos, 4288 testes).
- Sem impacto visual (mudança de sitemap/robots) — sem screenshots por isso.

## Refs

Closes #1212