### PR TITLE
chore(deps): subir o piso do fast-uri para 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
       "simple-git": ">=3.36.0",
       "fast-xml-parser": ">=5.7.0",
       "fast-xml-builder": ">=1.1.7",
-      "fast-uri": ">=4.0.1",
+      "fast-uri": ">=4.1.2",
       "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
       "socket.io-parser": ">=4.2.6",
       "flatted": ">=3.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   simple-git: '>=3.36.0'
   fast-xml-parser: '>=5.7.0'
   fast-xml-builder: '>=1.1.7'
-  fast-uri: '>=4.0.1'
+  fast-uri: '>=4.1.2'
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   socket.io-parser: '>=4.2.6'
   flatted: '>=3.4.2'
@@ -7250,8 +7250,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
@@ -18956,14 +18956,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -20832,7 +20832,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fast-wrap-ansi@0.1.6:
     dependencies:


### PR DESCRIPTION
## Sintoma

`Dependency Audit (pnpm)` falha em qualquer branch — terceira CVE do dia travando um repo, depois do `brace-expansion` aqui (#1336) e do `cryptography` na api (#1679).

```
1 high severity vulnerability
- [high] fast-uri: GHSA-7p8r-x3mc-p8w7
```

## Causa

| | |
|---|---|
| Faixa vulnerável | `>=4.0.0 <4.1.2` |
| Corrigido em | `>=4.1.2` |
| Instalado | `4.1.1` |
| Override existente | `>=4.0.1` — piso baixo demais |

## Correção

Piso do override para `>=4.1.2`. Mesmo tratamento dos outros dois: a versão corrigida está publicada, então é bump, não exceção. O allowlist do gate existe para advisory **sem** correção disponível.

## Validação

```
lock resolve fast-uri@4.1.2
node scripts/ci-audit-gate.cjs → Audit gate passed
pnpm install + eslint limpos
```

Descoberto ao destravar #1337 (documentos legais).

Closes #


Closes #1339
