### PR TITLE
fix(contracts): regenerar os tipos GraphQL, que ficaram atrás do schema da api

### DIFF
--- a/app/shared/types/generated/graphql.ts
+++ b/app/shared/types/generated/graphql.ts
@@ -1570,6 +1570,8 @@ export type QueryAiInsightChangeStatusArgs = {
 export type QueryAiInsightHistoryArgs = {
   page?: InputMaybe<Scalars['Int']['input']>;
   perPage?: InputMaybe<Scalars['Int']['input']>;
+  periodLabel?: InputMaybe<Scalars['String']['input']>;
+  periodType?: InputMaybe<Scalars['String']['input']>;
 };
 
 


### PR DESCRIPTION
## Resumo

O CI de `main` está vermelho no job `GraphQL Types (codegen check)` — e, por tabela, todo PR aberto. Não é regressão de nada que o web fez: o schema publicado em `auraxis-api/master/schema.graphql` ganhou dois argumentos em `aiInsightHistory` e o arquivo gerado aqui nunca acompanhou.

```diff
 export type QueryAiInsightHistoryArgs = {
   page?: InputMaybe<Scalars["Int"]["input"]>;
   perPage?: InputMaybe<Scalars["Int"]["input"]>;
+  periodLabel?: InputMaybe<Scalars["String"]["input"]>;
+  periodType?: InputMaybe<Scalars["String"]["input"]>;
 };
```

Duas linhas de tipagem gerada. Nenhuma query do web usa os argumentos novos ainda — este PR só faz o gate voltar a comparar coisas iguais.

## Validação

- `pnpm codegen:check` verde (era exit 1 em `main` limpo, reproduzido localmente antes do fix).
- `pnpm typecheck` verde.
- Run vermelha que motivou: [30779342303](https://github.com/italofelipe/auraxis-web/actions/runs/30779342303).

## Risco residual

- O gate lê o schema do **`master` do auraxis-api em tempo de execução**, então ele reprova sozinho sempre que a API publica schema novo, sem nenhum commit no web. Enquanto for assim, esse drift vai se repetir — vale uma issue para pinar o schema por versão/commit em vez de seguir o branch. Fora de escopo aqui: o objetivo deste PR é destravar `main`.

Closes #1321