### PR TITLE
fix(user-menu): nome acessível no gatilho derruba 8 das 12 violações de a11y

### DIFF
--- a/app/components/ui/UiUserMenu/UiUserMenu.vue
+++ b/app/components/ui/UiUserMenu/UiUserMenu.vue
@@ -28,8 +28,13 @@ const initial = computed(() => props.name.charAt(0).toUpperCase());
  *
  * O rótulo é fixo em vez de depender do avatar: um nome acessível que muda
  * conforme o usuário subiu foto ou não é pior que um nome estável.
+ *
+ * E não começa com "Abrir menu" de propósito: o gatilho do UiToolsShell já usa
+ * exatamente esse nome, e dois botões com o mesmo prefixo ficam ambíguos para
+ * quem navega por leitor de tela — além de quebrarem busca por papel+nome no
+ * E2E, que foi como a colisão apareceu.
  */
-const triggerLabel = computed(() => `Abrir menu da conta de ${props.name}`);
+const triggerLabel = computed(() => `Menu da conta de ${props.name}`);
 
 /** Toggles the dropdown open/closed state. */
 function toggle(): void {

--- a/app/components/ui/UiUserMenu/UiUserMenu.vue
+++ b/app/components/ui/UiUserMenu/UiUserMenu.vue
@@ -17,6 +17,20 @@ const menuRef = ref<HTMLElement | null>(null);
 
 const initial = computed(() => props.name.charAt(0).toUpperCase());
 
+/**
+ * Nome acessível do gatilho.
+ *
+ * Sem isto o botão fica mudo quando o usuário não tem avatar — que é o caso
+ * padrão: a inicial e o chevron são ambos `aria-hidden`, e sobra "botão" sem
+ * mais nada para quem usa leitor de tela. Como o componente vive no cabeçalho
+ * de toda tela autenticada, essa única omissão respondia por 8 das 12
+ * violações do baseline de a11y (#1324).
+ *
+ * O rótulo é fixo em vez de depender do avatar: um nome acessível que muda
+ * conforme o usuário subiu foto ou não é pior que um nome estável.
+ */
+const triggerLabel = computed(() => `Abrir menu da conta de ${props.name}`);
+
 /** Toggles the dropdown open/closed state. */
 function toggle(): void {
   isOpen.value = !isOpen.value;
@@ -45,6 +59,7 @@ onUnmounted(() => document.removeEventListener("mousedown", handleClickOutside))
   <div ref="menuRef" class="ui-user-menu">
     <button
       class="ui-user-menu__trigger"
+      :aria-label="triggerLabel"
       :aria-expanded="isOpen"
       aria-haspopup="menu"
       @click="toggle"

--- a/app/components/ui/UiUserMenu/__tests__/UiUserMenu.spec.ts
+++ b/app/components/ui/UiUserMenu/__tests__/UiUserMenu.spec.ts
@@ -92,7 +92,7 @@ describe("UiUserMenu", () => {
     });
     const trigger = wrapper.find(".ui-user-menu__trigger");
     expect(trigger.attributes("aria-label")).toBe(
-      "Abrir menu da conta de João Silva",
+      "Menu da conta de João Silva",
     );
   });
 
@@ -104,7 +104,7 @@ describe("UiUserMenu", () => {
     });
     expect(
       wrapper.find(".ui-user-menu__trigger").attributes("aria-label"),
-    ).toBe("Abrir menu da conta de João Silva");
+    ).toBe("Menu da conta de João Silva");
   });
 
   it("displays name initial when no avatarUrl provided", () => {

--- a/app/components/ui/UiUserMenu/__tests__/UiUserMenu.spec.ts
+++ b/app/components/ui/UiUserMenu/__tests__/UiUserMenu.spec.ts
@@ -83,6 +83,30 @@ describe("UiUserMenu", () => {
     expect(wrapper.find("[role=\"menu\"]").exists()).toBe(false);
   });
 
+  it("trigger has an accessible name without an avatar", () => {
+    // Sem avatar, a inicial e o chevron são ambos aria-hidden: sem rótulo, o
+    // botão fica mudo para leitor de tela. Como o menu vive no cabeçalho de
+    // toda tela autenticada, era 8 das 12 violações do baseline (#1324).
+    const wrapper = mount(UiUserMenu, {
+      props: { name: "João Silva" },
+    });
+    const trigger = wrapper.find(".ui-user-menu__trigger");
+    expect(trigger.attributes("aria-label")).toBe(
+      "Abrir menu da conta de João Silva",
+    );
+  });
+
+  it("keeps the same accessible name when an avatar is present", () => {
+    // O rótulo não pode depender de o usuário ter subido foto — nome
+    // acessível que muda de forma é pior que nome estável.
+    const wrapper = mount(UiUserMenu, {
+      props: { name: "João Silva", avatarUrl: "https://example.test/a.png" },
+    });
+    expect(
+      wrapper.find(".ui-user-menu__trigger").attributes("aria-label"),
+    ).toBe("Abrir menu da conta de João Silva");
+  });
+
   it("displays name initial when no avatarUrl provided", () => {
     const wrapper = mount(UiUserMenu, {
       props: { name: "João Silva" },


### PR DESCRIPTION
## O achado

Com o baseline de a11y finalmente **saindo do CI** (#1284, mergeado hoje), deu para ver a distribuição real das violações em vez de só o número:

> 12 critical/serious em 8 telas — e `button-name` aparece em **8 de 8**, sempre no **mesmo nó**: `button.ui-user-menu__trigger`.

Ou seja: **uma correção derruba 8 das 12**. Esse tipo de leitura era exatamente o que faltava enquanto o baseline não era publicado.

## Causa

O gatilho do menu fica **mudo quando o usuário não tem avatar** — que é o caso padrão:

```vue
<UiImage v-if="avatarUrl" :alt="name" />        <!-- com avatar: o alt nomeia -->
<span v-else aria-hidden="true">{{ initial }}</span>
<ChevronRight aria-hidden="true" />
```

Sem avatar, todo o conteúdo é `aria-hidden` e o leitor de tela anuncia só "botão". Como o componente vive no cabeçalho de **toda tela autenticada**, a mesma omissão se repetia em todas.

## A decisão que o código não mostra

O rótulo é **fixo**, não derivado do avatar. Nome acessível que muda de forma conforme o usuário subiu foto ou não é pior que nome estável — e é o tipo de diferença que passa despercebida em teste feito só com um dos dois estados. Por isso há um teste para **cada** estado.

## Validação

`pnpm test`: **498 arquivos, 4.517 testes, todos verdes**. Os dois novos falham sem o fix.

## Impacto esperado no baseline

12 → ~4 violações critical/serious. As restantes ficam visíveis para o próximo ciclo, agora que o artefato do CI publica o detalhe por tela.

Closes #1324