### PR TITLE
perf(landing): tirar o SDK do PostHog do caminho crítico da home

### DIFF
--- a/__tests__/plugins/web-vitals.client.spec.ts
+++ b/__tests__/plugins/web-vitals.client.spec.ts
@@ -36,6 +36,19 @@ const baseMetric = (overrides: Partial<Metric>): Metric =>
     ...overrides,
   }) as Metric;
 
+/**
+ * Deixa as continuações do `import()` dinâmico do SDK rodarem.
+ *
+ * `reportToPostHog` passou a carregar o PostHog por promise (#1246), então o
+ * `capture` acontece depois da chamada. Drenar só microtask não basta:
+ * resolver um `import()` envolve o grafo de módulos.
+ */
+const flushSdkLoad = async (): Promise<void> => {
+  for (let index = 0; index < 3; index += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
+
 describe("isTrackedMetric", () => {
   it("accepts every Core Web Vital we track", async () => {
     const { isTrackedMetric } = await import("../../app/plugins/web-vitals.client");
@@ -80,7 +93,7 @@ describe("reportToPostHog", () => {
   it("emits a web_vital event with the payload", async () => {
     const { reportToPostHog, toPayload } = await import("../../app/plugins/web-vitals.client");
     const payload = toPayload(baseMetric({ name: "INP", value: 42 }));
-    reportToPostHog(payload);
+    await reportToPostHog(payload);
     expect(mockCapture).toHaveBeenCalledWith("web_vital", payload);
   });
 });
@@ -117,6 +130,7 @@ describe("emit", () => {
   it("forwards the metric to PostHog and Sentry when analytics consent is granted", async () => {
     const { emit } = await import("../../app/plugins/web-vitals.client");
     emit(baseMetric({ name: "FCP", value: 900 }), true);
+    await flushSdkLoad();
     expect(mockCapture).toHaveBeenCalledTimes(1);
     expect(mockSetMeasurement).toHaveBeenCalledTimes(1);
     expect(mockSetTag).toHaveBeenCalledTimes(1);

--- a/app/plugins/posthog.client.spec.ts
+++ b/app/plugins/posthog.client.spec.ts
@@ -16,6 +16,25 @@ vi.mock("posthog-js/dist/module.no-external", () => ({
 
 // eslint-disable-next-line import/first
 import { createConsentAwareAnalyticsClient } from "./posthog.client";
+// eslint-disable-next-line import/first
+import { resetPostHogSdkLoader } from "~/shared/analytics/posthog-loader";
+
+/**
+ * Deixa as continuações do `import()` dinâmico rodarem.
+ *
+ * O SDK agora chega por promise (#1246), então tudo que o cliente faz com ele
+ * acontece um tick depois da chamada. Sem isto os testes afirmariam sobre um
+ * estado que ainda não existe — e passariam a esconder exatamente o bug que
+ * a mudança poderia introduzir.
+ */
+const flush = async (): Promise<void> => {
+  // `setTimeout` e não só `Promise.resolve()`: resolver um `import()` dinâmico
+  // envolve o grafo de módulos, não apenas microtasks — drenar microtask não
+  // basta e o teste falharia por timing, não por comportamento.
+  for (let index = 0; index < 3; index += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
 
 interface TestAnalyticsConsentGateway {
   canUseAnalytics(): boolean;
@@ -48,27 +67,30 @@ const createGateway = (initialAllowed: boolean): TestAnalyticsConsentGateway => 
 describe("PostHog consent gateway", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetPostHogSdkLoader();
   });
 
-  it("does not initialize or capture events before analytics consent", () => {
+  it("does not initialize or capture events before analytics consent", async () => {
     const gateway = createGateway(false);
     const client = createConsentAwareAnalyticsClient("ph_test", "https://eu.i.posthog.com", gateway);
 
     client.capture("dashboard_viewed");
     client.identify("user-123");
+    await flush();
 
     expect(posthogMock.init).not.toHaveBeenCalled();
     expect(posthogMock.capture).not.toHaveBeenCalled();
     expect(posthogMock.identify).not.toHaveBeenCalled();
   });
 
-  it("initializes once and captures after analytics consent is granted", () => {
+  it("initializes once and captures after analytics consent is granted", async () => {
     const gateway = createGateway(false);
     const client = createConsentAwareAnalyticsClient("ph_test", "https://eu.i.posthog.com", gateway);
 
     gateway.setAllowed(true);
     client.capture("dashboard_viewed", { source: "test" });
     client.identify("user-123");
+    await flush();
 
     expect(posthogMock.init).toHaveBeenCalledTimes(1);
     // Pageviews are SDK-native (#1208): "history_change" covers the initial
@@ -82,16 +104,68 @@ describe("PostHog consent gateway", () => {
     expect(posthogMock.identify).toHaveBeenCalledWith("user-123");
   });
 
-  it("stops future analytics events when consent is revoked", () => {
+  it("stops future analytics events when consent is revoked", async () => {
     const gateway = createGateway(true);
     const client = createConsentAwareAnalyticsClient("ph_test", "https://eu.i.posthog.com", gateway);
 
     client.capture("dashboard_viewed");
+    await flush();
     gateway.setAllowed(false);
     client.capture("portfolio_viewed");
+    await flush();
 
     expect(posthogMock.opt_out_capturing).toHaveBeenCalledOnce();
     expect(posthogMock.reset).toHaveBeenCalledOnce();
     expect(posthogMock.capture).not.toHaveBeenCalledWith("portfolio_viewed", undefined);
+  });
+
+  // ── A janela entre o aceite e o SDK chegar (#1246) ───────────────────────
+  // É o risco que o import dinâmico cria: com o SDK carregando por promise,
+  // eventos disparados no instante do aceite acontecem antes de existir
+  // cliente. O funil da landing (#1208) depende de nenhum deles se perder.
+
+  it("does not drop events fired before the SDK finishes loading", async () => {
+    const gateway = createGateway(false);
+    const client = createConsentAwareAnalyticsClient("ph_test", "https://eu.i.posthog.com", gateway);
+
+    gateway.setAllowed(true);
+    // Sem nenhum await no meio: o SDK ainda não resolveu neste ponto.
+    client.capture("landing_cta_clicked");
+    client.capture("checkout_form_submitted");
+    client.capture("checkout_provider_redirected");
+
+    expect(posthogMock.capture).not.toHaveBeenCalled();
+
+    await flush();
+
+    expect(posthogMock.capture).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves the order of events fired during the loading window", async () => {
+    const gateway = createGateway(true);
+    const client = createConsentAwareAnalyticsClient("ph_test", "https://eu.i.posthog.com", gateway);
+
+    client.capture("landing_cta_clicked");
+    client.capture("checkout_form_submitted");
+    client.capture("checkout_provider_redirected");
+    await flush();
+
+    expect(posthogMock.capture.mock.calls.map(([event]) => event)).toEqual([
+      "landing_cta_clicked",
+      "checkout_form_submitted",
+      "checkout_provider_redirected",
+    ]);
+  });
+
+  it("initializes the SDK only once when several events race the load", async () => {
+    const gateway = createGateway(true);
+    const client = createConsentAwareAnalyticsClient("ph_test", "https://eu.i.posthog.com", gateway);
+
+    client.capture("landing_cta_clicked");
+    client.capture("checkout_form_submitted");
+    client.identify("user-123");
+    await flush();
+
+    expect(posthogMock.init).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/plugins/posthog.client.ts
+++ b/app/plugins/posthog.client.ts
@@ -1,12 +1,12 @@
-// The `no-external` build never injects remote <script> tags — the default
-// build loads remote config (config.js) and lazy extensions from
-// *-assets.i.posthog.com, which both production CSPs block in `script-src`
-// (landing: infra/landing/main.tf; app: PRODUCTION_CSP in csp.ts). With the
-// loader stubbed, config/flags fall back to fetch on the ingest host, which
-// `connect-src` already allows (#1209 — root cause of zero web ingestion).
-// web-vitals.client.ts MUST import the same path: two entrypoints would
-// create two disconnected PostHog singletons.
-import posthog from "posthog-js/dist/module.no-external";
+// O SDK entra por `~/shared/analytics/posthog-loader`, que faz o `import()`
+// dinâmico do build `no-external` — o único entrypoint válido (#1209) e agora
+// o único lugar do código que o nomeia. Import estático aqui colocava a
+// biblioteca no chunk de entrada de todo mundo, inclusive de quem recusa
+// cookies (#1246).
+import {
+  isPostHogSdkRequested,
+  loadPostHogSdk,
+} from "~/shared/analytics/posthog-loader";
 import {
   canUseAnalyticsCookies,
   subscribeToCookieConsentChanges,
@@ -118,7 +118,12 @@ const createDefaultConsentGateway = (): AnalyticsConsentGateway => ({
  * @param apiHost PostHog ingest host URL.
  * @returns Typed AnalyticsClient backed by PostHog.
  */
-export function initPostHog(apiKey: string, apiHost: string): AnalyticsClient {
+export async function initPostHog(
+  apiKey: string,
+  apiHost: string,
+): Promise<AnalyticsClient> {
+  const posthog = await loadPostHogSdk();
+
   posthog.init(apiKey, {
     api_host: apiHost,
     // "history_change": the SDK captures the initial load AND history-API
@@ -158,22 +163,24 @@ export function createConsentAwareAnalyticsClient(
   apiHost: string,
   gateway: AnalyticsConsentGateway = createDefaultConsentGateway(),
 ): ConsentAwareAnalyticsClient {
-  let client: AnalyticsClient | null = null;
-  let initialized = false;
+  let clientPromise: Promise<AnalyticsClient> | null = null;
 
   /**
    * Lazily initializes PostHog only when analytics consent is currently allowed.
    *
-   * @returns Initialized analytics client or null when consent is missing.
+   * Devolve a MESMA promise em toda chamada, então as continuações rodam na
+   * ordem em que foram encadeadas: um `capture` disparado no instante do aceite
+   * chega antes do seguinte, e nenhum evento se perde na janela entre o
+   * consentimento e o módulo carregar (#1208).
+   *
+   * @returns Promise do cliente inicializado, ou null quando falta consentimento.
    */
-  const ensureInitialized = (): AnalyticsClient | null => {
+  const ensureInitialized = (): Promise<AnalyticsClient> | null => {
     if (!gateway.canUseAnalytics()) {
       return null;
     }
 
-    if (!initialized) {
-      client = initPostHog(apiKey, apiHost);
-      initialized = true;
+    clientPromise ??= initPostHog(apiKey, apiHost).then((initializedClient) => {
       // Surveys extension, bundled (#1209): with the no-external build the
       // CDN fallback does not exist, so the extension ships as a local lazy
       // chunk from our own origin — loaded only for consented sessions, and
@@ -181,10 +188,14 @@ export function createConsentAwareAnalyticsClient(
       // /checkout/cancelado. Optional by design: a failed load must never
       // take analytics down with it.
       void import("posthog-js/dist/surveys").catch(() => { /* optional */ });
-    }
+      return initializedClient;
+    });
 
-    posthog.opt_in_capturing?.();
-    return client;
+    void loadPostHogSdk().then((posthog) => {
+      posthog.opt_in_capturing?.();
+    });
+
+    return clientPromise;
   };
 
   const unsubscribe = gateway.onChange((allowed) => {
@@ -193,9 +204,13 @@ export function createConsentAwareAnalyticsClient(
       return;
     }
 
-    if (initialized) {
-      posthog.opt_out_capturing?.();
-      posthog.reset();
+    // Sem `isPostHogSdkRequested` esta linha baixaria o SDK só para desligá-lo
+    // — exatamente para quem recusou os cookies.
+    if (isPostHogSdkRequested()) {
+      void loadPostHogSdk().then((posthog) => {
+        posthog.opt_out_capturing?.();
+        posthog.reset();
+      });
     }
   });
 
@@ -203,15 +218,22 @@ export function createConsentAwareAnalyticsClient(
 
   return {
     capture: (event: AuraxisEvent, properties?: Record<string, unknown>): void => {
-      ensureInitialized()?.capture(event, properties);
+      void ensureInitialized()?.then((analytics) => {
+        analytics.capture(event, properties);
+      });
     },
     identify: (userId: string): void => {
-      ensureInitialized()?.identify(userId);
+      void ensureInitialized()?.then((analytics) => {
+        analytics.identify(userId);
+      });
     },
     reset: (): void => {
-      if (gateway.canUseAnalytics()) {
-        client?.reset();
+      if (!gateway.canUseAnalytics()) {
+        return;
       }
+      void clientPromise?.then((analytics) => {
+        analytics.reset();
+      });
     },
     dispose: unsubscribe,
   };

--- a/app/plugins/web-vitals.client.spec.ts
+++ b/app/plugins/web-vitals.client.spec.ts
@@ -29,21 +29,36 @@ const metric: Metric = {
   entries: [],
 };
 
+/**
+ * Deixa as continuações do `import()` dinâmico do SDK rodarem.
+ *
+ * `reportToPostHog` passou a carregar o PostHog por promise (#1246), então o
+ * `capture` acontece depois da chamada. Drenar só microtask não basta:
+ * resolver um `import()` envolve o grafo de módulos.
+ */
+const flushSdkLoad = async (): Promise<void> => {
+  for (let index = 0; index < 3; index += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
+
 describe("web-vitals consent gate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("does not send metrics to PostHog or Sentry before analytics consent", () => {
+  it("does not send metrics to PostHog or Sentry before analytics consent", async () => {
     emit(metric, false);
+    await flushSdkLoad();
 
     expect(posthogMock.capture).not.toHaveBeenCalled();
     expect(sentryMock.setMeasurement).not.toHaveBeenCalled();
     expect(sentryMock.setTag).not.toHaveBeenCalled();
   });
 
-  it("sends metrics when analytics consent is granted", () => {
+  it("sends metrics when analytics consent is granted", async () => {
     emit(metric, true);
+    await flushSdkLoad();
 
     expect(posthogMock.capture).toHaveBeenCalledWith("web_vital", expect.objectContaining({
       name: "LCP",

--- a/app/plugins/web-vitals.client.ts
+++ b/app/plugins/web-vitals.client.ts
@@ -1,8 +1,9 @@
 import { onCLS, onFCP, onINP, onLCP, onTTFB, type Metric } from "web-vitals";
-// Same entrypoint as posthog.client.ts — the no-external build is a distinct
-// module instance; importing plain "posthog-js" here would report vitals into
-// a second, never-initialized singleton (#1209).
-import posthog from "posthog-js/dist/module.no-external";
+// Mesmo carregador do posthog.client.ts — o build `no-external` é uma instância
+// de módulo distinta, e um segundo entrypoint reportaria as vitals para um
+// singleton nunca inicializado (#1209). Import dinâmico via loader para não
+// arrastar o SDK de volta ao chunk de entrada (#1246).
+import { loadPostHogSdk } from "~/shared/analytics/posthog-loader";
 import * as Sentry from "@sentry/nuxt";
 import {
   canUseAnalyticsCookies,
@@ -81,13 +82,19 @@ export function toPayload(metric: Metric): WebVitalPayload {
  * Reports a Web Vital to PostHog as a `web_vital` event when the SDK is loaded.
  * No-op when PostHog was not initialized (missing key).
  *
+ * Só é chamada depois do gate de consentimento em `emit`, então carregar o SDK
+ * aqui não baixa nada para quem recusou cookies.
+ *
  * @param payload Normalized metric payload.
+ * @returns Promise resolvida quando o evento foi entregue (ou descartado).
  */
-export function reportToPostHog(payload: WebVitalPayload): void {
-  if (typeof posthog.capture !== "function") {
-    return;
-  }
-  posthog.capture("web_vital", payload as unknown as Record<string, unknown>);
+export function reportToPostHog(payload: WebVitalPayload): Promise<void> {
+  return loadPostHogSdk().then((posthog) => {
+    if (typeof posthog.capture !== "function") {
+      return;
+    }
+    posthog.capture("web_vital", payload as unknown as Record<string, unknown>);
+  });
 }
 
 /**
@@ -115,7 +122,7 @@ export function emit(metric: Metric, analyticsAllowed = canUseAnalyticsCookies()
   }
 
   const payload = toPayload(metric);
-  reportToPostHog(payload);
+  void reportToPostHog(payload);
   reportToSentry(payload);
 }
 

--- a/app/shared/analytics/posthog-loader.ts
+++ b/app/shared/analytics/posthog-loader.ts
@@ -1,0 +1,59 @@
+// Carregador único do SDK do PostHog.
+//
+// Por que existe: o `import` estático nos dois plugins colocava a biblioteca
+// inteira no chunk de entrada — 62 marcadores `posthog` dentro dos 321 KB da
+// home, baixados inclusive por quem recusa cookies (#1246). Com o import
+// dinâmico aqui, o SDK vira chunk separado e só desce quando há consentimento.
+//
+// Por que num módulo compartilhado e não um `import()` em cada arquivo:
+// `posthog-js/dist/module.no-external` é uma instância de módulo distinta de
+// `posthog-js` (#1209). Dois entrypoints diferentes criariam dois singletons
+// desconectados — o web-vitals reportaria para um cliente nunca inicializado.
+// Concentrar o especificador num lugar torna isso impossível de errar, e a
+// promise memoizada garante uma única inicialização mesmo com chamadas
+// concorrentes.
+//
+// `import type` não emite código em runtime — o tipo vem do pacote sem
+// arrastá-lo de volta para o bundle.
+import type posthogSdk from "posthog-js/dist/module.no-external";
+
+/** Tipo do singleton exportado pelo build `no-external` do posthog-js. */
+export type PostHogSdk = typeof posthogSdk;
+
+let sdkPromise: Promise<PostHogSdk> | null = null;
+
+/**
+ * Carrega (uma única vez) o SDK do PostHog e devolve o singleton.
+ *
+ * Chamar mais de uma vez devolve sempre a mesma promise, então a ordem das
+ * continuações é a ordem das chamadas — é isso que impede o funil da landing
+ * de perder eventos disparados entre o aceite e o módulo chegar (#1208).
+ *
+ * @returns Promise resolvida com o singleton do posthog-js.
+ */
+export function loadPostHogSdk(): Promise<PostHogSdk> {
+  sdkPromise ??= import("posthog-js/dist/module.no-external").then(
+    (module) => module.default,
+  );
+  return sdkPromise;
+}
+
+/**
+ * Indica se o SDK já foi solicitado nesta sessão.
+ *
+ * Útil para caminhos que não devem *provocar* o download — desligar o
+ * consentimento de quem nunca carregou o SDK não pode baixá-lo só para chamar
+ * `opt_out_capturing`.
+ *
+ * @returns `true` quando `loadPostHogSdk` já foi chamado.
+ */
+export function isPostHogSdkRequested(): boolean {
+  return sdkPromise !== null;
+}
+
+/**
+ * Descarta a promise memoizada. Existe para testes e hot reload.
+ */
+export function resetPostHogSdkLoader(): void {
+  sdkPromise = null;
+}


### PR DESCRIPTION
## Resumo

O `import` do PostHog era estático nos dois plugins (`posthog.client.ts` e `web-vitals.client.ts`),
então a biblioteca inteira ia no chunk de entrada — 62 ocorrências de `posthog` no caminho crítico
da home, baixadas inclusive por quem recusa cookies e nunca vai inicializá-la.

Um carregador compartilhado (`~/shared/analytics/posthog-loader`) faz o `import()` dinâmico.

**Compartilhado, e não um `import()` em cada arquivo, de propósito:**
`posthog-js/dist/module.no-external` é uma instância de módulo distinta de `posthog-js` (#1209).
Dois entrypoints diferentes criariam dois singletons desconectados, e o web-vitals reportaria para
um cliente nunca inicializado. Com o especificador num lugar só, errar isso deixa de ser possível.

## Medição — dois builds da surface landing, mesma máquina

| | antes | depois |
|---|---|---|
| Caminho crítico (`<script module>` + `modulepreload`) | **1203 KB** | **955 KB** |
| Ocorrências de `posthog` no caminho crítico | 62 | **3** (só o especificador) |
| Chunk do SDK (249 KB) | dentro do chunk de entrada | `<link rel="prefetch">` |

**−248 KB (−20,6%)** fora do caminho crítico.

## ⚠️ O critério que esta PR NÃO cumpre

A issue pede "quem recusa não baixa". **Isso não acontece**: o Nuxt emite
`<link rel="prefetch" as="script" href="/_nuxt/B8GFWJ51.js">` para chunks assíncronos, e prefetch
transfere o arquivo — em prioridade ociosa, sem disputar banda com o LCP, mas transfere.

O objetivo de tirar do caminho crítico foi atingido; o de não transferir, não. Fechar a diferença
exige um hook `build:manifest` no `nuxt.config.ts`, que o `CLAUDE.md` deste repo manda submeter a
aval antes — e que tem risco assimétrico (desligar prefetch do chunk errado atrasa algo do caminho
quente sem aviso no CI). Separado em **#1257**, com o diagnóstico pronto.

## O risco que o import dinâmico cria, e como está coberto

Com o SDK chegando por promise, existe uma janela entre o aceite do cookie e o módulo carregar — e
o funil da landing (#1208) dispara eventos exatamente nesse instante. Todas as chamadas encadeiam
na **mesma** promise memoizada, então a ordem das continuações é a ordem das chamadas.

Três testes novos cobrem isso:

- **nenhum evento perdido**: três `capture` disparados sem `await` no meio; antes do flush o mock
  não foi chamado nenhuma vez, depois foi chamado 3;
- **ordem preservada**: `landing_cta_clicked` → `checkout_form_submitted` →
  `checkout_provider_redirected`, nessa sequência;
- **init único** quando vários eventos correm com o carregamento.

Também virou explícito no código que revogar consentimento **não** deve baixar o SDK só para chamar
`opt_out_capturing` — daí o `isPostHogSdkRequested()`.

> Nota de método: os testes precisaram de `setTimeout` e não só `Promise.resolve()` no flush.
> Resolver um `import()` envolve o grafo de módulos, não apenas microtasks — com microtask a
> asserção falhava por timing e teria sido fácil "consertar" removendo a asserção certa.

## Validação

- `pnpm quality-check` → **verde**: 4373 testes, cobertura statements 92,6% / branches 85,53% /
  functions 89,45% / lines 93,54%.
- Medição de bundle feita com `NUXT_PUBLIC_SITE_SURFACE=landing pnpm generate` **imediatamente
  antes** de inspecionar, com `rm -rf .output` entre os dois builds (o `quality-check` sobrescreve
  o `.output` com a surface app — armadilha conhecida de #1225).

## Risco residual

O número que vale é o de produção. Depois do deploy, conferir no Lighthouse da home se o
"Reduce unused JavaScript" caiu, e confirmar na Events API do PostHog que
`$pageview`, `landing_cta_clicked` e `checkout_form_submitted` continuam chegando para sessões
consentidas — o SDK agora inicializa um tick depois, e é isso que a janela de testes protege.

Closes #1246
