### PR TITLE
feat(seo): on-page das 27 calculadoras — titles de busca, hreflang e schema próprio

### DIFF
--- a/app/features/tools/composables/useToolPageStructuredData.spec.ts
+++ b/app/features/tools/composables/useToolPageStructuredData.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { buildToolAlternateLinks } from "./useToolPageStructuredData";
+
+describe("buildToolAlternateLinks", () => {
+  it("builds reciprocal pt-BR/en alternates with pt-BR as x-default", () => {
+    expect(buildToolAlternateLinks("https://auraxis.com.br", "juros-compostos")).toEqual([
+      {
+        rel: "alternate",
+        hreflang: "pt-BR",
+        href: "https://auraxis.com.br/tools/juros-compostos",
+      },
+      {
+        rel: "alternate",
+        hreflang: "en",
+        href: "https://auraxis.com.br/en/tools/juros-compostos",
+      },
+      {
+        rel: "alternate",
+        hreflang: "x-default",
+        href: "https://auraxis.com.br/tools/juros-compostos",
+      },
+    ]);
+  });
+
+  it("normalizes a trailing slash on the base URL", () => {
+    const links = buildToolAlternateLinks("https://auraxis.com.br/", "fire");
+    expect(links[0]?.href).toBe("https://auraxis.com.br/tools/fire");
+  });
+});

--- a/app/features/tools/composables/useToolPageStructuredData.ts
+++ b/app/features/tools/composables/useToolPageStructuredData.ts
@@ -1,6 +1,34 @@
 import { useToolStructuredData } from "./useToolStructuredData";
 import type { ToolFaqEntry } from "~/features/tools/model/structured-data.types";
 
