### PR TITLE
fix(contracts): regenerar os tipos GraphQL e destravar o CI de main

### DIFF
--- a/app/shared/types/generated/graphql.ts
+++ b/app/shared/types/generated/graphql.ts
@@ -1570,6 +1570,8 @@ export type QueryAiInsightChangeStatusArgs = {
 export type QueryAiInsightHistoryArgs = {
   page?: InputMaybe<Scalars['Int']['input']>;
   perPage?: InputMaybe<Scalars['Int']['input']>;
+  periodLabel?: InputMaybe<Scalars['String']['input']>;
+  periodType?: InputMaybe<Scalars['String']['input']>;
 };
 
 


### PR DESCRIPTION
## Problema

O gate `GraphQL Types (codegen check)` reprovava em `main` e, por consequência, **em todo PR aberto** do repositório.

## Causa

Drift cross-repo. `aiInsightHistory` ganhou dois argumentos no schema do `auraxis-api` (api#1661 — filtro de histórico de insights por período) e o web nunca regenerou:

```diff
 export type QueryAiInsightHistoryArgs = {
   page?: InputMaybe<Scalars['Int']['input']>;
   perPage?: InputMaybe<Scalars['Int']['input']>;
+  periodLabel?: InputMaybe<Scalars['String']['input']>;
+  periodType?: InputMaybe<Scalars['String']['input']>;
 };
```

É o mesmo padrão que já apareceu antes: mudança de schema na API quebra o codegen do web no primeiro PR seguinte, e **o sintoma aparece longe da causa** — num repositório que ninguém tocou, num PR que não tem nada a ver.

## Validação

`pnpm codegen` contra o schema publicado + `pnpm typecheck` verde (exit 0). O diff é de **2 linhas**, só no arquivo gerado — nenhum consumidor usa os argumentos novos ainda.

## Risco residual

Nenhum no runtime: o tipo gerado apenas passa a refletir o que a API já aceita.

Fica valendo o de sempre: **PR que muda schema na API precisa de `pnpm codegen` no web no mesmo ciclo**, senão o próximo PR de outra pessoa é que paga.

Closes #1321