### PR TITLE
fix(seo): tirar /admin e /auth do sitemap e do robots do host do app

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -517,6 +517,14 @@ export default defineNuxtConfig({
       // Checkout cancel — transactional, not useful in search
       "/checkout/cancel",
       "/en/checkout/cancel",
+      // #1340: superfície administrativa e callbacks de auth NUNCA entram no
+      // sitemap — anunciá-las publica a superfície de ataque.
+      "/admin",
+      "/admin/**",
+      "/auth/**",
+      "/en/admin",
+      "/en/admin/**",
+      "/en/auth/**",
     ],
   },
 

--- a/public/_robots.txt
+++ b/public/_robots.txt
@@ -14,6 +14,8 @@ Disallow: /budgets
 Disallow: /investor-profile
 Disallow: /settings/
 Disallow: /checkout/success
+Disallow: /admin
+Disallow: /auth
 
 # EN locale equivalents
 Disallow: /en/dashboard
@@ -29,4 +31,6 @@ Disallow: /en/budgets
 Disallow: /en/investor-profile
 Disallow: /en/settings/
 Disallow: /en/checkout/success
+Disallow: /en/admin
+Disallow: /en/auth
 


### PR DESCRIPTION
## Resumo

`app.auraxis.com.br/__sitemap__/pt-BR.xml` anunciava publicamente as 6 rotas `/admin*` e `/auth/callback`, e o robots.txt do host do app não tinha `Disallow` para nenhuma delas — superfície administrativa publicada às vésperas da divulgação do go-live, com IndexNow pingando a cada deploy.

## Mudanças

- `nuxt.config.ts`: `/admin", "/admin/**", "/auth/**` (+ variantes `/en`) no `exclude` do sitemap
- `public/_robots.txt` (fonte mesclada no robots do host do app): `Disallow: /admin` e `Disallow: /auth` (+ `/en`)

## Validação

- Build local: `__sitemap__/pt-BR.xml` gerado com **0** ocorrências de admin
- Robots: verificação final em prod pós-deploy (o merge do `_robots.txt` só acontece em env production — local emite `Disallow: /` por design)

## Risco residual

Nenhum — mudanças aditivas de exclusão; nenhuma rota pública afetada.

Closes #1340