+interface ToolAlternateLink {
+  rel: "alternate";
+  hreflang: string;
+  href: string;
+}
+
+/**
+ * Monta os alternates hreflang de uma tool (PT-BR ↔ EN, x-default = PT-BR,
+ * o idioma primário do produto). Puro para ser testável (#1222).
+ *
+ * @param baseUrl - Origin da surface ativa (ex.: `https://auraxis.com.br`).
+ * @param slug - Slug da tool sob /tools/.
+ * @returns Links prontos para o `useHead`.
+ */
+export const buildToolAlternateLinks = (
+  baseUrl: string,
+  slug: string,
+): ToolAlternateLink[] => {
+  const base = baseUrl.replace(/\/$/, "");
+  const ptUrl = `${base}/tools/${slug}`;
+  const enUrl = `${base}/en/tools/${slug}`;
+  return [
+    { rel: "alternate", hreflang: "pt-BR", href: ptUrl },
+    { rel: "alternate", hreflang: "en", href: enUrl },
+    { rel: "alternate", hreflang: "x-default", href: ptUrl },
+  ];
+};
+
 export interface UseToolPageStructuredDataInput {
   /** Tool slug, matching the URL segment under /tools/ (e.g. "juros-compostos"). */
   slug: string;
@@ -31,6 +59,10 @@ export const useToolPageStructuredData = (
   const localePrefix = locale.value === "en" ? "/en" : "";
   const toolsUrl = `${base}${localePrefix}/tools`;
   const toolUrl = `${toolsUrl}/${input.slug}`;
+
+  // hreflang recíproco PT↔EN + x-default (#1222) — as tools existem nos dois
+  // idiomas e sem os alternates o Google as trata como duplicatas sem relação.
+  useHead({ link: buildToolAlternateLinks(base, input.slug) });
 
   useToolStructuredData({
     name: input.name,

--- a/app/i18n/locales/pt.json
+++ b/app/i18n/locales/pt.json
@@ -718,7 +718,7 @@
     },
     "installmentVsCash": {
       "seo": {
-        "title": "Parcelamento vs À Vista — Calculadora Financeira",
+        "title": "Parcelar ou Pagar à Vista? Calculadora Financeira",
         "description": "Descubra se vale a pena parcelar ou pagar à vista. Calcule o custo de oportunidade e tome a melhor decisão financeira.",
         "ogTitle": "Parcelamento vs À Vista — Auraxis",
         "ogDescription": "Calculadora gratuita para comparar parcelamento e pagamento à vista."
@@ -2215,7 +2215,7 @@
   "inssIrFolha": {
     "seo": {
       "title": "Calculadora de INSS e IR na Folha — Desconto Real por Faixa",
-      "description": "Calcule exatamente quanto o INSS e o Imposto de Renda descontam do seu salário, faixa a faixa. Inclui deduções de dependentes, pensão alimentícia e previdência privada.",
+      "description": "Calcule quanto o INSS e o IR descontam do seu salário, faixa a faixa, com dependentes, pensão e previdência privada.",
       "ogTitle": "INSS + IR na Folha — Auraxis",
       "ogDescription": "Calculadora gratuita de INSS e IR progressivo com deduções de dependentes e previdência privada."
     },
@@ -2538,7 +2538,7 @@
   },
   "dividirConta": {
     "seo": {
-      "title": "Dividir Conta — Auraxis",
+      "title": "Calculadora de Dividir Conta — Rateio com Taxa e Gorjeta",
       "description": "Calcule quanto cada pessoa deve pagar na conta do restaurante, com taxa da casa, gorjeta e consumo individual.",
       "ogTitle": "Dividir Conta | Auraxis",
       "ogDescription": "Divida contas de restaurante com facilidade — taxa de serviço, gorjeta e modo individual."
@@ -2606,7 +2606,7 @@
   },
   "descontoMarkup": {
     "seo": {
-      "title": "Desconto, Markup e Margem — Auraxis",
+      "title": "Calculadora de Desconto, Markup e Margem de Lucro",
       "description": "Calcule descontos, markup de preço e margem de lucro em 4 modos: desconto, markup, margem e reverso.",
       "ogTitle": "Desconto, Markup e Margem | Auraxis",
       "ogDescription": "Calcule descontos, markup e margem de lucro com facilidade."
@@ -2663,7 +2663,7 @@
   },
   "jurosCompostos": {
     "seo": {
-      "title": "Juros Compostos e Taxa Real — Auraxis",
+      "title": "Calculadora de Juros Compostos com Taxa Real",
       "description": "Simule o crescimento do seu capital com aportes mensais e veja a taxa real descontada a inflação (fórmula de Fisher).",
       "ogTitle": "Juros Compostos e Taxa Real | Auraxis",
       "ogDescription": "Simule juros compostos com aportes mensais e calcule a taxa real via fórmula de Fisher."
@@ -2725,9 +2725,9 @@
   },
   "fgts": {
     "seo": {
-      "title": "Simulador de FGTS — Auraxis",
+      "title": "Simulador de FGTS — Saldo, Multa e Projeção",
       "description": "Calcule seu saldo projetado de FGTS, multa rescisória e valor a sacar conforme o tipo de desligamento.",
-      "ogTitle": "Simulador de FGTS — Auraxis",
+      "ogTitle": "Simulador de FGTS — Saldo, Multa e Projeção",
       "ogDescription": "Projete seu FGTS, veja a multa e o valor líquido disponível para saque."
     },
     "header": {
@@ -2795,9 +2795,9 @@
   },
   "cltVsPj": {
     "seo": {
-      "title": "CLT vs PJ — Comparativo de Renda — Auraxis",
+      "title": "CLT ou PJ? Calculadora de Comparação de Renda Líquida",
       "description": "Compare CLT e PJ considerando INSS, IR, benefícios e regime tributário. Descubra qual compensa mais.",
-      "ogTitle": "CLT vs PJ — Comparativo de Renda — Auraxis",
+      "ogTitle": "CLT ou PJ? Calculadora de Comparação de Renda Líquida",
       "ogDescription": "Simule CLT e PJ lado a lado e veja qual regime é mais vantajoso para o seu perfil."
     },
     "header": {
@@ -2870,7 +2870,7 @@
   },
   "mei": {
     "seo": {
-      "title": "Calculadora MEI — DAS e Benefícios — Auraxis",
+      "title": "Calculadora MEI — DAS, Limite e Benefícios",
       "description": "Calcule o DAS mensal do MEI por atividade, veja os benefícios previdenciários e compare com o PF autônomo.",
       "ogTitle": "Calculadora MEI — Auraxis",
       "ogDescription": "Simule o custo mensal do MEI, seus benefícios e compare com o regime PF autônomo."
@@ -2950,7 +2950,7 @@
   },
   "cdbLciLca": {
     "seo": {
-      "title": "CDB / LCI / LCA vs Poupança — Auraxis",
+      "title": "CDB, LCI e LCA ou Poupança? Calculadora de Rendimento",
       "description": "Compare a rentabilidade líquida real de CDB, LCI/LCA e Poupança com IR regressivo e ranking automático.",
       "ogTitle": "CDB / LCI / LCA vs Poupança",
       "ogDescription": "Veja qual renda fixa rende mais no seu prazo e valor."
@@ -3024,7 +3024,7 @@
   },
   "tesouroDireto": {
     "seo": {
-      "title": "Tesouro Direto — Auraxis",
+      "title": "Simulador Tesouro Direto — Selic, IPCA+ e Prefixado",
       "description": "Simule títulos Tesouro Selic, IPCA+ e Prefixado com taxa de custódia B3 e IR regressivo.",
       "ogTitle": "Simulador Tesouro Direto",
       "ogDescription": "Calcule o retorno líquido dos títulos públicos no seu prazo."
@@ -3099,7 +3099,7 @@
   },
   "aposentadoria": {
     "seo": {
-      "title": "Simulador de Aposentadoria — Auraxis",
+      "title": "Simulador de Aposentadoria — Quanto Poupar por Mês",
       "description": "Descubra quanto poupar por mês para se aposentar com a renda desejada usando a Regra dos 25x.",
       "ogTitle": "Simulador de Aposentadoria",
       "ogDescription": "Calcule seu patrimônio necessário e aporte mensal para a aposentadoria."
@@ -3171,7 +3171,7 @@
   },
   "fire": {
     "seo": {
-      "title": "Calculadora FIRE — Auraxis",
+      "title": "Calculadora FIRE — Independência Financeira",
       "description": "Planeje sua independência financeira com as variantes FIRE, Lean FIRE, Fat FIRE e Coast FIRE.",
       "ogTitle": "Calculadora FIRE",
       "ogDescription": "Descubra seu número FIRE e quanto investir por mês para se aposentar cedo."
@@ -3245,9 +3245,9 @@
   },
   "financiamentoImobiliario": {
     "seo": {
-      "title": "Financiamento Imobiliário — SAC vs PRICE | Auraxis",
+      "title": "Simulador de Financiamento Imobiliário — SAC vs PRICE",
       "description": "Compare SAC e PRICE lado a lado: primeira e última parcela, total de juros e CET estimado para o seu financiamento.",
-      "ogTitle": "Financiamento Imobiliário — SAC vs PRICE | Auraxis",
+      "ogTitle": "Simulador de Financiamento Imobiliário — SAC vs PRICE",
       "ogDescription": "Calcule e compare os sistemas SAC e PRICE para o seu financiamento imobiliário."
     },
     "hero": {
@@ -3315,7 +3315,7 @@
   },
   "aluguelVsCompra": {
     "seo": {
-      "title": "Aluguel vs Compra — Análise Patrimonial | Auraxis",
+      "title": "Alugar ou Comprar Imóvel? Calculadora Patrimonial",
       "description": "Compare o custo total de alugar ou comprar um imóvel com custo de oportunidade e projeção patrimonial.",
       "ogTitle": "Aluguel vs Compra | Auraxis",
       "ogDescription": "Descubra se vale mais a pena alugar ou comprar com projeção patrimonial e break-even."
@@ -3394,7 +3394,7 @@
   },
   "conversorMoeda": {
     "seo": {
-      "title": "Conversor de Moeda com Cotação em Tempo Real | Auraxis",
+      "title": "Conversor de Moedas — Cotação em Tempo Real",
       "description": "Converta entre Real e moedas estrangeiras com cotação ao vivo via BRAPI.",
       "ogTitle": "Conversor de Moeda — Auraxis",
       "ogDescription": "Cotação em tempo real para USD, EUR, GBP, BTC e mais."
@@ -3456,7 +3456,7 @@
   },
   "fii": {
     "seo": {
-      "title": "Calculadora de FII — Dividend Yield e Renda Passiva | Auraxis",
+      "title": "Calculadora de FII — Dividend Yield e Renda Passiva",
       "description": "Calcule o Dividend Yield, Yield on Cost e renda passiva de Fundos Imobiliários com dados reais via BRAPI.",
       "ogTitle": "Calculadora de FII — Auraxis",
       "ogDescription": "DY, YoC e renda mensal de FIIs com cotação ao vivo."
@@ -3726,7 +3726,7 @@
   },
   "salarioLiquido": {
     "seo": {
-      "title": "Calculadora de Salário Líquido CLT 2026 | Auraxis",
+      "title": "Calculadora de Salário Líquido CLT 2026",
       "description": "Calcule seu salário líquido CLT com todos os descontos: INSS, IR, VT, VA/VR, plano de saúde e custo do empregador.",
       "ogTitle": "Calculadora de Salário Líquido CLT | Auraxis",
       "ogDescription": "Descubra quanto você realmente recebe e quanto o empregador paga."
@@ -3772,9 +3772,9 @@
   },
   "reservaEmergencia": {
     "seo": {
-      "title": "Calculadora de Reserva de Emergência | Auraxis",
+      "title": "Calculadora de Reserva de Emergência",
       "description": "Calcule sua meta de reserva de emergência por perfil profissional e veja em quanto tempo você atinge o objetivo.",
-      "ogTitle": "Calculadora de Reserva de Emergência | Auraxis",
+      "ogTitle": "Calculadora de Reserva de Emergência",
       "ogDescription": "Descubra sua meta de reserva de emergência e compare investimentos."
     },
     "hero": {
@@ -3821,7 +3821,7 @@
   },
   "orcamento5030": {
     "seo": {
-      "title": "Orçamento 50/30/20 — Auraxis",
+      "title": "Calculadora de Orçamento 50/30/20 — Divida sua Renda",
       "description": "Distribua sua renda em necessidades, desejos e investimentos com a regra 50/30/20.",
       "ogTitle": "Orçamento 50/30/20 | Auraxis",
       "ogDescription": "Organize suas finanças com a regra 50/30/20."
@@ -3867,7 +3867,7 @@
   },
   "cet": {
     "seo": {
-      "title": "CET — Custo Efetivo Total — Auraxis",
+      "title": "Calculadora de CET — Custo Efetivo Total de Empréstimos",
       "description": "Descubra o custo real de um financiamento calculando o CET com IOF, TAC, seguro e todos os encargos.",
       "ogTitle": "CET — Custo Efetivo Total | Auraxis",
       "ogDescription": "Compare a taxa nominal com o CET real e saiba quanto você vai pagar."
@@ -3920,9 +3920,9 @@
   },
   "quitacaoDividas": {
     "seo": {
-      "title": "Simulador de Quitação de Dívidas | Auraxis",
+      "title": "Simulador de Quitação de Dívidas — Snowball e Avalanche",
       "description": "Compare Snowball e Avalanche para quitar suas dívidas mais rápido e pagar menos juros. Simulação gratuita, sem cadastro.",
-      "ogTitle": "Simulador de Quitação de Dívidas | Auraxis",
+      "ogTitle": "Simulador de Quitação de Dívidas — Snowball e Avalanche",
       "ogDescription": "Descubra a melhor estratégia para quitar suas dívidas e economize em juros."
     },
     "hero": {
@@ -4017,9 +4017,9 @@
   },
   "custoEstiloVida": {
     "seo": {
-      "title": "Quanto Seu Cafezinho Custa em 20 Anos? | Auraxis",
+      "title": "Quanto seu Cafezinho Custa em 20 Anos? Calculadora",
       "description": "Descubra o custo de oportunidade dos seus gastos recorrentes se investidos ao longo do tempo. Calcule grátis.",
-      "ogTitle": "Quanto Seu Cafezinho Custa em 20 Anos? | Auraxis",
+      "ogTitle": "Quanto seu Cafezinho Custa em 20 Anos? Calculadora",
       "ogDescription": "Veja quanto seus gastos recorrentes custariam se fossem investidos. Compartilhe o resultado."
     },
     "hero": {
@@ -4147,7 +4147,7 @@
   },
   "custoVidaRegional": {
     "seo": {
-      "title": "Calculadora de Custo de Vida por Estado | Auraxis",
+      "title": "Calculadora de Custo de Vida por Estado",
       "description": "Descubra quanto do seu salário o seu estilo de vida consome, compare com a média do seu estado e veja em quantos anos você poderia se aposentar.",
       "ogTitle": "Quanto Custa o Seu Estilo de Vida? | Auraxis",
       "ogDescription": "Compare o custo do seu estilo de vida com a média regional e descubra seu score de sustentabilidade financeira."

--- a/app/pages/tools/aluguel-vs-compra.spec.ts
+++ b/app/pages/tools/aluguel-vs-compra.spec.ts
@@ -194,6 +194,10 @@ vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const mockResult: AluguelVsCompraResult = {

--- a/app/pages/tools/aluguel-vs-compra.vue
+++ b/app/pages/tools/aluguel-vs-compra.vue
@@ -28,6 +28,7 @@ import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
 import UiChart from "~/components/ui/UiChart.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
@@ -60,6 +61,12 @@ const {
     name: t("aluguelVsCompra.simulation.goalName"),
     target_amount: result.propertyValueAtEnd,
   }),
+});
+
+useToolPageStructuredData({
+  slug: "aluguel-vs-compra",
+  name: t("aluguelVsCompra.seo.title"),
+  description: t("aluguelVsCompra.seo.description"),
 });
 
 useSeoMeta({

--- a/app/pages/tools/aposentadoria.spec.ts
+++ b/app/pages/tools/aposentadoria.spec.ts
@@ -141,6 +141,10 @@ vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 // ─── Test data ────────────────────────────────────────────────────────────────
 
 const mockResult: AposentadoriaResult = {

--- a/app/pages/tools/aposentadoria.vue
+++ b/app/pages/tools/aposentadoria.vue
@@ -29,6 +29,7 @@ import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
 import UiChart from "~/components/ui/UiChart.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
@@ -68,6 +69,12 @@ const {
       target_amount: result.requiredPatrimony,
     };
   },
+});
+
+useToolPageStructuredData({
+  slug: "aposentadoria",
+  name: t("aposentadoria.seo.title"),
+  description: t("aposentadoria.seo.description"),
 });
 
 useSeoMeta({

--- a/app/pages/tools/cdb-lci-lca.spec.ts
+++ b/app/pages/tools/cdb-lci-lca.spec.ts
@@ -136,6 +136,10 @@ vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 // ─── Test data ────────────────────────────────────────────────────────────────
 
 const mockResult: CdbLciLcaResult = {

--- a/app/pages/tools/cdb-lci-lca.vue
+++ b/app/pages/tools/cdb-lci-lca.vue
@@ -28,6 +28,7 @@ import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySum
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
@@ -76,6 +77,12 @@ const {
       result.poupanca.netAmount,
     ),
   }),
+});
+
+useToolPageStructuredData({
+  slug: "cdb-lci-lca",
+  name: t("cdbLciLca.seo.title"),
+  description: t("cdbLciLca.seo.description"),
 });
 
 useSeoMeta({

--- a/app/pages/tools/cet.spec.ts
+++ b/app/pages/tools/cet.spec.ts
@@ -50,6 +50,10 @@ vi.mock("~/features/tools/model/cet", () => ({
   calculateCet: mockCalculate,
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 vi.mock("~/features/simulations/queries/use-save-simulation-mutation", () => ({ useSaveSimulationMutation: (): { mutateAsync: typeof mockSaveMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false) }) }));
 vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({ useEntitlementQuery: (): { data: typeof mockHasPremiumAccess; isLoading: ReturnType<typeof ref<boolean>> } => ({ data: mockHasPremiumAccess, isLoading: ref(false) }) }));
 

--- a/app/pages/tools/cet.vue
+++ b/app/pages/tools/cet.vue
@@ -31,6 +31,7 @@ import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySum
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
@@ -38,6 +39,12 @@ const { t, n } = useI18n();
 const toast = useMessage();
 const { getErrorMessage } = useApiError();
 const sessionStore = useSessionStore();
+
+useToolPageStructuredData({
+  slug: "cet",
+  name: t("cet.seo.title"),
+  description: t("cet.seo.description"),
+});
 
 useSeoMeta({
   title: t("cet.seo.title"),

--- a/app/pages/tools/conversor-moeda.spec.ts
+++ b/app/pages/tools/conversor-moeda.spec.ts
@@ -171,6 +171,10 @@ vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const mockResult: ConversorMoedaResult = {

--- a/app/pages/tools/conversor-moeda.vue
+++ b/app/pages/tools/conversor-moeda.vue
@@ -28,10 +28,17 @@ import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySum
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
 const { t, n } = useI18n();
+
+useToolPageStructuredData({
+  slug: "conversor-moeda",
+  name: t("conversorMoeda.seo.title"),
+  description: t("conversorMoeda.seo.description"),
+});
 
 useSeoMeta({
   title: t("conversorMoeda.seo.title"),

--- a/app/pages/tools/custo-de-vida-regional.spec.ts
+++ b/app/pages/tools/custo-de-vida-regional.spec.ts
@@ -60,6 +60,10 @@ vi.mock("~/features/tools/model/custo-de-vida-regional", () => ({
   calculateRegionalCost: mockCalculate,
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 const mockResult: RegionalCostResult = {
   totalMonthlyCost: 6000,
   totalAnnualCost: 72000,

--- a/app/pages/tools/custo-de-vida-regional.vue
+++ b/app/pages/tools/custo-de-vida-regional.vue
@@ -36,12 +36,19 @@ import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
 import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySummaryCard.vue";
 import UiChart from "~/components/ui/UiChart.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
 const { t, n } = useI18n();
 const toast = useMessage();
 const sessionStore = useSessionStore();
+
+useToolPageStructuredData({
+  slug: "custo-de-vida-regional",
+  name: t("custoVidaRegional.seo.title"),
+  description: t("custoVidaRegional.seo.description"),
+});
 
 useSeoMeta({
   title: () => t("custoVidaRegional.seo.title"),

--- a/app/pages/tools/custo-estilo-vida.spec.ts
+++ b/app/pages/tools/custo-estilo-vida.spec.ts
@@ -55,6 +55,10 @@ vi.mock("~/features/tools/model/custo-estilo-vida", () => ({
   calculateCustoEstiloVida: mockCalculate,
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 vi.mock("~/features/simulations/queries/use-save-simulation-mutation", () => ({ useSaveSimulationMutation: (): { mutateAsync: typeof mockSaveMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false) }) }));
 vi.mock("~/features/goals/queries/use-create-goal-mutation", () => ({ useCreateGoalMutation: (): { mutateAsync: typeof mockCreateGoalMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockCreateGoalMutateAsync, isPending: ref(false) }) }));
 vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({ useEntitlementQuery: (): { data: typeof mockHasPremiumAccess; isLoading: ReturnType<typeof ref<boolean>> } => ({ data: mockHasPremiumAccess, isLoading: ref(false) }) }));

--- a/app/pages/tools/custo-estilo-vida.vue
+++ b/app/pages/tools/custo-estilo-vida.vue
@@ -39,6 +39,7 @@ import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
 import UiChart from "~/components/ui/UiChart.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
@@ -46,6 +47,12 @@ const { t, n } = useI18n();
 const toast = useMessage();
 const { getErrorMessage } = useApiError();
 const sessionStore = useSessionStore();
+
+useToolPageStructuredData({
+  slug: "custo-estilo-vida",
+  name: t("custoEstiloVida.seo.title"),
+  description: t("custoEstiloVida.seo.description"),
+});
 
 useSeoMeta({
   title: t("custoEstiloVida.seo.title"),

--- a/app/pages/tools/desconto-markup.spec.ts
+++ b/app/pages/tools/desconto-markup.spec.ts
@@ -169,6 +169,10 @@ vi.mock("~/features/goals/queries/use-create-goal-mutation", () => ({
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const mockResultDesconto: DescontoMarkupResult = {

--- a/app/pages/tools/desconto-markup.vue
+++ b/app/pages/tools/desconto-markup.vue
@@ -34,6 +34,7 @@ import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySum
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
@@ -41,6 +42,12 @@ const { t, n } = useI18n();
 const toast = useMessage();
 const { getErrorMessage } = useApiError();
 const sessionStore = useSessionStore();
+
+useToolPageStructuredData({
+  slug: "desconto-markup",
+  name: t("descontoMarkup.seo.title"),
+  description: t("descontoMarkup.seo.description"),
+});
 
 useSeoMeta({
   title: t("descontoMarkup.seo.title"),

--- a/app/pages/tools/dividir-conta.spec.ts
+++ b/app/pages/tools/dividir-conta.spec.ts
@@ -173,6 +173,10 @@ vi.mock("~/features/goals/queries/use-create-goal-mutation", () => ({
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const mockResult: DividirContaResult = {

--- a/app/pages/tools/dividir-conta.vue
+++ b/app/pages/tools/dividir-conta.vue
@@ -34,6 +34,7 @@ import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySum
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
@@ -41,6 +42,12 @@ const { t, n } = useI18n();
 const toast = useMessage();
 const { getErrorMessage } = useApiError();
 const sessionStore = useSessionStore();
+
+useToolPageStructuredData({
+  slug: "dividir-conta",
+  name: t("dividirConta.seo.title"),
+  description: t("dividirConta.seo.description"),
+});
 
 useSeoMeta({
   title: t("dividirConta.seo.title"),

--- a/app/pages/tools/fii.spec.ts
+++ b/app/pages/tools/fii.spec.ts
@@ -176,6 +176,10 @@ vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const mockResult: FiiResult = {

--- a/app/pages/tools/fii.vue
+++ b/app/pages/tools/fii.vue
@@ -29,10 +29,17 @@ import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySum
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
 const { t } = useI18n();
+
+useToolPageStructuredData({
+  slug: "fii",
+  name: t("fii.seo.title"),
+  description: t("fii.seo.description"),
+});
 
 useSeoMeta({
   title: t("fii.seo.title"),

--- a/app/pages/tools/financiamento-imobiliario.spec.ts
+++ b/app/pages/tools/financiamento-imobiliario.spec.ts
@@ -168,6 +168,10 @@ vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const mockScheduleRow = { month: 1, payment: 3800, amortization: 1111, interest: 2689, balance: 398889 };

--- a/app/pages/tools/financiamento-imobiliario.vue
+++ b/app/pages/tools/financiamento-imobiliario.vue
@@ -27,6 +27,7 @@ import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySum
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
@@ -60,6 +61,12 @@ const {
     name: t("financiamentoImobiliario.simulation.goalName"),
     target_amount: result.loanAmount,
   }),
+});
+
+useToolPageStructuredData({
+  slug: "financiamento-imobiliario",
+  name: t("financiamentoImobiliario.seo.title"),
+  description: t("financiamentoImobiliario.seo.description"),
 });
 
 useSeoMeta({

--- a/app/pages/tools/fire.spec.ts
+++ b/app/pages/tools/fire.spec.ts
@@ -148,6 +148,10 @@ vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 // ─── Test data ────────────────────────────────────────────────────────────────
 
 const mockResult: FireResult = {

--- a/app/pages/tools/fire.vue
+++ b/app/pages/tools/fire.vue
@@ -31,6 +31,7 @@ import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
 import UiChart from "~/components/ui/UiChart.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
@@ -72,6 +73,12 @@ const {
       target_amount: result.selectedVariant.requiredPatrimony,
     };
   },
+});
+
+useToolPageStructuredData({
+  slug: "fire",
+  name: t("fire.seo.title"),
+  description: t("fire.seo.description"),
 });
 
 useSeoMeta({

--- a/app/pages/tools/index.vue
+++ b/app/pages/tools/index.vue
@@ -36,8 +36,18 @@ useSeoMeta({
   twitterDescription: t("pages.tools.meta.description"),
 });
 
+// hreflang recíproco do índice (#1222) — o catálogo existe em PT e EN.
+const alternateLinks = computed(() => {
+  const base = (siteConfig.url ?? "https://app.auraxis.com.br").replace(/\/$/, "");
+  return [
+    { rel: "alternate", hreflang: "pt-BR", href: `${base}/tools` },
+    { rel: "alternate", hreflang: "en", href: `${base}/en/tools` },
+    { rel: "alternate", hreflang: "x-default", href: `${base}/tools` },
+  ];
+});
+
 useHead({
-  link: [{ rel: "canonical", href: canonicalUrl.value }],
+  link: [{ rel: "canonical", href: canonicalUrl.value }, ...alternateLinks.value],
   htmlAttrs: { lang: locale.value },
 });
 

--- a/app/pages/tools/inss-ir-folha.spec.ts
+++ b/app/pages/tools/inss-ir-folha.spec.ts
@@ -153,6 +153,10 @@ vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const mockResult: InssIrResult = {

--- a/app/pages/tools/inss-ir-folha.vue
+++ b/app/pages/tools/inss-ir-folha.vue
@@ -31,6 +31,7 @@ import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySum
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 import TaxBracketTable, {
   type TaxBracketRow,
 } from "~/components/tool/TaxBracketTable/TaxBracketTable.vue";
@@ -38,6 +39,12 @@ import TaxBracketTable, {
 definePageMeta({ layout: false });
 
 const { t, n } = useI18n();
+
+useToolPageStructuredData({
+  slug: "inss-ir-folha",
+  name: t("inssIrFolha.seo.title"),
+  description: t("inssIrFolha.seo.description"),
+});
 
 useSeoMeta({
   title: t("inssIrFolha.seo.title"),

--- a/app/pages/tools/installment-vs-cash.spec.ts
+++ b/app/pages/tools/installment-vs-cash.spec.ts
@@ -182,6 +182,10 @@ vi.mock("~/features/tools/queries/use-create-planned-expense-from-installment-vs
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 const globalStubs = {
   NuxtLayout: {
     props: ["name"],

--- a/app/pages/tools/installment-vs-cash.vue
+++ b/app/pages/tools/installment-vs-cash.vue
@@ -6,12 +6,19 @@
  *   app/features/tools/installment-vs-cash/page.vue
  */
 import InstallmentVsCashPage from "~/features/tools/installment-vs-cash/page.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({
   layout: false,
 });
 
 const { t } = useI18n();
+
+useToolPageStructuredData({
+  slug: "installment-vs-cash",
+  name: t("pages.installmentVsCash.seo.title"),
+  description: t("pages.installmentVsCash.seo.description"),
+});
 
 useSeoMeta({
   title: t("pages.installmentVsCash.seo.title"),

--- a/app/pages/tools/mei.spec.ts
+++ b/app/pages/tools/mei.spec.ts
@@ -178,6 +178,10 @@ vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 // ─── Mock result ──────────────────────────────────────────────────────────────
 
 const mockResult: MeiResult = {

--- a/app/pages/tools/mei.vue
+++ b/app/pages/tools/mei.vue
@@ -29,6 +29,7 @@ import UiStickySummaryCard from "~/components/ui/UiStickySummaryCard/UiStickySum
 import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
@@ -52,6 +53,12 @@ const {
     name: t("mei.simulation.goalName"),
     target_amount: result.annualRevenueProjection,
   }),
+});
+
+useToolPageStructuredData({
+  slug: "mei",
+  name: t("mei.seo.title"),
+  description: t("mei.seo.description"),
 });
 
 useSeoMeta({

--- a/app/pages/tools/quitacao-dividas.spec.ts
+++ b/app/pages/tools/quitacao-dividas.spec.ts
@@ -55,6 +55,10 @@ vi.mock("~/features/tools/model/quitacao-dividas", () => ({
   compareMethods: vi.fn(() => ({ bestStrategy: "avalanche", interestSaved: 500, monthsSaved: 1, recommendation: "Avalanche economiza mais." })),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 vi.mock("~/features/simulations/queries/use-save-simulation-mutation", () => ({ useSaveSimulationMutation: (): { mutateAsync: typeof mockSaveMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockSaveMutateAsync, isPending: ref(false) }) }));
 vi.mock("~/features/goals/queries/use-create-goal-mutation", () => ({ useCreateGoalMutation: (): { mutateAsync: typeof mockCreateGoalMutateAsync; isPending: ReturnType<typeof ref<boolean>> } => ({ mutateAsync: mockCreateGoalMutateAsync, isPending: ref(false) }) }));
 vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({ useEntitlementQuery: (): { data: typeof mockHasPremiumAccess; isLoading: ReturnType<typeof ref<boolean>> } => ({ data: mockHasPremiumAccess, isLoading: ref(false) }) }));

--- a/app/pages/tools/quitacao-dividas.vue
+++ b/app/pages/tools/quitacao-dividas.vue
@@ -39,6 +39,7 @@ import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
 import UiChart from "~/components/ui/UiChart.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
@@ -46,6 +47,12 @@ const { t, n } = useI18n();
 const toast = useMessage();
 const { getErrorMessage } = useApiError();
 const sessionStore = useSessionStore();
+
+useToolPageStructuredData({
+  slug: "quitacao-dividas",
+  name: t("quitacaoDividas.seo.title"),
+  description: t("quitacaoDividas.seo.description"),
+});
 
 useSeoMeta({
   title: t("quitacaoDividas.seo.title"),

--- a/app/pages/tools/tesouro-direto.spec.ts
+++ b/app/pages/tools/tesouro-direto.spec.ts
@@ -142,6 +142,10 @@ vi.mock("~/features/paywall/queries/use-entitlement-query", () => ({
   }),
 }));
 
+vi.mock("~/features/tools/composables/useToolPageStructuredData", () => ({
+  useToolPageStructuredData: vi.fn(),
+}));
+
 // ─── Test data ────────────────────────────────────────────────────────────────
 
 const mockResult: TesouroDiretoResult = {

--- a/app/pages/tools/tesouro-direto.vue
+++ b/app/pages/tools/tesouro-direto.vue
@@ -31,10 +31,17 @@ import UiPageHeader from "~/components/ui/UiPageHeader/UiPageHeader.vue";
 import UiGlassPanel from "~/components/ui/UiGlassPanel/UiGlassPanel.vue";
 import UiSurfaceCard from "~/components/ui/UiSurfaceCard/UiSurfaceCard.vue";
 import UiChart from "~/components/ui/UiChart.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
 
 const { t } = useI18n();
+
+useToolPageStructuredData({
+  slug: "tesouro-direto",
+  name: t("tesouroDireto.seo.title"),
+  description: t("tesouroDireto.seo.description"),
+});
 
 useSeoMeta({
   title: t("tesouroDireto.seo.title"),

--- a/app/pages/tools/thirteenth-salary.vue
+++ b/app/pages/tools/thirteenth-salary.vue
@@ -6,8 +6,15 @@
  *   app/features/tools/thirteenth-salary/page.vue
  */
 import ThirteenthSalaryPage from "~/features/tools/thirteenth-salary/page.vue";
+import { useToolPageStructuredData } from "~/features/tools/composables/useToolPageStructuredData";
 
 definePageMeta({ layout: false });
+
+useToolPageStructuredData({
+  slug: "thirteenth-salary",
+  name: useI18n().t("thirteenthSalary.seo.title"),
+  description: useI18n().t("thirteenthSalary.seo.description"),
+});
 
 useSeoMeta({
   title: useI18n().t("thirteenthSalary.seo.title"),


### PR DESCRIPTION
## Resumo

Primeira frente do pacote de SEO proativo pós-Onda 2. Auditoria do HTML **real em produção** apontou três buracos nas páginas que mais têm potencial de tráfego orgânico:

### 1. Titles que ninguém busca (22 reescritos)
- **12 duplicavam a marca** — a página escrevia "… — Auraxis" e o `titleTemplate` global anexava "| Auraxis" de novo.
- **12 não continham o termo de busca**: quem procura calculadora digita "simulador de aposentadoria", não "Aposentadoria — Auraxis".

Exemplos: `Tesouro Direto — Auraxis` → **`Simulador Tesouro Direto — Selic, IPCA+ e Prefixado`** · `Dividir Conta — Auraxis` → **`Calculadora de Dividir Conta — Rateio com Taxa e Gorjeta`** · `CET — Custo Efetivo Total — Auraxis` → **`Calculadora de CET — Custo Efetivo Total de Empréstimos`**. Todos ≤56 chars (sem truncar na SERP). Uma description de 168 chars também foi encurtada.

### 2. hreflang ausente (as 27 + o índice)
As tools existem em PT e EN sem nenhum `<link rel=alternate>` ligando as versões — o Google trata como páginas sem relação e pode servir a errada. Agora emitem `pt-BR`, `en` e `x-default` (PT como padrão), via o façade de structured data (com teste unitário do builder).

### 3. Schema genérico em 18 das 27
Só 9 páginas chamavam `useToolPageStructuredData`; as outras emitiam apenas o `WebApplication` global "Auraxis" — **nada descrevia a calculadora** e não havia `BreadcrumbList`. Agora todas declaram nome, descrição e trilha próprios.

## Validação

- `pnpm quality-check` verde: **481 arquivos, 4290 testes**.
- Specs das 17 páginas afetadas ganharam o mock do composable (mesmo padrão dos 9 que já o chamavam).
- Sem mudança visual — só `<head>` e JSON-LD, por isso sem screenshots.

## Como medir o efeito

Search Console → Desempenho → filtrar por página `/tools/`: impressões e **posição média** por consulta devem reagir em 2-4 semanas (o GSC leva ~1 semana para acumular após o recrawl).

Closes #1222