### PR TITLE
fix(tests): preencher o login pelo helper que confere se o valor ficou

### DIFF
--- a/e2e/helpers/mock-session.ts
+++ b/e2e/helpers/mock-session.ts
@@ -1,5 +1,7 @@
 import type { Page } from "@playwright/test";
 
+import { fillLoginForm, waitForHydration } from "./auth";
+
 /** Payload returned by the mocked login endpoint. */
 const LOGIN_RESPONSE = {
   success: true,
@@ -145,18 +147,20 @@ export async function mockAuthenticatedSession(
  * `e2e/specs/tools-catalog.spec.ts` and #1277. For those routes, click the
  * real link instead.
  *
+ * O formulário é preenchido pelo `fillLoginForm`, não por `page.fill` cru: o
+ * bootstrap de sessão que roda depois da hidratação remonta o form e limpa o
+ * campo preenchido primeiro. Quando isso acontecia, a senha ficava e o e-mail
+ * sumia, o clique submetia um form inválido ("Informe um e-mail válido.") e o
+ * `waitForURL` abaixo esperava 20s por uma navegação que nunca ia sair (#1313).
+ *
  * @param page Playwright page.
  * @param path Route to open after login.
  */
 export async function loginAndVisit(page: Page, path: string): Promise<void> {
   await page.goto("/login");
-  await page.waitForFunction(() => {
-    const el = document.getElementById("__nuxt");
-    return el !== null && (el as Element & { __vue_app__?: unknown }).__vue_app__ !== undefined;
-  });
+  await waitForHydration(page);
 
-  await page.fill("input[type='email']", "test@auraxis.com");
-  await page.fill("input[type='password']", "ValidPassword1!");
+  await fillLoginForm(page, "test@auraxis.com", "ValidPassword1!");
   await page.getByRole("button", { name: /entrar/i }).click();
   await page.waitForURL("**/dashboard", { timeout: 20_000 });
 


### PR DESCRIPTION
## O problema

`E2E Tests (Playwright)` vinha vermelho de forma recorrente no `main` — **3 das 5 execuções**
antes desta — sempre no mesmo ponto:

```
[chromium] [mobile-chrome] › e2e/specs/import-wizard.spec.ts:234:3
TimeoutError: page.waitForURL: Timeout 20000ms exceeded.
  waiting for navigation to "**/dashboard"     ← e2e/helpers/mock-session.ts → loginAndVisit
```

O `:234` é só o primeiro teste do `describe`; quem falha é o `signIn()` do `beforeAll`.

## A causa, com evidência

O snapshot de falha no artefato `playwright-report` mostra o estado exato do formulário:

```yaml
- textbox "E-mail":
    - /placeholder: voce@exemplo.com      # ← vazio
- alert: Informe um e-mail válido.
- textbox "Senha":
    - text: ValidPassword1!               # ← preenchida
```

**A senha ficou, o e-mail sumiu.** O bootstrap de sessão que roda depois da hidratação remonta o
formulário e limpa o campo preenchido primeiro. O clique em "Entrar" submete um form inválido, a
validação dispara e o `waitForURL` fica 20s esperando uma navegação que nunca vai sair.

Não é uma descoberta nova no repo — é o comportamento que o `fillLoginForm` de
`e2e/helpers/auth.ts` já existe para neutralizar, e que ele documenta no próprio JSDoc:

> First page loads can still run session/bootstrap work after Vue hydration, which may remount
> the auth form and clear a field while tests are filling it.

Faltava o `loginAndVisit` usá-lo: ele preenchia com `page.fill` cru, sem conferir nada. E como o
`signIn()` do import-wizard retentava **pelo mesmo caminho cru**, as 3 tentativas dele e os 2
retries do Playwright caíam todos na mesma corrida — por isso 9 tentativas seguidas falhavam.

## O que mudou

`loginAndVisit` passa a usar `waitForHydration` + `fillLoginForm` de `e2e/helpers/auth.ts`, que
preenche, espera assentar e reconfere os dois campos (3 tentativas) antes de submeter.

Uma mudança no helper cobre os dois consumidores: `import-wizard.spec.ts` e
`a11y-authenticated.spec.ts`.

## Validação

Local, sobre o build de CI (`pnpm build` com `NUXT_PUBLIC_APP_ENV=development`):

- `import-wizard.spec.ts` → **16/16** (chromium + mobile-chrome)
- `a11y-authenticated.spec.ts` com `A11Y_AUTH_GATE=1` → **8/8**
- `tools-catalog.spec.ts` → **3/3**
- `pnpm lint` ✅

## Risco residual

A corrida é rara localmente — **não consegui reproduzi-la nesta máquina**, então o verde local
prova ausência de regressão, não a correção em si. Quem prova é a causa: o snapshot do CI mostra
o campo vazio com o alerta de validação, e o helper adotado reconfere exatamente esse campo antes
de submeter. O sinal definitivo é o E2E deste PR e a sequência de execuções no `main` depois do
merge.

Closes #1313
