### PR TITLE
ci(landing): provar que o deploy chegou e medir a página que vende

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,6 +505,48 @@ jobs:
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
 
+  # ── 10b. Lighthouse CI — surface LANDING ───────────────────────────────
+  # O job acima audita a surface default (app), cuja home é a tela de login.
+  # A landing — a página que vende — nunca tinha sido medida (#1214).
+  # Warn-only por enquanto: subir com `error` sem baseline reprovaria PRs por
+  # um patamar que ninguém mediu, e o desfecho previsível seria desligar o job.
+  lighthouse-landing:
+    name: Lighthouse CI (surface landing)
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      # `rm -rf .output` antes: o runner é limpo, mas manter o passo aqui
+      # documenta a armadilha que morde localmente — resíduo de um build de
+      # outra surface no `.output` faz a medição comparar a página errada.
+      - name: Generate landing surface
+        run: |
+          rm -rf .output
+          pnpm generate
+        env:
+          NODE_ENV: production
+          NUXT_PUBLIC_SITE_SURFACE: landing
+
+      - name: Run Lighthouse CI (landing)
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: .lighthouserc.landing.yml
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+
   # ── 11. E2E Tests (Playwright) ─────────────────────────────────────────
   # Mandatory — runs on every PR. Uses MSW mock-first (no real backend needed).
   # Builds Nuxt locally and serves with `pnpm preview`

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -218,6 +218,103 @@ jobs:
             --query 'Invalidation.Id' \
             --output text)
           echo "✓ Invalidation created: $INVALIDATION_ID"
+          echo "INVALIDATION_ID=$INVALIDATION_ID" >> "$GITHUB_ENV"
+
+      - name: Wait for invalidation to complete
+        if: steps.cap.outputs.enabled == 'true'
+        run: |
+          echo "Waiting for CloudFront invalidation ${{ env.INVALIDATION_ID }}..."
+          aws cloudfront wait invalidation-completed \
+            --distribution-id "${{ vars.AURAXIS_LANDING_DISTRIBUTION_ID }}" \
+            --id "${{ env.INVALIDATION_ID }}"
+          echo "✓ CloudFront cache invalidated"
+
+      # ── Smoke test ──────────────────────────────────────────────────────────
+      # Portado do deploy.yml do app (#1213). Duas fases, porque a primeira
+      # sozinha não prova nada aqui: o CloudFront devolve 200 de fallback, então
+      # status HTTP responde "o CDN está de pé", não "o meu build está no ar".
+      # Já houve deploy silenciosamente ausente (#1197).
+      #
+      # A fase 2 compara o `x-build-id` gravado neste build com o servido. Ele é
+      # embutido em toda página via <meta name="x-build-id"> (NUXT_PUBLIC_BUILD_ID).
+      - name: Smoke test (HTTP + build id)
+        if: steps.cap.outputs.enabled == 'true'
+        env:
+          SITE_HOST: auraxis.com.br
+        run: |
+          EXPECTED_BUILD_ID="${{ github.run_id }}-${{ github.sha }}"
+          echo "Smoke test → https://${SITE_HOST}/"
+          echo "Expected buildId: $EXPECTED_BUILD_ID"
+
+          # Fase 1 — a home responde 200 com corpo
+          HTTP_CODE=""
+          for i in $(seq 1 10); do
+            HTTP_CODE=$(curl --silent --output /tmp/smoke.html \
+              --write-out "%{http_code}" --location "https://${SITE_HOST}/")
+            if [ "$HTTP_CODE" = "200" ] && [ -s /tmp/smoke.html ]; then
+              echo "✓ Fase 1 — HTTP $HTTP_CODE ($(wc -c < /tmp/smoke.html) bytes)"
+              break
+            fi
+            echo "  Tentativa $i/10 — HTTP $HTTP_CODE — nova tentativa em 3s..."
+            sleep 3
+          done
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "✗ Fase 1 falhou — home inacessível após 10 tentativas"
+            exit 1
+          fi
+
+          # Fase 2 — o conteúdo servido é ESTE build.
+          # O HTML vem minificado (todas as <meta> numa linha), então a âncora
+          # inclui name="x-build-id" — casar só por content="..." pegaria o
+          # atributo de qualquer outra meta da mesma linha.
+          for i in $(seq 1 15); do
+            SERVED_BUILD_ID=$(curl --silent "https://${SITE_HOST}/" \
+              | grep -o 'name="x-build-id" content="[^"]*"' \
+              | cut -d'"' -f4)
+            if [ "$SERVED_BUILD_ID" = "$EXPECTED_BUILD_ID" ]; then
+              echo "✓ Fase 2 — buildId confirmado: $SERVED_BUILD_ID"
+              exit 0
+            fi
+            echo "  Tentativa $i/15 — servido=$SERVED_BUILD_ID esperado=$EXPECTED_BUILD_ID — 5s..."
+            sleep 5
+          done
+          echo "✗ Fase 2 falhou — CloudFront ainda serve build antigo após 75s"
+          echo "  servido:   $SERVED_BUILD_ID"
+          echo "  esperado:  $EXPECTED_BUILD_ID"
+          exit 1
+
+      # O sitemap é o que sustenta a indexação do apex (72 URLs hoje). Ele já
+      # teve DOIS donos disputando o mesmo caminho — o `nitro.prerender` servia
+      # um diretório com redirect HTML enquanto o @nuxtjs/sitemap servia o XML,
+      # e o vencedor variava por build (#1233). Um deploy que devolva HTML aqui
+      # é regressão de SEO invisível: o Search Console só reclama dias depois.
+      - name: Validate published sitemap
+        if: steps.cap.outputs.enabled == 'true'
+        env:
+          SITE_HOST: auraxis.com.br
+          MIN_URLS: 60
+        run: |
+          CONTENT_TYPE=$(curl --silent --output /tmp/sitemap.xml \
+            --write-out "%{content_type}" "https://${SITE_HOST}/sitemap.xml")
+          echo "content-type: $CONTENT_TYPE"
+
+          case "$CONTENT_TYPE" in
+            *xml*) echo "✓ content-type é XML" ;;
+            *)
+              echo "✗ /sitemap.xml devolveu '$CONTENT_TYPE' — esperado XML."
+              echo "  Sintoma clássico do fallback SPA servindo HTML no lugar do sitemap."
+              head -c 300 /tmp/sitemap.xml
+              exit 1
+              ;;
+          esac
+
+          LOC_COUNT=$(grep -o '<loc>' /tmp/sitemap.xml | wc -l | tr -d ' ')
+          echo "URLs no sitemap: $LOC_COUNT (mínimo $MIN_URLS)"
+          if [ "$LOC_COUNT" -lt "$MIN_URLS" ]; then
+            echo "✗ Sitemap encolheu — provável regressão de exclusão de rotas por surface."
+            exit 1
+          fi
+          echo "✓ Sitemap validado"
 
       # Avisa Bing e parceiros (Seznam, Naver, Yandex) que as URLs mudaram —
       # protocolo aberto, sem conta nem credencial: a posse do domínio é

