### PR TITLE
fix(auth): redefinição de senha enviava o campo errado e quebrava em produção

### DIFF
--- a/app/composables/useAuth/api.spec.ts
+++ b/app/composables/useAuth/api.spec.ts
@@ -185,7 +185,7 @@ describe("createAuthApi", () => {
     expect(response.message).toBe("Email not found");
   });
 
-  it("resetPassword calls POST /auth/password/reset and returns the response data", async () => {
+  it("resetPassword posts the wire payload the API expects (new_password, not password)", async () => {
     const post = vi.fn().mockResolvedValue({
       data: { message: "Password reset successfully" },
     });
@@ -193,13 +193,23 @@ describe("createAuthApi", () => {
 
     const response = await authApi.resetPassword({
       token: "reset-token-123",
-      password: "NewPassword@1",
+      newPassword: "NewPassword@1",
     });
 
     expect(post).toHaveBeenCalledWith("/auth/password/reset", {
       token: "reset-token-123",
-      password: "NewPassword@1",
+      new_password: "NewPassword@1",
     });
     expect(response.message).toBe("Password reset successfully");
+  });
+
+  it("resetPassword never sends the form-level `password` field", async () => {
+    const post = vi.fn().mockResolvedValue({ data: { message: "ok" } });
+    const authApi = createAuthApi({ post });
+
+    await authApi.resetPassword({ token: "reset-token-123", newPassword: "NewPassword@1" });
+
+    const [, body] = post.mock.calls[0] as [string, Record<string, unknown>];
+    expect(body).not.toHaveProperty("password");
   });
 });

--- a/app/composables/useAuth/api.ts
+++ b/app/composables/useAuth/api.ts
@@ -8,8 +8,17 @@ import type {
   ResetPasswordRequest,
   ResetPasswordResponse,
 } from "~/types/contracts";
+import type { components } from "~/shared/types/generated/openapi";
 
 import type { AuthApi, HttpAdapter } from "./types";
+
+/**
+ * Wire payload for `POST /auth/password/reset`, taken straight from the
+ * generated OpenAPI schema so the field names can never drift from the backend
+ * unnoticed.
+ */
+type ResetPasswordWirePayload =
+  components["schemas"]["app_schemas_auth_schema_ResetPasswordSchema"];
 
 /** v2 envelope user object returned by auth endpoints. */
 type V2AuthUser = {
@@ -117,6 +126,26 @@ const normalizeForgotPasswordResponse = (
 };
 
 /**
+ * Translates the camelCase domain request into the snake_case body the API
+ * expects.
+ *
+ * Returning the generated OpenAPI type is the point: if the backend ever
+ * renames the field again, this fails `pnpm typecheck` instead of failing
+ * silently in production the way #1301 did.
+ *
+ * @param payload Domain-shaped reset-password request.
+ * @returns Wire payload for POST /auth/password/reset.
+ */
+const toResetPasswordWirePayload = (
+  payload: ResetPasswordRequest,
+): ResetPasswordWirePayload => {
+  return {
+    token: payload.token,
+    new_password: payload.newPassword,
+  };
+};
+
+/**
  * Creates the authentication API adapter from an HTTP client.
  *
  * @param http HTTP adapter with a post method.
@@ -149,7 +178,7 @@ export const createAuthApi = (http: HttpAdapter): AuthApi => {
     ): Promise<ResetPasswordResponse> => {
       const response = await http.post<ResetPasswordResponse>(
         "/auth/password/reset",
-        payload,
+        toResetPasswordWirePayload(payload),
       );
       return response.data;
     },

--- a/app/pages/reset-password.spec.ts
+++ b/app/pages/reset-password.spec.ts
@@ -1,0 +1,206 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ref, type App } from "vue";
+
+import ResetPasswordPage from "./reset-password.vue";
+
+const pushMock = vi.hoisted(() => vi.fn());
+const mutationHarness = vi.hoisted(() => ({
+  current: null as null | {
+    isPending: ReturnType<typeof ref<boolean>>;
+    mutateAsync: ReturnType<typeof vi.fn>;
+  },
+}));
+const routeQuery = vi.hoisted(() => ({
+  current: { token: "a".repeat(32) } as Record<string, string | undefined>,
+}));
+
+vi.mock("#imports", () => ({
+  definePageMeta: vi.fn(),
+  navigateTo: pushMock,
+  useI18n: (): { t: (key: string) => string } => ({ t: (key: string): string => key }),
+  useRoute: (): { query: Record<string, string | undefined> } => ({ query: routeQuery.current }),
+  useRouter: (): { push: typeof pushMock } => ({ push: pushMock }),
+  useSeoMeta: vi.fn(),
+}));
+
+vi.mock("#app", () => ({
+  navigateTo: pushMock,
+  useRoute: (): { query: Record<string, string | undefined> } => ({ query: routeQuery.current }),
+  useRouter: (): { push: typeof pushMock } => ({ push: pushMock }),
+}));
+
+vi.mock("vue-router", () => ({
+  useRoute: (): { query: Record<string, string | undefined> } => ({ query: routeQuery.current }),
+  useRouter: (): { push: typeof pushMock } => ({ push: pushMock }),
+}));
+
+// The page reaches `navigateTo` through Nuxt auto-imports, which resolve to
+// this module rather than to `#imports` — without this the real implementation
+// runs inside the redirect timeout and fails with "nuxt instance unavailable".
+vi.mock("#app/composables/router", () => ({
+  navigateTo: pushMock,
+  useRoute: (): { query: Record<string, string | undefined> } => ({ query: routeQuery.current }),
+  useRouter: (): { push: typeof pushMock } => ({ push: pushMock }),
+}));
+
+vi.mock("~/composables/useAuth", () => ({
+  useResetPasswordMutation: (): NonNullable<typeof mutationHarness.current> => {
+    if (!mutationHarness.current) {
+      throw new Error("mutationHarness.current must be set before mount");
+    }
+    return mutationHarness.current;
+  },
+}));
+
+vi.mock("~/composables/useApiError", () => ({
+  useApiError: (): { getErrorMessage: (error: unknown) => string } => ({
+    getErrorMessage: (): string => "erro-da-api",
+  }),
+}));
+
+const VALID_PASSWORD = "NovaSenha@1";
+
+/**
+ * Installs the minimum Nuxt app context expected by page-level Vue tests.
+ *
+ * @param app Test app instance.
+ */
+function nuxtContextPlugin(app: App): void {
+  Reflect.set(app, "$nuxt", {
+    _route: { path: "/reset-password", meta: {}, params: {}, query: routeQuery.current },
+    $router: { push: pushMock },
+    $config: { public: {} },
+    payload: { serverRendered: false },
+    ssrContext: { head: { push: vi.fn(() => ({ patch: vi.fn(), dispose: vi.fn() })) } },
+    static: { data: {} },
+    isHydrating: false,
+    deferHydration: (): void => {},
+    runWithContext: <T>(callback: () => T): T => callback(),
+    hooks: { callHook: vi.fn(), hook: vi.fn() },
+    _asyncDataPromises: {},
+    _asyncData: {},
+  });
+}
+
+/**
+ * Mounts the reset-password page with stable Nuxt and i18n test doubles.
+ *
+ * @returns Mounted page wrapper.
+ */
+function mountPage(): ReturnType<typeof mount> {
+  return mount(ResetPasswordPage, {
+    global: {
+      plugins: [{ install: nuxtContextPlugin }],
+      mocks: { $t: (key: string): string => key },
+      stubs: {
+        NuxtLink: { props: ["to"], template: "<a :href='to'><slot /></a>" },
+        UiFormField: { props: ["label", "fieldId", "error", "required"], template: "<div><slot /></div>" },
+      },
+    },
+  });
+}
+
+/**
+ * Fills both password inputs and submits the form.
+ *
+ * @param wrapper Mounted page wrapper.
+ * @param password Value typed into both fields.
+ */
+async function submitWith(
+  wrapper: ReturnType<typeof mount>,
+  password: string,
+): Promise<void> {
+  const inputs = wrapper.findAll("input");
+  await inputs[0]?.setValue(password);
+  await inputs[1]?.setValue(password);
+  await flushPromises();
+  await wrapper.find("form").trigger("submit");
+  // vee-validate settles validation across both microtasks and timer callbacks
+  // before the submit handler runs, so advancing fake timers is what actually
+  // lets the submission through.
+  await vi.advanceTimersByTimeAsync(50);
+  await flushPromises();
+}
+
+describe("ResetPasswordPage", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    pushMock.mockReset();
+    routeQuery.current = { token: "a".repeat(32) };
+    mutationHarness.current = {
+      isPending: ref(false),
+      mutateAsync: vi.fn().mockResolvedValue({ message: "ok" }),
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("submits the token with the domain-shaped newPassword field", async () => {
+    const wrapper = mountPage();
+
+    await submitWith(wrapper, VALID_PASSWORD);
+
+    expect(mutationHarness.current?.mutateAsync).toHaveBeenCalledWith({
+      token: "a".repeat(32),
+      newPassword: VALID_PASSWORD,
+    });
+  });
+
+  it("never sends a bare `password` field to the mutation", async () => {
+    const wrapper = mountPage();
+
+    await submitWith(wrapper, VALID_PASSWORD);
+
+    const [payload] = mutationHarness.current?.mutateAsync.mock.calls[0] as [
+      Record<string, unknown>,
+    ];
+    expect(payload).not.toHaveProperty("password");
+  });
+
+  it("renders the invalid-link state and does not call the API without a token", async () => {
+    routeQuery.current = {};
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("auth.resetPassword.noToken");
+    expect(wrapper.find("form").exists()).toBe(false);
+    expect(mutationHarness.current?.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("shows the success state and redirects to login", async () => {
+    const wrapper = mountPage();
+
+    await submitWith(wrapper, VALID_PASSWORD);
+
+    expect(wrapper.text()).toContain("auth.resetPassword.success");
+
+    // The page waits 2s on the success screen before sending the user to login.
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(pushMock).toHaveBeenCalledWith("/login");
+  });
+
+  it("surfaces the API error message when the reset fails", async () => {
+    mutationHarness.current = {
+      isPending: ref(false),
+      mutateAsync: vi.fn().mockRejectedValue(new Error("boom")),
+    };
+    const wrapper = mountPage();
+
+    await submitWith(wrapper, VALID_PASSWORD);
+
+    expect(wrapper.text()).toContain("erro-da-api");
+  });
+
+  it("blocks submission client-side when the password breaks the backend rules", async () => {
+    const wrapper = mountPage();
+
+    await submitWith(wrapper, "curta1!");
+
+    expect(mutationHarness.current?.mutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/app/pages/reset-password.vue
+++ b/app/pages/reset-password.vue
@@ -40,7 +40,7 @@ const onSubmit = handleSubmit(async (values) => {
   if (!token.value) { return; }
   serverError.value = null;
   try {
-    await resetMutation.mutateAsync({ token: token.value, password: values.password });
+    await resetMutation.mutateAsync({ token: token.value, newPassword: values.password });
     isSuccess.value = true;
     setTimeout(() => { navigateTo("/login"); }, 2000);
   } catch (err) {

--- a/app/types/contracts/auth.ts
+++ b/app/types/contracts/auth.ts
@@ -54,7 +54,15 @@ export interface ForgotPasswordResponse {
 
 export interface ResetPasswordRequest {
   readonly token: string;
-  readonly password: string;
+  /**
+   * The new password, in the camelCase domain shape used across this contract.
+   *
+   * The API expects `new_password` on the wire — `toResetPasswordWirePayload`
+   * in `composables/useAuth/api.ts` does that translation against the generated
+   * OpenAPI type, so a backend rename surfaces as a typecheck failure instead
+   * of a production incident (#1301).
+   */
+  readonly newPassword: string;
 }
 
 export interface ResetPasswordResponse {

--- a/e2e/auth/reset-password.spec.ts
+++ b/e2e/auth/reset-password.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, type Page } from "@playwright/test";
+
+import { fillInputAndVerify, waitForHydration } from "../helpers/auth";
+
+/**
+ * E2E suite: Reset password flow
+ *
+ * Uses page.route() to mock API responses — no live backend required.
+ *
+ * The anchor test is the wire-contract one: the API requires `new_password`,
+ * and shipping `password` instead broke every password reset in production
+ * (#1301). There was no E2E on this route at the time, which is why it went
+ * unnoticed.
+ */
+
+// The backend enforces `validate.Length(min=24)` on the token.
+const VALID_TOKEN = "3QXcbPV7pGg6NrT4EnEbZBZe227q0YskHGKdmmx";
+const VALID_PASSWORD = "NovaSenha@1";
+
+const RESET_URL = `/reset-password?token=${VALID_TOKEN}`;
+
+/**
+ * Fills both password fields with the same valid password.
+ *
+ * @param page Playwright page.
+ */
+async function fillPasswords(page: Page): Promise<void> {
+  await fillInputAndVerify(page, "#reset-password", VALID_PASSWORD);
+  await fillInputAndVerify(page, "#reset-confirm-password", VALID_PASSWORD);
+}
+
+test.describe("Auth — Reset Password", () => {
+  test("sends new_password on the wire and never the form-level password", async ({
+    page,
+  }) => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    await page.route("**/auth/password/reset", async (route) => {
+      capturedBody = route.request().postDataJSON() as Record<string, unknown>;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          message: "Password updated successfully",
+          data: {},
+        }),
+      });
+    });
+
+    await page.goto(RESET_URL);
+    await waitForHydration(page);
+    await fillPasswords(page);
+    await page.getByRole("button", { name: /redefinir senha|salvar nova senha/i }).click();
+
+    await expect
+      .poll(() => capturedBody, { timeout: 8_000 })
+      .not.toBeNull();
+
+    expect(capturedBody).toHaveProperty("new_password", VALID_PASSWORD);
+    expect(capturedBody).toHaveProperty("token", VALID_TOKEN);
+    expect(capturedBody).not.toHaveProperty("password");
+  });
+
+  test("shows the success state and lands on login", async ({ page }) => {
+    await page.route("**/auth/password/reset", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          message: "Password updated successfully",
+          data: {},
+        }),
+      });
+    });
+
+    await page.goto(RESET_URL);
+    await waitForHydration(page);
+    await fillPasswords(page);
+    await page.getByRole("button", { name: /redefinir senha|salvar nova senha/i }).click();
+
+    await expect(page.getByText(/senha (redefinida|alterada)/i)).toBeVisible({
+      timeout: 8_000,
+    });
+    await page.waitForURL("**/login", { timeout: 8_000 });
+  });
+
+  test("renders the invalid-link state when the token is missing", async ({ page }) => {
+    await page.goto("/reset-password");
+    await waitForHydration(page);
+
+    await expect(page.getByRole("link", { name: /novo link/i })).toBeVisible();
+    await expect(page.locator("#reset-password")).toHaveCount(0);
+  });
+
+  test("surfaces a server error instead of pretending it worked", async ({ page }) => {
+    await page.route("**/auth/password/reset", (route) => {
+      route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: false,
+          message: "Validation error",
+          error: { code: "VALIDATION_ERROR", details: {} },
+        }),
+      });
+    });
+
+    await page.goto(RESET_URL);
+    await waitForHydration(page);
+    await fillPasswords(page);
+    await page.getByRole("button", { name: /redefinir senha|salvar nova senha/i }).click();
+
+    await expect(page.getByRole("alert")).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByText(/senha (redefinida|alterada)/i)).toHaveCount(0);
+  });
+
+  test("blocks a password that breaks the backend rules before any request", async ({
+    page,
+  }) => {
+    let requested = false;
+    await page.route("**/auth/password/reset", (route) => {
+      requested = true;
+      route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+    });
+
+    await page.goto(RESET_URL);
+    await waitForHydration(page);
+    await fillInputAndVerify(page, "#reset-password", "curta1!");
+    await fillInputAndVerify(page, "#reset-confirm-password", "curta1!");
+    await page.getByRole("button", { name: /redefinir senha|salvar nova senha/i }).click();
+
+    await page.waitForTimeout(1_000);
+    expect(requested).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1301

## Problema

Toda tentativa de redefinir senha em produção respondia 400. O PO reproduziu duas vezes na conta dele.

```json
{"error":{"code":"VALIDATION_ERROR","details":{"errors":{"json":{"new_password":["Missing data for required field."]}}}},"success":false}
```

O frontend enviava `password`; a API exige `new_password`. Não era diferença de contrato v1/v2 — o header `x-api-contract` só troca o envelope de **resposta**.

O tipo gerado do OpenAPI (`app/shared/types/generated/openapi.ts:9044`) já dizia `new_password` havia tempo. Quem divergia era o contrato escrito à mão em `app/types/contracts/auth.ts`, e a página mandava o objeto do formulário cru, sem mapper — diferente de `login`/`register`, que passam por `normalize*Envelope`.

## Correção

Mapper na camada `api`, com o payload de rede tipado **pelo OpenAPI gerado**:

```
form (password/confirmPassword)
  → ResetPasswordRequest { token, newPassword }     ← camelCase, como LoginRequest
  → toResetPasswordWirePayload()
  → { token, new_password }                          ← tipo gerado
```

Corrigir só o literal fecharia este bug e deixaria a porta aberta para o próximo. Ancorando o payload no tipo gerado, um rename no backend passa a quebrar `pnpm typecheck` em vez de quebrar o usuário em produção.

## Por que passou despercebido

Não existia spec de página nem E2E para `/reset-password`. O único teste que tocava o assunto (`api.spec.ts`) **assertava o campo errado** — cristalizava o bug em vez de pegá-lo.

Os dois primeiros commits são o TDD: teste vermelho, depois correção.

## Validação

- `pnpm quality-check` verde, e os 8 gates do pre-push também
- `app/pages/reset-password.spec.ts` — 6 casos, novo
- `e2e/auth/reset-password.spec.ts` — 5 casos, novo. **20/20 nos quatro projetos** (chromium, firefox, mobile-chrome, mobile-safari)
- Teste âncora: captura o body do POST e prova que carrega `new_password` e **não** `password`

## Risco residual

- **Sem screenshots porque este PR não muda um pixel** — é contrato e teste. O redesign da tela (olho nas senhas, botão fora do design system, copy) vem em PR próprio, com issue separada.
- Smoke manual em produção continua necessário depois do deploy: pedir o link, seguir o e-mail, definir a senha nova e entrar com ela.
- A regra de senha do backend (≥10 caracteres, 1 maiúscula, 1 dígito, 1 símbolo) já é espelhada pelo zod, então o usuário é bloqueado no cliente antes do round-trip.