--- a/.lighthouserc.landing.yml
+++ b/.lighthouserc.landing.yml
@@ -1,0 +1,84 @@
+# Lighthouse CI — surface LANDING (auraxis.com.br)
+#
+# Por que um arquivo separado do `.lighthouserc.yml`: aquele audita a surface
+# default (app), cuja home é a tela de **login**. A landing — a página que
+# vende — nunca tinha sido medida no CI (#1214). São páginas com orçamento de
+# performance diferente: a landing carrega imagens de showcase e é SSG pura.
+#
+# Rodar local:
+#   rm -rf .output
+#   NUXT_PUBLIC_SITE_SURFACE=landing pnpm generate
+#   pnpm dlx @lhci/cli autorun --config=.lighthouserc.landing.yml
+#
+# ⚠️ O `rm -rf .output` não é zelo: `pnpm quality-check` termina com um build da
+# surface **app** e sobrescreve o `.output`. Medir logo depois compara a landing
+# contra a home de login e o número não quer dizer nada.
+
+ci:
+  collect:
+    # `generate` já rodou no job; o preview só serve o `.output` estático.
+    startServerCommand: NUXT_PUBLIC_SITE_SURFACE=landing NITRO_HOST=0.0.0.0 NITRO_PORT=3000 pnpm preview
+    startServerReadyPattern: 'Listening on'
+    startServerReadyTimeout: 120000
+    url:
+      - http://localhost:3000/
+      - http://localhost:3000/checkout
+      - http://localhost:3000/tools/juros-compostos
+    numberOfRuns: 3
+
+  assert:
+    preset: lighthouse:no-pwa
+    assertions:
+      # ── Warn-only enquanto a baseline não está registrada (#1214) ──────────
+      # Promover para `error` depois que houver histórico: subir com `error`
+      # agora reprovaria PRs por um patamar que ninguém mediu ainda, e o
+      # resultado seria desligar o job em vez de consertar a página.
+      'categories:performance':
+        - warn
+        - minScore: 0.9
+      'categories:accessibility':
+        - warn
+        - minScore: 0.95
+      'categories:best-practices':
+        - warn
+        - minScore: 0.9
+      'categories:seo':
+        - warn
+        - minScore: 0.9
+
+      # ── Artefatos de localhost — validados em outra camada ─────────────────
+      # Idênticos ao `.lighthouserc.yml`: HTTPS, compressão, cache e redirects
+      # são política do CloudFront, não desta medição.
+      uses-https:                          { severity: off }
+      no-vulnerable-libraries:             { severity: off }
+      valid-source-maps:                   { severity: off }
+      uses-text-compression:               { severity: off }
+      uses-long-cache-ttl:                 { severity: off }
+      redirects-http:                      { severity: off }
+      bf-cache:                            { severity: off }
+      unused-css-rules:                    { severity: off }
+
+      # `unused-javascript` fica LIGADO aqui (no perfil do app está off): é
+      # exatamente o sinal que motivou #1246/#1257 na home da landing, e
+      # desligá-lo cegaria o CI para a regressão que acabamos de corrigir.
+      unused-javascript:
+        - warn
+        - maxLength: 1
+
+      largest-contentful-paint:
+        - warn
+        - maxNumericValue: 4000
+
+      total-blocking-time:
+        - warn
+        - maxNumericValue: 1200
+
+      cumulative-layout-shift:
+        - warn
+        - maxNumericValue: 0.1
+
+      first-contentful-paint:              { severity: off }
+      speed-index:                         { severity: off }
+
+  upload:
+    target: temporary-public-storage


### PR DESCRIPTION
## Resumo

Dois furos no pipeline da landing, ambos no mesmo domínio (CI/deploy da surface que vende), por isso
numa PR só.

### #1213 — o deploy da landing não provava nada

Não havia smoke, e a invalidação do CloudFront rodava sem `wait`. Status HTTP aqui **não prova
deploy**: o CloudFront devolve 200 de fallback, e já houve deploy silenciosamente ausente (#1197).

Portadas as duas fases do `deploy.yml` do app, precedidas do wait da invalidação:

1. HTTP 200 com corpo (10 tentativas, 3s);
2. o `x-build-id` servido == o gravado **neste** build (15 tentativas, 5s).

**Validação do sitemap**, passo próprio: `content-type` XML e piso de 60 `<loc>` (hoje são 72).
O `/sitemap.xml` já teve **dois donos** disputando o mesmo caminho — o `nitro.prerender` servindo um
diretório com redirect HTML e o `@nuxtjs/sitemap` servindo o XML, com o vencedor variando por build
(#1233). Um deploy que devolva HTML ali é regressão de SEO invisível: o Search Console só reclama
dias depois.

### #1214 — a landing nunca tinha sido medida

O job `lighthouse` builda a surface default, cuja home é a tela de **login**. Job novo
`lighthouse-landing` com `.lighthouserc.landing.yml` próprio, auditando `/`, `/checkout` e
`/tools/juros-compostos`.

**Warn-only por ora**, como a issue pede. Subir com `error` sem baseline reprovaria PRs por um
patamar que ninguém mediu, e o desfecho previsível seria desligar o job em vez de consertar a
página. Promover depois que houver histórico.

Uma diferença deliberada em relação ao perfil do app: **`unused-javascript` fica LIGADO** aqui (lá
está `off`). É exatamente o sinal que motivou #1246 e #1257 — desligá-lo cegaria o CI para a
regressão que acabamos de corrigir.

## Verificação que evitou quebrar todo deploy

A fase 2 do smoke depende da meta `x-build-id`. No build local da landing ela **não aparecia** — o
que teria reprovado todo deploy da landing a partir desta PR.

Gerei a surface com `NUXT_PUBLIC_BUILD_ID` setado (como o CI faz) e confirmei:

```
home:                 name="x-build-id" content="12345-abcdef"
/tools/juros-compostos: name="x-build-id" content="12345-abcdef"
sitemap.xml:          72 <loc>
```

A ausência anterior era só o unhead omitindo meta com `content` vazio. Sem essa checagem o smoke
teria ido para a `main` quebrado.

## Validação

- `actionlint` nos dois workflows: **zero achados novos**. Confirmei por comparação com `git stash`
  que o único `SC2086` era meu (`>> $GITHUB_ENV` sem aspas) e corrigi; o `SC2038` remanescente é
  pré-existente do passo do IndexNow.
- YAML dos três arquivos parseado; os 21 jobs do `ci.yml` seguem íntegros com o novo entre eles.
- Piso de 60 URLs escolhido com folga sobre as 72 atuais — aperta se o sitemap encolher por
  regressão de exclusão por surface, sem alarme falso a cada post novo do blog.

## Risco residual

- O `lighthouse-landing` acrescenta um build extra ao CI (~4 min). Roda em paralelo aos demais e é
  **não-required**, então não bloqueia merge — se o custo incomodar, dá para restringir a PRs que
  toquem a landing.
- O smoke agora pode **reprovar um deploy** que antes passaria silenciosamente. É o objetivo, mas
  significa que uma falha de propagação do CloudFront vira deploy vermelho em vez de erro
  silencioso — o retry de 75s da fase 2 é a folga contra flake de propagação.

Closes #1213
Closes #1214
